### PR TITLE
AoS verlet lists

### DIFF
--- a/src/containers/LinkedCells.h
+++ b/src/containers/LinkedCells.h
@@ -166,6 +166,9 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell> {
   }
 
  protected:
+  /**
+   * object to manage the block of cells
+   */
   CellBlock3D<ParticleCell> _cellBlock;
   // ThreeDimensionalCellHandler
 };

--- a/src/containers/LinkedCells.h
+++ b/src/containers/LinkedCells.h
@@ -68,8 +68,9 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell> {
   }
 
   /**
-   * same as iteratePairwiseAoS, but faster, as the class of the functor is
-   * known and thus the compiler can do some better optimizations.
+   * same as iteratePairwiseAoS, but potentially faster (if called with the
+   * derived functor), as the class of the functor is known and thus the
+   * compiler can do some better optimizations.
    * @tparam ParticleFunctor
    * @param f
    * @param useNewton3 defines whether newton3 should be used
@@ -164,7 +165,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell> {
     //    }
   }
 
- private:
+ protected:
   CellBlock3D<ParticleCell> _cellBlock;
   // ThreeDimensionalCellHandler
 };

--- a/src/containers/VerletLists.h
+++ b/src/containers/VerletLists.h
@@ -76,6 +76,10 @@ class VerletLists : public LinkedCells<Particle, ParticleCell> {
     }
   }
 
+  /**
+   * get the actual neighbour list
+   * @return the neighbour list
+   */
   verletlist_storage_type& getVerletLists(){
     return _verletLists;
   }

--- a/src/containers/VerletLists.h
+++ b/src/containers/VerletLists.h
@@ -8,12 +8,23 @@
 #ifndef SRC_CONTAINERS_VERLETLISTS_H_
 #define SRC_CONTAINERS_VERLETLISTS_H_
 
