### PR TITLE
Fewer SoALoad/Extract calls

### DIFF
--- a/src/containers/DirectSum.h
+++ b/src/containers/DirectSum.h
@@ -120,6 +120,9 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
    */
   template <class ParticleFunctor>
   void iteratePairwiseSoA2(ParticleFunctor *f, bool useNewton3 = true) {
+    f->SoALoader(*getCell(), (*getCell())._particleSoABuffer);
+    f->SoALoader(*getHaloCell(), (*getHaloCell())._particleSoABuffer);
+
     if (useNewton3) {
       CellFunctor<Particle, ParticleCell, ParticleFunctor, true, true>
           cellFunctor(f);
@@ -131,6 +134,9 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
       cellFunctor.processCell(*getCell());
       cellFunctor.processCellPair(*getCell(), *getHaloCell());
     }
+
+    f->SoAExtractor((*getCell()), (*getCell())._particleSoABuffer);
+    f->SoAExtractor((*getHaloCell()), (*getHaloCell())._particleSoABuffer);
   }
 
   void updateContainer() override {

--- a/src/containers/LinkedCells.h
+++ b/src/containers/LinkedCells.h
@@ -228,7 +228,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell> {
    * @param functor
    */
   template <class ParticleFunctor>
-  void loadSoAs(ParticleFunctor &functor) {
+  void loadSoAs(ParticleFunctor *functor) {
 #ifdef AUTOPAS_OPENMP
     //TODO find a condition on when to use omp or when it is just overhead
 #pragma omp parallel for
@@ -244,7 +244,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell> {
    * @param functor
    */
   template <class ParticleFunctor>
-  void extractSoAs(ParticleFunctor &functor) {
+  void extractSoAs(ParticleFunctor *functor) {
 #ifdef AUTOPAS_OPENMP
     //TODO find a condition on when to use omp or when it is just overhead
 #pragma omp parallel for

--- a/src/containers/LinkedCells.h
+++ b/src/containers/LinkedCells.h
@@ -231,10 +231,10 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell> {
   void fillSoAs(ParticleFunctor &functor) {
 #ifdef AUTOPAS_OPENMP
     //TODO find a condition on when to use omp or when it is just overhead
-#pragma omp parrallel for
+#pragma omp parallel for
 #endif
-    for(auto & cell : this->_data) {
-      functor->SoALoader(cell, cell._particleSoABuffer);
+    for(auto i = 0; i < this->_data.size(); ++i) {
+      functor->SoALoader(this->_data[i], this->_data[i]._particleSoABuffer);
     }
   }
 
@@ -247,10 +247,10 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell> {
   void extractSoAs(ParticleFunctor &functor) {
 #ifdef AUTOPAS_OPENMP
     //TODO find a condition on when to use omp or when it is just overhead
-#pragma omp parrallel for
+#pragma omp parallel for
 #endif
-    for(auto & cell : this->_data) {
-      functor->SoAExtractor(cell, cell._particleSoABuffer);
+    for(auto i = 0; i < this->_data.size(); ++i) {
+      functor->SoAExtractor(this->_data[i], this->_data[i]._particleSoABuffer);
     }
   }
 };

--- a/src/containers/LinkedCells.h
+++ b/src/containers/LinkedCells.h
@@ -135,7 +135,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell> {
   template <class ParticleFunctor>
   void iteratePairwiseSoA2(ParticleFunctor *f, bool useNewton3 = true) {
 
-    fillSoAs(f);
+    loadSoAs(f);
 
     auto envTraversal = std::getenv("AUTOPAS_TRAVERSAL");
     if (useNewton3) {
@@ -217,18 +217,18 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell> {
 
  protected:
   /**
-   * object to manage the block of cells
+   * object to manage the block of cells.
    */
   CellBlock3D<ParticleCell> _cellBlock;
   // ThreeDimensionalCellHandler
 
   /**
-   * Iterate over all cells and load the data in the SoAs
+   * Iterate over all cells and load the data in the SoAs.
    * @tparam ParticleFunctor
    * @param functor
    */
   template <class ParticleFunctor>
-  void fillSoAs(ParticleFunctor &functor) {
+  void loadSoAs(ParticleFunctor &functor) {
 #ifdef AUTOPAS_OPENMP
     //TODO find a condition on when to use omp or when it is just overhead
 #pragma omp parallel for
@@ -239,7 +239,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell> {
   }
 
   /**
-   * Iterate over all cells and fetch the data from the SoAs
+   * Iterate over all cells and fetch the data from the SoAs.
    * @tparam ParticleFunctor
    * @param functor
    */

--- a/src/pairwiseFunctors/CellFunctor.h
+++ b/src/pairwiseFunctors/CellFunctor.h
@@ -167,44 +167,24 @@ class CellFunctor {
   }
 
   void processCellPairSoAN3(ParticleCell &cell1, ParticleCell &cell2) {
-    _functor->SoALoader(cell1, &cell1._particleSoABuffer);
-    _functor->SoALoader(cell2, &cell2._particleSoABuffer);
-
     _functor->SoAFunctor(cell1._particleSoABuffer, cell2._particleSoABuffer,
                          true);
-
-    _functor->SoAExtractor(&cell1, &cell1._particleSoABuffer);
-    _functor->SoAExtractor(&cell2, &cell2._particleSoABuffer);
   }
 
   void processCellPairSoANoN3(ParticleCell &cell1, ParticleCell &cell2) {
-    _functor->SoALoader(cell1, &cell1._particleSoABuffer);
-    _functor->SoALoader(cell2, &cell2._particleSoABuffer);
-
     _functor->SoAFunctor(cell1._particleSoABuffer, cell2._particleSoABuffer,
                          false);
     _functor->SoAFunctor(cell2._particleSoABuffer, cell1._particleSoABuffer,
                          false);
-
-    _functor->SoAExtractor(&cell1, &cell1._particleSoABuffer);
-    _functor->SoAExtractor(&cell2, &cell2._particleSoABuffer);
   }
 
   void processCellSoAN3(ParticleCell &cell) {
-    _functor->SoALoader(cell, &cell._particleSoABuffer);
-
     _functor->SoAFunctor(cell._particleSoABuffer, true);
-
-    _functor->SoAExtractor(&cell, &cell._particleSoABuffer);
   }
 
   void processCellSoANoN3(ParticleCell &cell) {
-    _functor->SoALoader(cell, &cell._particleSoABuffer);
-
     _functor->SoAFunctor(cell._particleSoABuffer,
                          false);  // the functor has to enable this...
-
-    _functor->SoAExtractor(&cell, &cell._particleSoABuffer);
   }
 
  private:

--- a/src/pairwiseFunctors/Functor.h
+++ b/src/pairwiseFunctors/Functor.h
@@ -73,7 +73,7 @@ class Functor {
    * @param soa  Structure of arrays where the data is copied to.
    */
 
-  virtual void SoALoader(ParticleCell &cell, SoA *soa) {}
+  virtual void SoALoader(ParticleCell &cell, SoA &soa) {}
 
   /**
    * @brief Copies the data stored in the soa back into the cell.
@@ -81,7 +81,7 @@ class Functor {
    * @param cell Cell where the data should be stored.
    * @param soa  Structure of arrays from where the data is loaded.
    */
-  virtual void SoAExtractor(ParticleCell *cell, SoA *soa) {}
+  virtual void SoAExtractor(ParticleCell &cell, SoA &soa) {}
 
   /**
    * Specifies whether the functor is capable of Newton3-like functors.

--- a/src/pairwiseFunctors/LJFunctor.h
+++ b/src/pairwiseFunctors/LJFunctor.h
@@ -190,23 +190,23 @@ class LJFunctor : public Functor<Particle, ParticleCell> {
     }
   }
 
-  void SoALoader(ParticleCell &cell, SoA *soa) override {
-    soa->resizeArrays(cell.numParticles());
+  void SoALoader(ParticleCell &cell, SoA &soa) override {
+    soa.resizeArrays(cell.numParticles());
     if (cell.numParticles() == 0) return;
 
-    double *const __restrict__ idptr = soa->begin(Particle::AttributeNames::id);
+    double *const __restrict__ idptr = soa.begin(Particle::AttributeNames::id);
     double *const __restrict__ xptr =
-        soa->begin(Particle::AttributeNames::posX);
+        soa.begin(Particle::AttributeNames::posX);
     double *const __restrict__ yptr =
-        soa->begin(Particle::AttributeNames::posY);
+        soa.begin(Particle::AttributeNames::posY);
     double *const __restrict__ zptr =
-        soa->begin(Particle::AttributeNames::posZ);
+        soa.begin(Particle::AttributeNames::posZ);
     double *const __restrict__ fxptr =
-        soa->begin(Particle::AttributeNames::forceX);
+        soa.begin(Particle::AttributeNames::forceX);
     double *const __restrict__ fyptr =
-        soa->begin(Particle::AttributeNames::forceY);
+        soa.begin(Particle::AttributeNames::forceY);
     double *const __restrict__ fzptr =
-        soa->begin(Particle::AttributeNames::forceZ);
+        soa.begin(Particle::AttributeNames::forceZ);
 
     SingleCellIterator<Particle, ParticleCell> cellIter(&cell);
     // load particles in SoAs
@@ -221,23 +221,23 @@ class LJFunctor : public Functor<Particle, ParticleCell> {
     }
   }
 
-  void SoAExtractor(ParticleCell *cell, SoA *soa) override {
-    if (soa->getNumParticles() == 0) return;
+  void SoAExtractor(ParticleCell &cell, SoA &soa) override {
+    if (soa.getNumParticles() == 0) return;
 
-    SingleCellIterator<Particle, ParticleCell> cellIter(cell);
+    SingleCellIterator<Particle, ParticleCell> cellIter(&cell);
 
 #ifndef NDEBUG
-    double *const __restrict__ idptr = soa->begin(Particle::AttributeNames::id);
+    double *const __restrict__ idptr = soa.begin(Particle::AttributeNames::id);
 #endif
 
     double *const __restrict__ fxptr =
-        soa->begin(Particle::AttributeNames::forceX);
+        soa.begin(Particle::AttributeNames::forceX);
     double *const __restrict__ fyptr =
-        soa->begin(Particle::AttributeNames::forceY);
+        soa.begin(Particle::AttributeNames::forceY);
     double *const __restrict__ fzptr =
-        soa->begin(Particle::AttributeNames::forceZ);
+        soa.begin(Particle::AttributeNames::forceZ);
 
-    for (unsigned int i = 0; i < soa->getNumParticles(); ++i, ++cellIter) {
+    for (unsigned int i = 0; i < soa.getNumParticles(); ++i, ++cellIter) {
       assert(idptr[i] == (*cellIter).getID());
       (*cellIter).setF({fxptr[i], fyptr[i], fzptr[i]});
     }

--- a/tests/testAutopas/AoSvsSoATest.cpp
+++ b/tests/testAutopas/AoSvsSoATest.cpp
@@ -59,7 +59,7 @@ TEST_F(AoSvsSoATest, testAoSvsSoA) {
     cell.addParticle(p);
   }
 
-  ljFunctor.SoALoader(cell, &cell._particleSoABuffer);
+  ljFunctor.SoALoader(cell, cell._particleSoABuffer);
   start = std::chrono::high_resolution_clock::now();
   ljFunctor.SoAFunctor(cell._particleSoABuffer, cell._particleSoABuffer);
   stop = std::chrono::high_resolution_clock::now();
@@ -71,7 +71,7 @@ TEST_F(AoSvsSoATest, testAoSvsSoA) {
   // copy back to particle array
   particlesSoA.clear();
 
-  ljFunctor.SoAExtractor(&cell, &cell._particleSoABuffer);
+  ljFunctor.SoAExtractor(cell, cell._particleSoABuffer);
 
   //  ASSERT_EQ(particlesAoS.size(), particlesSoA.size());
   ASSERT_EQ(particlesAoS.size(), cell.numParticles());

--- a/tests/testAutopas/mocks/MockFunctor.h
+++ b/tests/testAutopas/mocks/MockFunctor.h
@@ -33,10 +33,10 @@ class MockFunctor : public autopas::Functor<Particle, ParticleCell> {
                void(autopas::SoA &soa, autopas::SoA &soa2, bool newton3));
 
   // virtual void SoALoader(ParticleCell &cell, autopas::SoA *soa) {}
-  MOCK_METHOD2_T(SoALoader, void(ParticleCell &cell, autopas::SoA *soa));
+  MOCK_METHOD2_T(SoALoader, void(ParticleCell &cell, autopas::SoA &soa));
 
   // virtual void SoAExtractor(ParticleCell *cell, autopas::SoA *soa) {}
-  MOCK_METHOD2_T(SoAExtractor, void(ParticleCell *cell, autopas::SoA *soa));
+  MOCK_METHOD2_T(SoAExtractor, void(ParticleCell &cell, autopas::SoA &soa));
 
   // virtual bool allowsNewton3() { return true; }
   MOCK_METHOD0(allowsNewton3, bool());


### PR DESCRIPTION
Referencing #42 

This removes the `SoALoad/Extract` calls from the cell functor since it called `Load/Extract` for each pairwise interaction. The `Load/Extract` is now done in separate iterations in the `iteratePairwiseSoA` methods of the containers.

Speed improvement on a grid example:

Container | Iterations | \#Particles | grid spacing | cutoff | 
--------------|--------------|--------------|---------------|-----------
Linked-Cells | 10 | 60^3 | 1 | 2.5 | 

Time for one iteratePairwise call in s:

Traversal | Old | New | Speedup
-------------|------|--------|--------------
c08 | .96 | .84 | 1.14
sli | .93 | .82 | 1.13