### PR TITLE
corrects exception throwing of ExceptionHandler

### DIFF
--- a/src/utils/ExceptionHandler.cpp
+++ b/src/utils/ExceptionHandler.cpp
@@ -9,4 +9,19 @@
 std::mutex autopas::utils::ExceptionHandler::exceptionMutex;
 autopas::utils::ExceptionBehavior autopas::utils::ExceptionHandler::_behavior =
     ExceptionBehavior::throwException;
-std::function<void()> autopas::utils::ExceptionHandler::_customAbortFunction = abort;
+std::function<void()> autopas::utils::ExceptionHandler::_customAbortFunction =
+    abort;
+
+template <>
+void autopas::utils::ExceptionHandler::exception(
+    const std::string exceptionString) {
+  // no lock here, as a different public function is called!!!
+  AutoPasException autoPasException(exceptionString);
+  exception(autoPasException);
+}
+
+template <>
+void autopas::utils::ExceptionHandler::exception(
+    const char* const exceptionString) {
+  exception(std::string(exceptionString));
+}

--- a/src/utils/ExceptionHandler.cpp
+++ b/src/utils/ExceptionHandler.cpp
@@ -25,3 +25,21 @@ void autopas::utils::ExceptionHandler::exception(
     const char* const exceptionString) {
   exception(std::string(exceptionString));
 }
+
+void autopas::utils::ExceptionHandler::rethrow() {
+  std::lock_guard<std::mutex> guard(exceptionMutex);
+  std::exception_ptr p = std::current_exception();
+  if (p == std::exception_ptr()) {
+    exception("ExceptionHandler::rethrow() called outside of a catch block");
+  }
+  switch (_behavior) {
+    case throwException:
+      std::rethrow_exception(p);
+    default:
+      try {
+        std::rethrow_exception(p);
+      } catch (std::exception& e) {
+        nonThrowException(e);
+      }
+  }
+}