-#include "ParticleContainer.h"
+#include "LinkedCells.h"
 
 namespace autopas {
 
 template <class Particle, class ParticleCell>
-class VerletLists : public ParticleContainer<Particle, ParticleCell> {
+class VerletLists : public LinkedCells<Particle, ParticleCell> {
+ public:
+  /**
+   * Constructor of the VerletLists class
+   * @param boxMin
+   * @param boxMax
+   * @param cutoff
+   */
+  VerletLists(const std::array<double, 3> boxMin,
+              const std::array<double, 3> boxMax, double cutoff)
+      : LinkedCells<Particle, ParticleCell>(boxMin, boxMax, cutoff) {}
+
  private:
   // ThreeDimensionalCellHandler
 };

--- a/src/containers/VerletLists.h
+++ b/src/containers/VerletLists.h
@@ -52,27 +52,9 @@ class VerletLists : public LinkedCells<Particle, ParticleCell> {
   void iteratePairwiseAoS2(ParticleFunctor* f, bool useNewton3 = true) {
     if (useNewton3) {
       this->updateVerletListsN3();
-      CellFunctor<Particle, ParticleCell, ParticleFunctor, false, true>
-          cellFunctor(f);
-      //		cellFunctor.processCellAoSN3(this->_data[13]);
-      SlicedTraversal<ParticleCell, CellFunctor<Particle, ParticleCell,
-                                                ParticleFunctor, false, true>>
-          traversal(this->_data,
-                    this->_cellBlock.getCellsPerDimensionWithHalo(),
-                    &cellFunctor);
 
-      traversal.traverseCellPairs();
     } else {
-      CellFunctor<Particle, ParticleCell, ParticleFunctor, false, false>
-          cellFunctor(f);
-      //		cellFunctor.processCellAoSN3(this->_data[13]);
-      SlicedTraversal<ParticleCell, CellFunctor<Particle, ParticleCell,
-                                                ParticleFunctor, false, false>>
-          traversal(this->_data,
-                    this->_cellBlock.getCellsPerDimensionWithHalo(),
-                    &cellFunctor);
-
-      traversal.traverseCellPairs();
+      /// @todo verlet list non-newton3
     }
   }
 
@@ -80,9 +62,7 @@ class VerletLists : public LinkedCells<Particle, ParticleCell> {
    * get the actual neighbour list
    * @return the neighbour list
    */
-  verletlist_storage_type& getVerletLists(){
-    return _verletLists;
-  }
+  verletlist_storage_type& getVerletLists() { return _verletLists; }
 
  private:
   class VerletListGeneratorFunctor
@@ -118,7 +98,7 @@ class VerletLists : public LinkedCells<Particle, ParticleCell> {
     VerletListGeneratorFunctor f(_verletLists, _particleIDtoVerletListIndexMap,
                                  (this->getCutoff() * this->getCutoff()));
 
-    LinkedCells<Particle, ParticleCell>::iteratePairwiseAoS2(&f,true);
+    LinkedCells<Particle, ParticleCell>::iteratePairwiseAoS2(&f, true);
   }
 
   size_t updateIdMap() {
@@ -144,7 +124,6 @@ class VerletLists : public LinkedCells<Particle, ParticleCell> {
   verletlist_storage_type _verletLists;
 
   double _skin;
-
 };
 
 } /* namespace autopas */

--- a/src/containers/VerletLists.h
+++ b/src/containers/VerletLists.h
@@ -1,17 +1,21 @@
-/*
- * VerletLists.h
- *
- *  Created on: 17 Jan 2018
- *      Author: tchipevn
+/**
+ * @file VerletLists.h
+ * @author seckler
+ * @date 19.04.18
  */
 
-#ifndef SRC_CONTAINERS_VERLETLISTS_H_
-#define SRC_CONTAINERS_VERLETLISTS_H_
+#pragma once
 
 #include "LinkedCells.h"
 
 namespace autopas {
 
+/**
+ * Verlet Lists container.
+ * This class builds neighbour lists for the particle interactions.
+ * @tparam Particle
+ * @tparam ParticleCell
+ */
 template <class Particle, class ParticleCell>
 class VerletLists : public LinkedCells<Particle, ParticleCell> {
  public:
@@ -25,10 +29,65 @@ class VerletLists : public LinkedCells<Particle, ParticleCell> {
               const std::array<double, 3> boxMax, double cutoff)
       : LinkedCells<Particle, ParticleCell>(boxMin, boxMax, cutoff) {}
 
+  void iteratePairwiseAoS(Functor<Particle, ParticleCell> *f,
+                          bool useNewton3 = true) override {
+    iteratePairwiseAoS2(f, useNewton3);
+  }
+
+  /**
+   * same as iteratePairwiseAoS, but potentially faster (if called with the
+   * derived functor), as the class of the functor is known and thus the
+   * compiler can do some better optimizations.
+   * @tparam ParticleFunctor
+   * @param f
+   * @param useNewton3 defines whether newton3 should be used
+   */
+  template <class ParticleFunctor>
+  void iteratePairwiseAoS2(ParticleFunctor *f, bool useNewton3 = true) {
+    if (useNewton3) {
+      this->updateVerletListsN3();
+      CellFunctor<Particle, ParticleCell, ParticleFunctor, false, true>
+          cellFunctor(f);
+      //		cellFunctor.processCellAoSN3(this->_data[13]);
+      SlicedTraversal<ParticleCell, CellFunctor<Particle, ParticleCell,
+                                                ParticleFunctor, false, true>>
+          traversal(this->_data,
+                    this->_cellBlock.getCellsPerDimensionWithHalo(),
+                    &cellFunctor);
+
+      traversal.traverseCellPairs();
+    } else {
+      CellFunctor<Particle, ParticleCell, ParticleFunctor, false, false>
+          cellFunctor(f);
+      //		cellFunctor.processCellAoSN3(this->_data[13]);
+      SlicedTraversal<ParticleCell, CellFunctor<Particle, ParticleCell,
+                                                ParticleFunctor, false, false>>
+          traversal(this->_data,
+                    this->_cellBlock.getCellsPerDimensionWithHalo(),
+                    &cellFunctor);
+
+      traversal.traverseCellPairs();
+    }
+  }
+
  private:
+  class VerletListGeneratorFunctor
+      : public autopas::Functor<Particle, ParticleCell> {};
+
+  void updateVerletListsN3() {
+    VerletListGeneratorFunctor f;
+    CellFunctor<Particle, ParticleCell, VerletListGeneratorFunctor, false, true>
+        cellFunctor(&f);
+    //		cellFunctor.processCellAoSN3(this->_data[13]);
+    SlicedTraversal<ParticleCell,
+                    CellFunctor<Particle, ParticleCell,
+                                VerletListGeneratorFunctor, false, true>>
+        traversal(this->_data, this->_cellBlock.getCellsPerDimensionWithHalo(),
+                  &cellFunctor);
+
+    traversal.traverseCellPairs();
+  }
   // ThreeDimensionalCellHandler
 };
 
 } /* namespace autopas */
-
-#endif /* SRC_CONTAINERS_VERLETLISTS_H_ */

--- a/src/containers/VerletLists.h
+++ b/src/containers/VerletLists.h
@@ -18,18 +18,24 @@ namespace autopas {
  */
 template <class Particle, class ParticleCell>
 class VerletLists : public LinkedCells<Particle, ParticleCell> {
+  typedef std::vector<std::vector<size_t>> verletlist_storage_type;
+  typedef std::map<decltype(Particle().getID()), size_t>
+      particleid_to_verletlist_index_map_type;
+
  public:
   /**
    * Constructor of the VerletLists class
    * @param boxMin
    * @param boxMax
    * @param cutoff
+   * @param skin
    */
   VerletLists(const std::array<double, 3> boxMin,
-              const std::array<double, 3> boxMax, double cutoff)
-      : LinkedCells<Particle, ParticleCell>(boxMin, boxMax, cutoff) {}
+              const std::array<double, 3> boxMax, double cutoff, double skin)
+      : LinkedCells<Particle, ParticleCell>(boxMin, boxMax, cutoff + skin),
+        _skin(skin) {}
 
-  void iteratePairwiseAoS(Functor<Particle, ParticleCell> *f,
+  void iteratePairwiseAoS(Functor<Particle, ParticleCell>* f,
                           bool useNewton3 = true) override {
     iteratePairwiseAoS2(f, useNewton3);
   }
@@ -43,7 +49,7 @@ class VerletLists : public LinkedCells<Particle, ParticleCell> {
    * @param useNewton3 defines whether newton3 should be used
    */
   template <class ParticleFunctor>
-  void iteratePairwiseAoS2(ParticleFunctor *f, bool useNewton3 = true) {
+  void iteratePairwiseAoS2(ParticleFunctor* f, bool useNewton3 = true) {
     if (useNewton3) {
       this->updateVerletListsN3();
       CellFunctor<Particle, ParticleCell, ParticleFunctor, false, true>
@@ -70,24 +76,71 @@ class VerletLists : public LinkedCells<Particle, ParticleCell> {
     }
   }
 
+  verletlist_storage_type& getVerletLists(){
+    return _verletLists;
+  }
+
  private:
   class VerletListGeneratorFunctor
-      : public autopas::Functor<Particle, ParticleCell> {};
+      : public autopas::Functor<Particle, ParticleCell> {
+   public:
+    VerletListGeneratorFunctor(
+        verletlist_storage_type& verletLists,
+        particleid_to_verletlist_index_map_type& particleIDtoVerletListIndexMap,
+        double cutoffskinsquared)
+        : _verletLists(verletLists),
+          _particleIDtoVerletListIndexMap(particleIDtoVerletListIndexMap),
+          _cutoffskinsquared(cutoffskinsquared) {}
+
+    void AoSFunctor(Particle& i, Particle& j, bool newton3 = true) override {
+      auto dist = arrayMath::sub(i.getR(), j.getR());
+      double distsquare = arrayMath::dot(dist, dist);
+
+      if (distsquare < _cutoffskinsquared)
+        _verletLists[_particleIDtoVerletListIndexMap[i.getID()]].push_back(
+            _particleIDtoVerletListIndexMap[j.getID()]);
+    }
+
+   private:
+    verletlist_storage_type& _verletLists;
+    particleid_to_verletlist_index_map_type& _particleIDtoVerletListIndexMap;
+    double _cutoffskinsquared;
+  };
 
   void updateVerletListsN3() {
-    VerletListGeneratorFunctor f;
-    CellFunctor<Particle, ParticleCell, VerletListGeneratorFunctor, false, true>
-        cellFunctor(&f);
-    //		cellFunctor.processCellAoSN3(this->_data[13]);
-    SlicedTraversal<ParticleCell,
-                    CellFunctor<Particle, ParticleCell,
-                                VerletListGeneratorFunctor, false, true>>
-        traversal(this->_data, this->_cellBlock.getCellsPerDimensionWithHalo(),
-                  &cellFunctor);
+    size_t particleNumber = updateIdMap();
+    _verletLists.clear();
+    _verletLists.resize(particleNumber);
+    VerletListGeneratorFunctor f(_verletLists, _particleIDtoVerletListIndexMap,
+                                 (this->getCutoff() * this->getCutoff()));
 
-    traversal.traverseCellPairs();
+    LinkedCells<Particle, ParticleCell>::iteratePairwiseAoS2(&f,true);
   }
-  // ThreeDimensionalCellHandler
+
+  size_t updateIdMap() {
+    _particleIDtoVerletListIndexMap.clear();  // this is not necessary, but it
+                                              // does not hurt too much,
+                                              // probably...
+    size_t i = 0;
+    for (auto iter = this->begin(); iter.isValid(); ++iter, ++i) {
+      _particleIDtoVerletListIndexMap[iter->getID()] = i;
+    }
+
+    return i;
+  }
+
+  /// map that converts the id type of the particle to the actual position in
+  /// the verlet list.
+  /// This is needed, as the particles don't have a local id.
+  /// @todo remove this and add local id to the particles (this saves a
+  /// relatively costly lookup)
+  particleid_to_verletlist_index_map_type _particleIDtoVerletListIndexMap;
+
+  /// verlet lists.
+  verletlist_storage_type _verletLists;
+
+  double _skin;
+
 };
 
 } /* namespace autopas */

--- a/tests/testAutopas/VerletListsTest.cpp
+++ b/tests/testAutopas/VerletListsTest.cpp
@@ -1,0 +1,15 @@
+/**
+ * @file VerletListsTest.cpp
+ * @author seckler
+ * @date 19.04.18
+ */
+
+#include "VerletListsTest.h"
+
+TEST_F(VerletListsTest, VerletListConstructor) {
+  std::array<double, 3> min = {1, 1, 1};
+  std::array<double, 3> max = {3, 3, 3};
+  double cutoff = 1.;
+
+  autopas::VerletLists<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> verletLists(min, max, cutoff);
+}

--- a/tests/testAutopas/VerletListsTest.cpp
+++ b/tests/testAutopas/VerletListsTest.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "VerletListsTest.h"
+#include "mocks/MockFunctor.h"
 
 TEST_F(VerletListsTest, VerletListConstructor) {
   std::array<double, 3> min = {1, 1, 1};
@@ -37,16 +38,82 @@ TEST_F(VerletListsTest, testVerletListBuild) {
       emptyFunctor;
   verletLists.iteratePairwiseAoS2(&emptyFunctor, true);
 
-  auto& list = verletLists.getVerletLists();
+  auto& list = verletLists.getVerletListsAoS();
 
   EXPECT_EQ(list.size(), 2);
-  ASSERT_EQ(list[0].size() + list[1].size(), 1);
-  if (list[0].size() == 1) {
-    EXPECT_EQ(list[0][0], 1);
-  } else if (list[1].size() == 1) {
-    EXPECT_EQ(list[1][0], 0);
+  int partners = 0;
+  for (auto i : list) {
+    partners += i.second.size();
   }
+  EXPECT_EQ(partners, 1);
 }
+
+TEST_F(VerletListsTest, testVerletList) {
+  std::array<double, 3> min = {1, 1, 1};
+  std::array<double, 3> max = {3, 3, 3};
+  double cutoff = 1.;
+  double skin = 0.2;
+  autopas::VerletLists<autopas::Particle,
+                       autopas::FullParticleCell<autopas::Particle>>
+      verletLists(min, max, cutoff, skin);
+
+  std::array<double, 3> r = {2, 2, 2};
+  autopas::Particle p(r, {0., 0., 0.}, 0);
+  verletLists.addParticle(p);
+  std::array<double, 3> r2 = {1.5, 2, 2};
+  autopas::Particle p2(r2, {0., 0., 0.}, 1);
+  verletLists.addParticle(p2);
+
+
+  MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> mockFunctor;
+  using ::testing::_;       // anything is ok
+  EXPECT_CALL(mockFunctor, AoSFunctor(_, _, true));
+
+  verletLists.iteratePairwiseAoS2(&mockFunctor, true);
+
+  auto& list = verletLists.getVerletListsAoS();
+
+  EXPECT_EQ(list.size(), 2);
+  int partners = 0;
+  for (auto i : list) {
+    partners += i.second.size();
+  }
+  EXPECT_EQ(partners, 1);
+}
+
+TEST_F(VerletListsTest, testVerletListInSkin) {
+  std::array<double, 3> min = {1, 1, 1};
+  std::array<double, 3> max = {3, 3, 3};
+  double cutoff = 1.;
+  double skin = 0.2;
+  autopas::VerletLists<autopas::Particle,
+                       autopas::FullParticleCell<autopas::Particle>>
+      verletLists(min, max, cutoff, skin);
+
+  std::array<double, 3> r = {1.4, 2, 2};
+  autopas::Particle p(r, {0., 0., 0.}, 0);
+  verletLists.addParticle(p);
+  std::array<double, 3> r2 = {2.5, 2, 2};
+  autopas::Particle p2(r2, {0., 0., 0.}, 1);
+  verletLists.addParticle(p2);
+
+
+  MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> mockFunctor;
+  using ::testing::_;       // anything is ok
+  EXPECT_CALL(mockFunctor, AoSFunctor(_, _, true));
+
+  verletLists.iteratePairwiseAoS2(&mockFunctor, true);
+
+  auto& list = verletLists.getVerletListsAoS();
+
+  EXPECT_EQ(list.size(), 2);
+  int partners = 0;
+  for (auto i : list) {
+    partners += i.second.size();
+  }
+  EXPECT_EQ(partners, 1);
+}
+
 
 TEST_F(VerletListsTest, testVerletListBuildTwice) {
   std::array<double, 3> min = {1, 1, 1};
@@ -71,17 +138,15 @@ TEST_F(VerletListsTest, testVerletListBuildTwice) {
 
   verletLists.iteratePairwiseAoS2(&emptyFunctor, true);
 
-  auto& list = verletLists.getVerletLists();
+  auto& list = verletLists.getVerletListsAoS();
 
   EXPECT_EQ(list.size(), 2);
-  ASSERT_EQ(list[0].size() + list[1].size(), 1);
-  if (list[0].size() == 1) {
-    EXPECT_EQ(list[0][0], 1);
-  } else if (list[1].size() == 1) {
-    EXPECT_EQ(list[1][0], 0);
+  int partners = 0;
+  for (auto i : list) {
+    partners += i.second.size();
   }
+  EXPECT_EQ(partners, 1);
 }
-
 
 TEST_F(VerletListsTest, testVerletListBuildFarAway) {
   std::array<double, 3> min = {1, 1, 1};
@@ -109,9 +174,46 @@ TEST_F(VerletListsTest, testVerletListBuildFarAway) {
       emptyFunctor;
   verletLists.iteratePairwiseAoS2(&emptyFunctor, true);
 
-  auto& list = verletLists.getVerletLists();
+  auto& list = verletLists.getVerletListsAoS();
 
-  EXPECT_EQ(list.size(), 3);
-  EXPECT_EQ(list[0].size() + list[1].size() + list[2].size(), 1);
+  ASSERT_EQ(list.size(), 3);
+  int partners = 0;
+  for (auto i : list) {
+    partners += i.second.size();
+  }
+  ASSERT_EQ(partners, 1);
+}
 
+TEST_F(VerletListsTest, testVerletListBuildHalo) {
+  std::array<double, 3> min = {1, 1, 1};
+  std::array<double, 3> max = {3, 3, 3};
+  double cutoff = 1.;
+  double skin = 0.2;
+  autopas::VerletLists<autopas::Particle,
+                       autopas::FullParticleCell<autopas::Particle>>
+      verletLists(min, max, cutoff, skin);
+
+  std::array<double, 3> r = {0.9, 0.9, 0.9};
+  autopas::Particle p(r, {0., 0., 0.}, 0);
+  verletLists.addHaloParticle(p);
+  std::array<double, 3> r2 = {1.1, 1.1, 1.1};
+  autopas::Particle p2(r2, {0., 0., 0.}, 1);
+  verletLists.addParticle(p2);
+
+  autopas::Functor<autopas::Particle,
+                   autopas::FullParticleCell<autopas::Particle>>
+      emptyFunctor;
+  verletLists.iteratePairwiseAoS2(&emptyFunctor, true);
+
+  verletLists.iteratePairwiseAoS2(&emptyFunctor, true);
+
+  auto& list = verletLists.getVerletListsAoS();
+
+  ASSERT_EQ(list.size(), 2);
+  EXPECT_EQ(list.size(), 2);
+  int partners = 0;
+  for (auto i : list) {
+    partners += i.second.size();
+  }
+  ASSERT_EQ(partners, 1);
 }

--- a/tests/testAutopas/VerletListsTest.cpp
+++ b/tests/testAutopas/VerletListsTest.cpp
@@ -10,6 +10,108 @@ TEST_F(VerletListsTest, VerletListConstructor) {
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
+  double skin = 0.2;
+  autopas::VerletLists<autopas::Particle,
+                       autopas::FullParticleCell<autopas::Particle>>
+      verletLists(min, max, cutoff, skin);
+}
 
-  autopas::VerletLists<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> verletLists(min, max, cutoff);
+TEST_F(VerletListsTest, testVerletListBuild) {
+  std::array<double, 3> min = {1, 1, 1};
+  std::array<double, 3> max = {3, 3, 3};
+  double cutoff = 1.;
+  double skin = 0.2;
+  autopas::VerletLists<autopas::Particle,
+                       autopas::FullParticleCell<autopas::Particle>>
+      verletLists(min, max, cutoff, skin);
+
+  std::array<double, 3> r = {2, 2, 2};
+  autopas::Particle p(r, {0., 0., 0.}, 0);
+  verletLists.addParticle(p);
+  std::array<double, 3> r2 = {1.5, 2, 2};
+  autopas::Particle p2(r2, {0., 0., 0.}, 1);
+  verletLists.addParticle(p2);
+
+  autopas::Functor<autopas::Particle,
+                   autopas::FullParticleCell<autopas::Particle>>
+      emptyFunctor;
+  verletLists.iteratePairwiseAoS2(&emptyFunctor, true);
+
+  auto& list = verletLists.getVerletLists();
+
+  EXPECT_EQ(list.size(), 2);
+  ASSERT_EQ(list[0].size() + list[1].size(), 1);
+  if (list[0].size() == 1) {
+    EXPECT_EQ(list[0][0], 1);
+  } else if (list[1].size() == 1) {
+    EXPECT_EQ(list[1][0], 0);
+  }
+}
+
+TEST_F(VerletListsTest, testVerletListBuildTwice) {
+  std::array<double, 3> min = {1, 1, 1};
+  std::array<double, 3> max = {3, 3, 3};
+  double cutoff = 1.;
+  double skin = 0.2;
+  autopas::VerletLists<autopas::Particle,
+                       autopas::FullParticleCell<autopas::Particle>>
+      verletLists(min, max, cutoff, skin);
+
+  std::array<double, 3> r = {2, 2, 2};
+  autopas::Particle p(r, {0., 0., 0.}, 0);
+  verletLists.addParticle(p);
+  std::array<double, 3> r2 = {1.5, 2, 2};
+  autopas::Particle p2(r2, {0., 0., 0.}, 1);
+  verletLists.addParticle(p2);
+
+  autopas::Functor<autopas::Particle,
+                   autopas::FullParticleCell<autopas::Particle>>
+      emptyFunctor;
+  verletLists.iteratePairwiseAoS2(&emptyFunctor, true);
+
+  verletLists.iteratePairwiseAoS2(&emptyFunctor, true);
+
+  auto& list = verletLists.getVerletLists();
+
+  EXPECT_EQ(list.size(), 2);
+  ASSERT_EQ(list[0].size() + list[1].size(), 1);
+  if (list[0].size() == 1) {
+    EXPECT_EQ(list[0][0], 1);
+  } else if (list[1].size() == 1) {
+    EXPECT_EQ(list[1][0], 0);
+  }
+}
+
+
+TEST_F(VerletListsTest, testVerletListBuildFarAway) {
+  std::array<double, 3> min = {1, 1, 1};
+  std::array<double, 3> max = {5, 5, 5};
+  double cutoff = 1.;
+  double skin = 0.2;
+  autopas::VerletLists<autopas::Particle,
+                       autopas::FullParticleCell<autopas::Particle>>
+      verletLists(min, max, cutoff, skin);
+
+  std::array<double, 3> r = {2, 2, 2};
+  autopas::Particle p(r, {0., 0., 0.}, 0);
+  verletLists.addParticle(p);
+
+  std::array<double, 3> r2 = {1.5, 2, 2};
+  autopas::Particle p2(r2, {0., 0., 0.}, 1);
+  verletLists.addParticle(p2);
+
+  std::array<double, 3> r3 = {4.5, 4.5, 4.5};
+  autopas::Particle p3(r3, {0., 0., 0.}, 2);
+  verletLists.addParticle(p3);
+
+  autopas::Functor<autopas::Particle,
+                   autopas::FullParticleCell<autopas::Particle>>
+      emptyFunctor;
+  verletLists.iteratePairwiseAoS2(&emptyFunctor, true);
+
+  auto& list = verletLists.getVerletLists();
+
+  EXPECT_EQ(list.size(), 3);
+  EXPECT_EQ(list[0].size() + list[1].size() + list[2].size(), 1);
+
 }

--- a/tests/testAutopas/VerletListsTest.h
+++ b/tests/testAutopas/VerletListsTest.h
@@ -1,0 +1,12 @@
+/**
+ * @file VerletListsTest.h
+ * @author seckler
+ * @date 19.04.18
+ */
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include "autopasIncludes.h"
+
+class VerletListsTest : public testing::Test {};


### PR DESCRIPTION
This feature integrates verlet lists using AoS (SoA support comes later).
* the Verlet lists use LinkedCells in the background
* a std::map<Particle*, std::vector<Particle*>> describes the neighbour lists.
* the neighbour list is generated using the normal iterateAoS2 function of LinkedCells, i.e. it reuses the traversal from LinkedCells.
* the neighbour list is tested (using the MockFunctor) and documented
* the neighbour list can not yet be reused in the next step

things to think about:
* convert the map to a std::vector existing for each Particle. This could be done by extending the Particle class by the necessary properties.

references #10 