### PR TITLE
Check Examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,12 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 # let ccmake and cmake-gui offer the default build type options
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug;Release;RelWithDebInfo;MinSizeRel")
 
+# set Release as the default build type if it is not yet set.
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING
+            "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
+endif(NOT CMAKE_BUILD_TYPE)
+
 ENABLE_TESTING()
 
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -199,8 +199,8 @@ pipeline{
                     },
                     "checkExamples": {
                         container('autopas-gcc7-cmake-make') {
-                            dir("build"){
-                                sh 'make checkExamples'
+                            dir("build/examples") {
+                                sh 'ctest -C checkExamples -j8'
                             }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -196,6 +196,13 @@ pipeline{
                                 sh './tests/testAutopas/runTests'
                             }
                         }
+                    },
+                    "checkExamples": {
+                        container('autopas-gcc7-cmake-make') {
+                            dir("build"){
+                                sh 'make checkExamples'
+                            }
+                        }
                     }
                 )
             }

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,5 @@
-ADD_CUSTOM_TARGET(checkExamples)
+ADD_CUSTOM_TARGET(checkExamples
+        COMMAND ctest -C checkExamples -j 4)
 
 ADD_SUBDIRECTORY(basic)
 ADD_SUBDIRECTORY(md-flexible)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,5 @@
+ADD_CUSTOM_TARGET(checkExamples)
+
 ADD_SUBDIRECTORY(basic)
 ADD_SUBDIRECTORY(md-flexible)
 ADD_SUBDIRECTORY(md)
@@ -5,3 +7,4 @@ ADD_SUBDIRECTORY(sph)
 ADD_SUBDIRECTORY(sph-mpi)
 ADD_SUBDIRECTORY(sph-verlet)
 ADD_SUBDIRECTORY(sphDiagramGeneration)
+