--- a/src/utils/ExceptionHandler.h
+++ b/src/utils/ExceptionHandler.h
@@ -110,11 +110,23 @@ class ExceptionHandler {
 
 
  public:
+  /**
+   * Default exception class for autopas exceptions.
+   * @note normally generated using ExceptionHandler::exception("some string")
+   */
   class AutoPasException : public std::exception {
    public:
+    /**
+     * constructor
+     * @param description a descriptive string
+     */
     explicit AutoPasException(const std::string& description)
         : _description(description){};
 
+    /**
+     * returns the description
+     * @return
+     */
     virtual const char* what() const throw() override {
       return _description.c_str();
     }

--- a/src/utils/ExceptionHandler.h
+++ b/src/utils/ExceptionHandler.h
@@ -55,12 +55,7 @@ class ExceptionHandler {
     std::exception_ptr p;
     switch (_behavior) {
       case throwException:
-        p = std::current_exception();
-        if (p == std::exception_ptr()) {
-          throw e;
-        } else {
-          std::rethrow_exception(p);
-        }
+        throw e;
       default:
         nonThrowException(e);
     }
@@ -68,7 +63,8 @@ class ExceptionHandler {
 
   /**
    * Rethrows the current exception or prints it.
-   * Depending on the set behavior the currently active exception is either rethrown, printed or otherwise handled.
+   * Depending on the set behavior the currently active exception is either
+   * rethrown, printed or otherwise handled.
    * @note Use this only inside a catch clause.
    */
   static void rethrow();
@@ -86,7 +82,6 @@ class ExceptionHandler {
   static std::mutex exceptionMutex;
   static ExceptionBehavior _behavior;
   static std::function<void()> _customAbortFunction;
-
 
   static void nonThrowException(const std::exception& e) {
     switch (_behavior) {
@@ -107,7 +102,6 @@ class ExceptionHandler {
         break;
     }
   }
-
 
  public:
   /**

--- a/src/utils/ExceptionHandler.h
+++ b/src/utils/ExceptionHandler.h
@@ -31,7 +31,6 @@ enum ExceptionBehavior {
  */
 class ExceptionHandler {
  public:
-
   /**
    * Set the behavior of the handler
    * @param behavior the behavior
@@ -44,8 +43,11 @@ class ExceptionHandler {
   /**
    * Handle an exception derived by std::exception
    * @param e the exception to be handled
+   * @tparam Exception the type of the exception, needed as throw only uses the
+   * static type of e
    */
-  static void exception(const std::exception& e) {
+  template <class Exception>
+  static void exception(const Exception e) {
     std::lock_guard<std::mutex> guard(exceptionMutex);
     switch (_behavior) {
       case ignore:
@@ -69,16 +71,6 @@ class ExceptionHandler {
   }
 
   /**
-   * Handles an exception that is defined using the input string
-   * @param exceptionString the string to describe the exception
-   */
-  static void exception(const std::string& exceptionString) {
-    // no lock here, as a different public function is called!!!
-    AutoPasException autoPasException(exceptionString);
-    exception(autoPasException);
-  }
-
-  /**
    * Set a custom abort function
    * @param function the custom abort function
    */
@@ -91,7 +83,7 @@ class ExceptionHandler {
   static std::mutex exceptionMutex;
   static ExceptionBehavior _behavior;
   static std::function<void()> _customAbortFunction;
-
+ public:
   class AutoPasException : public std::exception {
    public:
     explicit AutoPasException(const std::string& description)
@@ -105,5 +97,19 @@ class ExceptionHandler {
     std::string _description;
   };
 };
+
+/**
+ * Handles an exception that is defined using the input string
+ * @param exceptionString the string to describe the exception
+ */
+template <>
+void ExceptionHandler::exception(const std::string exceptionString);
+
+/**
+ * Handles an exception that is defined using the input string
+ * @param exceptionString the string to describe the exception
+ */
+template <>
+void ExceptionHandler::exception(const char* const exceptionString);
 }
 }

--- a/tests/testAutopas/ExceptionHandlerTest.cpp
+++ b/tests/testAutopas/ExceptionHandlerTest.cpp
@@ -78,7 +78,7 @@ TEST_F(ExceptionHandlerTest, TestTryRethrow) {
   try{
     throw std::runtime_error("me throwing things");
   } catch(std::exception& e){
-    EXPECT_THROW(ExceptionHandler::exception(e), std::runtime_error);
+    EXPECT_THROW(ExceptionHandler::rethrow(), std::runtime_error);
   }
 }
 

--- a/tests/testAutopas/ExceptionHandlerTest.cpp
+++ b/tests/testAutopas/ExceptionHandlerTest.cpp
@@ -26,10 +26,13 @@ void ExceptionHandlerTest::TearDown() {
 }
 
 
+TEST_F(ExceptionHandlerTest, TestThrowCustom) {
+  EXPECT_THROW(ExceptionHandler::exception(std::runtime_error("runtimeerror")), std::runtime_error);
+}
 
 TEST_F(ExceptionHandlerTest, TestDefault) {
-  EXPECT_ANY_THROW(ExceptionHandler::exception("testignore"));
-  EXPECT_ANY_THROW(ExceptionHandler::exception(std::exception()));
+  EXPECT_THROW(ExceptionHandler::exception("testthrow"), ExceptionHandler::AutoPasException);
+  EXPECT_THROW(ExceptionHandler::exception(std::exception()), std::exception);
   ExceptionHandler::setBehavior(ExceptionBehavior::printCustomAbortFunction);
   EXPECT_DEATH(ExceptionHandler::exception("testignore"), "");
   EXPECT_DEATH(ExceptionHandler::exception(std::exception()), "");
@@ -43,9 +46,10 @@ TEST_F(ExceptionHandlerTest, TestIgnore) {
 
 TEST_F(ExceptionHandlerTest, TestThrow) {
   ExceptionHandler::setBehavior(ExceptionBehavior::throwException);
-  EXPECT_ANY_THROW(ExceptionHandler::exception("testignore"));
 
-  EXPECT_ANY_THROW(ExceptionHandler::exception(std::exception()));
+  EXPECT_THROW(ExceptionHandler::exception("testignore"), ExceptionHandler::AutoPasException);
+
+  EXPECT_THROW(ExceptionHandler::exception(std::exception()), std::exception);
 }
 
 TEST_F(ExceptionHandlerTest, TestAbort) {

--- a/tests/testAutopas/ExceptionHandlerTest.cpp
+++ b/tests/testAutopas/ExceptionHandlerTest.cpp
@@ -14,7 +14,6 @@ using autopas::utils::ExceptionHandler;
 using autopas::utils::ExceptionBehavior;
 
 void ExceptionHandlerTest::SetUp() {
-  //::testing::FLAGS_gtest_death_test_style = "threadsafe";
   autopas::logger::create();
 }
 
@@ -53,8 +52,6 @@ TEST_F(ExceptionHandlerTest, TestThrow) {
 }
 
 TEST_F(ExceptionHandlerTest, TestAbort) {
-  //  autopas::logger =
-  //      std::unique_ptr<autopas::log::Logger>(new autopas::log::Logger());
   ExceptionHandler::setBehavior(ExceptionBehavior::printAbort);
 
   EXPECT_DEATH(ExceptionHandler::exception("testignore"), "");
@@ -63,8 +60,6 @@ TEST_F(ExceptionHandlerTest, TestAbort) {
 }
 
 TEST_F(ExceptionHandlerTest, TestAbortCustom) {
-  //  autopas::logger =
-  //      std::unique_ptr<autopas::log::Logger>(new autopas::log::Logger());
 
   auto abortFunction = []() -> void {
     AutoPasLogger->error("TESTABORTCUSTOMCALL123");
@@ -77,6 +72,14 @@ TEST_F(ExceptionHandlerTest, TestAbortCustom) {
   EXPECT_DEATH(ExceptionHandler::exception("testignore"), "");
 
   EXPECT_DEATH(ExceptionHandler::exception(std::exception()), "");
+}
+
+TEST_F(ExceptionHandlerTest, TestTryRethrow) {
+  try{
+    throw std::runtime_error("me throwing things");
+  } catch(std::exception& e){
+    EXPECT_THROW(ExceptionHandler::exception(e), std::runtime_error);
+  }
 }
 
 #ifdef _OPENMP

--- a/tests/testAutopas/ExceptionHandlerTest.h
+++ b/tests/testAutopas/ExceptionHandlerTest.h
@@ -11,5 +11,7 @@
 #include "AutoPasTestBase.h"
 
 class ExceptionHandlerTest : public AutoPasTestBase {
+  void SetUp() override;
 
+  void TearDown() override;
 };


### PR DESCRIPTION
we assume that ExceptionHandler::_behavior is set to throw throughout the explanations of this PR.

adds tests to properly check for the thrown error/exception when using the ExceptionHandler

if behavior is set to throw:
* fixes: throwing exceptions always produced a std::exception with meaningless what() methods
* feature: throwing a caught exception using the ExceptionHandler looses the type of the exception
e.g.
```C++
try{
 // sth. that produces an error
} catch (std::exception& e){
 ExceptionHandler::exception(e);  // produced wrong result
}
```
calling `ExceptionHandler::rethrow();` inside a catch block will now rethrow the caught exception. You can still reuse the normal `exception()` method, to provide additional information.

```C++
try{
 // sth. that produces an error
} catch (std::logic_error&) {
 ExceptionHandler::exception("logic error caught you should do input parameters properly");  // will throw an AutoPasException
}
catch (...) {
 ExceptionHandler::rethrow();  // will rethrow the current error
}
```

closes #19 