### PR TITLE
Added Jenkinsfile, fix 13

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,71 @@
+pipeline{
+    agent { label 'atsccs11' }
+    stages{
+        stage('setup'){
+            steps{
+                echo 'Starting AutoPas Pipeline'
+            }
+        }
+        stage("build") {
+            steps{
+                dir("build"){
+                    sh "cmake .."
+                    sh "make"
+                }
+            }
+        }
+        stage("test") {
+            steps{
+                dir("build"){
+                    //sh "env CTEST_OUTPUT_ON_FAILURE=1 make test"
+                    sh 'env GTEST_OUTPUT="xml:$(pwd)/test.xml" ctest'
+                }
+                dir("build-addresssanitizer"){
+                    sh "cmake -DCodeCoverage=OFF -DCMAKE_BUILD_TYPE=Debug -DENABLE_ADDRESS_SANITIZER=ON .."
+                    sh "make -j 4"
+                    sh "make test"
+                }
+                dir("build-threadsanitizer"){
+                    sh "cmake -DCodeCoverage=OFF -DCMAKE_BUILD_TYPE=Debug -DENABLE_THREAD_SANITIZER=ON .."
+                    sh "make -j 4"
+                    sh "make test"
+                }
+            }
+        }
+        stage("documentation and coverage"){
+            steps{
+                dir("build"){
+                    sh 'make doc_doxygen 2>DoxygenWarningLog.txt'
+                    sh 'touch /import/www/wwwsccs/html/AutoPas/doxygen_doc/master || echo 0'
+                    sh 'rm -rf /import/www/wwwsccs/html/AutoPas/doxygen_doc/master || echo 0'
+                    sh 'cp -r doc_doxygen/html /import/www/wwwsccs/html/AutoPas/doxygen_doc/master'
+                }
+                junit 'build/test.xml'
+                warnings canComputeNew: false, canResolveRelativePaths: false, categoriesPattern: '', defaultEncoding: '', excludePattern: '.*README.*', healthy: '', includePattern: '', messagesPattern: '', parserConfigurations: [[parserName: 'Doxygen', pattern: 'build/DoxygenWarningLog.txt']], unHealthy: '', unstableTotalAll: '0'
+
+                dir("coverage"){
+                    sh "cmake -DCodeCoverage=ON -DCMAKE_BUILD_TYPE=Debug .."
+                    sh "make AutoPas_cobertura"
+                    cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: 'coverage.xml', conditionalCoverageTargets: '70, 0, 0', failUnhealthy: false, failUnstable: false, lineCoverageTargets: '80, 0, 0', maxNumberOfBuilds: 0, methodCoverageTargets: '80, 0, 0', onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false
+                }
+            }
+        }
+    }
+    post {
+        changed {
+            echo "change"
+        }
+        unstable {
+            echo "unstable"
+        }
+        success {
+            echo "success"
+        }
+        failure {
+            echo "failure"
+        }
+        aborted {
+            echo "aborted"
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,13 +4,13 @@ pipeline{
         stage('setup'){
             steps{
                 echo 'Starting AutoPas Pipeline'
-                githubNotify context: 'build', description: 'build pending...',  status: 'PENDING'
-                githubNotify context: 'test', description: 'test pending...',  status: 'PENDING'
+                githubNotify context: 'build', description: 'build pending...',  status: 'PENDING', targetUrl: currentBuild.absoluteUrl
+                githubNotify context: 'test', description: 'test pending...',  status: 'PENDING', targetUrl: currentBuild.absoluteUrl
             }
         }
         stage("build") {
             steps{
-                githubNotify context: 'build', description: 'build in progress...',  status: 'PENDING'
+                githubNotify context: 'build', description: 'build in progress...',  status: 'PENDING', targetUrl: currentBuild.absoluteUrl
                 dir("build"){
                     sh "cmake .."
                     sh "make"
@@ -18,22 +18,22 @@ pipeline{
             }
             post{
                 success{
-                    githubNotify context: 'build', description: 'build successful! (${currentBuild.durationString})',  status: 'SUCCESS'
+                    githubNotify context: 'build', description: currentBuild.durationString,  status: 'SUCCESS', targetUrl: currentBuild.absoluteUrl
                 }
                 failure{
-                    githubNotify context: 'build', description: 'build failed: ${currentBuild.description}',  status: 'FAILURE'
+                    githubNotify context: 'build', description: currentBuild.description, status: 'FAILURE', targetUrl: currentBuild.absoluteUrl
                 }
                 unstable{
-                    githubNotify context: 'build', description: 'build unstable: ${currentBuild.description}',  status: 'FAILURE'
+                    githubNotify context: 'build', description: currentBuild.description, status: 'FAILURE', targetUrl: currentBuild.absoluteUrl
                 }
                 aborted{
-                    githubNotify context: 'build', description: 'build aborted',  status: 'ERROR'
+                    githubNotify context: 'build', description: 'build aborted',  status: 'ERROR', targetUrl: currentBuild.absoluteUrl
                 }
             }
         }
         stage("test") {
             steps{
-                githubNotify context: 'test', description: 'test in progress...',  status: 'PENDING'
+                githubNotify context: 'test', description: 'test in progress...',  status: 'PENDING', targetUrl: currentBuild.absoluteUrl
                 dir("build"){
                     //sh "env CTEST_OUTPUT_ON_FAILURE=1 make test"
                     sh 'env GTEST_OUTPUT="xml:$(pwd)/test.xml" ctest'
@@ -51,16 +51,16 @@ pipeline{
             }
             post{
                 success{
-                    githubNotify context: 'test', description: 'test successful! (${currentBuild.durationString})',  status: 'SUCCESS'
+                    githubNotify context: 'test', description: currentBuild.durationString,  status: 'SUCCESS', targetUrl: currentBuild.absoluteUrl
                 }
                 failure{
-                    githubNotify context: 'test', description: 'test failed: ${currentBuild.description}',  status: 'FAILURE'
+                    githubNotify context: 'test', description: currentBuild.description,  status: 'FAILURE', targetUrl: currentBuild.absoluteUrl
                 }
                 unstable{
-                    githubNotify context: 'test', description: 'test unstable: ${currentBuild.description}',  status: 'FAILURE'
+                    githubNotify context: 'test', description: currentBuild.description,  status: 'FAILURE', targetUrl: currentBuild.absoluteUrl
                 }
                 aborted{
-                    githubNotify context: 'test', description: 'build aborted',  status: 'ERROR'
+                    githubNotify context: 'test', description: 'build aborted',  status: 'ERROR', targetUrl: currentBuild.absoluteUrl
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,14 +32,23 @@ pipeline{
                 }
             }
         }
-        stage("documentation and coverage"){
+        stage("build documentation"){
+            steps{
+                dir("build") { sh 'make doc_doxygen 2>DoxygenWarningLog.txt' }
+            }
+        }
+        stage("update documentation"){
+            when{ branch 'master' }
             steps{
                 dir("build"){
-                    sh 'make doc_doxygen 2>DoxygenWarningLog.txt'
                     sh 'touch /import/www/wwwsccs/html/AutoPas/doxygen_doc/master || echo 0'
                     sh 'rm -rf /import/www/wwwsccs/html/AutoPas/doxygen_doc/master || echo 0'
                     sh 'cp -r doc_doxygen/html /import/www/wwwsccs/html/AutoPas/doxygen_doc/master'
                 }
+            }
+        }
+        stage("generate coverage report"){
+            steps{
                 junit 'build/test.xml'
                 warnings canComputeNew: false, canResolveRelativePaths: false, categoriesPattern: '', defaultEncoding: '', excludePattern: '.*README.*', healthy: '', includePattern: '', messagesPattern: '', parserConfigurations: [[parserName: 'Doxygen', pattern: 'build/DoxygenWarningLog.txt']], unHealthy: '', unstableTotalAll: '0'
 


### PR DESCRIPTION
This should fix #13. The job was moved to a multi-branch project, so we now have the opportunity to store the pipeline directly in the source tree. There are various advantages to this approach, because it allows us to use some smart new features.

I also removed the e-mail notification that went out to the core development team on every build to reduce the verbosity. I would propose to replace that with either email that is only sent to the last committer. Another option would be to have Jenkins simply post a comment on the commit/Pull-Request, that way every user can specify whether they want to receive an e-mail in their GitHub settings.

The latter option could be a good idea either way, because we could also display useful additional information like test coverage in a comment.