--- a/examples/basic/CMakeLists.txt
+++ b/examples/basic/CMakeLists.txt
@@ -10,3 +10,15 @@ ADD_EXECUTABLE(basic
 
 TARGET_LINK_LIBRARIES(basic
         autopas)
+
+#-----------------test-----------------
+# add check for current target
+add_custom_target(
+        basic_test
+        COMMAND basic > /dev/null
+)
+# make the test depend on current target, to ensure that the target is build
+add_dependencies(basic_test basic)
+
+# add the test to checkExamples
+add_dependencies(checkExamples basic_test)

--- a/examples/basic/CMakeLists.txt
+++ b/examples/basic/CMakeLists.txt
@@ -14,7 +14,7 @@ TARGET_LINK_LIBRARIES(basic
 #-----------------test-----------------
 # add check for current target
 add_test(
-        NAME basic_test
+        NAME basic.test
         COMMAND basic
         CONFIGURATIONS checkExamples
 )

--- a/examples/basic/CMakeLists.txt
+++ b/examples/basic/CMakeLists.txt
@@ -13,12 +13,11 @@ TARGET_LINK_LIBRARIES(basic
 
 #-----------------test-----------------
 # add check for current target
-add_custom_target(
-        basic_test
-        COMMAND basic > /dev/null
+add_test(
+        NAME basic_test
+        COMMAND basic
+        CONFIGURATIONS checkExamples
 )
-# make the test depend on current target, to ensure that the target is build
-add_dependencies(basic_test basic)
 
 # add the test to checkExamples
-add_dependencies(checkExamples basic_test)
+add_dependencies(checkExamples basic)

--- a/examples/md-flexible/CMakeLists.txt
+++ b/examples/md-flexible/CMakeLists.txt
@@ -18,3 +18,17 @@ ADD_EXECUTABLE(md-flexible
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -qopt-report-phase=vec")
 TARGET_LINK_LIBRARIES(md-flexible
         autopas)
+
+#-----------------test-----------------
+# add check for current target
+add_custom_target(
+        md-flexible_test
+        COMMAND md-flexible --container linked --cutoff 1. --data-layout soa --functor lj --iterations 10 --particles-per-dimension 10
+            --particle-spacing 0.4 > /dev/null
+)
+
+# make the test depend on current target, to ensure that the target is build
+add_dependencies(md-flexible_test md-flexible)
+
+# add the test to checkExamples
+add_dependencies(checkExamples md-flexible_test)

--- a/examples/md-flexible/CMakeLists.txt
+++ b/examples/md-flexible/CMakeLists.txt
@@ -21,14 +21,12 @@ TARGET_LINK_LIBRARIES(md-flexible
 
 #-----------------test-----------------
 # add check for current target
-add_custom_target(
-        md-flexible_test
-        COMMAND md-flexible --container linked --cutoff 1. --data-layout soa --functor lj --iterations 10 --particles-per-dimension 10
-            --particle-spacing 0.4 > /dev/null
+add_test(
+        NAME md-flexible_test
+        COMMAND md-flexible --container linked --cutoff 1. --data-layout soa --functor lj --iterations 10
+            --particles-per-dimension 10 --particle-spacing 0.4
+        CONFIGURATIONS checkExamples
 )
 
-# make the test depend on current target, to ensure that the target is build
-add_dependencies(md-flexible_test md-flexible)
-
-# add the test to checkExamples
-add_dependencies(checkExamples md-flexible_test)
+# add the executable to checkExamples as dependency
+add_dependencies(checkExamples md-flexible)

--- a/examples/md-flexible/CMakeLists.txt
+++ b/examples/md-flexible/CMakeLists.txt
@@ -22,7 +22,7 @@ TARGET_LINK_LIBRARIES(md-flexible
 #-----------------test-----------------
 # add check for current target
 add_test(
-        NAME md-flexible_test
+        NAME md-flexible.test
         COMMAND md-flexible --container linked --cutoff 1. --data-layout soa --functor lj --iterations 10
             --particles-per-dimension 10 --particle-spacing 0.4
         CONFIGURATIONS checkExamples

--- a/examples/md/CMakeLists.txt
+++ b/examples/md/CMakeLists.txt
@@ -9,3 +9,15 @@ ADD_EXECUTABLE(md-main
 
 TARGET_LINK_LIBRARIES(md-main
         autopas)
+
+#-----------------test-----------------
+# add check for current target
+add_custom_target(
+        md-main_test
+        COMMAND md-main > /dev/null
+)
+# make the test depend on current target, to ensure that the target is build
+add_dependencies(md-main_test md-main)
+
+# add the test to checkExamples
+add_dependencies(checkExamples md-main_test)

--- a/examples/md/CMakeLists.txt
+++ b/examples/md/CMakeLists.txt
@@ -12,12 +12,11 @@ TARGET_LINK_LIBRARIES(md-main
 
 #-----------------test-----------------
 # add check for current target
-add_custom_target(
-        md-main_test
-        COMMAND md-main > /dev/null
+add_test(
+        NAME md-main_test
+        COMMAND md-main
+        CONFIGURATIONS checkExamples
 )
-# make the test depend on current target, to ensure that the target is build
-add_dependencies(md-main_test md-main)
 
 # add the test to checkExamples
-add_dependencies(checkExamples md-main_test)
+add_dependencies(checkExamples md-main)

--- a/examples/md/CMakeLists.txt
+++ b/examples/md/CMakeLists.txt
@@ -11,12 +11,43 @@ TARGET_LINK_LIBRARIES(md-main
         autopas)
 
 #-----------------test-----------------
-# add check for current target
+# default execttion
 add_test(
-        NAME md-main_test
+        NAME md-main.test-default
         COMMAND md-main
         CONFIGURATIONS checkExamples
 )
+# linked cells
+add_test(
+        NAME md-main.test-linked-cells
+        COMMAND md-main 0 1000 2
+        CONFIGURATIONS checkExamples
+)
+# linked cells soa
+add_test(
+        NAME md-main.test-linked-cells-soa
+        COMMAND md-main 0 1000 2 soa
+        CONFIGURATIONS checkExamples
+)
+# verlet
+add_test(
+        NAME md-main.test-verlet
+        COMMAND md-main 2 1000 4 2 0.1
+        CONFIGURATIONS checkExamples
+)
+# verlet soa
+add_test(
+        NAME md-main.test-verlet-soa
+        COMMAND md-main 2 1000 4 2 0.1 soa
+        CONFIGURATIONS checkExamples
+)
+# direct sum
+add_test(
+        NAME md-main.test-direct-sum
+        COMMAND md-main 1 1000 2
+        CONFIGURATIONS checkExamples
+)
+
 
 # add the test to checkExamples
 add_dependencies(checkExamples md-main)

--- a/examples/sph-mpi/CMakeLists.txt
+++ b/examples/sph-mpi/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 # add check for current target
 add_test(
         NAME sph-main-mpi.test
-        COMMAND mpirun -n 4 --oversubscribe sph-main-mpi | grep "time step" | grep -v "the time step" | tail -1 | grep -q "time step 50"
+        COMMAND mpirun -n 4 sph-main-mpi | grep "time step" | grep -v "the time step" | tail -1 | grep -q "time step 50"
         CONFIGURATIONS checkExamples checkExamplesMPI
 )
 

--- a/examples/sph-mpi/CMakeLists.txt
+++ b/examples/sph-mpi/CMakeLists.txt
@@ -36,12 +36,11 @@ endif()
 
 #-----------------test-----------------
 # add check for current target
-add_custom_target(
-        sph-main-mpi_test
+add_test(
+        NAME sph-main-mpi_test
         COMMAND mpirun -n 4 sph-main-mpi | grep "time step" | grep -v "the time step" | tail -1 | grep -q "time step 50"
+        CONFIGURATIONS checkExamples
 )
-# make the test depend on current target, to ensure that the target is build
-add_dependencies(sph-main-mpi_test sph-main-mpi)
 
-# add the test to checkExamples
-add_dependencies(checkExamples sph-main-mpi_test)
+# add the executable to checkExamples as dependency
+add_dependencies(checkExamples sph-main-mpi)

--- a/examples/sph-mpi/CMakeLists.txt
+++ b/examples/sph-mpi/CMakeLists.txt
@@ -37,7 +37,7 @@ endif()
 #-----------------test-----------------
 # add check for current target
 add_test(
-        NAME sph-main-mpi_test
+        NAME sph-main-mpi.test
         COMMAND mpirun -n 4 sph-main-mpi | grep "time step" | grep -v "the time step" | tail -1 | grep -q "time step 50"
         CONFIGURATIONS checkExamples
 )

--- a/examples/sph-mpi/CMakeLists.txt
+++ b/examples/sph-mpi/CMakeLists.txt
@@ -32,3 +32,16 @@ if(MPI_LINK_FLAGS)
     SET_TARGET_PROPERTIES(sph-main-mpi PROPERTIES
             LINK_FLAGS "${MPI_LINK_FLAGS}")
 endif()
+
+
+#-----------------test-----------------
+# add check for current target
+add_custom_target(
+        sph-main-mpi_test
+        COMMAND mpirun -n 4 sph-main-mpi | grep "time step" | grep -v "the time step" | tail -1 | grep -q "time step 50"
+)
+# make the test depend on current target, to ensure that the target is build
+add_dependencies(sph-main-mpi_test sph-main-mpi)
+
+# add the test to checkExamples
+add_dependencies(checkExamples sph-main-mpi_test)

--- a/examples/sph-mpi/CMakeLists.txt
+++ b/examples/sph-mpi/CMakeLists.txt
@@ -38,8 +38,8 @@ endif()
 # add check for current target
 add_test(
         NAME sph-main-mpi.test
-        COMMAND mpirun -n 4 sph-main-mpi | grep "time step" | grep -v "the time step" | tail -1 | grep -q "time step 50"
-        CONFIGURATIONS checkExamples
+        COMMAND mpirun -n 4 --oversubscribe sph-main-mpi | grep "time step" | grep -v "the time step" | tail -1 | grep -q "time step 50"
+        CONFIGURATIONS checkExamples checkExamplesMPI
 )
 
 # add the executable to checkExamples as dependency

--- a/examples/sph-mpi/sph-main-mpi.cpp
+++ b/examples/sph-mpi/sph-main-mpi.cpp
@@ -520,8 +520,12 @@ int main(int argc, char* argv[]) {
 
   // 1 ---- START MAIN LOOP ----
   size_t step = 0;
+  int rank;
+  MPI_Comm_rank(comm, &rank);
   for (double time = 0.; time < t_end && step < 55; time += dt, ++step) {
-    std::cout << "\n-------------------------\ntime step " << step << "(t = " << time << ")..." << std::endl;
+    if (rank == 0) {
+      std::cout << "\n-------------------------\ntime step " << step << "(t = " << time << ")..." << std::endl;
+    }
     // 1.1 Leap frog: Initial Kick & Full Drift
     leapfrogInitialKick(sphSystem, dt);
     leapfrogFullDrift(sphSystem, dt);  // changes position

--- a/examples/sph-verlet/CMakeLists.txt
+++ b/examples/sph-verlet/CMakeLists.txt
@@ -12,12 +12,11 @@ TARGET_LINK_LIBRARIES(sph-main-verlet
 
 #-----------------test-----------------
 # add check for current target
-add_custom_target(
-        sph-main-verlet_test
+add_test(
+        NAME sph-main-verlet_test
         COMMAND sph-main-verlet | grep "time step" | tail -2 | head -1 | grep -q "time step 50"
+        CONFIGURATIONS checkExamples
 )
-# make the test depend on current target, to ensure that the target is build
-add_dependencies(sph-main-verlet_test sph-main-verlet)
 
-# add the test to checkExamples
-add_dependencies(checkExamples sph-main-verlet_test)
+# add the executable to checkExamples as dependency
+add_dependencies(checkExamples sph-main-verlet)

--- a/examples/sph-verlet/CMakeLists.txt
+++ b/examples/sph-verlet/CMakeLists.txt
@@ -9,3 +9,15 @@ ADD_EXECUTABLE(sph-main-verlet
 
 TARGET_LINK_LIBRARIES(sph-main-verlet
         autopas)
+
+#-----------------test-----------------
+# add check for current target
+add_custom_target(
+        sph-main-verlet_test
+        COMMAND sph-main-verlet | grep "time step" | tail -2 | head -1 | grep -q "time step 50"
+)
+# make the test depend on current target, to ensure that the target is build
+add_dependencies(sph-main-verlet_test sph-main-verlet)
+
+# add the test to checkExamples
+add_dependencies(checkExamples sph-main-verlet_test)

--- a/examples/sph-verlet/CMakeLists.txt
+++ b/examples/sph-verlet/CMakeLists.txt
@@ -13,7 +13,7 @@ TARGET_LINK_LIBRARIES(sph-main-verlet
 #-----------------test-----------------
 # add check for current target
 add_test(
-        NAME sph-main-verlet_test
+        NAME sph-main-verlet.test
         COMMAND sph-main-verlet | grep "time step" | tail -2 | head -1 | grep -q "time step 50"
         CONFIGURATIONS checkExamples
 )

--- a/examples/sph/CMakeLists.txt
+++ b/examples/sph/CMakeLists.txt
@@ -9,3 +9,16 @@ ADD_EXECUTABLE(sph-main
 
 TARGET_LINK_LIBRARIES(sph-main
         autopas)
+
+
+#-----------------test-----------------
+# add check for current target
+add_custom_target(
+        sph-main_test
+        COMMAND sph-main | grep "time step" | tail -2 | head -1 | grep -q "time step 50"
+)
+# make the test depend on current target, to ensure that the target is build
+add_dependencies(sph-main_test sph-main)
+
+# add the test to checkExamples
+add_dependencies(checkExamples sph-main_test)

--- a/examples/sph/CMakeLists.txt
+++ b/examples/sph/CMakeLists.txt
@@ -14,7 +14,7 @@ TARGET_LINK_LIBRARIES(sph-main
 #-----------------test-----------------
 # add check for current target
 add_test(
-        NAME sph-main_test
+        NAME sph-main.test
         COMMAND sph-main | grep "time step" | tail -2 | head -1 | grep -q "time step 50"
         CONFIGURATIONS checkExamples
 )

--- a/examples/sph/CMakeLists.txt
+++ b/examples/sph/CMakeLists.txt
@@ -13,12 +13,11 @@ TARGET_LINK_LIBRARIES(sph-main
 
 #-----------------test-----------------
 # add check for current target
-add_custom_target(
-        sph-main_test
+add_test(
+        NAME sph-main_test
         COMMAND sph-main | grep "time step" | tail -2 | head -1 | grep -q "time step 50"
+        CONFIGURATIONS checkExamples
 )
-# make the test depend on current target, to ensure that the target is build
-add_dependencies(sph-main_test sph-main)
 
-# add the test to checkExamples
-add_dependencies(checkExamples sph-main_test)
+# add the executable to checkExamples as dependency
+add_dependencies(checkExamples sph-main)

--- a/examples/sphDiagramGeneration/CMakeLists.txt
+++ b/examples/sphDiagramGeneration/CMakeLists.txt
@@ -9,3 +9,19 @@ ADD_EXECUTABLE(sph-diagram-generation
 
 TARGET_LINK_LIBRARIES(sph-diagram-generation
         autopas)
+
+
+#-----------------test-----------------
+# add check for current target
+add_custom_target(
+        sph-diagram-generation_test
+        COMMAND sph-diagram-generation 1000 2 0 0 > /dev/null
+        COMMAND sph-diagram-generation 1000 2 1 0 > /dev/null
+)
+# make the test depend on current target, to ensure that the target is build
+add_dependencies(sph-diagram-generation_test sph-diagram-generation)
+
+# add the test to checkExamples
+add_dependencies(checkExamples sph-diagram-generation_test)
+
+#sph-diagram-generation ${Mols[$i]} ${Reps[$i]} ${iCont} 0

--- a/examples/sphDiagramGeneration/CMakeLists.txt
+++ b/examples/sphDiagramGeneration/CMakeLists.txt
@@ -13,15 +13,18 @@ TARGET_LINK_LIBRARIES(sph-diagram-generation
 
 #-----------------test-----------------
 # add check for current target
-add_custom_target(
-        sph-diagram-generation_test
-        COMMAND sph-diagram-generation 1000 2 0 0 > /dev/null
-        COMMAND sph-diagram-generation 1000 2 1 0 > /dev/null
+add_test(
+        NAME sph-diagram-generation_test_direct_sum
+        COMMAND sph-diagram-generation 1000 2 1 0
+        CONFIGURATIONS checkExamples checkExamplesSPHDia
 )
-# make the test depend on current target, to ensure that the target is build
-add_dependencies(sph-diagram-generation_test sph-diagram-generation)
+add_test(
+        NAME sph-diagram-generation_test_linked_cells
+        COMMAND sph-diagram-generation 1000 2 0 0
+        CONFIGURATIONS checkExamples checkExamplesSPHDia
+)
 
-# add the test to checkExamples
-add_dependencies(checkExamples sph-diagram-generation_test)
+# add the executable to checkExamples as dependency
+add_dependencies(checkExamples sph-diagram-generation)
 
 #sph-diagram-generation ${Mols[$i]} ${Reps[$i]} ${iCont} 0

--- a/examples/sphDiagramGeneration/CMakeLists.txt
+++ b/examples/sphDiagramGeneration/CMakeLists.txt
@@ -14,12 +14,12 @@ TARGET_LINK_LIBRARIES(sph-diagram-generation
 #-----------------test-----------------
 # add check for current target
 add_test(
-        NAME sph-diagram-generation_test_direct_sum
+        NAME sph-diagram-generation.test_direct_sum
         COMMAND sph-diagram-generation 1000 2 1 0
         CONFIGURATIONS checkExamples checkExamplesSPHDia
 )
 add_test(
-        NAME sph-diagram-generation_test_linked_cells
+        NAME sph-diagram-generation.test_linked_cells
         COMMAND sph-diagram-generation 1000 2 0 0
         CONFIGURATIONS checkExamples checkExamplesSPHDia
 )

--- a/tests/testAutopas/CMakeLists.txt
+++ b/tests/testAutopas/CMakeLists.txt
@@ -26,8 +26,3 @@ else()
     # more robust, queries the compiled executable
     GTEST_DISCOVER_TESTS(runTests)
 endif()
-
-# this test is needed for a proper generation of xml files of the test
-# it runs ALL tests
-ADD_TEST(NAME testAutopas
-        COMMAND runTests)


### PR DESCRIPTION
fixes #54 
* `make checkExamples` or `ninja checkExamples` will check the examples. The checks are disabled for the normal `make test` (`ninja test`) or `ctest`.
* adds the check to jenkins using the release target. (everything else is too time-costly)
* the checks use ctest's addTest() feature.

To add new tests just copy one of the other tests.

build failing because of #53 