### PR TITLE
verlet list rebuild optimizations

### DIFF
--- a/src/containers/VerletListHelpers.h
+++ b/src/containers/VerletListHelpers.h
@@ -51,17 +51,16 @@ class VerletListHelpers {
     virtual void SoAFunctor(SoA &soa, bool /*newton3*/ = true) override {
       if (soa.getNumParticles() == 0) return;
 
-      Particle **const __restrict__ idptr = reinterpret_cast<Particle * *const>(soa.begin(Particle::AttributeNames::id));
+      Particle **const __restrict__ idptr = reinterpret_cast<Particle **const>(soa.begin(Particle::AttributeNames::id));
       double *const __restrict__ xptr = soa.begin(Particle::AttributeNames::posX);
       double *const __restrict__ yptr = soa.begin(Particle::AttributeNames::posY);
       double *const __restrict__ zptr = soa.begin(Particle::AttributeNames::posZ);
 
-      for (unsigned int i = 0; i < soa.getNumParticles(); ++i) {
+      size_t numPart = soa.getNumParticles();
+      for (unsigned int i = 0; i < numPart; ++i) {
         auto &currentList = _verletListsAoS.at(idptr[i]);
 
-        for (unsigned int j = i + 1; j < soa.getNumParticles(); ++j) {
-          if (i == j) continue;
-
+        for (unsigned int j = i + 1; j < numPart; ++j) {
           const double drx = xptr[i] - xptr[j];
           const double dry = yptr[i] - yptr[j];
           const double drz = zptr[i] - zptr[j];
@@ -82,20 +81,25 @@ class VerletListHelpers {
     virtual void SoAFunctor(SoA &soa1, SoA &soa2, bool /*newton3*/ = true) override {
       if (soa1.getNumParticles() == 0 || soa2.getNumParticles() == 0) return;
 
-      Particle **const __restrict__ id1ptr = reinterpret_cast<Particle * *const>(soa1.begin(Particle::AttributeNames::id));
+      Particle **const __restrict__ id1ptr =
+          reinterpret_cast<Particle **const>(soa1.begin(Particle::AttributeNames::id));
       double *const __restrict__ x1ptr = soa1.begin(Particle::AttributeNames::posX);
       double *const __restrict__ y1ptr = soa1.begin(Particle::AttributeNames::posY);
       double *const __restrict__ z1ptr = soa1.begin(Particle::AttributeNames::posZ);
 
-      Particle **const __restrict__ id2ptr = reinterpret_cast<Particle * *const>(soa2.begin(Particle::AttributeNames::id));
+      Particle **const __restrict__ id2ptr =
+          reinterpret_cast<Particle **const>(soa2.begin(Particle::AttributeNames::id));
       double *const __restrict__ x2ptr = soa2.begin(Particle::AttributeNames::posX);
       double *const __restrict__ y2ptr = soa2.begin(Particle::AttributeNames::posY);
       double *const __restrict__ z2ptr = soa2.begin(Particle::AttributeNames::posZ);
 
-      for (unsigned int i = 0; i < soa1.getNumParticles(); ++i) {
+      size_t numPart1 = soa1.getNumParticles();
+      for (unsigned int i = 0; i < numPart1; ++i) {
         auto &currentList = _verletListsAoS.at(id1ptr[i]);
 
-        for (unsigned int j = 0; j < soa2.getNumParticles(); ++j) {
+        size_t numPart2 = soa2.getNumParticles();
+
+        for (unsigned int j = 0; j < numPart2; ++j) {
           const double drx = x1ptr[i] - x2ptr[j];
           const double dry = y1ptr[i] - y2ptr[j];
           const double drz = z1ptr[i] - z2ptr[j];
@@ -127,8 +131,8 @@ class VerletListHelpers {
       auto cellIter = cell.begin();
       // load particles in SoAs
       for (size_t i = 0; cellIter.isValid(); ++cellIter, ++i) {
-        Particle* pptr = &(*cellIter);
-        idptr[i] = reinterpret_cast<double&>(pptr);
+        Particle *pptr = &(*cellIter);
+        idptr[i] = reinterpret_cast<double &>(pptr);
         xptr[i] = cellIter->getR()[0];
         yptr[i] = cellIter->getR()[1];
         zptr[i] = cellIter->getR()[2];

--- a/src/containers/VerletListHelpers.h
+++ b/src/containers/VerletListHelpers.h
@@ -45,7 +45,98 @@ class VerletListHelpers {
         // (ensured by traversals)
         // also the list is not allowed to be resized!
 
-        _verletListsAoS[&i].push_back(&j);
+        _verletListsAoS.at(&i).push_back(&j);
+    }
+
+    virtual void SoAFunctor(SoA &soa, bool /*newton3*/ = true) override {
+      if (soa.getNumParticles() == 0) return;
+
+      Particle **const __restrict__ idptr = reinterpret_cast<Particle * *const>(soa.begin(Particle::AttributeNames::id));
+      double *const __restrict__ xptr = soa.begin(Particle::AttributeNames::posX);
+      double *const __restrict__ yptr = soa.begin(Particle::AttributeNames::posY);
+      double *const __restrict__ zptr = soa.begin(Particle::AttributeNames::posZ);
+
+      for (unsigned int i = 0; i < soa.getNumParticles(); ++i) {
+        auto &currentList = _verletListsAoS.at(idptr[i]);
+
+        for (unsigned int j = i + 1; j < soa.getNumParticles(); ++j) {
+          if (i == j) continue;
+
+          const double drx = xptr[i] - xptr[j];
+          const double dry = yptr[i] - yptr[j];
+          const double drz = zptr[i] - zptr[j];
+
+          const double drx2 = drx * drx;
+          const double dry2 = dry * dry;
+          const double drz2 = drz * drz;
+
+          const double dr2 = drx2 + dry2 + drz2;
+
+          if (dr2 < _cutoffskinsquared) {
+            currentList.push_back(idptr[j]);
+          }
+        }
+      }
+    }
+
+    virtual void SoAFunctor(SoA &soa1, SoA &soa2, bool /*newton3*/ = true) override {
+      if (soa1.getNumParticles() == 0 || soa2.getNumParticles() == 0) return;
+
+      Particle **const __restrict__ id1ptr = reinterpret_cast<Particle * *const>(soa1.begin(Particle::AttributeNames::id));
+      double *const __restrict__ x1ptr = soa1.begin(Particle::AttributeNames::posX);
+      double *const __restrict__ y1ptr = soa1.begin(Particle::AttributeNames::posY);
+      double *const __restrict__ z1ptr = soa1.begin(Particle::AttributeNames::posZ);
+
+      Particle **const __restrict__ id2ptr = reinterpret_cast<Particle * *const>(soa2.begin(Particle::AttributeNames::id));
+      double *const __restrict__ x2ptr = soa2.begin(Particle::AttributeNames::posX);
+      double *const __restrict__ y2ptr = soa2.begin(Particle::AttributeNames::posY);
+      double *const __restrict__ z2ptr = soa2.begin(Particle::AttributeNames::posZ);
+
+      for (unsigned int i = 0; i < soa1.getNumParticles(); ++i) {
+        auto &currentList = _verletListsAoS.at(id1ptr[i]);
+
+        for (unsigned int j = 0; j < soa2.getNumParticles(); ++j) {
+          const double drx = x1ptr[i] - x2ptr[j];
+          const double dry = y1ptr[i] - y2ptr[j];
+          const double drz = z1ptr[i] - z2ptr[j];
+
+          const double drx2 = drx * drx;
+          const double dry2 = dry * dry;
+          const double drz2 = drz * drz;
+
+          const double dr2 = drx2 + dry2 + drz2;
+
+          if (dr2 < _cutoffskinsquared) {
+            currentList.push_back(id2ptr[j]);
+          }
+        }
+      }
+    }
+
+    virtual void SoALoader(ParticleCell &cell, SoA &soa, size_t offset = 0) override {
+      assert(offset == 0);
+      soa.resizeArrays(cell.numParticles());
+
+      if (cell.numParticles() == 0) return;
+
+      double *const __restrict__ idptr = soa.begin(Particle::AttributeNames::id);
+      double *const __restrict__ xptr = soa.begin(Particle::AttributeNames::posX);
+      double *const __restrict__ yptr = soa.begin(Particle::AttributeNames::posY);
+      double *const __restrict__ zptr = soa.begin(Particle::AttributeNames::posZ);
+
+      auto cellIter = cell.begin();
+      // load particles in SoAs
+      for (size_t i = 0; cellIter.isValid(); ++cellIter, ++i) {
+        Particle* pptr = &(*cellIter);
+        idptr[i] = reinterpret_cast<double&>(pptr);
+        xptr[i] = cellIter->getR()[0];
+        yptr[i] = cellIter->getR()[1];
+        zptr[i] = cellIter->getR()[2];
+      }
+    }
+
+    virtual void SoAExtractor(ParticleCell &cell, SoA &soa, size_t offset = 0) override {
+      // nothing yet...
     }
 
    private:
@@ -99,5 +190,5 @@ class VerletListHelpers {
     std::atomic<bool> _valid;
   };
 
-};  // class verlet_internal
+};  // class VerletListHelpers
 }  // namespace autopas

--- a/src/containers/VerletLists.h
+++ b/src/containers/VerletLists.h
@@ -262,7 +262,8 @@ class VerletLists : public LinkedCells<Particle, ParticleCell> {
     updateIdMapAoS();
     typename verlet_internal::VerletListGeneratorFunctor f(_aosNeighborLists, (this->getCutoff() * this->getCutoff()));
 
-    LinkedCells<Particle, ParticleCell>::iteratePairwiseAoS2(&f, useNewton3);
+    //LinkedCells<Particle, ParticleCell>::iteratePairwiseAoS2(&f, useNewton3);
+    LinkedCells<Particle, ParticleCell>::iteratePairwiseSoA2(&f, useNewton3);
     _soaListIsValid = false;
   }
 
@@ -369,7 +370,8 @@ class VerletLists : public LinkedCells<Particle, ParticleCell> {
     _soaNeighborLists.resize(_aosNeighborLists.size());
     // clear the aos 2 soa map
     _aos2soaMap.clear();
-    //_aos2soaMap.reserve(_aosNeighborLists.size());
+
+    _aos2soaMap.reserve(_aosNeighborLists.size());
     size_t i = 0;
     for (auto iter = this->begin(); iter.isValid(); ++iter, ++i) {
       // set the map

--- a/src/containers/VerletLists.h
+++ b/src/containers/VerletLists.h
@@ -50,6 +50,7 @@ class VerletLists : public LinkedCells<Particle, ParticleCell> {
    * @param rebuildFrequency specifies after how many pair-wise traversals the
    * neighbor lists are to be rebuild. A frequency of 1 means that they are
    * always rebuild, 10 means they are rebuild after 10 traversals.
+   * @param buildVerletListType specifies how the verlet list should be build, see BuildVerletListType
    */
   VerletLists(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, double cutoff, double skin,
               unsigned int rebuildFrequency = 1,

--- a/src/containers/VerletLists.h
+++ b/src/containers/VerletLists.h
@@ -281,7 +281,8 @@ class VerletLists : public LinkedCells<Particle, ParticleCell> {
         LinkedCells<Particle, ParticleCell>::iteratePairwiseSoA2(&f, useNewton3);
         break;
       default:
-        utils::ExceptionHandler::exception("VerletLists::updateVerletListsAoS(): unsupported BuildVerletListType");
+        utils::ExceptionHandler::exception("VerletLists::updateVerletListsAoS(): unsupported BuildVerletListType: {}",
+                                           _buildVerletListType);
         break;
     }
     _soaListIsValid = false;

--- a/src/utils/ExceptionHandler.h
+++ b/src/utils/ExceptionHandler.h
@@ -62,6 +62,27 @@ class ExceptionHandler {
   }
 
   /**
+   * Handles an exception that is defined using exceptionString as well as multiple arguments.
+   * It uses the same fmt library that is also used in spdlog and AutoPasLogger. Call it using e.g.:
+   * exception("failure, because {} is not less than {}", 4, 3);
+   *
+   * @tparam First the template type of the first argument
+   * @tparam Args types of multiple
+   * @param exceptionString the basic exception string
+   * @param first the first argument
+   * @param args more arguments
+   * @note First is needed to differentiate this from the template with exception(const Exception e)
+   * @note this is a variadic function, and can thus incorporate an arbitrary amount of arguments
+   */
+  template <typename First, typename... Args>
+  static void exception(std::string exceptionString, First first, Args... args)  // recursive variadic function
+  {
+    std::string s = fmt::format(exceptionString, first, args...);
+
+    exception(s);
+  }
+
+  /**
    * Rethrows the current exception or prints it.
    * Depending on the set behavior the currently active exception is either
    * rethrown, printed or otherwise handled.

--- a/src/utils/SoA.h
+++ b/src/utils/SoA.h
@@ -1,6 +1,7 @@
 #ifndef AUTOPAS_SOA_H
 #define AUTOPAS_SOA_H
 
+#include <algorithm>
 #include <cassert>
 #include <map>
 #include <vector>

--- a/tests/testAutopas/ExceptionHandlerTest.cpp
+++ b/tests/testAutopas/ExceptionHandlerTest.cpp
@@ -48,6 +48,29 @@ TEST_F(ExceptionHandlerTest, TestThrow) {
   EXPECT_THROW(ExceptionHandler::exception(std::exception()), std::exception);
 }
 
+TEST_F(ExceptionHandlerTest, TestVariadicExceptionMessages) {
+  ExceptionHandler::setBehavior(ExceptionBehavior::throwException);
+
+  try {
+    ExceptionHandler::exception("testexception {}", 1);
+    FAIL() << "Expected ExceptionHandler::AutoPasException";
+  } catch (ExceptionHandler::AutoPasException& err) {
+    EXPECT_EQ(err.what(), std::string("testexception 1"));
+  } catch (...) {
+    FAIL() << "Expected std::out_of_range";
+  }
+
+  try {
+    ExceptionHandler::exception("testexception {} {} {}", 1, "hallo", true);
+    FAIL() << "Expected ExceptionHandler::AutoPasException";
+  } catch (ExceptionHandler::AutoPasException& err) {
+    EXPECT_EQ(err.what(), std::string("testexception 1 hallo true"));
+  } catch (...) {
+    FAIL() << "Expected std::out_of_range";
+  }
+
+}
+
 TEST_F(ExceptionHandlerTest, TestAbort) {
   ExceptionHandler::setBehavior(ExceptionBehavior::printAbort);
 

--- a/tests/testAutopas/ExceptionHandlerTest.cpp
+++ b/tests/testAutopas/ExceptionHandlerTest.cpp
@@ -68,7 +68,6 @@ TEST_F(ExceptionHandlerTest, TestVariadicExceptionMessages) {
   } catch (...) {
     FAIL() << "Expected std::out_of_range";
   }
-
 }
 
 TEST_F(ExceptionHandlerTest, TestAbort) {


### PR DESCRIPTION
the verlet-lists are now (re)build using SoA's.
This saves a lot of lookups (hash generations) and some other things.

Speedup is clearly visible, especially as soon as there are more than one particle per cell:
Verlet Lists (md-main, 1000 cells):

type | particle count | rebuild time before | rebuild time now | kernel time (LJ)
------ | ----------------- | ------------------------ | ---------------------- | -----------------
soa | 10.000 | 0.12 | 0.07 | 0.010
aos | 10.000 | 0.10 | 0.05 | 0.018
soa | 1.000 | 1.8e-3 | 1.4e-3 | 1.9e-4
aos | 1.000 | 1.6e-3 | 1.2e-3 | 1.8e-4

Linked Cells (md-main, 1000 cells):

type | particle count | kernel time (LJ)
------ | --------------- | ----
soa | 10.000 | 0.032
aos | 10.000 | 0.07
soa | 1.000 | 6.8e-4
aos | 1.000 | 1.0e-3

meaning, that in this case verlet lists are faster than linked cells, as soon as the rebuild happens at most every 4 time steps.

remaining optimization possibilities:
* from what I see, vectorization is not really possible here, as there are not really any flops done. the main time is spent in storing the lists
* upper optimization limit for the rebuild time should be roughly that of the kernel time of the aos LJ  linked-cells iteration. so we are already close to optimal.
* put neighborlists into particle class to prevent lookup alltogether -- involves lots of template magic and might not pay off