### PR TITLE
Verlet list changes -- delegation, smaller soas, inlining

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -32,3 +32,7 @@ QT_AUTOBRIEF           = YES # default NO
 #WARN_IF_UNDOCUMENTED   = YES # default YES
 #WARN_IF_DOC_ERROR      = YES # default YES
 WARN_NO_PARAMDOC       = YES # default NO
+
+
+#Macro expansion settings:
+MACRO_EXPANSION        = YES

--- a/examples/md/md-main.cpp
+++ b/examples/md/md-main.cpp
@@ -122,8 +122,8 @@ void measure(int which, int numMolecules, int numIterations, int rebuildFrequenc
 
   LinkedCells<PrintableMolecule, FullParticleCell<PrintableMolecule>> lcCont(boxMin, boxMax, cutoff);
   DirectSum<PrintableMolecule, FullParticleCell<PrintableMolecule>> dirCont(boxMin, boxMax, cutoff);
-  VerletLists<PrintableMolecule> verletListsCont(
-      boxMin, boxMax, cutoff, cutoff * skinRadiusToCutoffRatio, rebuildFrequency);
+  VerletLists<PrintableMolecule> verletListsCont(boxMin, boxMax, cutoff, cutoff * skinRadiusToCutoffRatio,
+                                                 rebuildFrequency);
 
   fillContainerWithMolecules(numMolecules, &lcCont);
   for (auto it = lcCont.begin(); it.isValid(); ++it) {

--- a/examples/md/md-main.cpp
+++ b/examples/md/md-main.cpp
@@ -122,7 +122,7 @@ void measure(int which, int numMolecules, int numIterations, int rebuildFrequenc
 
   LinkedCells<PrintableMolecule, FullParticleCell<PrintableMolecule>> lcCont(boxMin, boxMax, cutoff);
   DirectSum<PrintableMolecule, FullParticleCell<PrintableMolecule>> dirCont(boxMin, boxMax, cutoff);
-  VerletLists<PrintableMolecule, FullParticleCell<PrintableMolecule>> verletListsCont(
+  VerletLists<PrintableMolecule> verletListsCont(
       boxMin, boxMax, cutoff, cutoff * skinRadiusToCutoffRatio, rebuildFrequency);
 
   fillContainerWithMolecules(numMolecules, &lcCont);

--- a/examples/md/md-main.cpp
+++ b/examples/md/md-main.cpp
@@ -41,10 +41,10 @@ int main(int argc, char *argv[]) {
   PrintableMolecule p1({0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, 0);
   PrintableMolecule p2({1.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, 1);
   LJFunctor<PrintableMolecule, FullParticleCell<PrintableMolecule>> func;
-  func.AoSFunctor(p1, p2);
+  func.AoSFunctor(p1, p2, true);
   //	p1.print();
   //	p2.print();
-  func.AoSFunctor(p2, p1);
+  func.AoSFunctor(p2, p1, true);
   //	p1.print();
   //	p2.print();
 

--- a/examples/md/md-main.cpp
+++ b/examples/md/md-main.cpp
@@ -89,15 +89,15 @@ void measureContainer(Container *cont, int numMolecules, int numIterations, doub
 
   utils::Timer t;
 
-  cont->iteratePairwiseAoS2(&flopFunctor);
+  cont->iteratePairwiseAoS(&flopFunctor);
   double flopsPerIteration = flopFunctor.getFlops(func.getNumFlopsPerKernelCall());
 
   t.start();
   for (int i = 0; i < numIterations; ++i) {
     if (soa)
-      cont->iteratePairwiseSoA2(&func);
+      cont->iteratePairwiseSoA(&func);
     else
-      cont->iteratePairwiseAoS2(&func);
+      cont->iteratePairwiseAoS(&func);
   }
   double elapsedTime = t.stop();
 
@@ -162,7 +162,7 @@ void testForceLJ() {
   container.addParticle(p4);
 
   LJFunctor<PrintableMolecule, FullParticleCell<PrintableMolecule>> func;
-  container.iteratePairwiseAoS2(&func);
+  container.iteratePairwiseAoS(&func);
 
   //	for (auto it = container.begin(); it.isValid(); ++it) {
   //		it->print();

--- a/examples/sph-mpi/sph-main-mpi.cpp
+++ b/examples/sph-mpi/sph-main-mpi.cpp
@@ -403,7 +403,7 @@ void densityPressureHydroForce(Container& sphSystem, MPI_Comm& comm, const std::
     part->setDensity(part->getDensity() / 2);
   }
 
-  sphSystem.iteratePairwiseAoS2(&densityFunctor);
+  sphSystem.iteratePairwiseAoS(&densityFunctor);
   // 1.3 delete halo particles, as their values are no longer valid
   deleteHaloParticles(sphSystem);
 
@@ -423,7 +423,7 @@ void densityPressureHydroForce(Container& sphSystem, MPI_Comm& comm, const std::
     part->setAcceleration(std::array<double, 3>{0., 0., 0.});
     part->setEngDot(0.);
   }
-  sphSystem.iteratePairwiseAoS2(&hydroForceFunctor);
+  sphSystem.iteratePairwiseAoS(&hydroForceFunctor);
   // 0.3.3 delete halo particles, as their values are no longer valid
   deleteHaloParticles(sphSystem);
 }

--- a/examples/sph-verlet/sph-main-verlet.cpp
+++ b/examples/sph-verlet/sph-main-verlet.cpp
@@ -280,7 +280,7 @@ void densityPressureHydroForce(Container& sphSystem) {
     part->setDensity(part->getDensity() / 2);
   }
   std::cout << "calculation of density... started" << std::endl;
-  sphSystem.iteratePairwiseAoS2(&densityFunctor);
+  sphSystem.iteratePairwiseAoS(&densityFunctor);
   std::cout << "calculation of density... completed" << std::endl;
   // 1.3 delete halo particles, as their values are no longer valid
   // deleteHaloParticles(sphSystem);
@@ -304,7 +304,7 @@ void densityPressureHydroForce(Container& sphSystem) {
     part->setEngDot(0.);
   }
   std::cout << "calculation of hydroforces... started" << std::endl;
-  sphSystem.iteratePairwiseAoS2(&hydroForceFunctor);
+  sphSystem.iteratePairwiseAoS(&hydroForceFunctor);
   std::cout << "calculation of hydroforces... completed" << std::endl;
   // 0.3.3 delete halo particles, as their values are no longer valid
   // deleteHaloParticles(sphSystem);

--- a/examples/sph-verlet/sph-main-verlet.cpp
+++ b/examples/sph-verlet/sph-main-verlet.cpp
@@ -14,7 +14,7 @@
 //    autopas::FullParticleCell<autopas::sph::SPHParticle>>
 //    Container;
 
-typedef autopas::VerletLists<autopas::sph::SPHParticle, autopas::FullParticleCell<autopas::sph::SPHParticle>> Container;
+typedef autopas::VerletLists<autopas::sph::SPHParticle> Container;
 
 // typedef autopas::DirectSum<
 //    autopas::sph::SPHParticle,

--- a/examples/sph/sph-main.cpp
+++ b/examples/sph/sph-main.cpp
@@ -275,7 +275,7 @@ void densityPressureHydroForce(Container& sphSystem) {
     part->setDensity(part->getDensity() / 2);
   }
   std::cout << "calculation of density... started" << std::endl;
-  sphSystem.iteratePairwiseAoS2(&densityFunctor);
+  sphSystem.iteratePairwiseAoS(&densityFunctor);
   std::cout << "calculation of density... completed" << std::endl;
   // 1.3 delete halo particles, as their values are no longer valid
   deleteHaloParticles(sphSystem);
@@ -311,7 +311,7 @@ void densityPressureHydroForce(Container& sphSystem) {
     part->setEngDot(0.);
   }
   std::cout << "calculation of hydroforces... started" << std::endl;
-  sphSystem.iteratePairwiseAoS2(&hydroForceFunctor);
+  sphSystem.iteratePairwiseAoS(&hydroForceFunctor);
   std::cout << "calculation of hydroforces... completed" << std::endl;
   // 0.3.3 delete halo particles, as their values are no longer valid
   deleteHaloParticles(sphSystem);

--- a/examples/sphDiagramGeneration/sph-diagram-generation.cpp
+++ b/examples/sphDiagramGeneration/sph-diagram-generation.cpp
@@ -100,12 +100,12 @@ void measureContainer(Container *cont, int numParticles, int numIterations) {
 
   autopas::utils::Timer t;
 
-  cont->iteratePairwiseAoS2(&flopFunctor);
+  cont->iteratePairwiseAoS(&flopFunctor);
   double flopsPerIteration = flopFunctor.getFlops(func.getNumFlopsPerKernelCall());
 
   t.start();
   for (int i = 0; i < numIterations; ++i) {
-    cont->iteratePairwiseAoS2(&func);
+    cont->iteratePairwiseAoS(&func);
   }
   double elapsedTime = t.stop();
 

--- a/src/AutoPas.h
+++ b/src/AutoPas.h
@@ -138,8 +138,7 @@ class AutoPas {
     switch (dataLayoutOption) {
       case autopas::aos: {
         // WithStaticContainerType(container, container->iteratePairwiseAoS2(f, useNewton3););
-        WithStaticContainerType(container, container->iteratePairwiseAoS2(f, useNewton3);)
-        break;
+        WithStaticContainerType(container, container->iteratePairwiseAoS2(f, useNewton3);) break;
       }
       case autopas::soa: {
         WithStaticContainerType(container, container->iteratePairwiseSoA2(f, useNewton3);)

--- a/src/AutoPas.h
+++ b/src/AutoPas.h
@@ -137,11 +137,11 @@ class AutoPas {
     }
     switch (dataLayoutOption) {
       case autopas::aos: {
-        // WithStaticContainerType(container, container->iteratePairwiseAoS2(f, useNewton3););
-        WithStaticContainerType(container, container->iteratePairwiseAoS2(f, useNewton3);) break;
+        // WithStaticContainerType(container, container->iteratePairwiseAoS(f, useNewton3););
+        WithStaticContainerType(container, container->iteratePairwiseAoS(f, useNewton3);) break;
       }
       case autopas::soa: {
-        WithStaticContainerType(container, container->iteratePairwiseSoA2(f, useNewton3);)
+        WithStaticContainerType(container, container->iteratePairwiseSoA(f, useNewton3);)
       }
     }
   }

--- a/src/AutoPas.h
+++ b/src/AutoPas.h
@@ -123,7 +123,7 @@ class AutoPas {
    * @param f Functor that describes the pair-potential
    * @param dataLayoutOption useSoA Bool to decide if SoA or AoS should be used.
    */
-  void iteratePairwise(autopas::Functor<Particle, ParticleCell> *f, autopas::DataLayoutOption dataLayoutOption) {
+  void iteratePairwise(autopas::Functor<Particle, ParticleCell, typename Particle::SoAArraysType> *f, autopas::DataLayoutOption dataLayoutOption) {
     bool newton3Allowed = f->allowsNewton3();
     bool nonNewton3Allowed = f->allowsNonNewton3();
     bool useNewton3 = true;

--- a/src/AutoPas.h
+++ b/src/AutoPas.h
@@ -138,11 +138,12 @@ class AutoPas {
     }
     switch (dataLayoutOption) {
       case autopas::aos: {
-        // WithStaticContainerType(container, container->iteratePairwiseAoS(f, useNewton3););
-        WithStaticContainerType(container, container->iteratePairwiseAoS(f, useNewton3);) break;
+        WithStaticContainerType(container, container->iteratePairwiseAoS(f, useNewton3););
+        break;
       }
       case autopas::soa: {
-        WithStaticContainerType(container, container->iteratePairwiseSoA(f, useNewton3);)
+        WithStaticContainerType(container, container->iteratePairwiseSoA(f, useNewton3););
+        break;
       }
     }
   }

--- a/src/AutoPas.h
+++ b/src/AutoPas.h
@@ -122,6 +122,7 @@ class AutoPas {
    * This function only handles short-range interactions.
    * @param f Functor that describes the pair-potential
    * @param dataLayoutOption useSoA Bool to decide if SoA or AoS should be used.
+   * @tparam Functor type of the functor
    */
   template <class Functor>
   void iteratePairwise(Functor *f, autopas::DataLayoutOption dataLayoutOption) {

--- a/src/AutoPas.h
+++ b/src/AutoPas.h
@@ -123,7 +123,8 @@ class AutoPas {
    * @param f Functor that describes the pair-potential
    * @param dataLayoutOption useSoA Bool to decide if SoA or AoS should be used.
    */
-  void iteratePairwise(autopas::Functor<Particle, ParticleCell, typename Particle::SoAArraysType> *f, autopas::DataLayoutOption dataLayoutOption) {
+   template <class Functor>
+  void iteratePairwise(Functor *f, autopas::DataLayoutOption dataLayoutOption) {
     bool newton3Allowed = f->allowsNewton3();
     bool nonNewton3Allowed = f->allowsNonNewton3();
     bool useNewton3 = true;
@@ -136,11 +137,12 @@ class AutoPas {
     }
     switch (dataLayoutOption) {
       case autopas::aos: {
-        container->iteratePairwiseAoS(f, useNewton3);
+
+        WithStaticContainerType(container, container->iteratePairwiseAoS2(f, useNewton3));
         break;
       }
       case autopas::soa: {
-        container->iteratePairwiseSoA(f, useNewton3);
+        WithStaticContainerType(container, container->iteratePairwiseSoA2(f, useNewton3));
       }
     }
   }

--- a/src/AutoPas.h
+++ b/src/AutoPas.h
@@ -123,7 +123,7 @@ class AutoPas {
    * @param f Functor that describes the pair-potential
    * @param dataLayoutOption useSoA Bool to decide if SoA or AoS should be used.
    */
-   template <class Functor>
+  template <class Functor>
   void iteratePairwise(Functor *f, autopas::DataLayoutOption dataLayoutOption) {
     bool newton3Allowed = f->allowsNewton3();
     bool nonNewton3Allowed = f->allowsNonNewton3();
@@ -137,12 +137,12 @@ class AutoPas {
     }
     switch (dataLayoutOption) {
       case autopas::aos: {
-
-        WithStaticContainerType(container, container->iteratePairwiseAoS2(f, useNewton3));
+        // WithStaticContainerType(container, container->iteratePairwiseAoS2(f, useNewton3););
+        WithStaticContainerType(container, container->iteratePairwiseAoS2(f, useNewton3);)
         break;
       }
       case autopas::soa: {
-        WithStaticContainerType(container, container->iteratePairwiseSoA2(f, useNewton3));
+        WithStaticContainerType(container, container->iteratePairwiseSoA2(f, useNewton3);)
       }
     }
   }

--- a/src/autopasIncludes.h
+++ b/src/autopasIncludes.h
@@ -15,6 +15,7 @@
 #include "utils/ArrayMath.h"
 #include "utils/Logger.h"
 #include "utils/SoA.h"
+#include "utils/StaticSelectorMacros.h"
 #include "utils/Timer.h"
 
 // particles

--- a/src/cells/FullParticleCell.h
+++ b/src/cells/FullParticleCell.h
@@ -18,7 +18,7 @@ namespace autopas {
  * This class handles the storage of particles in their full form.
  * @tparam Particle
  */
-template <class Particle>
+template <class Particle, class SoAArraysType = typename Particle::SoAArraysType>
 class FullParticleCell : public ParticleCell<Particle> {
  public:
   FullParticleCell() {}
@@ -27,7 +27,7 @@ class FullParticleCell : public ParticleCell<Particle> {
 
   virtual SingleCellIteratorWrapper<Particle> begin() override {
     return SingleCellIteratorWrapper<Particle>(
-        new internal::SingleCellIterator<Particle, FullParticleCell<Particle>>(this));
+        new internal::SingleCellIterator<Particle, FullParticleCell<Particle, SoAArraysType>>(this));
   }
 
   unsigned long numParticles() const override { return _particles.size(); }
@@ -53,7 +53,7 @@ class FullParticleCell : public ParticleCell<Particle> {
   /**
    * the soa buffer of this cell
    */
-  SoA<Particle> _particleSoABuffer;
+  SoA<SoAArraysType> _particleSoABuffer;
 
   /**
    * friend class iterator

--- a/src/cells/RMMParticleCell2T.h
+++ b/src/cells/RMMParticleCell2T.h
@@ -61,7 +61,7 @@ class RMMParticleCell2T : public ParticleCell<Particle> {
   /**
    * the soa buffer of the particle, all information is stored here.
    */
-  SoA<Particle> _particleSoABuffer;
+  SoA<typename Particle::SoAArraysType> _particleSoABuffer;
 
  private:
   void buildParticleFromSoA(size_t i, Particle *&rmm_or_not_pointer) {

--- a/src/containers/DirectSum.h
+++ b/src/containers/DirectSum.h
@@ -59,27 +59,6 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
 
   void deleteHaloParticles() override { getHaloCell()->clear(); }
 
-  void iteratePairwiseAoS(Functor<Particle, ParticleCell, typename Particle::SoAArraysType> *f,
-                          bool useNewton3 = true) override {
-    //		CellFunctor<Particle, ParticleCell,LJFunctor<Particle>>
-    // cellFunctor(f);
-    //		cellFunctor.processCellAoSN3(*getCell());
-    iteratePairwiseAoS2(f, useNewton3);
-#if 0
-		for (auto outer = getIt(); outer.isValid(); ++outer) {
-			Particle & p1 = *outer;
-
-			int ind = outer.getIndex() + 1;
-
-			for (auto inner = getIt(ind); inner.isValid(); ++inner) {
-				Particle & p2 = *inner;
-
-				f->AoSFunctor(p1, p2);
-			}
-		}
-#endif
-  }
-
   /**
    * same as iteratePairwiseAoS, but faster, as the class of the functor is
    * known and thus the compiler can do some better optimizations.
@@ -98,11 +77,6 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
       cellFunctor.processCell(*getCell());
       cellFunctor.processCellPair(*getCell(), *getHaloCell());
     }
-  }
-
-  void iteratePairwiseSoA(Functor<Particle, ParticleCell, typename Particle::SoAArraysType> *f,
-                          bool useNewton3 = true) override {
-    iteratePairwiseSoA2(f, useNewton3);
   }
 
   /**

--- a/src/containers/DirectSum.h
+++ b/src/containers/DirectSum.h
@@ -59,7 +59,7 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
 
   void deleteHaloParticles() override { getHaloCell()->clear(); }
 
-  /*
+  /**
    * @copydoc LinkedCells::iteratePairwiseAoS
    */
   template <class ParticleFunctor>

--- a/src/containers/DirectSum.h
+++ b/src/containers/DirectSum.h
@@ -59,7 +59,8 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
 
   void deleteHaloParticles() override { getHaloCell()->clear(); }
 
-  void iteratePairwiseAoS(Functor<Particle, ParticleCell> *f, bool useNewton3 = true) override {
+  void iteratePairwiseAoS(Functor<Particle, ParticleCell, typename Particle::SoAArraysType> *f,
+                          bool useNewton3 = true) override {
     //		CellFunctor<Particle, ParticleCell,LJFunctor<Particle>>
     // cellFunctor(f);
     //		cellFunctor.processCellAoSN3(*getCell());
@@ -99,7 +100,8 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
     }
   }
 
-  void iteratePairwiseSoA(Functor<Particle, ParticleCell> *f, bool useNewton3 = true) override {
+  void iteratePairwiseSoA(Functor<Particle, ParticleCell, typename Particle::SoAArraysType> *f,
+                          bool useNewton3 = true) override {
     iteratePairwiseSoA2(f, useNewton3);
   }
 

--- a/src/containers/DirectSum.h
+++ b/src/containers/DirectSum.h
@@ -59,15 +59,11 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
 
   void deleteHaloParticles() override { getHaloCell()->clear(); }
 
-  /**
-   * same as iteratePairwiseAoS, but faster, as the class of the functor is
-   * known and thus the compiler can do some better optimizations.
-   * @tparam ParticleFunctor
-   * @param f
-   * @param useNewton3 defines whether newton3 should be used
+  /*
+   * @copydoc LinkedCells::iteratePairwiseAoS
    */
   template <class ParticleFunctor>
-  void iteratePairwiseAoS2(ParticleFunctor *f, bool useNewton3 = true) {
+  void iteratePairwiseAoS(ParticleFunctor *f, bool useNewton3 = true) {
     if (useNewton3) {
       CellFunctor<Particle, ParticleCell, ParticleFunctor, false, true> cellFunctor(f);
       cellFunctor.processCell(*getCell());
@@ -80,14 +76,10 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
   }
 
   /**
-   * same as iteratePairwiseSoA, but faster, as the class of the functor is
-   * known and thus the compiler can do some better optimizations.
-   * @tparam ParticleFunctor
-   * @param f
-   * @param useNewton3
+   * @copydoc LinkedCells::iteratePairwiseSoA
    */
   template <class ParticleFunctor>
-  void iteratePairwiseSoA2(ParticleFunctor *f, bool useNewton3 = true) {
+  void iteratePairwiseSoA(ParticleFunctor *f, bool useNewton3 = true) {
     f->SoALoader(*getCell(), (*getCell())._particleSoABuffer);
     f->SoALoader(*getHaloCell(), (*getHaloCell())._particleSoABuffer);
 

--- a/src/containers/LinkedCells.h
+++ b/src/containers/LinkedCells.h
@@ -26,7 +26,7 @@ namespace autopas {
  * @tparam ParticleCell type of the ParticleCells that are used to store the
  * particles
  */
-template <class Particle, class ParticleCell, class SoAArraysType=typename Particle::SoAArraysType>
+template <class Particle, class ParticleCell, class SoAArraysType = typename Particle::SoAArraysType>
 class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysType> {
  public:
   /**
@@ -64,7 +64,6 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
   }
 
   void deleteHaloParticles() override { _cellBlock.clearHaloCells(); }
-
 
   /**
    * same as iteratePairwiseAoS, but potentially faster (if called with the
@@ -106,7 +105,6 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
       }
     }
   }
-
 
   /**
    * same as iteratePairwiseSoA, but faster, as the class of the functor is
@@ -196,13 +194,9 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
         &this->_data, lowerCorner, higherCorner, &_cellBlock, behavior));
   }
 
-  CellBlock3D<ParticleCell>& getCellBlock(){
-    return _cellBlock;
-  }
+  CellBlock3D<ParticleCell> &getCellBlock() { return _cellBlock; }
 
-  std::vector<ParticleCell>& getData(){
-    return this->_data;
-  }
+  std::vector<ParticleCell> &getData() { return this->_data; }
 
  protected:
   /**

--- a/src/containers/LinkedCells.h
+++ b/src/containers/LinkedCells.h
@@ -65,7 +65,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
 
   void deleteHaloParticles() override { _cellBlock.clearHaloCells(); }
 
-  /*
+  /**
    * Function to iterate over all pairs of particles in an array of structures setting. This function only handles
    * short-range interactions.
    * @tparam the type of ParticleFunctor
@@ -105,7 +105,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
     }
   }
 
-  /*
+  /**
    * function to iterate over all pairs of particles in a structure of array
    * setting. This function is often better vectorizable.
    * @tparam ParticleFunctor

--- a/src/containers/LinkedCells.h
+++ b/src/containers/LinkedCells.h
@@ -65,20 +65,19 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
 
   void deleteHaloParticles() override { _cellBlock.clearHaloCells(); }
 
-  /**
-   * same as iteratePairwiseAoS, but potentially faster (if called with the
-   * derived functor), as the class of the functor is known and thus the
-   * compiler can do some better optimizations.
-   * @tparam ParticleFunctor
-   * @param f
+  /*
+   * Function to iterate over all pairs of particles in an array of structures setting. This function only handles
+   * short-range interactions.
+   * @tparam the type of ParticleFunctor
+   * @param f functor that describes the pair-potential
    * @param useNewton3 defines whether newton3 should be used
    */
   template <class ParticleFunctor>
-  void iteratePairwiseAoS2(ParticleFunctor *f, bool useNewton3 = true) {
+  void iteratePairwiseAoS(ParticleFunctor *f, bool useNewton3 = true) {
     auto envTraversal = std::getenv("AUTOPAS_TRAVERSAL");
     if (useNewton3) {
       CellFunctor<Particle, ParticleCell, ParticleFunctor, false, true> cellFunctor(f);
-      // TODO: REVMOVE SELECTION VIA ENVIRONMENT VAR AS SOON AS SELECTOR IS
+      // TODO: REMOVE SELECTION VIA ENVIRONMENT VAR AS SOON AS SELECTOR IS
       // IMPLEMENTED
       if (envTraversal != nullptr && strcmp(envTraversal, "C08") == 0) {
         C08Traversal<ParticleCell, CellFunctor<Particle, ParticleCell, ParticleFunctor, false, true>> traversal(
@@ -106,15 +105,15 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
     }
   }
 
-  /**
-   * same as iteratePairwiseSoA, but faster, as the class of the functor is
-   * known and thus the compiler can do some better optimizations.
+  /*
+   * function to iterate over all pairs of particles in a structure of array
+   * setting. This function is often better vectorizable.
    * @tparam ParticleFunctor
-   * @param f
-   * @param useNewton3
+   * @param f functor that describes the pair-potential
+   * @param useNewton3 defines whether newton3 should be used
    */
   template <class ParticleFunctor>
-  void iteratePairwiseSoA2(ParticleFunctor *f, bool useNewton3 = true) {
+  void iteratePairwiseSoA(ParticleFunctor *f, bool useNewton3 = true) {
     loadSoAs(f);
 
     auto envTraversal = std::getenv("AUTOPAS_TRAVERSAL");

--- a/src/containers/LinkedCells.h
+++ b/src/containers/LinkedCells.h
@@ -207,6 +207,10 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
     return _cellBlock;
   }
 
+  std::vector<ParticleCell>& getData(){
+    return this->_data;
+  }
+
  protected:
   /**
    * object to manage the block of cells.

--- a/src/containers/LinkedCells.h
+++ b/src/containers/LinkedCells.h
@@ -26,8 +26,8 @@ namespace autopas {
  * @tparam ParticleCell type of the ParticleCells that are used to store the
  * particles
  */
-template <class Particle, class ParticleCell>
-class LinkedCells : public ParticleContainer<Particle, ParticleCell> {
+template <class Particle, class ParticleCell, class SoAArraysType=typename Particle::SoAArraysType>
+class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysType> {
  public:
   /**
    * Constructor of the LinkedCells class
@@ -36,7 +36,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell> {
    * @param cutoff
    */
   LinkedCells(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, double cutoff)
-      : ParticleContainer<Particle, ParticleCell>(boxMin, boxMax, cutoff),
+      : ParticleContainer<Particle, ParticleCell, SoAArraysType>(boxMin, boxMax, cutoff),
         _cellBlock(this->_data, boxMin, boxMax, cutoff) {}
 
   void addParticle(Particle &p) override {
@@ -65,7 +65,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell> {
 
   void deleteHaloParticles() override { _cellBlock.clearHaloCells(); }
 
-  void iteratePairwiseAoS(Functor<Particle, ParticleCell, typename Particle::SoAArraysType> *f, bool useNewton3 = true) override {
+  void iteratePairwiseAoS(Functor<Particle, ParticleCell, SoAArraysType> *f, bool useNewton3 = true) override {
     iteratePairwiseAoS2(f, useNewton3);
   }
 
@@ -110,7 +110,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell> {
     }
   }
 
-  void iteratePairwiseSoA(Functor<Particle, ParticleCell, typename Particle::SoAArraysType> *f, bool useNewton3 = true) override {
+  void iteratePairwiseSoA(Functor<Particle, ParticleCell, SoAArraysType> *f, bool useNewton3 = true) override {
     /// @todo iteratePairwiseSoA
     iteratePairwiseSoA2(f, useNewton3);
   }
@@ -201,6 +201,10 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell> {
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
     return ParticleIteratorWrapper<Particle>(new internal::RegionParticleIterator<Particle, ParticleCell>(
         &this->_data, lowerCorner, higherCorner, &_cellBlock, behavior));
+  }
+
+  CellBlock3D<ParticleCell>& getCellBlock(){
+    return _cellBlock;
   }
 
  protected:

--- a/src/containers/LinkedCells.h
+++ b/src/containers/LinkedCells.h
@@ -65,9 +65,6 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
 
   void deleteHaloParticles() override { _cellBlock.clearHaloCells(); }
 
-  void iteratePairwiseAoS(Functor<Particle, ParticleCell, SoAArraysType> *f, bool useNewton3 = true) override {
-    iteratePairwiseAoS2(f, useNewton3);
-  }
 
   /**
    * same as iteratePairwiseAoS, but potentially faster (if called with the
@@ -110,10 +107,6 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
     }
   }
 
-  void iteratePairwiseSoA(Functor<Particle, ParticleCell, SoAArraysType> *f, bool useNewton3 = true) override {
-    /// @todo iteratePairwiseSoA
-    iteratePairwiseSoA2(f, useNewton3);
-  }
 
   /**
    * same as iteratePairwiseSoA, but faster, as the class of the functor is

--- a/src/containers/LinkedCells.h
+++ b/src/containers/LinkedCells.h
@@ -65,7 +65,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell> {
 
   void deleteHaloParticles() override { _cellBlock.clearHaloCells(); }
 
-  void iteratePairwiseAoS(Functor<Particle, ParticleCell> *f, bool useNewton3 = true) override {
+  void iteratePairwiseAoS(Functor<Particle, ParticleCell, typename Particle::SoAArraysType> *f, bool useNewton3 = true) override {
     iteratePairwiseAoS2(f, useNewton3);
   }
 
@@ -110,7 +110,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell> {
     }
   }
 
-  void iteratePairwiseSoA(Functor<Particle, ParticleCell> *f, bool useNewton3 = true) override {
+  void iteratePairwiseSoA(Functor<Particle, ParticleCell, typename Particle::SoAArraysType> *f, bool useNewton3 = true) override {
     /// @todo iteratePairwiseSoA
     iteratePairwiseSoA2(f, useNewton3);
   }

--- a/src/containers/LinkedCells.h
+++ b/src/containers/LinkedCells.h
@@ -194,8 +194,16 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
         &this->_data, lowerCorner, higherCorner, &_cellBlock, behavior));
   }
 
+  /**
+   * Get the cell block, not supposed to be used except by verlet lists
+   * @return the cell block
+   */
   CellBlock3D<ParticleCell> &getCellBlock() { return _cellBlock; }
 
+  /**
+   * returns reference to the data of LinkedCells
+   * @return the data
+   */
   std::vector<ParticleCell> &getData() { return this->_data; }
 
  protected:

--- a/src/containers/LinkedCells.h
+++ b/src/containers/LinkedCells.h
@@ -23,8 +23,8 @@ namespace autopas {
  * therefore short-range interactions only need to be calculated between
  * particles in neighboring cells.
  * @tparam Particle type of the particles that need to be stored
- * @tparam ParticleCell type of the ParticleCells that are used to store the
- * particles
+ * @tparam ParticleCell type of the ParticleCells that are used to store the particles
+ * @tparam SoAArraysType type of the SoA, needed for verlet lists
  */
 template <class Particle, class ParticleCell, class SoAArraysType = typename Particle::SoAArraysType>
 class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysType> {

--- a/src/containers/ParticleContainer.h
+++ b/src/containers/ParticleContainer.h
@@ -25,6 +25,8 @@ namespace autopas {
 template <class Particle, class ParticleCell, class SoAArraysType = typename Particle::SoAArraysType>
 class ParticleContainer : public ParticleContainerInterface<Particle> {
  public:
+  typedef Particle ParticleType;
+  typedef ParticleCell ParticleCellType;
   /**
    * Constructor of ParticleContainer
    * @param boxMin

--- a/src/containers/ParticleContainer.h
+++ b/src/containers/ParticleContainer.h
@@ -60,7 +60,7 @@ class ParticleContainer : public ParticleContainerInterface<Particle> {
    * @param f functor that describes the pair-potential
    * @param useNewton3 defines whether newton3 should be used
    */
-  virtual void iteratePairwiseAoS(Functor<Particle, ParticleCell, SoAArraysType> *f, bool useNewton3 = true) = 0;
+  //virtual void iteratePairwiseAoS(Functor<Particle, ParticleCell, SoAArraysType> *f, bool useNewton3 = true) = 0;
 
   /**
    * function to iterate over all pairs of particles in a structure of array
@@ -68,7 +68,7 @@ class ParticleContainer : public ParticleContainerInterface<Particle> {
    * @param f functor that describes the pair-potential
    * @param useNewton3 defines whether newton3 should be used
    */
-  virtual void iteratePairwiseSoA(Functor<Particle, ParticleCell, SoAArraysType> *f, bool useNewton3 = true) = 0;
+  //virtual void iteratePairwiseSoA(Functor<Particle, ParticleCell, SoAArraysType> *f, bool useNewton3 = true) = 0;
 
   /**
    * get the upper corner of the container

--- a/src/containers/ParticleContainer.h
+++ b/src/containers/ParticleContainer.h
@@ -62,7 +62,7 @@ class ParticleContainer : public ParticleContainerInterface<Particle> {
    * @param f functor that describes the pair-potential
    * @param useNewton3 defines whether newton3 should be used
    */
-  //virtual void iteratePairwiseAoS(Functor<Particle, ParticleCell, SoAArraysType> *f, bool useNewton3 = true) = 0;
+  // virtual void iteratePairwiseAoS(Functor<Particle, ParticleCell, SoAArraysType> *f, bool useNewton3 = true) = 0;
 
   /**
    * function to iterate over all pairs of particles in a structure of array
@@ -70,7 +70,7 @@ class ParticleContainer : public ParticleContainerInterface<Particle> {
    * @param f functor that describes the pair-potential
    * @param useNewton3 defines whether newton3 should be used
    */
-  //virtual void iteratePairwiseSoA(Functor<Particle, ParticleCell, SoAArraysType> *f, bool useNewton3 = true) = 0;
+  // virtual void iteratePairwiseSoA(Functor<Particle, ParticleCell, SoAArraysType> *f, bool useNewton3 = true) = 0;
 
   /**
    * get the upper corner of the container

--- a/src/containers/ParticleContainer.h
+++ b/src/containers/ParticleContainer.h
@@ -60,7 +60,7 @@ class ParticleContainer : public ParticleContainerInterface<Particle> {
    * @param f functor that describes the pair-potential
    * @param useNewton3 defines whether newton3 should be used
    */
-  virtual void iteratePairwiseAoS(Functor<Particle, ParticleCell> *f, bool useNewton3 = true) = 0;
+  virtual void iteratePairwiseAoS(Functor<Particle, ParticleCell, typename Particle::SoAArraysType> *f, bool useNewton3 = true) = 0;
 
   /**
    * function to iterate over all pairs of particles in a structure of array
@@ -68,7 +68,7 @@ class ParticleContainer : public ParticleContainerInterface<Particle> {
    * @param f functor that describes the pair-potential
    * @param useNewton3 defines whether newton3 should be used
    */
-  virtual void iteratePairwiseSoA(Functor<Particle, ParticleCell> *f, bool useNewton3 = true) = 0;
+  virtual void iteratePairwiseSoA(Functor<Particle, ParticleCell, typename Particle::SoAArraysType> *f, bool useNewton3 = true) = 0;
 
   /**
    * get the upper corner of the container

--- a/src/containers/ParticleContainer.h
+++ b/src/containers/ParticleContainer.h
@@ -22,7 +22,7 @@ namespace autopas {
  * @tparam Particle Class for particles
  * @tparam ParticleCell Class for the particle cells
  */
-template <class Particle, class ParticleCell>
+template <class Particle, class ParticleCell, class SoAArraysType = typename Particle::SoAArraysType>
 class ParticleContainer : public ParticleContainerInterface<Particle> {
  public:
   /**
@@ -60,7 +60,7 @@ class ParticleContainer : public ParticleContainerInterface<Particle> {
    * @param f functor that describes the pair-potential
    * @param useNewton3 defines whether newton3 should be used
    */
-  virtual void iteratePairwiseAoS(Functor<Particle, ParticleCell, typename Particle::SoAArraysType> *f, bool useNewton3 = true) = 0;
+  virtual void iteratePairwiseAoS(Functor<Particle, ParticleCell, SoAArraysType> *f, bool useNewton3 = true) = 0;
 
   /**
    * function to iterate over all pairs of particles in a structure of array
@@ -68,7 +68,7 @@ class ParticleContainer : public ParticleContainerInterface<Particle> {
    * @param f functor that describes the pair-potential
    * @param useNewton3 defines whether newton3 should be used
    */
-  virtual void iteratePairwiseSoA(Functor<Particle, ParticleCell, typename Particle::SoAArraysType> *f, bool useNewton3 = true) = 0;
+  virtual void iteratePairwiseSoA(Functor<Particle, ParticleCell, SoAArraysType> *f, bool useNewton3 = true) = 0;
 
   /**
    * get the upper corner of the container

--- a/src/containers/ParticleContainer.h
+++ b/src/containers/ParticleContainer.h
@@ -59,22 +59,6 @@ class ParticleContainer : public ParticleContainerInterface<Particle> {
    */
   ParticleContainer &operator=(const ParticleContainer &other) = delete;
 
-  // /*
-  //  * function to iterate over all pairs of particles in an array of structures
-  //  * setting. This function only handles short-range interactions.
-  //  * @param f functor that describes the pair-potential
-  //  * @param useNewton3 defines whether newton3 should be used
-  //  */
-  // virtual void iteratePairwiseAoS(Functor<Particle, ParticleCell, SoAArraysType> *f, bool useNewton3 = true) = 0;
-
-  //  /*
-  //   * function to iterate over all pairs of particles in a structure of array
-  //   * setting. This function is often better vectorizable.
-  //   * @param f functor that describes the pair-potential
-  //   * @param useNewton3 defines whether newton3 should be used
-  //   */
-  // virtual void iteratePairwiseSoA(Functor<Particle, ParticleCell, SoAArraysType> *f, bool useNewton3 = true) = 0;
-
   /**
    * get the upper corner of the container
    * @return upper corner of the container

--- a/src/containers/ParticleContainer.h
+++ b/src/containers/ParticleContainer.h
@@ -25,7 +25,10 @@ namespace autopas {
 template <class Particle, class ParticleCell, class SoAArraysType = typename Particle::SoAArraysType>
 class ParticleContainer : public ParticleContainerInterface<Particle> {
  public:
+  /// type of the Particle
   typedef Particle ParticleType;
+
+  /// type of the ParticleCell
   typedef ParticleCell ParticleCellType;
   /**
    * Constructor of ParticleContainer
@@ -56,20 +59,20 @@ class ParticleContainer : public ParticleContainerInterface<Particle> {
    */
   ParticleContainer &operator=(const ParticleContainer &other) = delete;
 
-  /**
-   * function to iterate over all pairs of particles in an array of structures
-   * setting. This function only handles short-range interactions.
-   * @param f functor that describes the pair-potential
-   * @param useNewton3 defines whether newton3 should be used
-   */
+  // /*
+  //  * function to iterate over all pairs of particles in an array of structures
+  //  * setting. This function only handles short-range interactions.
+  //  * @param f functor that describes the pair-potential
+  //  * @param useNewton3 defines whether newton3 should be used
+  //  */
   // virtual void iteratePairwiseAoS(Functor<Particle, ParticleCell, SoAArraysType> *f, bool useNewton3 = true) = 0;
 
-  /**
-   * function to iterate over all pairs of particles in a structure of array
-   * setting. This function is often better vectorizable.
-   * @param f functor that describes the pair-potential
-   * @param useNewton3 defines whether newton3 should be used
-   */
+  //  /*
+  //   * function to iterate over all pairs of particles in a structure of array
+  //   * setting. This function is often better vectorizable.
+  //   * @param f functor that describes the pair-potential
+  //   * @param useNewton3 defines whether newton3 should be used
+  //   */
   // virtual void iteratePairwiseSoA(Functor<Particle, ParticleCell, SoAArraysType> *f, bool useNewton3 = true) = 0;
 
   /**

--- a/src/containers/VerletListHelpers.h
+++ b/src/containers/VerletListHelpers.h
@@ -9,6 +9,8 @@
 #include <atomic>
 #include "cells/FullParticleCell.h"
 #include "pairwiseFunctors/Functor.h"
+#include "utils/ArrayMath.h"
+#include "utils/SoA.h"
 namespace autopas {
 
 /**

--- a/src/containers/VerletListHelpers.h
+++ b/src/containers/VerletListHelpers.h
@@ -49,7 +49,7 @@ class VerletListHelpers {
     VerletListGeneratorFunctor(AoS_verletlist_storage_type &verletListsAoS, double cutoffskinsquared)
         : _verletListsAoS(verletListsAoS), _cutoffskinsquared(cutoffskinsquared) {}
 
-    void AoSFunctor(Particle &i, Particle &j, bool newton3 = true) override {
+    void AoSFunctor(Particle &i, Particle &j, bool newton3) override {
       auto dist = ArrayMath::sub(i.getR(), j.getR());
       double distsquare = ArrayMath::dot(dist, dist);
       if (distsquare < _cutoffskinsquared)
@@ -66,7 +66,7 @@ class VerletListHelpers {
      * SoAFunctor for verlet list generation. (two cell version)
      * @param soa the soa
      */
-    void SoAFunctor(SoA<SoAArraysType> &soa, bool /*newton3*/ = true) override {
+    void SoAFunctor(SoA<SoAArraysType> &soa, bool /*newton3*/) override {
       if (soa.getNumParticles() == 0) return;
 
       Particle **const __restrict__ idptr = reinterpret_cast<Particle **const>(soa.begin<AttributeNames::id>());
@@ -101,7 +101,7 @@ class VerletListHelpers {
      * @param soa1 soa of first cell
      * @param soa2 soa of second cell
      */
-    void SoAFunctor(SoA<SoAArraysType> &soa1, SoA<SoAArraysType> &soa2, bool /*newton3*/ = true) override {
+    void SoAFunctor(SoA<SoAArraysType> &soa1, SoA<SoAArraysType> &soa2, bool /*newton3*/) override {
       if (soa1.getNumParticles() == 0 || soa2.getNumParticles() == 0) return;
 
       Particle **const __restrict__ id1ptr = reinterpret_cast<Particle **const>(soa1.begin<AttributeNames::id>());
@@ -203,7 +203,7 @@ class VerletListHelpers {
     VerletListValidityCheckerFunctor(AoS_verletlist_storage_type &verletListsAoS, double cutoffsquared)
         : _verletListsAoS(verletListsAoS), _cutoffsquared(cutoffsquared), _valid(true) {}
 
-    void AoSFunctor(Particle &i, Particle &j, bool newton3 = true) override {
+    void AoSFunctor(Particle &i, Particle &j, bool newton3) override {
       auto dist = ArrayMath::sub(i.getR(), j.getR());
       double distsquare = ArrayMath::dot(dist, dist);
       if (distsquare < _cutoffsquared) {

--- a/src/containers/VerletListHelpers.h
+++ b/src/containers/VerletListHelpers.h
@@ -16,7 +16,6 @@ namespace autopas {
 /**
  * class of helpers for verlet lists
  * @tparam Particle
-
  */
 template <class Particle>
 class VerletListHelpers {

--- a/src/containers/VerletListHelpers.h
+++ b/src/containers/VerletListHelpers.h
@@ -62,6 +62,10 @@ class VerletListHelpers {
         _verletListsAoS.at(&i).push_back(&j);
     }
 
+    /**
+     * SoAFunctor for verlet list generation. (two cell version)
+     * @param soa the soa
+     */
     void SoAFunctor(SoA<SoAArraysType> &soa, bool /*newton3*/ = true) override {
       if (soa.getNumParticles() == 0) return;
 
@@ -92,6 +96,11 @@ class VerletListHelpers {
       }
     }
 
+    /**
+     * SoAfunctor for the verlet list generation. (two cell version)
+     * @param soa1 soa of first cell
+     * @param soa2 soa of second cell
+     */
     void SoAFunctor(SoA<SoAArraysType> &soa1, SoA<SoAArraysType> &soa2, bool /*newton3*/ = true) override {
       if (soa1.getNumParticles() == 0 || soa2.getNumParticles() == 0) return;
 
@@ -129,6 +138,13 @@ class VerletListHelpers {
       }
     }
 
+    /**
+     * SoALoader for verlet list generator.
+     * Only loads IDs and positions
+     * @param cell
+     * @param soa
+     * @param offset
+     */
     void SoALoader(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override {
       assert(offset == 0);
       soa.resizeArrays(cell.numParticles());
@@ -151,6 +167,13 @@ class VerletListHelpers {
       }
     }
 
+    /**
+     * SoAExtractor for verlet list generation.
+     * Currently empty.
+     * @param cell
+     * @param soa
+     * @param offset
+     */
     void SoAExtractor(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override {
       // nothing yet...
     }

--- a/src/containers/VerletListHelpers.h
+++ b/src/containers/VerletListHelpers.h
@@ -12,20 +12,28 @@ namespace autopas {
 /**
  * class of helpers for verlet lists
  * @tparam Particle
- * @tparam ParticleCell
+
  */
-template <class Particle, class ParticleCell>
+template <class Particle>
 class VerletListHelpers {
  public:
   /// AOS verlet list storage
   typedef std::unordered_map<Particle *, std::vector<Particle *>> AoS_verletlist_storage_type;
 
+  /// typedef for soa's of verlet list's linked cells (only id and position needs to be stored)
+  typedef utils::SoAType<size_t, double, double, double> SoAArraysType;
+
+  /// attributes for soa's of verlet list's linked cells (only id and position needs to be stored)
+  enum AttributeNames : int { id, posX, posY, posZ };
+
   /**
    * This functor can generate verlet lists using the typical pairwise
    * traversal.
+   * @tparam ParticleCell
    * @todo: SoA?
    */
-  class VerletListGeneratorFunctor : public autopas::Functor<Particle, ParticleCell> {
+  template <class ParticleCell>
+  class VerletListGeneratorFunctor : public autopas::Functor<Particle, ParticleCell, SoAArraysType> {
    public:
     /**
      * Constructor
@@ -48,14 +56,14 @@ class VerletListHelpers {
         _verletListsAoS.at(&i).push_back(&j);
     }
 
-    virtual void SoAFunctor(SoA<Particle> &soa, bool /*newton3*/ = true) override {
+    virtual void SoAFunctor(SoA<SoAArraysType> &soa, bool /*newton3*/ = true) override {
       if (soa.getNumParticles() == 0) return;
 
       Particle **const __restrict__ idptr =
-          reinterpret_cast<Particle **const>(soa.template begin<Particle::AttributeNames::id>());
-      double *const __restrict__ xptr = soa.template begin<Particle::AttributeNames::posX>();
-      double *const __restrict__ yptr = soa.template begin<Particle::AttributeNames::posY>();
-      double *const __restrict__ zptr = soa.template begin<Particle::AttributeNames::posZ>();
+          reinterpret_cast<Particle **const>(soa.template begin<AttributeNames::id>());
+      double *const __restrict__ xptr = soa.template begin<AttributeNames::posX>();
+      double *const __restrict__ yptr = soa.template begin<AttributeNames::posY>();
+      double *const __restrict__ zptr = soa.template begin<AttributeNames::posZ>();
 
       size_t numPart = soa.getNumParticles();
       for (unsigned int i = 0; i < numPart; ++i) {
@@ -79,20 +87,20 @@ class VerletListHelpers {
       }
     }
 
-    virtual void SoAFunctor(SoA<Particle> &soa1, SoA<Particle> &soa2, bool /*newton3*/ = true) override {
+    virtual void SoAFunctor(SoA<SoAArraysType> &soa1, SoA<SoAArraysType> &soa2, bool /*newton3*/ = true) override {
       if (soa1.getNumParticles() == 0 || soa2.getNumParticles() == 0) return;
 
       Particle **const __restrict__ id1ptr =
-          reinterpret_cast<Particle **const>(soa1.template begin<Particle::AttributeNames::id>());
-      double *const __restrict__ x1ptr = soa1.template begin<Particle::AttributeNames::posX>();
-      double *const __restrict__ y1ptr = soa1.template begin<Particle::AttributeNames::posY>();
-      double *const __restrict__ z1ptr = soa1.template begin<Particle::AttributeNames::posZ>();
+          reinterpret_cast<Particle **const>(soa1.template begin<AttributeNames::id>());
+      double *const __restrict__ x1ptr = soa1.template begin<AttributeNames::posX>();
+      double *const __restrict__ y1ptr = soa1.template begin<AttributeNames::posY>();
+      double *const __restrict__ z1ptr = soa1.template begin<AttributeNames::posZ>();
 
       Particle **const __restrict__ id2ptr =
-          reinterpret_cast<Particle **const>(soa2.template begin<Particle::AttributeNames::id>());
-      double *const __restrict__ x2ptr = soa2.template begin<Particle::AttributeNames::posX>();
-      double *const __restrict__ y2ptr = soa2.template begin<Particle::AttributeNames::posY>();
-      double *const __restrict__ z2ptr = soa2.template begin<Particle::AttributeNames::posZ>();
+          reinterpret_cast<Particle **const>(soa2.template begin<AttributeNames::id>());
+      double *const __restrict__ x2ptr = soa2.template begin<AttributeNames::posX>();
+      double *const __restrict__ y2ptr = soa2.template begin<AttributeNames::posY>();
+      double *const __restrict__ z2ptr = soa2.template begin<AttributeNames::posZ>();
 
       size_t numPart1 = soa1.getNumParticles();
       for (unsigned int i = 0; i < numPart1; ++i) {
@@ -118,16 +126,16 @@ class VerletListHelpers {
       }
     }
 
-    virtual void SoALoader(ParticleCell &cell, SoA<Particle> &soa, size_t offset = 0) override {
+    virtual void SoALoader(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override {
       assert(offset == 0);
       soa.resizeArrays(cell.numParticles());
 
       if (cell.numParticles() == 0) return;
 
-      unsigned long *const __restrict__ idptr = soa.template begin<Particle::AttributeNames::id>();
-      double *const __restrict__ xptr = soa.template begin<Particle::AttributeNames::posX>();
-      double *const __restrict__ yptr = soa.template begin<Particle::AttributeNames::posY>();
-      double *const __restrict__ zptr = soa.template begin<Particle::AttributeNames::posZ>();
+      unsigned long *const __restrict__ idptr = soa.template begin<AttributeNames::id>();
+      double *const __restrict__ xptr = soa.template begin<AttributeNames::posX>();
+      double *const __restrict__ yptr = soa.template begin<AttributeNames::posY>();
+      double *const __restrict__ zptr = soa.template begin<AttributeNames::posZ>();
 
       auto cellIter = cell.begin();
       // load particles in SoAs
@@ -140,7 +148,7 @@ class VerletListHelpers {
       }
     }
 
-    virtual void SoAExtractor(ParticleCell &cell, SoA<Particle> &soa, size_t offset = 0) override {
+    virtual void SoAExtractor(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override {
       // nothing yet...
     }
 
@@ -156,8 +164,10 @@ class VerletListHelpers {
    * If the pair is not present in the list the neigborhood lists are invalid
    * and neighborlistsAreValid()  will return false.
    * @todo: SoA?
+   * @tparam ParticleCell
    */
-  class VerletListValidityCheckerFunctor : public autopas::Functor<Particle, ParticleCell> {
+  template <class ParticleCell>
+  class VerletListValidityCheckerFunctor : public autopas::Functor<Particle, ParticleCell, SoAArraysType> {
    public:
     /**
      * Constructor

--- a/src/containers/VerletListHelpers.h
+++ b/src/containers/VerletListHelpers.h
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <atomic>
+#include "cells/FullParticleCell.h"
+#include "pairwiseFunctors/Functor.h"
 namespace autopas {
 
 /**
@@ -26,12 +28,16 @@ class VerletListHelpers {
   /// attributes for soa's of verlet list's linked cells (only id and position needs to be stored)
   enum AttributeNames : int { id, posX, posY, posZ };
 
+  /// typedef for verlet-list particle cell type
+  typedef FullParticleCell<Particle, SoAArraysType> VerletListParticleCellType;
+
   /**
    * This functor can generate verlet lists using the typical pairwise
    * traversal.
    */
- class VerletListGeneratorFunctor : public autopas::Functor<Particle, autopas::FullParticleCell<Particle, SoAArraysType>, SoAArraysType> {
-   typedef autopas::FullParticleCell<Particle, SoAArraysType> ParticleCell;
+  class VerletListGeneratorFunctor : public autopas::Functor<Particle, VerletListParticleCellType, SoAArraysType> {
+    typedef VerletListParticleCellType ParticleCell;
+
    public:
     /**
      * Constructor
@@ -57,8 +63,7 @@ class VerletListHelpers {
     void SoAFunctor(SoA<SoAArraysType> &soa, bool /*newton3*/ = true) override {
       if (soa.getNumParticles() == 0) return;
 
-      Particle **const __restrict__ idptr =
-          reinterpret_cast<Particle **const>(soa.begin<AttributeNames::id>());
+      Particle **const __restrict__ idptr = reinterpret_cast<Particle **const>(soa.begin<AttributeNames::id>());
       double *const __restrict__ xptr = soa.begin<AttributeNames::posX>();
       double *const __restrict__ yptr = soa.begin<AttributeNames::posY>();
       double *const __restrict__ zptr = soa.begin<AttributeNames::posZ>();
@@ -88,14 +93,12 @@ class VerletListHelpers {
     void SoAFunctor(SoA<SoAArraysType> &soa1, SoA<SoAArraysType> &soa2, bool /*newton3*/ = true) override {
       if (soa1.getNumParticles() == 0 || soa2.getNumParticles() == 0) return;
 
-      Particle **const __restrict__ id1ptr =
-          reinterpret_cast<Particle **const>(soa1.begin<AttributeNames::id>());
+      Particle **const __restrict__ id1ptr = reinterpret_cast<Particle **const>(soa1.begin<AttributeNames::id>());
       double *const __restrict__ x1ptr = soa1.begin<AttributeNames::posX>();
       double *const __restrict__ y1ptr = soa1.begin<AttributeNames::posY>();
       double *const __restrict__ z1ptr = soa1.begin<AttributeNames::posZ>();
 
-      Particle **const __restrict__ id2ptr =
-          reinterpret_cast<Particle **const>(soa2.begin<AttributeNames::id>());
+      Particle **const __restrict__ id2ptr = reinterpret_cast<Particle **const>(soa2.begin<AttributeNames::id>());
       double *const __restrict__ x2ptr = soa2.begin<AttributeNames::posX>();
       double *const __restrict__ y2ptr = soa2.begin<AttributeNames::posY>();
       double *const __restrict__ z2ptr = soa2.begin<AttributeNames::posZ>();

--- a/src/containers/VerletLists.h
+++ b/src/containers/VerletLists.h
@@ -65,10 +65,6 @@ class VerletLists : public ParticleContainer<Particle, ParticleCell> {
         _soa(),
         _buildVerletListType(buildVerletListType) {}
 
-  void iteratePairwiseAoS(Functor<Particle, ParticleCell, typename Particle::SoAArraysType>* f,
-                          bool useNewton3 = true) override {
-    iteratePairwiseAoS2(f, useNewton3);
-  }
 
   /**
    * @copydoc LinkedCells::iteratePairwiseAoS2
@@ -85,11 +81,6 @@ class VerletLists : public ParticleContainer<Particle, ParticleCell> {
     this->iterateVerletListsAoS(f, useNewton3);
     // we iterated, so increase traversal counter
     _traversalsSinceLastRebuild++;
-  }
-
-  void iteratePairwiseSoA(Functor<Particle, ParticleCell, typename Particle::SoAArraysType>* f,
-                          bool useNewton3 = true) override {
-    iteratePairwiseSoA2(f, useNewton3);
   }
 
   /**

--- a/src/containers/VerletLists.h
+++ b/src/containers/VerletLists.h
@@ -25,9 +25,9 @@ namespace autopas {
  * @todo deleting particles should also invalidate the verlet lists - should be
  * implemented somehow
  */
-template <class Particle, class ParticleCell>
+template <class Particle, class ParticleCell = FullParticleCell<Particle, typename VerletListHelpers<Particle>::SoAArraysType>>
 class VerletLists : public LinkedCells<Particle, ParticleCell> {
-  typedef VerletListHelpers<Particle, ParticleCell> verlet_internal;
+  typedef VerletListHelpers<Particle> verlet_internal;
 
  public:
   /**
@@ -64,7 +64,8 @@ class VerletLists : public LinkedCells<Particle, ParticleCell> {
         _soa(),
         _buildVerletListType(buildVerletListType) {}
 
-  void iteratePairwiseAoS(Functor<Particle, ParticleCell>* f, bool useNewton3 = true) override {
+  void iteratePairwiseAoS(Functor<Particle, ParticleCell, typename Particle::SoAArraysType>* f,
+                          bool useNewton3 = true) override {
     iteratePairwiseAoS2(f, useNewton3);
   }
 
@@ -85,7 +86,8 @@ class VerletLists : public LinkedCells<Particle, ParticleCell> {
     _traversalsSinceLastRebuild++;
   }
 
-  void iteratePairwiseSoA(Functor<Particle, ParticleCell>* f, bool useNewton3 = true) override {
+  void iteratePairwiseSoA(Functor<Particle, ParticleCell, typename Particle::SoAArraysType>* f,
+                          bool useNewton3 = true) override {
     iteratePairwiseSoA2(f, useNewton3);
   }
 
@@ -171,7 +173,7 @@ class VerletLists : public LinkedCells<Particle, ParticleCell> {
     }
 
     // particles can also simply be very close already:
-    typename verlet_internal::VerletListValidityCheckerFunctor validityCheckerFunctor(
+    typename verlet_internal::template VerletListValidityCheckerFunctor<ParticleCell> validityCheckerFunctor(
         _aosNeighborLists, ((this->getCutoff() - _skin) * (this->getCutoff() - _skin)));
 
     LinkedCells<Particle, ParticleCell>::iteratePairwiseAoS2(&validityCheckerFunctor, useNewton3);
@@ -262,7 +264,7 @@ class VerletLists : public LinkedCells<Particle, ParticleCell> {
    */
   virtual void updateVerletListsAoS(bool useNewton3) {
     updateIdMapAoS();
-    typename verlet_internal::VerletListGeneratorFunctor f(_aosNeighborLists, (this->getCutoff() * this->getCutoff()));
+    typename verlet_internal::template VerletListGeneratorFunctor<ParticleCell> f(_aosNeighborLists, (this->getCutoff() * this->getCutoff()));
 
     switch (_buildVerletListType) {
       case BuildVerletListType::VerletAoS:
@@ -442,7 +444,7 @@ class VerletLists : public LinkedCells<Particle, ParticleCell> {
   bool _soaListIsValid;
 
   /// global SoA of verlet lists
-  SoA<Particle> _soa;
+  SoA<typename Particle::SoAArraysType> _soa;
 
   /// specifies how the verlet lists are build
   BuildVerletListType _buildVerletListType;

--- a/src/containers/VerletLists.h
+++ b/src/containers/VerletLists.h
@@ -22,13 +22,13 @@ namespace autopas {
  * Cells are created using a cell size of at least cutoff + skin radius.
  * @note This class does NOT work with RMM cells and is not intended to!
  * @tparam Particle
- * @tparam ParticleCell
  * @todo deleting particles should also invalidate the verlet lists - should be
  * implemented somehow
  */
-template <class Particle, class ParticleCell = FullParticleCell<Particle>>
-class VerletLists : public ParticleContainer<Particle, ParticleCell> {
+template <class Particle>
+class VerletLists : public ParticleContainer<Particle, autopas::FullParticleCell<Particle>> {
   typedef VerletListHelpers<Particle> verlet_internal;
+  typedef FullParticleCell<Particle> ParticleCell;
 
  public:
   /**
@@ -70,7 +70,7 @@ class VerletLists : public ParticleContainer<Particle, ParticleCell> {
    * @copydoc LinkedCells::iteratePairwiseAoS
    */
   template <class ParticleFunctor>
-  void iteratePairwiseAoS(ParticleFunctor *f, bool useNewton3 = true) {
+  void iteratePairwiseAoS(ParticleFunctor* f, bool useNewton3 = true) {
     if (needsRebuild()) {  // if we need to rebuild the list, we should rebuild
                            // it!
       this->updateVerletListsAoS(useNewton3);
@@ -87,7 +87,7 @@ class VerletLists : public ParticleContainer<Particle, ParticleCell> {
    * @copydoc LinkedCells::iteratePairwiseSoA
    */
   template <class ParticleFunctor>
-  void iteratePairwiseSoA(ParticleFunctor *f, bool useNewton3 = true) {
+  void iteratePairwiseSoA(ParticleFunctor* f, bool useNewton3 = true) {
     if (needsRebuild()) {
       this->updateVerletListsAoS(useNewton3);
       // the neighbor list is now valid
@@ -270,7 +270,8 @@ class VerletLists : public ParticleContainer<Particle, ParticleCell> {
     typename verlet_internal::VerletListGeneratorFunctor f(_aosNeighborLists, (this->getCutoff() * this->getCutoff()));
 
     switch (_buildVerletListType) {
-      case BuildVerletListType::VerletAoS:_linkedCells.iteratePairwiseAoS(&f, useNewton3);
+      case BuildVerletListType::VerletAoS:
+        _linkedCells.iteratePairwiseAoS(&f, useNewton3);
         break;
       case BuildVerletListType::VerletSoA:
         _linkedCells.iteratePairwiseSoA(&f, useNewton3);

--- a/src/containers/VerletLists.h
+++ b/src/containers/VerletLists.h
@@ -67,10 +67,10 @@ class VerletLists : public ParticleContainer<Particle, ParticleCell> {
         _buildVerletListType(buildVerletListType) {}
 
   /**
-   * @copydoc LinkedCells::iteratePairwiseAoS2
+   * @copydoc LinkedCells::iteratePairwiseAoS
    */
   template <class ParticleFunctor>
-  void iteratePairwiseAoS2(ParticleFunctor* f, bool useNewton3 = true) {
+  void iteratePairwiseAoS(ParticleFunctor *f, bool useNewton3 = true) {
     if (needsRebuild()) {  // if we need to rebuild the list, we should rebuild
                            // it!
       this->updateVerletListsAoS(useNewton3);
@@ -84,10 +84,10 @@ class VerletLists : public ParticleContainer<Particle, ParticleCell> {
   }
 
   /**
-   * @copydoc LinkedCells::iteratePairwiseSoA2
+   * @copydoc LinkedCells::iteratePairwiseSoA
    */
   template <class ParticleFunctor>
-  void iteratePairwiseSoA2(ParticleFunctor* f, bool useNewton3 = true) {
+  void iteratePairwiseSoA(ParticleFunctor *f, bool useNewton3 = true) {
     if (needsRebuild()) {
       this->updateVerletListsAoS(useNewton3);
       // the neighbor list is now valid
@@ -168,7 +168,7 @@ class VerletLists : public ParticleContainer<Particle, ParticleCell> {
     typename verlet_internal::template VerletListValidityCheckerFunctor<ParticleCell> validityCheckerFunctor(
         _aosNeighborLists, ((this->getCutoff() - _skin) * (this->getCutoff() - _skin)));
 
-    _linkedCells.iteratePairwiseAoS2(&validityCheckerFunctor, useNewton3);
+    _linkedCells.iteratePairwiseAoS(&validityCheckerFunctor, useNewton3);
 
     return validityCheckerFunctor.neighborlistsAreValid();
   }
@@ -270,11 +270,10 @@ class VerletLists : public ParticleContainer<Particle, ParticleCell> {
     typename verlet_internal::VerletListGeneratorFunctor f(_aosNeighborLists, (this->getCutoff() * this->getCutoff()));
 
     switch (_buildVerletListType) {
-      case BuildVerletListType::VerletAoS:
-        _linkedCells.iteratePairwiseAoS2(&f, useNewton3);
+      case BuildVerletListType::VerletAoS:_linkedCells.iteratePairwiseAoS(&f, useNewton3);
         break;
       case BuildVerletListType::VerletSoA:
-        _linkedCells.iteratePairwiseSoA2(&f, useNewton3);
+        _linkedCells.iteratePairwiseSoA(&f, useNewton3);
         break;
       default:
         utils::ExceptionHandler::exception("VerletLists::updateVerletListsAoS(): unsupported BuildVerletListType: {}",

--- a/src/containers/VerletLists.h
+++ b/src/containers/VerletLists.h
@@ -430,7 +430,7 @@ class VerletLists : public ParticleContainer<Particle, ParticleCell> {
   std::vector<Particle*> _soa2aosmap;
 
   /// verlet list for SoA:
-  std::vector<std::vector<size_t, AlignedAllocator<size_t>>> _soaNeighborLists;
+  std::vector<std::vector<size_t, autopas::AlignedAllocator<size_t>>> _soaNeighborLists;
 
   /// skin radius
   double _skin;

--- a/src/containers/VerletLists.h
+++ b/src/containers/VerletLists.h
@@ -7,8 +7,8 @@
 #pragma once
 
 #include "../utils/ArrayMath.h"
-#include "ParticleContainer.h"
 #include "LinkedCells.h"
+#include "ParticleContainer.h"
 #include "VerletListHelpers.h"
 
 namespace autopas {
@@ -29,6 +29,7 @@ namespace autopas {
 template <class Particle, class ParticleCell = FullParticleCell<Particle>>
 class VerletLists : public ParticleContainer<Particle, ParticleCell> {
   typedef VerletListHelpers<Particle> verlet_internal;
+
  public:
   /**
    * Enum that specifies how the verlet lists should be build
@@ -64,7 +65,6 @@ class VerletLists : public ParticleContainer<Particle, ParticleCell> {
         _soaListIsValid(false),
         _soa(),
         _buildVerletListType(buildVerletListType) {}
-
 
   /**
    * @copydoc LinkedCells::iteratePairwiseAoS2
@@ -250,7 +250,8 @@ class VerletLists : public ParticleContainer<Particle, ParticleCell> {
    * @param particleI
    * @return
    */
-  bool checkParticleInCellAndUpdate(FullParticleCell<Particle, typename verlet_internal::SoAArraysType>& cellI, Particle& particleI) {
+  bool checkParticleInCellAndUpdate(FullParticleCell<Particle, typename verlet_internal::SoAArraysType>& cellI,
+                                    Particle& particleI) {
     for (auto iterator = cellI.begin(); iterator.isValid(); ++iterator) {
       if (iterator->getID() == particleI.getID()) {
         *iterator = particleI;
@@ -419,7 +420,9 @@ class VerletLists : public ParticleContainer<Particle, ParticleCell> {
   typename verlet_internal::AoS_verletlist_storage_type _aosNeighborLists;
 
   /// internal linked cells storage, handles Particle storage and used to build verlet lists
-  LinkedCells<Particle, FullParticleCell<Particle, typename verlet_internal::SoAArraysType>, typename verlet_internal::SoAArraysType> _linkedCells;
+  LinkedCells<Particle, FullParticleCell<Particle, typename verlet_internal::SoAArraysType>,
+              typename verlet_internal::SoAArraysType>
+      _linkedCells;
 
   /// map converting from the aos type index (Particle *) to the soa type index
   /// (continuous, size_t)
@@ -453,7 +456,6 @@ class VerletLists : public ParticleContainer<Particle, ParticleCell> {
 
   /// specifies how the verlet lists are build
   BuildVerletListType _buildVerletListType;
-
 };
 
 }  // namespace autopas

--- a/src/containers/VerletLists.h
+++ b/src/containers/VerletLists.h
@@ -183,13 +183,13 @@ class VerletLists : public ParticleContainer<Particle, ParticleCell> {
   }
 
   bool isContainerUpdateNeeded() override {
-    for (size_t cellIndex1d = 0; cellIndex1d < this->_data.size(); ++cellIndex1d) {
+    for (size_t cellIndex1d = 0; cellIndex1d < _linkedCells.getData().size(); ++cellIndex1d) {
       std::array<double, 3> boxmin{0., 0., 0.};
       std::array<double, 3> boxmax{0., 0., 0.};
       _linkedCells.getCellBlock().getCellBoundingBox(cellIndex1d, boxmin, boxmax);
       boxmin = ArrayMath::addScalar(boxmin, -_skin / 2.);
       boxmax = ArrayMath::addScalar(boxmax, +_skin / 2.);
-      for (auto iter = this->_data[cellIndex1d].begin(); iter.isValid(); ++iter) {
+      for (auto iter = _linkedCells.getData()[cellIndex1d].begin(); iter.isValid(); ++iter) {
         if (not iter->inBox(boxmin, boxmax)) {
           AutoPasLogger->debug(
               "VerletLists: containerUpdate needed! Particles are fast. You "
@@ -365,7 +365,7 @@ class VerletLists : public ParticleContainer<Particle, ParticleCell> {
   template <class ParticleFunctor>
   void loadVerletSoA(ParticleFunctor* functor) {
     size_t offset = 0;
-    for (auto& cell : this->_data) {
+    for (auto& cell : _linkedCells.getData()) {
       functor->SoALoader(cell, _soa, offset);
       offset += cell.numParticles();
     }
@@ -381,7 +381,7 @@ class VerletLists : public ParticleContainer<Particle, ParticleCell> {
   template <class ParticleFunctor>
   void extractVerletSoA(ParticleFunctor* functor) {
     size_t offset = 0;
-    for (auto& cell : this->_data) {
+    for (auto& cell : _linkedCells.getData()) {
       functor->SoAExtractor(cell, _soa, offset);
       offset += cell.numParticles();
     }

--- a/src/pairwiseFunctors/CellFunctor.h
+++ b/src/pairwiseFunctors/CellFunctor.h
@@ -89,7 +89,7 @@ class CellFunctor {
       for (; inner.isValid(); ++inner) {
         Particle &p2 = *inner;
 
-        _functor->AoSFunctor(p1, p2);
+        _functor->AoSFunctor(p1, p2, true);
       }
     }
   }
@@ -135,7 +135,7 @@ class CellFunctor {
       for (auto inner = cell2.begin(); inner.isValid(); ++inner) {
         Particle &p2 = *inner;
 
-        _functor->AoSFunctor(p1, p2);
+        _functor->AoSFunctor(p1, p2, true);
       }
     }
   }

--- a/src/pairwiseFunctors/FlopCounterFunctor.h
+++ b/src/pairwiseFunctors/FlopCounterFunctor.h
@@ -29,7 +29,7 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell, SoAArraysType>
    * constructor of FlopCounterFunctor
    * @param cutoffRadius the cutoff radius
    */
-  explicit FlopCounterFunctor<Particle, ParticleCell>(double cutoffRadius)
+  explicit FlopCounterFunctor<Particle, ParticleCell, SoAArraysType>(double cutoffRadius)
       : autopas::Functor<Particle, ParticleCell, SoAArraysType>(),
         _cutoffSquare(cutoffRadius * cutoffRadius),
         _distanceCalculations(0ul),

--- a/src/pairwiseFunctors/FlopCounterFunctor.h
+++ b/src/pairwiseFunctors/FlopCounterFunctor.h
@@ -159,7 +159,8 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell, SoAArraysType>
       })
 
   /**
-   * empty SoAExtractor
+   * empty SoAExtractor.
+   * nothing to be done yet.
    */
   AUTOPAS_FUNCTOR_SOAEXTRACTOR(, , , )
 

--- a/src/pairwiseFunctors/FlopCounterFunctor.h
+++ b/src/pairwiseFunctors/FlopCounterFunctor.h
@@ -158,9 +158,10 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell, SoAArraysType>
         zptr[i] = cellIter->getR()[2];
       })
 
-  AUTOPAS_FUNCTOR_SOAEXTRACTOR(, , ,
-                               // no body needed, but definition
-  )
+  /**
+   * empty SoAExtractor
+   */
+  AUTOPAS_FUNCTOR_SOAEXTRACTOR(, , , )
 
   /**
    * get the hit rate of the pair-wise interaction, i.e. the ratio of the number

--- a/src/pairwiseFunctors/FlopCounterFunctor.h
+++ b/src/pairwiseFunctors/FlopCounterFunctor.h
@@ -22,15 +22,17 @@ namespace autopas {
  * @tparam Particle
  * @tparam ParticleCell
  */
-template <class Particle, class ParticleCell, class SoAArraysType = typename Particle::SoAArraysType>
-class FlopCounterFunctor : public Functor<Particle, ParticleCell, SoAArraysType> {
+template <class Particle, class ParticleCell>
+class FlopCounterFunctor : public Functor<Particle, ParticleCell> {
+  typedef typename Particle::SoAArraysType SoAArraysType;
+
  public:
   /**
    * constructor of FlopCounterFunctor
    * @param cutoffRadius the cutoff radius
    */
-  explicit FlopCounterFunctor<Particle, ParticleCell, SoAArraysType>(double cutoffRadius)
-      : autopas::Functor<Particle, ParticleCell, SoAArraysType>(),
+  explicit FlopCounterFunctor<Particle, ParticleCell>(double cutoffRadius)
+      : autopas::Functor<Particle, ParticleCell>(),
         _cutoffSquare(cutoffRadius * cutoffRadius),
         _distanceCalculations(0ul),
         _kernelCalls(0ul) {}

--- a/src/pairwiseFunctors/FlopCounterFunctor.h
+++ b/src/pairwiseFunctors/FlopCounterFunctor.h
@@ -159,7 +159,7 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell, SoAArraysType>
       })
 
   AUTOPAS_FUNCTOR_SOAEXTRACTOR(, , ,
-  // no body needed, but definition
+                               // no body needed, but definition
   )
 
   /**

--- a/src/pairwiseFunctors/FlopCounterFunctor.h
+++ b/src/pairwiseFunctors/FlopCounterFunctor.h
@@ -35,7 +35,7 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell, SoAArraysType>
         _distanceCalculations(0ul),
         _kernelCalls(0ul) {}
 
-  void AoSFunctor(Particle &i, Particle &j, bool newton3 = true) override {
+  void AoSFunctor(Particle &i, Particle &j, bool newton3) override {
     auto dr = ArrayMath::sub(i.getR(), j.getR());
     double dr2 = ArrayMath::dot(dr, dr);
 #ifdef AUTOPAS_OPENMP
@@ -48,7 +48,7 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell, SoAArraysType>
     };
   }
 
-  void SoAFunctor(SoA<SoAArraysType> &soa, bool newton3 = true) override {
+  void SoAFunctor(SoA<SoAArraysType> &soa, bool newton3) override {
     if (soa.getNumParticles() == 0) return;
 
     double *const __restrict__ x1ptr = soa.template begin<Particle::AttributeNames::posX>();
@@ -87,7 +87,7 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell, SoAArraysType>
     }
   }
 
-  void SoAFunctor(SoA<SoAArraysType> &soa1, SoA<SoAArraysType> &soa2, bool newton3 = true) override {
+  void SoAFunctor(SoA<SoAArraysType> &soa1, SoA<SoAArraysType> &soa2, bool newton3) override {
     double *const __restrict__ x1ptr = soa1.template begin<Particle::AttributeNames::posX>();
     double *const __restrict__ y1ptr = soa1.template begin<Particle::AttributeNames::posY>();
     double *const __restrict__ z1ptr = soa1.template begin<Particle::AttributeNames::posZ>();
@@ -133,7 +133,7 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell, SoAArraysType>
 
   void SoAFunctor(SoA<SoAArraysType> &soa,
                   const std::vector<std::vector<size_t, autopas::AlignedAllocator<size_t>>> &neighborList, size_t iFrom,
-                  size_t iTo, bool newton3 = true) override {
+                  size_t iTo, bool newton3) override {
     utils::ExceptionHandler::exception("Functor::SoAFunctor(verlet): not yet implemented");
   }
 

--- a/src/pairwiseFunctors/FlopCounterFunctor.h
+++ b/src/pairwiseFunctors/FlopCounterFunctor.h
@@ -22,15 +22,15 @@ namespace autopas {
  * @tparam Particle
  * @tparam ParticleCell
  */
-template <class Particle, class ParticleCell>
-class FlopCounterFunctor : public Functor<Particle, ParticleCell> {
+template <class Particle, class ParticleCell, class SoAArraysType = typename Particle::SoAArraysType>
+class FlopCounterFunctor : public Functor<Particle, ParticleCell, SoAArraysType> {
  public:
   /**
    * constructor of FlopCounterFunctor
    * @param cutoffRadius the cutoff radius
    */
   explicit FlopCounterFunctor<Particle, ParticleCell>(double cutoffRadius)
-      : autopas::Functor<Particle, ParticleCell>(),
+      : autopas::Functor<Particle, ParticleCell, SoAArraysType>(),
         _cutoffSquare(cutoffRadius * cutoffRadius),
         _distanceCalculations(0ul),
         _kernelCalls(0ul) {}
@@ -48,7 +48,7 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell> {
     };
   }
 
-  void SoAFunctor(SoA<Particle> &soa, bool newton3 = true) override {
+  void SoAFunctor(SoA<SoAArraysType> &soa, bool newton3 = true) override {
     if (soa.getNumParticles() == 0) return;
 
     double *const __restrict__ x1ptr = soa.template begin<Particle::AttributeNames::posX>();
@@ -87,7 +87,7 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell> {
     }
   }
 
-  void SoAFunctor(SoA<Particle> &soa1, SoA<Particle> &soa2, bool newton3 = true) override {
+  void SoAFunctor(SoA<SoAArraysType> &soa1, SoA<SoAArraysType> &soa2, bool newton3 = true) override {
     double *const __restrict__ x1ptr = soa1.template begin<Particle::AttributeNames::posX>();
     double *const __restrict__ y1ptr = soa1.template begin<Particle::AttributeNames::posY>();
     double *const __restrict__ z1ptr = soa1.template begin<Particle::AttributeNames::posZ>();
@@ -131,7 +131,7 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell> {
     }
   }
 
-  void SoALoader(ParticleCell &cell, SoA<Particle> &soa, size_t offset = 0) override {
+  void SoALoader(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override {
     soa.resizeArrays(offset + cell.numParticles());
 
     if (cell.numParticles() == 0) return;
@@ -151,7 +151,7 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell> {
     }
   }
 
-  void SoAExtractor(ParticleCell &cell, SoA<Particle> &soa, size_t offset = 0) override {}
+  void SoAExtractor(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override {}
   /**
    * get the hit rate of the pair-wise interaction, i.e. the ratio of the number
    * of kernel calls compared to the number of distance calculations

--- a/src/pairwiseFunctors/FlopCounterFunctor.h
+++ b/src/pairwiseFunctors/FlopCounterFunctor.h
@@ -131,27 +131,33 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell, SoAArraysType>
     }
   }
 
-  void SoALoader(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override {
-    soa.resizeArrays(offset + cell.numParticles());
-
-    if (cell.numParticles() == 0) return;
-
-    unsigned long *const __restrict__ idptr = soa.template begin<Particle::AttributeNames::id>();
-    double *const __restrict__ xptr = soa.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict__ yptr = soa.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict__ zptr = soa.template begin<Particle::AttributeNames::posZ>();
-
-    auto cellIter = cell.begin();
-    // load particles in SoAs
-    for (size_t i = offset; cellIter.isValid(); ++cellIter, ++i) {
-      idptr[i] = cellIter->getID();
-      xptr[i] = cellIter->getR()[0];
-      yptr[i] = cellIter->getR()[1];
-      zptr[i] = cellIter->getR()[2];
-    }
+  void SoAFunctor(SoA<SoAArraysType> &soa,
+                  const std::vector<std::vector<size_t, autopas::AlignedAllocator<size_t>>> &neighborList, size_t iFrom,
+                  size_t iTo, bool newton3 = true) override {
+    utils::ExceptionHandler::exception("Functor::SoAFunctor(verlet): not yet implemented");
   }
 
-  void SoAExtractor(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override {}
+  AUTOPAS_FUNCTOR_SOALOADER(
+      soa.resizeArrays(offset + cell.numParticles());
+
+      if (cell.numParticles() == 0) return;
+
+      unsigned long *const __restrict__ idptr = soa.template begin<Particle::AttributeNames::id>();
+      double *const __restrict__ xptr = soa.template begin<Particle::AttributeNames::posX>();
+      double *const __restrict__ yptr = soa.template begin<Particle::AttributeNames::posY>();
+      double *const __restrict__ zptr = soa.template begin<Particle::AttributeNames::posZ>();
+
+      auto cellIter = cell.begin();
+      // load particles in SoAs
+      for (size_t i = offset; cellIter.isValid(); ++cellIter, ++i) {
+        idptr[i] = cellIter->getID();
+        xptr[i] = cellIter->getR()[0];
+        yptr[i] = cellIter->getR()[1];
+        zptr[i] = cellIter->getR()[2];
+      })
+
+  AUTOPAS_FUNCTOR_SOAEXTRACTOR()
+
   /**
    * get the hit rate of the pair-wise interaction, i.e. the ratio of the number
    * of kernel calls compared to the number of distance calculations

--- a/src/pairwiseFunctors/FlopCounterFunctor.h
+++ b/src/pairwiseFunctors/FlopCounterFunctor.h
@@ -138,6 +138,8 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell, SoAArraysType>
   }
 
   AUTOPAS_FUNCTOR_SOALOADER(
+      cell, soa, offset,
+      // body start
       soa.resizeArrays(offset + cell.numParticles());
 
       if (cell.numParticles() == 0) return;
@@ -156,7 +158,9 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell, SoAArraysType>
         zptr[i] = cellIter->getR()[2];
       })
 
-  AUTOPAS_FUNCTOR_SOAEXTRACTOR()
+  AUTOPAS_FUNCTOR_SOAEXTRACTOR(, , ,
+  // no body needed, but definition
+  )
 
   /**
    * get the hit rate of the pair-wise interaction, i.e. the ratio of the number

--- a/src/pairwiseFunctors/Functor.h
+++ b/src/pairwiseFunctors/Functor.h
@@ -43,7 +43,7 @@ class Functor {
    * @param j Particle j
    * @param newton3 defines whether or whether not to use newton 3
    */
-  virtual void AoSFunctor(Particle &i, Particle &j, bool newton3 = true) {
+  virtual void AoSFunctor(Particle &i, Particle &j, bool newton3) {
     utils::ExceptionHandler::exception("Functor::AoSFunctor: not yet implemented");
   }
 
@@ -57,7 +57,7 @@ class Functor {
    * @param soa Structure of arrays
    * @param newton3 defines whether or whether not to use newton 3
    */
-  virtual void SoAFunctor(SoA<SoAArraysType> &soa, bool newton3 = true) {
+  virtual void SoAFunctor(SoA<SoAArraysType> &soa, bool newton3) {
     utils::ExceptionHandler::exception("Functor::SoAFunctor(one soa): not yet implemented");
   }
 
@@ -82,7 +82,7 @@ class Functor {
    */
   virtual void SoAFunctor(SoA<SoAArraysType> &soa,
                           const std::vector<std::vector<size_t, autopas::AlignedAllocator<size_t>>> &neighborList,
-                          size_t iFrom, size_t iTo, bool newton3 = true) {
+                          size_t iFrom, size_t iTo, bool newton3) {
     utils::ExceptionHandler::exception("Functor::SoAFunctor(verlet): not yet implemented");
   }
 
@@ -97,7 +97,7 @@ class Functor {
    * @param soa2 Second structure of arrays.
    * @param newton3 defines whether or whether not to use newton 3
    */
-  virtual void SoAFunctor(SoA<SoAArraysType> &soa1, SoA<SoAArraysType> &soa2, bool newton3 = true) {
+  virtual void SoAFunctor(SoA<SoAArraysType> &soa1, SoA<SoAArraysType> &soa2, bool newton3) {
     utils::ExceptionHandler::exception("Functor::SoAFunctor(two soa): not yet implemented");
   }
 

--- a/src/pairwiseFunctors/Functor.h
+++ b/src/pairwiseFunctors/Functor.h
@@ -160,8 +160,7 @@ class Functor {
 #define AUTOPAS_FUNCTOR_SOALOADER(cell, soa, offset, body)                                                        \
   void SoALoader(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override { body }                \
   /** @copydoc SoALoader(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset) */                           \
-  template <typename /*dummy*/ = void,                                                                            \
-            typename = std::enable_if_t<not std::is_same<                                                         \
+  template <typename = std::enable_if_t<not std::is_same<                                                         \
                 typename VerletListHelpers<Particle>::VerletListParticleCellType, ParticleCell>::value>>          \
   void SoALoader(typename VerletListHelpers<Particle>::VerletListParticleCellType &cell, SoA<SoAArraysType> &soa, \
                  size_t offset = 0) {                                                                             \
@@ -181,8 +180,7 @@ class Functor {
 #define AUTOPAS_FUNCTOR_SOAEXTRACTOR(cell, soa, offset, body)                                                        \
   void SoAExtractor(ParticleCell &cell, ::autopas::SoA<SoAArraysType> &soa, size_t offset = 0) override { body }     \
   /** @copydoc SoAExtractor(ParticleCell &, ::autopas::SoA<SoAArraysType> &, size_t) */                              \
-  template <typename /*dummy*/ = void,                                                                               \
-            typename = std::enable_if_t<not std::is_same<                                                            \
+  template <typename = std::enable_if_t<not std::is_same<                                                            \
                 typename VerletListHelpers<Particle>::VerletListParticleCellType, ParticleCell>::value>>             \
   void SoAExtractor(typename VerletListHelpers<Particle>::VerletListParticleCellType &cell, SoA<SoAArraysType> &soa, \
                     size_t offset = 0) {                                                                             \

--- a/src/pairwiseFunctors/Functor.h
+++ b/src/pairwiseFunctors/Functor.h
@@ -25,7 +25,7 @@ namespace autopas {
  * @tparam Particle the type of Particle
  * @tparam ParticleCell the type of ParticleCell
  */
-template <class Particle, class ParticleCell>
+template <class Particle, class ParticleCell, class SoAArraysType>
 class Functor {
  public:
   virtual ~Functor() = default;
@@ -54,7 +54,7 @@ class Functor {
    * @param soa Structure of arrays
    * @param newton3 defines whether or whether not to use newton 3
    */
-  virtual void SoAFunctor(SoA<Particle> &soa, bool newton3 = true) {
+  virtual void SoAFunctor(SoA<SoAArraysType> &soa, bool newton3 = true) {
     utils::ExceptionHandler::exception("Functor::SoAFunctor(one soa): not yet implemented");
   }
 
@@ -77,7 +77,7 @@ class Functor {
    * least iFrom and less than soa.size())
    * @param newton3 defines whether or whether not to use newton 3
    */
-  virtual void SoAFunctor(SoA<Particle> &soa,
+  virtual void SoAFunctor(SoA<SoAArraysType> &soa,
                           const std::vector<std::vector<size_t, autopas::AlignedAllocator<size_t>>> &neighborList,
                           size_t iFrom, size_t iTo, bool newton3 = true) {
     utils::ExceptionHandler::exception("Functor::SoAFunctor(verlet): not yet implemented");
@@ -94,7 +94,7 @@ class Functor {
    * @param soa2 Second structure of arrays.
    * @param newton3 defines whether or whether not to use newton 3
    */
-  virtual void SoAFunctor(SoA<Particle> &soa1, SoA<Particle> &soa2, bool newton3 = true) {
+  virtual void SoAFunctor(SoA<SoAArraysType> &soa1, SoA<SoAArraysType> &soa2, bool newton3 = true) {
     utils::ExceptionHandler::exception("Functor::SoAFunctor(two soa): not yet implemented");
   }
 
@@ -106,8 +106,7 @@ class Functor {
    * @param offset Offset within the SoA. The data of the cell should be added
    * to the SoA with the specified offset.
    */
-
-  virtual void SoALoader(ParticleCell &cell, SoA<Particle> &soa, size_t offset = 0) {
+  virtual void SoALoader(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) {
     utils::ExceptionHandler::exception("Functor::SoALoader: not yet implemented");
   }
 
@@ -119,7 +118,7 @@ class Functor {
    * @param offset Offset within the SoA. The data of the soa should be
    * extracted starting at offset.
    */
-  virtual void SoAExtractor(ParticleCell &cell, SoA<Particle> &soa, size_t offset = 0) {
+  virtual void SoAExtractor(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) {
     utils::ExceptionHandler::exception("Functor::SoAExtractor: not yet implemented");
   }
 

--- a/src/pairwiseFunctors/Functor.h
+++ b/src/pairwiseFunctors/Functor.h
@@ -149,6 +149,7 @@ class Functor {
 
 #define AUTOPAS_FUNCTOR_SOALOADER(body)                                                                           \
   void SoALoader(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override { body }                \
+                                                                                                                  \
   template <typename /*dummy*/ = void,                                                                            \
             typename = std::enable_if_t<not std::is_same<                                                         \
                 typename VerletListHelpers<Particle>::VerletListParticleCellType, ParticleCell>::value>>          \
@@ -158,7 +159,8 @@ class Functor {
   }
 
 #define AUTOPAS_FUNCTOR_SOAEXTRACTOR(body)                                                                           \
-  void SoAExtractor(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override { body }                \
+  void SoAExtractor(ParticleCell &cell, ::autopas::SoA<SoAArraysType> &soa, size_t offset = 0) override { body }     \
+                                                                                                                     \
   template <typename /*dummy*/ = void,                                                                               \
             typename = std::enable_if_t<not std::is_same<                                                            \
                 typename VerletListHelpers<Particle>::VerletListParticleCellType, ParticleCell>::value>>             \

--- a/src/pairwiseFunctors/Functor.h
+++ b/src/pairwiseFunctors/Functor.h
@@ -157,11 +157,11 @@ class Functor {
  * @note generates two loaders, one for verlet lists, one for the normal case.
  * @note the need for this could be removed if the soa's are removed from the particlecells (highly unlikely)
  */
-#define AUTOPAS_FUNCTOR_SOALOADER(cell, soa, offset, body)                                                   \
-  void SoALoader(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override { body }            \
+#define AUTOPAS_FUNCTOR_SOALOADER(cell, soa, offset, body)                                                        \
+  void SoALoader(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override { body }                \
   /**                                                                                                             \
    * @copydoc SoALoader(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset)                               \
-   * @note verlet list variant                                                                                          \
+   * @note verlet list variant                                                                                    \
    */                                                                                                             \
   template <typename /*dummy*/ = void,                                                                            \
             typename = std::enable_if_t<not std::is_same<                                                         \
@@ -181,10 +181,10 @@ class Functor {
  * @note generates two extractors, one for verlet lists, one for the normal case.
  * @note the need for this could be removed if the soa's are removed from the particlecells (highly unlikely)
  */
-#define AUTOPAS_FUNCTOR_SOAEXTRACTOR(cell, soa, offset, body)                                                   \
+#define AUTOPAS_FUNCTOR_SOAEXTRACTOR(cell, soa, offset, body)                                                        \
   void SoAExtractor(ParticleCell &cell, ::autopas::SoA<SoAArraysType> &soa, size_t offset = 0) override { body }     \
   /**                                                                                                                \
-   * @copydoc SoAExtractor(ParticleCell &, ::autopas::SoA<SoAArraysType> &, size_t)                               \
+   * @copydoc SoAExtractor(ParticleCell &, ::autopas::SoA<SoAArraysType> &, size_t)                                  \
    * @note verlet list variant                                                                                       \
    */                                                                                                                \
   template <typename /*dummy*/ = void,                                                                               \

--- a/src/pairwiseFunctors/Functor.h
+++ b/src/pairwiseFunctors/Functor.h
@@ -159,10 +159,7 @@ class Functor {
  */
 #define AUTOPAS_FUNCTOR_SOALOADER(cell, soa, offset, body)                                                        \
   void SoALoader(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override { body }                \
-  /**                                                                                                             \
-   * @copydoc SoALoader(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset)                               \
-   * @note verlet list variant                                                                                    \
-   */                                                                                                             \
+  /** @copydoc SoALoader(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset) */                           \
   template <typename /*dummy*/ = void,                                                                            \
             typename = std::enable_if_t<not std::is_same<                                                         \
                 typename VerletListHelpers<Particle>::VerletListParticleCellType, ParticleCell>::value>>          \
@@ -183,10 +180,7 @@ class Functor {
  */
 #define AUTOPAS_FUNCTOR_SOAEXTRACTOR(cell, soa, offset, body)                                                        \
   void SoAExtractor(ParticleCell &cell, ::autopas::SoA<SoAArraysType> &soa, size_t offset = 0) override { body }     \
-  /**                                                                                                                \
-   * @copydoc SoAExtractor(ParticleCell &, ::autopas::SoA<SoAArraysType> &, size_t)                                  \
-   * @note verlet list variant                                                                                       \
-   */                                                                                                                \
+  /** @copydoc SoAExtractor(ParticleCell &, ::autopas::SoA<SoAArraysType> &, size_t) */                              \
   template <typename /*dummy*/ = void,                                                                               \
             typename = std::enable_if_t<not std::is_same<                                                            \
                 typename VerletListHelpers<Particle>::VerletListParticleCellType, ParticleCell>::value>>             \

--- a/src/pairwiseFunctors/Functor.h
+++ b/src/pairwiseFunctors/Functor.h
@@ -25,7 +25,7 @@ namespace autopas {
  * @tparam Particle the type of Particle
  * @tparam ParticleCell the type of ParticleCell
  */
-template <class Particle, class ParticleCell, class SoAArraysType>
+template <class Particle, class ParticleCell, class SoAArraysType = typename Particle::SoAArraysType>
 class Functor {
  public:
   virtual ~Functor() = default;

--- a/src/pairwiseFunctors/Functor.h
+++ b/src/pairwiseFunctors/Functor.h
@@ -13,6 +13,9 @@
 
 namespace autopas {
 
+template <class Particle>
+class VerletListHelpers;
+
 /**
  * Functor class. This class describes the pairwise interactions between
  * particles.
@@ -110,6 +113,14 @@ class Functor {
     utils::ExceptionHandler::exception("Functor::SoALoader: not yet implemented");
   }
 
+  template <typename /*dummy*/ = void,
+            typename = std::enable_if_t<not std::is_same<
+                typename VerletListHelpers<Particle>::VerletListParticleCellType, ParticleCell>::value>>
+  void SoALoader(typename VerletListHelpers<Particle>::VerletListParticleCellType &cell, SoA<SoAArraysType> &soa,
+                 size_t offset = 0) {
+    utils::ExceptionHandler::exception("Functor::SoAExtractor_Verlet: not yet implemented");
+  }
+
   /**
    * @brief Copies the data stored in the soa back into the cell.
    *
@@ -120,6 +131,14 @@ class Functor {
    */
   virtual void SoAExtractor(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) {
     utils::ExceptionHandler::exception("Functor::SoAExtractor: not yet implemented");
+  }
+
+  template <typename /*dummy*/ = void,
+            typename = std::enable_if_t<not std::is_same<
+                typename VerletListHelpers<Particle>::VerletListParticleCellType, ParticleCell>::value>>
+  void SoAExtractor(typename VerletListHelpers<Particle>::VerletListParticleCellType &cell, SoA<SoAArraysType> &soa,
+                    size_t offset = 0) {
+    utils::ExceptionHandler::exception("Functor::SoAExtractor_Verlet: not yet implemented");
   }
 
   /**
@@ -144,4 +163,26 @@ class Functor {
   virtual bool allowsNonNewton3() { return false; }
 };
 
+#define AUTOPAS_FUNCTOR_SOALOADER(body)                                                                           \
+  void SoALoader(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override { body }                \
+  template <typename /*dummy*/ = void,                                                                            \
+            typename = std::enable_if_t<not std::is_same<                                                         \
+                typename VerletListHelpers<Particle>::VerletListParticleCellType, ParticleCell>::value>>          \
+  void SoALoader(typename VerletListHelpers<Particle>::VerletListParticleCellType &cell, SoA<SoAArraysType> &soa, \
+                 size_t offset = 0) {                                                                             \
+    body                                                                                                          \
+  }
+
+#define AUTOPAS_FUNCTOR_SOAEXTRACTOR(body)                                                                           \
+  void SoAExtractor(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override { body }                \
+  template <typename /*dummy*/ = void,                                                                               \
+            typename = std::enable_if_t<not std::is_same<                                                            \
+                typename VerletListHelpers<Particle>::VerletListParticleCellType, ParticleCell>::value>>             \
+  void SoAExtractor(typename VerletListHelpers<Particle>::VerletListParticleCellType &cell, SoA<SoAArraysType> &soa, \
+                    size_t offset = 0) {                                                                             \
+    body                                                                                                             \
+  }
+
 }  // namespace autopas
+
+#include "containers/VerletListHelpers.h"

--- a/src/pairwiseFunctors/Functor.h
+++ b/src/pairwiseFunctors/Functor.h
@@ -113,14 +113,6 @@ class Functor {
     utils::ExceptionHandler::exception("Functor::SoALoader: not yet implemented");
   }
 
-  template <typename /*dummy*/ = void,
-            typename = std::enable_if_t<not std::is_same<
-                typename VerletListHelpers<Particle>::VerletListParticleCellType, ParticleCell>::value>>
-  void SoALoader(typename VerletListHelpers<Particle>::VerletListParticleCellType &cell, SoA<SoAArraysType> &soa,
-                 size_t offset = 0) {
-    utils::ExceptionHandler::exception("Functor::SoAExtractor_Verlet: not yet implemented");
-  }
-
   /**
    * @brief Copies the data stored in the soa back into the cell.
    *
@@ -131,14 +123,6 @@ class Functor {
    */
   virtual void SoAExtractor(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) {
     utils::ExceptionHandler::exception("Functor::SoAExtractor: not yet implemented");
-  }
-
-  template <typename /*dummy*/ = void,
-            typename = std::enable_if_t<not std::is_same<
-                typename VerletListHelpers<Particle>::VerletListParticleCellType, ParticleCell>::value>>
-  void SoAExtractor(typename VerletListHelpers<Particle>::VerletListParticleCellType &cell, SoA<SoAArraysType> &soa,
-                    size_t offset = 0) {
-    utils::ExceptionHandler::exception("Functor::SoAExtractor_Verlet: not yet implemented");
   }
 
   /**

--- a/src/pairwiseFunctors/Functor.h
+++ b/src/pairwiseFunctors/Functor.h
@@ -148,7 +148,7 @@ class Functor {
 };
 
 /**
- * Macro to define the SoALoaders. The parameters are:
+ * Macro to define the SoALoaders.
  * @param cell name for cell like parameter
  * @param soa name for soa
  * @param offset name for offset
@@ -157,9 +157,12 @@ class Functor {
  * @note generates two loaders, one for verlet lists, one for the normal case.
  * @note the need for this could be removed if the soa's are removed from the particlecells (highly unlikely)
  */
-#define AUTOPAS_FUNCTOR_SOALOADER(cell, soa, offset, body)                                                        \
-  void SoALoader(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override { body }                \
-                                                                                                                  \
+#define AUTOPAS_FUNCTOR_SOALOADER(cell, soa, offset, body)                                                   \
+  void SoALoader(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override { body }            \
+  /**                                                                                                             \
+   * @copydoc SoALoader(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset)                               \
+   * @note verlet list variant                                                                                          \
+   */                                                                                                             \
   template <typename /*dummy*/ = void,                                                                            \
             typename = std::enable_if_t<not std::is_same<                                                         \
                 typename VerletListHelpers<Particle>::VerletListParticleCellType, ParticleCell>::value>>          \
@@ -169,7 +172,7 @@ class Functor {
   }
 
 /**
- * Macro to define the SoAExtractors. The parameters are:
+ * Macro to define the SoAExtractors.
  * @param cell name for cell like parameter
  * @param soa name for soa
  * @param offset name for offset
@@ -178,9 +181,12 @@ class Functor {
  * @note generates two extractors, one for verlet lists, one for the normal case.
  * @note the need for this could be removed if the soa's are removed from the particlecells (highly unlikely)
  */
-#define AUTOPAS_FUNCTOR_SOAEXTRACTOR(cell, soa, offset, body)                                                        \
+#define AUTOPAS_FUNCTOR_SOAEXTRACTOR(cell, soa, offset, body)                                                   \
   void SoAExtractor(ParticleCell &cell, ::autopas::SoA<SoAArraysType> &soa, size_t offset = 0) override { body }     \
-                                                                                                                     \
+  /**                                                                                                                \
+   * @copydoc SoAExtractor(ParticleCell &, ::autopas::SoA<SoAArraysType> &, size_t)                               \
+   * @note verlet list variant                                                                                       \
+   */                                                                                                                \
   template <typename /*dummy*/ = void,                                                                               \
             typename = std::enable_if_t<not std::is_same<                                                            \
                 typename VerletListHelpers<Particle>::VerletListParticleCellType, ParticleCell>::value>>             \

--- a/src/pairwiseFunctors/Functor.h
+++ b/src/pairwiseFunctors/Functor.h
@@ -147,7 +147,17 @@ class Functor {
   virtual bool allowsNonNewton3() { return false; }
 };
 
-#define AUTOPAS_FUNCTOR_SOALOADER(body)                                                                           \
+/**
+ * Macro to define the SoALoaders. The parameters are:
+ * @param cell name for cell like parameter
+ * @param soa name for soa
+ * @param offset name for offset
+ * @param body the actual function body for the soa loader
+ *
+ * @note generates two loaders, one for verlet lists, one for the normal case.
+ * @note the need for this could be removed if the soa's are removed from the particlecells (highly unlikely)
+ */
+#define AUTOPAS_FUNCTOR_SOALOADER(cell, soa, offset, body)                                                        \
   void SoALoader(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override { body }                \
                                                                                                                   \
   template <typename /*dummy*/ = void,                                                                            \
@@ -158,7 +168,17 @@ class Functor {
     body                                                                                                          \
   }
 
-#define AUTOPAS_FUNCTOR_SOAEXTRACTOR(body)                                                                           \
+/**
+ * Macro to define the SoAExtractors. The parameters are:
+ * @param cell name for cell like parameter
+ * @param soa name for soa
+ * @param offset name for offset
+ * @param body the actual function body for the soa loader
+ *
+ * @note generates two extractors, one for verlet lists, one for the normal case.
+ * @note the need for this could be removed if the soa's are removed from the particlecells (highly unlikely)
+ */
+#define AUTOPAS_FUNCTOR_SOAEXTRACTOR(cell, soa, offset, body)                                                        \
   void SoAExtractor(ParticleCell &cell, ::autopas::SoA<SoAArraysType> &soa, size_t offset = 0) override { body }     \
                                                                                                                      \
   template <typename /*dummy*/ = void,                                                                               \

--- a/src/pairwiseFunctors/LJFunctor.h
+++ b/src/pairwiseFunctors/LJFunctor.h
@@ -24,8 +24,8 @@ namespace autopas {
  * @tparam Particle the type of particle
  * @tparam ParticleCell the type of particlecell
  */
-template <class Particle, class ParticleCell>
-class LJFunctor : public Functor<Particle, ParticleCell> {
+template <class Particle, class ParticleCell, class SoAArraysType = typename Particle::SoAArraysType>
+class LJFunctor : public Functor<Particle, ParticleCell, SoAArraysType> {
  public:
   void AoSFunctor(Particle &i, Particle &j, bool newton3 = true) override {
     auto dr = ArrayMath::sub(i.getR(), j.getR());
@@ -44,7 +44,7 @@ class LJFunctor : public Functor<Particle, ParticleCell> {
     j.subF(f);
   }
 
-  void SoAFunctor(SoA<Particle> &soa, bool newton3 = true) override {
+  void SoAFunctor(SoA<SoAArraysType> &soa, bool newton3 = true) override {
     if (soa.getNumParticles() == 0) return;
 
     double *const __restrict__ xptr = soa.template begin<Particle::AttributeNames::posX>();
@@ -104,7 +104,7 @@ class LJFunctor : public Functor<Particle, ParticleCell> {
     }
   }
 
-  void SoAFunctor(SoA<Particle> &soa1, SoA<Particle> &soa2, bool newton3 = true) override {
+  void SoAFunctor(SoA<SoAArraysType> &soa1, SoA<SoAArraysType> &soa2, bool newton3 = true) override {
     if (soa1.getNumParticles() == 0 || soa2.getNumParticles() == 0) return;
 
     double *const __restrict__ x1ptr = soa1.template begin<Particle::AttributeNames::posX>();
@@ -179,7 +179,7 @@ class LJFunctor : public Functor<Particle, ParticleCell> {
    * are no dependencies, i.e. introduce colors and specify iFrom and iTo accordingly
    */
   // clang-format on
-  virtual void SoAFunctor(SoA<Particle> &soa,
+  virtual void SoAFunctor(SoA<SoAArraysType> &soa,
                           const std::vector<std::vector<size_t, autopas::AlignedAllocator<size_t>>> &neighborList,
                           size_t iFrom, size_t iTo, bool newton3 = true) override {
     auto numParts = soa.getNumParticles();
@@ -331,7 +331,7 @@ class LJFunctor : public Functor<Particle, ParticleCell> {
     }
   }
 
-  void SoALoader(ParticleCell &cell, SoA<Particle> &soa, size_t offset = 0) override {
+  void SoALoader(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override {
     /// @todo it is probably better to resize the soa only once, before calling
     /// SoALoader (verlet-list only)
     soa.resizeArrays(offset + cell.numParticles());
@@ -359,7 +359,7 @@ class LJFunctor : public Functor<Particle, ParticleCell> {
     }
   }
 
-  void SoAExtractor(ParticleCell &cell, SoA<Particle> &soa, size_t offset = 0) override {
+  void SoAExtractor(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override {
     if (soa.getNumParticles() == 0) return;
 
     auto cellIter = cell.begin();
@@ -409,16 +409,16 @@ class LJFunctor : public Functor<Particle, ParticleCell> {
 
 };  // namespace autopas
 
-template <class T, class U>
-double LJFunctor<T, U>::CUTOFFSQUARE;
+template <class T, class U, class V>
+double LJFunctor<T, U, V>::CUTOFFSQUARE;
 
-template <class T, class U>
-double LJFunctor<T, U>::EPSILON24;
+template <class T, class U, class V>
+double LJFunctor<T, U, V>::EPSILON24;
 
-template <class T, class U>
-double LJFunctor<T, U>::SIGMASQUARE;
+template <class T, class U, class V>
+double LJFunctor<T, U, V>::SIGMASQUARE;
 
-template <class T, class U>
-double LJFunctor<T, U>::SHIFT6;
+template <class T, class U, class V>
+double LJFunctor<T, U, V>::SHIFT6;
 
 }  // namespace autopas

--- a/src/pairwiseFunctors/LJFunctor.h
+++ b/src/pairwiseFunctors/LJFunctor.h
@@ -174,7 +174,7 @@ class LJFunctor : public Functor<Particle, ParticleCell, SoAArraysType> {
   }
   // clang-format off
   /**
-   * @copydoc Functor::SoAFunctor(SoA<Particle> &soa, const std::vector<std::vector<size_t, autopas::AlignedAllocator<size_t>>> &neighborList, size_t iFrom, size_t iTo, bool newton3 = true)
+   * @copydoc Functor::SoAFunctor(SoA<SoAArraysType> &soa, const std::vector<std::vector<size_t, autopas::AlignedAllocator<size_t>>> &neighborList, size_t iFrom, size_t iTo, bool newton3 = true)
    * @note if you want to parallelize this by openmp, please ensure that there
    * are no dependencies, i.e. introduce colors and specify iFrom and iTo accordingly
    */
@@ -332,6 +332,7 @@ class LJFunctor : public Functor<Particle, ParticleCell, SoAArraysType> {
   }
 
   AUTOPAS_FUNCTOR_SOALOADER(
+      cell, soa, offset,
       /// @todo it is probably better to resize the soa only once, before calling
       /// SoALoader (verlet-list only)
       soa.resizeArrays(offset + cell.numParticles());
@@ -359,6 +360,8 @@ class LJFunctor : public Functor<Particle, ParticleCell, SoAArraysType> {
       })
 
   AUTOPAS_FUNCTOR_SOAEXTRACTOR(
+      cell, soa, offset,
+      // body start
       if (soa.getNumParticles() == 0) return;
 
       auto cellIter = cell.begin();

--- a/src/pairwiseFunctors/LJFunctor.h
+++ b/src/pairwiseFunctors/LJFunctor.h
@@ -331,10 +331,16 @@ class LJFunctor : public Functor<Particle, ParticleCell, SoAArraysType> {
     }
   }
 
+  /**
+   * SoALoader
+   * @param cell
+   * @param soa
+   * @param offset
+   */
   AUTOPAS_FUNCTOR_SOALOADER(
       cell, soa, offset,
-      /// @todo it is probably better to resize the soa only once, before calling
-      /// SoALoader (verlet-list only)
+      // todo it is probably better to resize the soa only once, before calling
+      // SoALoader (verlet-list only)
       soa.resizeArrays(offset + cell.numParticles());
 
       if (cell.numParticles() == 0) return;
@@ -358,7 +364,12 @@ class LJFunctor : public Functor<Particle, ParticleCell, SoAArraysType> {
         fyptr[i] = cellIter->getF()[1];
         fzptr[i] = cellIter->getF()[2];
       })
-
+  /**
+   * soaextractor
+   * @param cell
+   * @param soa
+   * @param offset
+   */
   AUTOPAS_FUNCTOR_SOAEXTRACTOR(
       cell, soa, offset,
       // body start
@@ -374,7 +385,7 @@ class LJFunctor : public Functor<Particle, ParticleCell, SoAArraysType> {
       double *const __restrict__ fyptr = soa.template begin<Particle::AttributeNames::forceY>();
       double *const __restrict__ fzptr = soa.template begin<Particle::AttributeNames::forceZ>();
 
-      for (unsigned int i = offset; cellIter.isValid(); ++i, ++cellIter) {
+      for (size_t i = offset; cellIter.isValid(); ++i, ++cellIter) {
         assert(idptr[i] == cellIter->getID());
         cellIter->setF({fxptr[i], fyptr[i], fzptr[i]});
       })

--- a/src/pairwiseFunctors/LJFunctor.h
+++ b/src/pairwiseFunctors/LJFunctor.h
@@ -27,7 +27,7 @@ namespace autopas {
 template <class Particle, class ParticleCell, class SoAArraysType = typename Particle::SoAArraysType>
 class LJFunctor : public Functor<Particle, ParticleCell, SoAArraysType> {
  public:
-  void AoSFunctor(Particle &i, Particle &j, bool newton3 = true) override {
+  void AoSFunctor(Particle &i, Particle &j, bool newton3) override {
     auto dr = ArrayMath::sub(i.getR(), j.getR());
     double dr2 = ArrayMath::dot(dr, dr);
 
@@ -44,7 +44,7 @@ class LJFunctor : public Functor<Particle, ParticleCell, SoAArraysType> {
     j.subF(f);
   }
 
-  void SoAFunctor(SoA<SoAArraysType> &soa, bool newton3 = true) override {
+  void SoAFunctor(SoA<SoAArraysType> &soa, bool newton3) override {
     if (soa.getNumParticles() == 0) return;
 
     double *const __restrict__ xptr = soa.template begin<Particle::AttributeNames::posX>();
@@ -104,7 +104,7 @@ class LJFunctor : public Functor<Particle, ParticleCell, SoAArraysType> {
     }
   }
 
-  void SoAFunctor(SoA<SoAArraysType> &soa1, SoA<SoAArraysType> &soa2, bool newton3 = true) override {
+  void SoAFunctor(SoA<SoAArraysType> &soa1, SoA<SoAArraysType> &soa2, bool newton3) override {
     if (soa1.getNumParticles() == 0 || soa2.getNumParticles() == 0) return;
 
     double *const __restrict__ x1ptr = soa1.template begin<Particle::AttributeNames::posX>();
@@ -174,14 +174,14 @@ class LJFunctor : public Functor<Particle, ParticleCell, SoAArraysType> {
   }
   // clang-format off
   /**
-   * @copydoc Functor::SoAFunctor(SoA<SoAArraysType> &soa, const std::vector<std::vector<size_t, autopas::AlignedAllocator<size_t>>> &neighborList, size_t iFrom, size_t iTo, bool newton3 = true)
+   * @copydoc Functor::SoAFunctor(SoA<SoAArraysType> &soa, const std::vector<std::vector<size_t, autopas::AlignedAllocator<size_t>>> &neighborList, size_t iFrom, size_t iTo, bool newton3)
    * @note if you want to parallelize this by openmp, please ensure that there
    * are no dependencies, i.e. introduce colors and specify iFrom and iTo accordingly
    */
   // clang-format on
   virtual void SoAFunctor(SoA<SoAArraysType> &soa,
                           const std::vector<std::vector<size_t, autopas::AlignedAllocator<size_t>>> &neighborList,
-                          size_t iFrom, size_t iTo, bool newton3 = true) override {
+                          size_t iFrom, size_t iTo, bool newton3) override {
     auto numParts = soa.getNumParticles();
     AutoPasLogger->debug("LJFunctor::SoAFunctorVerlet: {}", soa.getNumParticles());
 

--- a/src/pairwiseFunctors/LJFunctor.h
+++ b/src/pairwiseFunctors/LJFunctor.h
@@ -331,52 +331,50 @@ class LJFunctor : public Functor<Particle, ParticleCell, SoAArraysType> {
     }
   }
 
-  void SoALoader(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override {
-    /// @todo it is probably better to resize the soa only once, before calling
-    /// SoALoader (verlet-list only)
-    soa.resizeArrays(offset + cell.numParticles());
+  AUTOPAS_FUNCTOR_SOALOADER(
+      /// @todo it is probably better to resize the soa only once, before calling
+      /// SoALoader (verlet-list only)
+      soa.resizeArrays(offset + cell.numParticles());
 
-    if (cell.numParticles() == 0) return;
+      if (cell.numParticles() == 0) return;
 
-    unsigned long *const __restrict__ idptr = soa.template begin<Particle::AttributeNames::id>();
-    double *const __restrict__ xptr = soa.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict__ yptr = soa.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict__ zptr = soa.template begin<Particle::AttributeNames::posZ>();
-    double *const __restrict__ fxptr = soa.template begin<Particle::AttributeNames::forceX>();
-    double *const __restrict__ fyptr = soa.template begin<Particle::AttributeNames::forceY>();
-    double *const __restrict__ fzptr = soa.template begin<Particle::AttributeNames::forceZ>();
+      unsigned long *const __restrict__ idptr = soa.template begin<Particle::AttributeNames::id>();
+      double *const __restrict__ xptr = soa.template begin<Particle::AttributeNames::posX>();
+      double *const __restrict__ yptr = soa.template begin<Particle::AttributeNames::posY>();
+      double *const __restrict__ zptr = soa.template begin<Particle::AttributeNames::posZ>();
+      double *const __restrict__ fxptr = soa.template begin<Particle::AttributeNames::forceX>();
+      double *const __restrict__ fyptr = soa.template begin<Particle::AttributeNames::forceY>();
+      double *const __restrict__ fzptr = soa.template begin<Particle::AttributeNames::forceZ>();
 
-    auto cellIter = cell.begin();
-    // load particles in SoAs
-    for (size_t i = offset; cellIter.isValid(); ++cellIter, ++i) {
-      idptr[i] = cellIter->getID();
-      xptr[i] = cellIter->getR()[0];
-      yptr[i] = cellIter->getR()[1];
-      zptr[i] = cellIter->getR()[2];
-      fxptr[i] = cellIter->getF()[0];
-      fyptr[i] = cellIter->getF()[1];
-      fzptr[i] = cellIter->getF()[2];
-    }
-  }
+      auto cellIter = cell.begin();
+      // load particles in SoAs
+      for (size_t i = offset; cellIter.isValid(); ++cellIter, ++i) {
+        idptr[i] = cellIter->getID();
+        xptr[i] = cellIter->getR()[0];
+        yptr[i] = cellIter->getR()[1];
+        zptr[i] = cellIter->getR()[2];
+        fxptr[i] = cellIter->getF()[0];
+        fyptr[i] = cellIter->getF()[1];
+        fzptr[i] = cellIter->getF()[2];
+      })
 
-  void SoAExtractor(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override {
-    if (soa.getNumParticles() == 0) return;
+  AUTOPAS_FUNCTOR_SOAEXTRACTOR(
+      if (soa.getNumParticles() == 0) return;
 
-    auto cellIter = cell.begin();
+      auto cellIter = cell.begin();
 
 #ifndef NDEBUG
-    unsigned long *const __restrict__ idptr = soa.template begin<Particle::AttributeNames::id>();
+      unsigned long *const __restrict__ idptr = soa.template begin<Particle::AttributeNames::id>();
 #endif
 
-    double *const __restrict__ fxptr = soa.template begin<Particle::AttributeNames::forceX>();
-    double *const __restrict__ fyptr = soa.template begin<Particle::AttributeNames::forceY>();
-    double *const __restrict__ fzptr = soa.template begin<Particle::AttributeNames::forceZ>();
+      double *const __restrict__ fxptr = soa.template begin<Particle::AttributeNames::forceX>();
+      double *const __restrict__ fyptr = soa.template begin<Particle::AttributeNames::forceY>();
+      double *const __restrict__ fzptr = soa.template begin<Particle::AttributeNames::forceZ>();
 
-    for (unsigned int i = offset; cellIter.isValid(); ++i, ++cellIter) {
-      assert(idptr[i] == cellIter->getID());
-      cellIter->setF({fxptr[i], fyptr[i], fzptr[i]});
-    }
-  }
+      for (unsigned int i = offset; cellIter.isValid(); ++i, ++cellIter) {
+        assert(idptr[i] == cellIter->getID());
+        cellIter->setF({fxptr[i], fyptr[i], fzptr[i]});
+      })
 
   /**
    * Set the global values, i.e. cutoff, epsilon, sigma and shift

--- a/src/sph/SPHCalcDensityFunctor.h
+++ b/src/sph/SPHCalcDensityFunctor.h
@@ -16,7 +16,7 @@ namespace sph {
  * Class that defines the density functor.
  * It is used to calculate the density based on the given SPH kernel.
  */
-class SPHCalcDensityFunctor : public Functor<SPHParticle, FullParticleCell<SPHParticle>> {
+class SPHCalcDensityFunctor : public Functor<SPHParticle, FullParticleCell<SPHParticle>, SPHParticle::SoAArraysType> {
  public:
   /**
    * Calculates the density contribution of the interaction of particle i and j.

--- a/src/sph/SPHCalcDensityFunctor.h
+++ b/src/sph/SPHCalcDensityFunctor.h
@@ -16,7 +16,7 @@ namespace sph {
  * Class that defines the density functor.
  * It is used to calculate the density based on the given SPH kernel.
  */
-class SPHCalcDensityFunctor : public Functor<SPHParticle, FullParticleCell<SPHParticle>, SPHParticle::SoAArraysType> {
+class SPHCalcDensityFunctor : public Functor<SPHParticle, FullParticleCell<SPHParticle>> {
  public:
   /**
    * Calculates the density contribution of the interaction of particle i and j.

--- a/src/sph/SPHCalcHydroForceFunctor.h
+++ b/src/sph/SPHCalcHydroForceFunctor.h
@@ -16,8 +16,7 @@ namespace sph {
  * It is used to calculate the force based on the given SPH kernels.
  */
 class SPHCalcHydroForceFunctor
-    : public autopas::Functor<SPHParticle, autopas::FullParticleCell<autopas::sph::SPHParticle>,
-                              SPHParticle::SoAArraysType> {
+    : public autopas::Functor<SPHParticle, autopas::FullParticleCell<autopas::sph::SPHParticle>> {
  public:
   /**
    * Calculates the contribution of the interaction of particle i and j to the

--- a/src/sph/SPHCalcHydroForceFunctor.h
+++ b/src/sph/SPHCalcHydroForceFunctor.h
@@ -16,7 +16,8 @@ namespace sph {
  * It is used to calculate the force based on the given SPH kernels.
  */
 class SPHCalcHydroForceFunctor
-    : public autopas::Functor<SPHParticle, autopas::FullParticleCell<autopas::sph::SPHParticle>> {
+    : public autopas::Functor<SPHParticle, autopas::FullParticleCell<autopas::sph::SPHParticle>,
+                              SPHParticle::SoAArraysType> {
  public:
   /**
    * Calculates the contribution of the interaction of particle i and j to the

--- a/src/utils/SoA.h
+++ b/src/utils/SoA.h
@@ -14,6 +14,7 @@
 #include "AlignedAllocator.h"
 #include "ExceptionHandler.h"
 #include "SoAStorage.h"
+#include "SoAType.h"
 
 namespace autopas {
 

--- a/src/utils/SoA.h
+++ b/src/utils/SoA.h
@@ -18,10 +18,10 @@
 namespace autopas {
 
 /**
- * structur of array class
- * @tparam Particle The particle type for which the SoA should be generated
+ * Structur of the array class.
+ * @tparam SoAArraysType The SoAArrayType to be used for storage.
  */
-template <class Particle>
+template <class SoAArraysType>
 class SoA {
  public:
   /**
@@ -146,7 +146,7 @@ class SoA {
     soaStorage.apply([=](auto &list) { std::swap(list[a], list[b]); });
   }
 
-  /**primary
+  /**
    * delete the last particle in the soa
    */
   void pop_back() {
@@ -154,9 +154,6 @@ class SoA {
   }
 
  private:
-  // storage container for the SoA's
-  utils::SoAStorage<typename Particle::SoAArraysType> soaStorage;
-
   // actual implementation of read
   template <int attribute, int... attributes, class ValueArrayType>
   void read_impl(size_t particleId, ValueArrayType &values, int _current = 0) {
@@ -179,5 +176,10 @@ class SoA {
   // Stop of the recursive write_impl call
   template <class ValueArrayType>
   void write_impl(size_t particleId, const ValueArrayType &values, int _current = 0) {}
+
+  // ------------- members ---------------
+
+  // storage container for the SoA's
+  utils::SoAStorage<SoAArraysType> soaStorage;
 };
 }  // namespace autopas

--- a/src/utils/StaticSelectorMacros.h
+++ b/src/utils/StaticSelectorMacros.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-// either LinkedCells<Particle,ParticleCell>
+// either LinkedCells<Particle, ParticleCell>
 // or VerletLists<Particle>
 // or DirectSum<Particle, ParticleCell>
 /**

--- a/src/utils/StaticSelectorMacros.h
+++ b/src/utils/StaticSelectorMacros.h
@@ -6,5 +6,27 @@
 
 #pragma once
 
-#define WithStaticContainerType(container, body) \
-  {}
+// either LinkedCells<Particle,ParticleCell>
+// or VerletLists<Particle>
+// or DirectSum
+#define WithStaticContainerType(container, body)                                                                    \
+  {                                                                                                                 \
+    auto container_ptr = container.get();                                                                           \
+    if (auto container = dynamic_cast<                                                                              \
+            autopas::LinkedCells<typename std::remove_pointer_t<decltype(container_ptr)>::ParticleType,             \
+                                 typename std::remove_pointer_t<decltype(container_ptr)>::ParticleCellType>*>(      \
+            container_ptr)) {                                                                                       \
+      body                                                                                                          \
+    } else if (auto container = dynamic_cast<                                                                       \
+                   autopas::VerletLists<typename std::remove_pointer_t<decltype(container_ptr)>::ParticleType>*>(   \
+                   container_ptr)) {                                                                                \
+      body                                                                                                          \
+    } else if (auto container = dynamic_cast<                                                                       \
+                   autopas::DirectSum<typename std::remove_pointer_t<decltype(container_ptr)>::ParticleType,        \
+                                      typename std::remove_pointer_t<decltype(container_ptr)>::ParticleCellType>*>( \
+                   container_ptr)) {                                                                                \
+      body                                                                                                          \
+    } else {                                                                                                        \
+      autopas::utils::ExceptionHandler::exception("wrong type of container in StaticSelectorMacros.h");             \
+    }                                                                                                               \
+  }

--- a/src/utils/StaticSelectorMacros.h
+++ b/src/utils/StaticSelectorMacros.h
@@ -8,7 +8,13 @@
 
 // either LinkedCells<Particle,ParticleCell>
 // or VerletLists<Particle>
-// or DirectSum
+// or DirectSum<Particle, ParticleCell>
+/**
+ * Will execute the passed body with the static container type of container, i.e. either
+ * LinkedCells, VerletLists or DirectSum
+ * @param container the container to be used
+ * @param body the function body to be executed
+ */
 #define WithStaticContainerType(container, body)                                                                    \
   {                                                                                                                 \
     auto container_ptr = container.get();                                                                           \

--- a/src/utils/StaticSelectorMacros.h
+++ b/src/utils/StaticSelectorMacros.h
@@ -1,0 +1,10 @@
+/**
+ * @file StaticSelectorMacros.h
+ * @author seckler
+ * @date 21.06.18
+ */
+
+#pragma once
+
+#define WithStaticContainerType(container, body) \
+  {}

--- a/tests/testAutopas/AoSvsSoATest.cpp
+++ b/tests/testAutopas/AoSvsSoATest.cpp
@@ -40,7 +40,7 @@ TEST_F(AoSvsSoATest, testAoSvsSoA) {
   for (unsigned int i = 0; i < PARTICLES_PER_DIM * PARTICLES_PER_DIM; ++i) {
     for (unsigned int j = i + 1; j < PARTICLES_PER_DIM * PARTICLES_PER_DIM; ++j) {
       if (i != j) {
-        ljFunctor.AoSFunctor(particlesAoS[i], particlesAoS[j]);
+        ljFunctor.AoSFunctor(particlesAoS[i], particlesAoS[j], true);
       }
     }
   }
@@ -57,7 +57,7 @@ TEST_F(AoSvsSoATest, testAoSvsSoA) {
 
   ljFunctor.SoALoader(cell, cell._particleSoABuffer);
   start = std::chrono::high_resolution_clock::now();
-  ljFunctor.SoAFunctor(cell._particleSoABuffer);
+  ljFunctor.SoAFunctor(cell._particleSoABuffer, true);
   stop = std::chrono::high_resolution_clock::now();
   duration = std::chrono::duration_cast<std::chrono::microseconds>(stop - start).count();
 

--- a/tests/testAutopas/C08TraversalTest.cpp
+++ b/tests/testAutopas/C08TraversalTest.cpp
@@ -28,7 +28,7 @@ TEST_F(C08TraversalTest, testTraversalCube) {
 
   // every particle interacts with 13 others. Last layer of each dim is covered
   // by previous interactions
-  EXPECT_CALL(functor, AoSFunctor(_, _)).Times((edgeLength - 1) * (edgeLength - 1) * (edgeLength - 1) * 13);
+  EXPECT_CALL(functor, AoSFunctor(_, _, true)).Times((edgeLength - 1) * (edgeLength - 1) * (edgeLength - 1) * 13);
   c08Traversal.traverseCellPairs();
 #ifdef AUTOPAS_OPENMP
   omp_set_num_threads(numThreadsBefore);
@@ -53,7 +53,7 @@ TEST_F(C08TraversalTest, testTraversal2x2x2) {
 
   // every particle interacts with 13 others. Last layer of each dim is covered
   // by previous interactions
-  EXPECT_CALL(functor, AoSFunctor(_, _)).Times((edgeLength - 1) * (edgeLength - 1) * (edgeLength - 1) * 13);
+  EXPECT_CALL(functor, AoSFunctor(_, _, true)).Times((edgeLength - 1) * (edgeLength - 1) * (edgeLength - 1) * 13);
   c08Traversal.traverseCellPairs();
 #ifdef AUTOPAS_OPENMP
   omp_set_num_threads(numThreadsBefore);
@@ -80,7 +80,7 @@ TEST_F(C08TraversalTest, testTraversal2x3x4) {
 
   // every particle interacts with 13 others. Last layer of each dim is covered
   // by previous interactions
-  EXPECT_CALL(functor, AoSFunctor(_, _)).Times((edgeLength[0] - 1) * (edgeLength[1] - 1) * (edgeLength[2] - 1) * 13);
+  EXPECT_CALL(functor, AoSFunctor(_, _, true)).Times((edgeLength[0] - 1) * (edgeLength[1] - 1) * (edgeLength[2] - 1) * 13);
   c08Traversal.traverseCellPairs();
 #ifdef AUTOPAS_OPENMP
   omp_set_num_threads(numThreadsBefore);

--- a/tests/testAutopas/C08TraversalTest.cpp
+++ b/tests/testAutopas/C08TraversalTest.cpp
@@ -80,7 +80,8 @@ TEST_F(C08TraversalTest, testTraversal2x3x4) {
 
   // every particle interacts with 13 others. Last layer of each dim is covered
   // by previous interactions
-  EXPECT_CALL(functor, AoSFunctor(_, _, true)).Times((edgeLength[0] - 1) * (edgeLength[1] - 1) * (edgeLength[2] - 1) * 13);
+  EXPECT_CALL(functor, AoSFunctor(_, _, true))
+      .Times((edgeLength[0] - 1) * (edgeLength[1] - 1) * (edgeLength[2] - 1) * 13);
   c08Traversal.traverseCellPairs();
 #ifdef AUTOPAS_OPENMP
   omp_set_num_threads(numThreadsBefore);

--- a/tests/testAutopas/FlopCounterTest.h
+++ b/tests/testAutopas/FlopCounterTest.h
@@ -7,11 +7,11 @@
 
 #pragma once
 
-#include <AutoPas.h>
+#include "AutoPas.h"
 #include "AutoPasTestBase.h"
 
 typedef autopas::Particle Particle;
-typedef autopas::FullParticleCell<autopas::Particle> FPCell;
+typedef autopas::FullParticleCell<Particle> FPCell;
 
 class FlopCounterTest : public AutoPasTestBase {
  public:

--- a/tests/testAutopas/LinkedCellsVersusDirectSumTest.cpp
+++ b/tests/testAutopas/LinkedCellsVersusDirectSumTest.cpp
@@ -56,8 +56,8 @@ void LinkedCellsVersusDirectSumTest::test(unsigned long numMolecules, double rel
   }
 
   autopas::LJFunctor<autopas::MoleculeLJ, autopas::FullParticleCell<autopas::MoleculeLJ>> func;
-  _directSum.iteratePairwiseAoS2(&func);
-  _linkedCells.iteratePairwiseAoS2(&func);
+  _directSum.iteratePairwiseAoS(&func);
+  _linkedCells.iteratePairwiseAoS(&func);
 
   auto itDirect = _directSum.begin();
   auto itLinked = _linkedCells.begin();
@@ -87,8 +87,8 @@ void LinkedCellsVersusDirectSumTest::test(unsigned long numMolecules, double rel
   autopas::FlopCounterFunctor<autopas::MoleculeLJ, autopas::FullParticleCell<autopas::MoleculeLJ>> flopsDirect(
       getCutoff()),
       flopsLinked(getCutoff());
-  _directSum.iteratePairwiseAoS2(&flopsDirect);
-  _linkedCells.iteratePairwiseAoS2(&flopsLinked);
+  _directSum.iteratePairwiseAoS(&flopsDirect);
+  _linkedCells.iteratePairwiseAoS(&flopsLinked);
 
   ASSERT_EQ(flopsLinked.getKernelCalls(), flopsDirect.getKernelCalls());
   ASSERT_LE(flopsLinked.getDistanceCalculations(), flopsDirect.getDistanceCalculations());

--- a/tests/testAutopas/LinkedCellsVersusVerletListsTest.cpp
+++ b/tests/testAutopas/LinkedCellsVersusVerletListsTest.cpp
@@ -30,8 +30,8 @@ void LinkedCellsVersusVerletListsTest::test(unsigned long numMolecules, double r
   }
 
   autopas::LJFunctor<autopas::MoleculeLJ, autopas::FullParticleCell<autopas::MoleculeLJ>> func;
-  _verletLists.iteratePairwiseAoS2(&func);
-  _linkedCells.iteratePairwiseAoS2(&func);
+  _verletLists.iteratePairwiseAoS(&func);
+  _linkedCells.iteratePairwiseAoS(&func);
 
   auto itDirect = _verletLists.begin();
   auto itLinked = _linkedCells.begin();
@@ -61,8 +61,8 @@ void LinkedCellsVersusVerletListsTest::test(unsigned long numMolecules, double r
   autopas::FlopCounterFunctor<autopas::MoleculeLJ, autopas::FullParticleCell<autopas::MoleculeLJ>> flopsVerlet(
       getCutoff()),
       flopsLinked(getCutoff());
-  _verletLists.iteratePairwiseAoS2(&flopsVerlet);
-  _linkedCells.iteratePairwiseAoS2(&flopsLinked);
+  _verletLists.iteratePairwiseAoS(&flopsVerlet);
+  _linkedCells.iteratePairwiseAoS(&flopsLinked);
 
   ASSERT_EQ(flopsLinked.getKernelCalls(), flopsVerlet.getKernelCalls());
   ASSERT_GE(flopsLinked.getDistanceCalculations(), flopsVerlet.getDistanceCalculations());

--- a/tests/testAutopas/LinkedCellsVersusVerletListsTest.h
+++ b/tests/testAutopas/LinkedCellsVersusVerletListsTest.h
@@ -26,6 +26,6 @@ class LinkedCellsVersusVerletListsTest : public AutoPasTestBase {
  protected:
   void test(unsigned long numMolecules, double rel_err_tolerance);
 
-  autopas::VerletLists<autopas::MoleculeLJ, autopas::FullParticleCell<autopas::MoleculeLJ>> _verletLists;
+  autopas::VerletLists<autopas::MoleculeLJ> _verletLists;
   autopas::LinkedCells<autopas::MoleculeLJ, autopas::FullParticleCell<autopas::MoleculeLJ>> _linkedCells;
 };

--- a/tests/testAutopas/Newton3OnOffTest.cpp
+++ b/tests/testAutopas/Newton3OnOffTest.cpp
@@ -50,7 +50,7 @@ TEST_F(Newton3OnOffTest, testAoS) {
       callsNewton3++;
     }));
     EXPECT_CALL(mockFunctor, AoSFunctor(_, _, false)).Times(0);  // disables newton3 variant
-    EXPECT_CALL(mockFunctor, AoSFunctor(_, _)).Times(0); // disables 2 parameter variant
+    EXPECT_CALL(mockFunctor, AoSFunctor(_, _)).Times(0);         // disables 2 parameter variant
     autoPas.iteratePairwise(&mockFunctor, autopas::DataLayoutOption::aos);
 
     // without newton 3:
@@ -61,7 +61,7 @@ TEST_F(Newton3OnOffTest, testAoS) {
     EXPECT_CALL(mockFunctor, AoSFunctor(_, _, false)).WillRepeatedly(testing::InvokeWithoutArgs([&]() {
       callsNonNewton3++;
     }));
-    EXPECT_CALL(mockFunctor, AoSFunctor(_, _)).Times(0); // disables 2 parameter variant
+    EXPECT_CALL(mockFunctor, AoSFunctor(_, _)).Times(0);  // disables 2 parameter variant
     autoPas.iteratePairwise(&mockFunctor, autopas::DataLayoutOption::aos);
 
     EXPECT_EQ(callsNewton3 * 2,

--- a/tests/testAutopas/Newton3OnOffTest.cpp
+++ b/tests/testAutopas/Newton3OnOffTest.cpp
@@ -49,6 +49,8 @@ TEST_F(Newton3OnOffTest, testAoS) {
     EXPECT_CALL(mockFunctor, AoSFunctor(_, _, true)).WillRepeatedly(testing::InvokeWithoutArgs([&]() {
       callsNewton3++;
     }));
+    EXPECT_CALL(mockFunctor, AoSFunctor(_, _, false)).Times(0);  // disables newton3 variant
+    EXPECT_CALL(mockFunctor, AoSFunctor(_, _)).Times(0); // disables 2 parameter variant
     autoPas.iteratePairwise(&mockFunctor, autopas::DataLayoutOption::aos);
 
     // without newton 3:
@@ -59,6 +61,7 @@ TEST_F(Newton3OnOffTest, testAoS) {
     EXPECT_CALL(mockFunctor, AoSFunctor(_, _, false)).WillRepeatedly(testing::InvokeWithoutArgs([&]() {
       callsNonNewton3++;
     }));
+    EXPECT_CALL(mockFunctor, AoSFunctor(_, _)).Times(0); // disables 2 parameter variant
     autoPas.iteratePairwise(&mockFunctor, autopas::DataLayoutOption::aos);
 
     EXPECT_EQ(callsNewton3 * 2,
@@ -72,8 +75,8 @@ TEST_F(Newton3OnOffTest, testSoA) {
     fillContainerWithMolecules(100, autoPas);
 
     // loader and extractor will be called, we don't care how often.
-    EXPECT_CALL(mockFunctor, SoALoader(_, _, _)).Times(testing::AtLeast(1));
-    EXPECT_CALL(mockFunctor, SoAExtractor(_, _, _)).Times(testing::AtLeast(1));
+    EXPECT_CALL(mockFunctor, SoALoader(_, _)).Times(testing::AtLeast(1));
+    EXPECT_CALL(mockFunctor, SoAExtractor(_, _)).Times(testing::AtLeast(1));
 
     // with newton 3:
     int callsNewton3SC = 0;    // same cell

--- a/tests/testAutopas/Newton3OnOffTest.cpp
+++ b/tests/testAutopas/Newton3OnOffTest.cpp
@@ -50,7 +50,6 @@ TEST_F(Newton3OnOffTest, testAoS) {
       callsNewton3++;
     }));
     EXPECT_CALL(mockFunctor, AoSFunctor(_, _, false)).Times(0);  // disables newton3 variant
-    EXPECT_CALL(mockFunctor, AoSFunctor(_, _)).Times(0);         // disables 2 parameter variant
     autoPas.iteratePairwise(&mockFunctor, autopas::DataLayoutOption::aos);
 
     // without newton 3:
@@ -61,7 +60,6 @@ TEST_F(Newton3OnOffTest, testAoS) {
     EXPECT_CALL(mockFunctor, AoSFunctor(_, _, false)).WillRepeatedly(testing::InvokeWithoutArgs([&]() {
       callsNonNewton3++;
     }));
-    EXPECT_CALL(mockFunctor, AoSFunctor(_, _)).Times(0);  // disables 2 parameter variant
     autoPas.iteratePairwise(&mockFunctor, autopas::DataLayoutOption::aos);
 
     EXPECT_EQ(callsNewton3 * 2,

--- a/tests/testAutopas/ParticleIteratorTest.cpp
+++ b/tests/testAutopas/ParticleIteratorTest.cpp
@@ -270,7 +270,7 @@ TEST_F(ParticleIteratorTest, testIteratorBehaviorLinkedCells) {
 }
 
 TEST_F(ParticleIteratorTest, testIteratorBehaviorVerletLists) {
-  VerletLists<MoleculeLJ, FullParticleCell<MoleculeLJ>> verletLists({0., 0., 0.}, {10., 10., 10.}, 3, 0., 1);
+  VerletLists<MoleculeLJ> verletLists({0., 0., 0.}, {10., 10., 10.}, 3, 0., 1);
   MoleculeLJ mol({1., 1., 1.}, {0., 0., 0.}, 1);
   verletLists.addParticle(mol);
   MoleculeLJ haloMol({-1., 1., 1.}, {0., 0., 0.}, 2);

--- a/tests/testAutopas/SlicedTraversalTest.cpp
+++ b/tests/testAutopas/SlicedTraversalTest.cpp
@@ -45,7 +45,7 @@ TEST_F(SlicedTraversalTest, testTraversalCube) {
 
   // every particle interacts with 13 others. Last layer of each dim is covered
   // by previous interactions
-  EXPECT_CALL(functor, AoSFunctor(_, _)).Times((edgeLength - 1) * (edgeLength - 1) * (edgeLength - 1) * 13);
+  EXPECT_CALL(functor, AoSFunctor(_, _, true)).Times((edgeLength - 1) * (edgeLength - 1) * (edgeLength - 1) * 13);
   slicedTraversal.traverseCellPairs();
 #ifdef AUTOPAS_OPENMP
   omp_set_num_threads(numThreadsBefore);
@@ -72,7 +72,7 @@ TEST_F(SlicedTraversalTest, testTraversalCuboid) {
 
   // every particle interacts with 13 others. Last layer of each dim is covered
   // by previous interactions
-  EXPECT_CALL(functor, AoSFunctor(_, _)).Times((edgeLength[0] - 1) * (edgeLength[1] - 1) * (edgeLength[2] - 1) * 13);
+  EXPECT_CALL(functor, AoSFunctor(_, _, true)).Times((edgeLength[0] - 1) * (edgeLength[1] - 1) * (edgeLength[2] - 1) * 13);
   slicedTraversal.traverseCellPairs();
 #ifdef AUTOPAS_OPENMP
   omp_set_num_threads(numThreadsBefore);

--- a/tests/testAutopas/SlicedTraversalTest.cpp
+++ b/tests/testAutopas/SlicedTraversalTest.cpp
@@ -72,7 +72,8 @@ TEST_F(SlicedTraversalTest, testTraversalCuboid) {
 
   // every particle interacts with 13 others. Last layer of each dim is covered
   // by previous interactions
-  EXPECT_CALL(functor, AoSFunctor(_, _, true)).Times((edgeLength[0] - 1) * (edgeLength[1] - 1) * (edgeLength[2] - 1) * 13);
+  EXPECT_CALL(functor, AoSFunctor(_, _, true))
+      .Times((edgeLength[0] - 1) * (edgeLength[1] - 1) * (edgeLength[2] - 1) * 13);
   slicedTraversal.traverseCellPairs();
 #ifdef AUTOPAS_OPENMP
   omp_set_num_threads(numThreadsBefore);

--- a/tests/testAutopas/SoATest.cpp
+++ b/tests/testAutopas/SoATest.cpp
@@ -90,7 +90,7 @@ TEST_F(SoATest, SoAStorageTestApply) {
 TEST_F(SoATest, SoATestPush) {
   // default soa using autopas::Particle
   using autopas::Particle;
-  autopas::SoA<Particle> soa;
+  autopas::SoA<Particle::SoAArraysType> soa;
 
   EXPECT_EQ(soa.getNumParticles(), 0);
 
@@ -116,7 +116,7 @@ TEST_F(SoATest, SoATestPush) {
 TEST_F(SoATest, SoATestClear) {
   // default soa using autopas::Particle
   using autopas::Particle;
-  autopas::SoA<Particle> soa;
+  autopas::SoA<Particle::SoAArraysType> soa;
 
   EXPECT_EQ(soa.getNumParticles(), 0);
 
@@ -132,7 +132,7 @@ TEST_F(SoATest, SoATestClear) {
 TEST_F(SoATest, SoATestSwap) {
   // default soa using autopas::Particle
   using autopas::Particle;
-  autopas::SoA<Particle> soa;
+  autopas::SoA<Particle::SoAArraysType> soa;
 
   soa.resizeArrays(2);
 
@@ -190,7 +190,7 @@ TEST_F(SoATest, SoATestSwap) {
 TEST_F(SoATest, SoATestMultiWriteRead) {
   // default soa using autopas::Particle
   using autopas::Particle;
-  autopas::SoA<Particle> soa;
+  autopas::SoA<Particle::SoAArraysType> soa;
 
   soa.resizeArrays(1);
 
@@ -227,7 +227,7 @@ TEST_F(SoATest, SoATestMultiWriteRead) {
 TEST_F(SoATest, SoATestComplicatedAccess) {
   // default soa using autopas::Particle
   using autopas::Particle;
-  autopas::SoA<Particle> soa;
+  autopas::SoA<Particle::SoAArraysType> soa;
 
   EXPECT_EQ(soa.getNumParticles(), 0);
 

--- a/tests/testAutopas/TraversalRaceConditionTest.h
+++ b/tests/testAutopas/TraversalRaceConditionTest.h
@@ -27,7 +27,7 @@ class TraversalRaceConditionTest : public AutoPasTestBase {
     typedef PrintableMolecule::SoAArraysType SoAArraysType;
     typedef autopas::FullParticleCell<PrintableMolecule> ParticleCell;
 
-    void AoSFunctor(PrintableMolecule &i, PrintableMolecule &j, bool newton3 = true) override {
+    void AoSFunctor(PrintableMolecule &i, PrintableMolecule &j, bool newton3) override {
       auto coordsI = i.getR();
       auto coordsJ = j.getR();
 

--- a/tests/testAutopas/TraversalRaceConditionTest.h
+++ b/tests/testAutopas/TraversalRaceConditionTest.h
@@ -52,9 +52,9 @@ class TraversalRaceConditionTest : public AutoPasTestBase {
       j.subF(f);
     }
 
-    AUTOPAS_FUNCTOR_SOAEXTRACTOR();
+    AUTOPAS_FUNCTOR_SOAEXTRACTOR(,,,);
 
-    AUTOPAS_FUNCTOR_SOALOADER();
+    AUTOPAS_FUNCTOR_SOALOADER(,,,);
 
    private:
     // in a grid with separation 1 this includes all neighbors with a Chebyshev

--- a/tests/testAutopas/TraversalRaceConditionTest.h
+++ b/tests/testAutopas/TraversalRaceConditionTest.h
@@ -22,6 +22,11 @@ class TraversalRaceConditionTest : public AutoPasTestBase {
    * constant force of 1.
    */
   class SimpleFunctor : public autopas::Functor<PrintableMolecule, autopas::FullParticleCell<PrintableMolecule>> {
+   public:
+    typedef PrintableMolecule Particle;
+    typedef PrintableMolecule::SoAArraysType SoAArraysType;
+    typedef autopas::FullParticleCell<PrintableMolecule> ParticleCell;
+
     void AoSFunctor(PrintableMolecule &i, PrintableMolecule &j, bool newton3 = true) override {
       auto coordsI = i.getR();
       auto coordsJ = j.getR();
@@ -46,6 +51,10 @@ class TraversalRaceConditionTest : public AutoPasTestBase {
       i.addF(f);
       j.subF(f);
     }
+
+    AUTOPAS_FUNCTOR_SOAEXTRACTOR();
+
+    AUTOPAS_FUNCTOR_SOALOADER();
 
    private:
     // in a grid with separation 1 this includes all neighbors with a Chebyshev

--- a/tests/testAutopas/TraversalRaceConditionTest.h
+++ b/tests/testAutopas/TraversalRaceConditionTest.h
@@ -52,9 +52,9 @@ class TraversalRaceConditionTest : public AutoPasTestBase {
       j.subF(f);
     }
 
-    AUTOPAS_FUNCTOR_SOAEXTRACTOR(,,,);
+    AUTOPAS_FUNCTOR_SOAEXTRACTOR(, , , );
 
-    AUTOPAS_FUNCTOR_SOALOADER(,,,);
+    AUTOPAS_FUNCTOR_SOALOADER(, , , );
 
    private:
     // in a grid with separation 1 this includes all neighbors with a Chebyshev

--- a/tests/testAutopas/VerletListsTest.cpp
+++ b/tests/testAutopas/VerletListsTest.cpp
@@ -206,8 +206,7 @@ TEST_F(VerletListsTest, testVerletListBuildHalo) {
 }
 
 TEST_F(VerletListsTest, testRebuildFrequencyAlways) {
-  MockVerletLists<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> mockVerletLists(
-      {0., 0., 0.}, {10., 10., 10.}, 1., 0.3, 1);
+  MockVerletLists<autopas::Particle> mockVerletLists({0., 0., 0.}, {10., 10., 10.}, 1., 0.3, 1);
 
   MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(4);
@@ -218,8 +217,7 @@ TEST_F(VerletListsTest, testRebuildFrequencyAlways) {
 }
 
 TEST_F(VerletListsTest, testRebuildFrequencyEvery3) {
-  MockVerletLists<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> mockVerletLists(
-      {0., 0., 0.}, {10., 10., 10.}, 1., 0.3, 3);
+  MockVerletLists<autopas::Particle> mockVerletLists({0., 0., 0.}, {10., 10., 10.}, 1., 0.3, 3);
 
   MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
 
@@ -239,25 +237,16 @@ TEST_F(VerletListsTest, testRebuildFrequencyEvery3) {
 
 TEST_F(VerletListsTest, testForceRebuild) {
   // generate Velet list with rebuild frequency of 3
-  MockVerletLists<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> mockVerletLists(
-      {0., 0., 0.}, {10., 10., 10.}, 1., 0.3, 3);
+  MockVerletLists<autopas::Particle> mockVerletLists({0., 0., 0.}, {10., 10., 10.}, 1., 0.3, 3);
   // delegating to parent
   ON_CALL(mockVerletLists, addParticle(_))
-      .WillByDefault(Invoke(
-          &mockVerletLists,
-          &MockVerletLists<autopas::Particle, autopas::FullParticleCell<autopas::Particle>>::addParticleVerletLists));
+      .WillByDefault(Invoke(&mockVerletLists, &MockVerletLists<autopas::Particle>::addParticleVerletLists));
   // delegating to parent
   ON_CALL(mockVerletLists, addHaloParticle(_))
-      .WillByDefault(
-          Invoke(&mockVerletLists,
-                 &MockVerletLists<autopas::Particle,
-                                  autopas::FullParticleCell<autopas::Particle>>::addHaloParticleVerletLists));
+      .WillByDefault(Invoke(&mockVerletLists, &MockVerletLists<autopas::Particle>::addHaloParticleVerletLists));
   // delegating to parent
   ON_CALL(mockVerletLists, updateContainer())
-      .WillByDefault(
-          Invoke(&mockVerletLists,
-                 &MockVerletLists<autopas::Particle,
-                                  autopas::FullParticleCell<autopas::Particle>>::updateContainerVerletLists));
+      .WillByDefault(Invoke(&mockVerletLists, &MockVerletLists<autopas::Particle>::updateContainerVerletLists));
 
   MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
 

--- a/tests/testAutopas/VerletListsTest.cpp
+++ b/tests/testAutopas/VerletListsTest.cpp
@@ -8,6 +8,8 @@
 #include "mocks/MockFunctor.h"
 #include "mocks/MockVerletLists.h"
 #include "testingHelpers/RandomGenerator.h"
+#include "cells/FullParticleCell.h"
+#include "particles/Particle.h"
 
 using ::testing::_;
 using ::testing::AtLeast;
@@ -18,8 +20,7 @@ TEST_F(VerletListsTest, VerletListConstructor) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skin = 0.2;
-  autopas::VerletLists<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> verletLists(min, max, cutoff,
-                                                                                                    skin);
+  autopas::VerletLists<autopas::Particle> verletLists(min, max, cutoff, skin);
 }
 
 TEST_F(VerletListsTest, testVerletListBuild) {
@@ -27,8 +28,7 @@ TEST_F(VerletListsTest, testVerletListBuild) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skin = 0.2;
-  autopas::VerletLists<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> verletLists(min, max, cutoff,
-                                                                                                    skin);
+  autopas::VerletLists<autopas::Particle> verletLists(min, max, cutoff, skin);
 
   std::array<double, 3> r = {2, 2, 2};
   autopas::Particle p(r, {0., 0., 0.}, 0);
@@ -56,8 +56,7 @@ TEST_F(VerletListsTest, testVerletList) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skin = 0.2;
-  autopas::VerletLists<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> verletLists(min, max, cutoff,
-                                                                                                    skin);
+  autopas::VerletLists<autopas::Particle> verletLists(min, max, cutoff, skin);
 
   std::array<double, 3> r = {2, 2, 2};
   autopas::Particle p(r, {0., 0., 0.}, 0);
@@ -87,8 +86,7 @@ TEST_F(VerletListsTest, testVerletListInSkin) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skin = 0.2;
-  autopas::VerletLists<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> verletLists(min, max, cutoff,
-                                                                                                    skin);
+  autopas::VerletLists<autopas::Particle> verletLists(min, max, cutoff, skin);
 
   std::array<double, 3> r = {1.4, 2, 2};
   autopas::Particle p(r, {0., 0., 0.}, 0);
@@ -118,8 +116,7 @@ TEST_F(VerletListsTest, testVerletListBuildTwice) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skin = 0.2;
-  autopas::VerletLists<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> verletLists(min, max, cutoff,
-                                                                                                    skin);
+  autopas::VerletLists<autopas::Particle> verletLists(min, max, cutoff, skin);
 
   std::array<double, 3> r = {2, 2, 2};
   autopas::Particle p(r, {0., 0., 0.}, 0);
@@ -149,8 +146,7 @@ TEST_F(VerletListsTest, testVerletListBuildFarAway) {
   std::array<double, 3> max = {5, 5, 5};
   double cutoff = 1.;
   double skin = 0.2;
-  autopas::VerletLists<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> verletLists(min, max, cutoff,
-                                                                                                    skin);
+  autopas::VerletLists<autopas::Particle> verletLists(min, max, cutoff, skin);
 
   std::array<double, 3> r = {2, 2, 2};
   autopas::Particle p(r, {0., 0., 0.}, 0);
@@ -183,8 +179,7 @@ TEST_F(VerletListsTest, testVerletListBuildHalo) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skin = 0.2;
-  autopas::VerletLists<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> verletLists(min, max, cutoff,
-                                                                                                    skin);
+  autopas::VerletLists<autopas::Particle> verletLists(min, max, cutoff, skin);
 
   std::array<double, 3> r = {0.9, 0.9, 0.9};
   autopas::Particle p(r, {0., 0., 0.}, 0);
@@ -216,10 +211,10 @@ TEST_F(VerletListsTest, testRebuildFrequencyAlways) {
 
   MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(4);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);
 }
 
 TEST_F(VerletListsTest, testRebuildFrequencyEvery3) {
@@ -229,17 +224,17 @@ TEST_F(VerletListsTest, testRebuildFrequencyEvery3) {
   MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
 
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);  // 1
+  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);  // 1
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(0);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);  // 2
+  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);  // 2
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(0);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);  // 3
+  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);  // 3
 }
 
 TEST_F(VerletListsTest, testForceRebuild) {
@@ -250,51 +245,52 @@ TEST_F(VerletListsTest, testForceRebuild) {
   ON_CALL(mockVerletLists, addParticle(_))
       .WillByDefault(Invoke(
           &mockVerletLists,
-          &MockVerletLists<autopas::Particle, autopas::FullParticleCell<autopas::Particle>>::addParticleVerletLists));
+          &MockVerletLists<autopas::Particle,
+                           autopas::FullParticleCell<autopas::Particle>>::addParticleVerletLists));
   // delegating to parent
   ON_CALL(mockVerletLists, addHaloParticle(_))
-      .WillByDefault(
-          Invoke(&mockVerletLists,
-                 &MockVerletLists<autopas::Particle,
-                                  autopas::FullParticleCell<autopas::Particle>>::addHaloParticleVerletLists));
+      .WillByDefault(Invoke(
+          &mockVerletLists,
+          &MockVerletLists<autopas::Particle,
+                           autopas::FullParticleCell<autopas::Particle>>::addHaloParticleVerletLists));
   // delegating to parent
   ON_CALL(mockVerletLists, updateContainer())
-      .WillByDefault(
-          Invoke(&mockVerletLists,
-                 &MockVerletLists<autopas::Particle,
-                                  autopas::FullParticleCell<autopas::Particle>>::updateContainerVerletLists));
+      .WillByDefault(Invoke(
+          &mockVerletLists,
+          &MockVerletLists<autopas::Particle,
+                           autopas::FullParticleCell<autopas::Particle>>::updateContainerVerletLists));
 
   MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
 
   // check that the second call does not need a rebuild
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor,
-                                     true);  // rebuild happens here
+  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor,
+                                      true);  // rebuild happens here
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(0);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);
 
   // check that updateContainer() requires a rebuild
   EXPECT_CALL(mockVerletLists, updateContainer());
   mockVerletLists.updateContainer();
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor,
-                                     true);  // rebuild happens here
+  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor,
+                                      true);  // rebuild happens here
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(0);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);
 
   // check that adding particles requires a rebuild
   autopas::Particle p({1.1, 1.1, 1.1}, {0., 0., 0.}, 1);
   EXPECT_CALL(mockVerletLists, addParticle(_));
   mockVerletLists.addParticle(p);
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor,
-                                     true);  // rebuild happens here
+  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor,
+                                      true);  // rebuild happens here
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(0);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor,
-                                     true);  // rebuild happens here
+  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor,
+                                      true);  // rebuild happens here
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(0);
 
   // check that adding halo particles requires a rebuild
@@ -302,8 +298,8 @@ TEST_F(VerletListsTest, testForceRebuild) {
   EXPECT_CALL(mockVerletLists, addHaloParticle(_));
   mockVerletLists.addHaloParticle(p2);
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor,
-                                     true);  // rebuild happens here
+  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor,
+                                      true);  // rebuild happens here
 
   // check that deleting particles requires a rebuild
   /// @todo: reenable once implemented
@@ -312,19 +308,18 @@ TEST_F(VerletListsTest, testForceRebuild) {
     iterator.deleteCurrentParticle();
   }
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor,
+  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor,
                                      true);  // rebuild happens here
 */
   // check that deleting halo particles requires a rebuild
   mockVerletLists.deleteHaloParticles();
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor,
-                                     true);  // rebuild happens here
+  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor,
+                                      true);  // rebuild happens here
 }
 
 TEST_F(VerletListsTest, testCheckNeighborListsAreValidAfterBuild) {
-  autopas::VerletLists<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> verletLists(
-      {0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
+  autopas::VerletLists<autopas::Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
 
   MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, true)).Times(AtLeast(1));
@@ -343,8 +338,7 @@ TEST_F(VerletListsTest, testCheckNeighborListsAreValidAfterBuild) {
 }
 
 TEST_F(VerletListsTest, testCheckNeighborListsAreValidAfterSmallMove) {
-  autopas::VerletLists<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> verletLists(
-      {0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
+  autopas::VerletLists<autopas::Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
 
   MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
 
@@ -368,8 +362,7 @@ TEST_F(VerletListsTest, testCheckNeighborListsAreValidAfterSmallMove) {
 }
 
 TEST_F(VerletListsTest, testCheckNeighborListsAreInvalidAfterMoveLarge) {
-  autopas::VerletLists<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> verletLists(
-      {0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
+  autopas::VerletLists<autopas::Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
 
   MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
 
@@ -393,8 +386,7 @@ TEST_F(VerletListsTest, testCheckNeighborListsAreInvalidAfterMoveLarge) {
 }
 
 TEST_F(VerletListsTest, testCheckNeighborListsInvalidMoveFarOutsideCell) {
-  autopas::VerletLists<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> verletLists(
-      {0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
+  autopas::VerletLists<autopas::Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
 
   MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
 
@@ -419,8 +411,7 @@ TEST_F(VerletListsTest, testCheckNeighborListsInvalidMoveFarOutsideCell) {
 }
 
 TEST_F(VerletListsTest, testCheckNeighborListsValidMoveLittleOutsideCell) {
-  autopas::VerletLists<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> verletLists(
-      {0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
+  autopas::VerletLists<autopas::Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
 
   MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
 
@@ -458,8 +449,7 @@ void moveUpdateAndExpectEqual(Container& container, Particle& particle, std::arr
 };
 
 TEST_F(VerletListsTest, testUpdateHaloParticle) {
-  autopas::VerletLists<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> verletLists(
-      {0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
+  autopas::VerletLists<autopas::Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
 
   autopas::Particle p({-.1, 10.1, -.1}, {0., 0., 0.}, 1);
   verletLists.addHaloParticle(p);
@@ -505,24 +495,22 @@ TEST_F(VerletListsTest, testUpdateHaloParticle) {
 }
 
 TEST_F(VerletListsTest, LoadExtractSoA) {
-  autopas::VerletLists<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> verletLists(
-      {0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
+  autopas::VerletLists<autopas::Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
 
   autopas::Particle p({-.1, 10.1, -.1}, {0., 0., 0.}, 1);
   verletLists.addHaloParticle(p);
 
   MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> mockFunctor;
 
-  EXPECT_CALL(mockFunctor, SoALoader(_, _, _)).Times(216);  // 6*6*6=216 cells
-  EXPECT_CALL(mockFunctor, SoAExtractor(_, _, _)).Times(216);
+  EXPECT_CALL(mockFunctor, SoALoaderVerlet(_, _, _)).Times(216);  // 6*6*6=216 cells
+  EXPECT_CALL(mockFunctor, SoAExtractorVerlet(_, _, _)).Times(216);
   EXPECT_CALL(mockFunctor, SoAFunctor(_, _, _, _)).Times(0);
   EXPECT_CALL(mockFunctor, SoAFunctor(_, _, _, _, _)).Times(1);
   verletLists.iteratePairwiseSoA2(&mockFunctor, true);
 }
 
 TEST_F(VerletListsTest, LoadExtractSoALJ) {
-  autopas::VerletLists<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> verletLists(
-      {0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
+  autopas::VerletLists<autopas::Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
 
   autopas::Particle p({-.1, 10.1, -.1}, {0., 0., 0.}, 1);
   verletLists.addHaloParticle(p);
@@ -534,11 +522,9 @@ TEST_F(VerletListsTest, LoadExtractSoALJ) {
 
 TEST_F(VerletListsTest, SoAvsAoSLJ) {
   double cutoff = 2.;
-  autopas::VerletLists<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> verletLists1(
-      {0., 0., 0.}, {10., 10., 10.}, cutoff, 0.3, 3);
+  autopas::VerletLists<autopas::Particle> verletLists1({0., 0., 0.}, {10., 10., 10.}, cutoff, 0.3, 3);
 
-  autopas::VerletLists<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> verletLists2(
-      {0., 0., 0.}, {10., 10., 10.}, cutoff, 0.3, 3);
+  autopas::VerletLists<autopas::Particle> verletLists2({0., 0., 0.}, {10., 10., 10.}, cutoff, 0.3, 3);
 
   RandomGenerator::fillWithParticles(verletLists1, autopas::Particle({0., 0., 0.}, {0., 0., 0.}, 0), 100);
   RandomGenerator::fillWithParticles(verletLists2, autopas::Particle({0., 0., 0.}, {0., 0., 0.}, 0), 100);

--- a/tests/testAutopas/VerletListsTest.cpp
+++ b/tests/testAutopas/VerletListsTest.cpp
@@ -5,11 +5,11 @@
  */
 
 #include "VerletListsTest.h"
+#include "cells/FullParticleCell.h"
 #include "mocks/MockFunctor.h"
 #include "mocks/MockVerletLists.h"
-#include "testingHelpers/RandomGenerator.h"
-#include "cells/FullParticleCell.h"
 #include "particles/Particle.h"
+#include "testingHelpers/RandomGenerator.h"
 
 using ::testing::_;
 using ::testing::AtLeast;
@@ -245,20 +245,19 @@ TEST_F(VerletListsTest, testForceRebuild) {
   ON_CALL(mockVerletLists, addParticle(_))
       .WillByDefault(Invoke(
           &mockVerletLists,
-          &MockVerletLists<autopas::Particle,
-                           autopas::FullParticleCell<autopas::Particle>>::addParticleVerletLists));
+          &MockVerletLists<autopas::Particle, autopas::FullParticleCell<autopas::Particle>>::addParticleVerletLists));
   // delegating to parent
   ON_CALL(mockVerletLists, addHaloParticle(_))
-      .WillByDefault(Invoke(
-          &mockVerletLists,
-          &MockVerletLists<autopas::Particle,
-                           autopas::FullParticleCell<autopas::Particle>>::addHaloParticleVerletLists));
+      .WillByDefault(
+          Invoke(&mockVerletLists,
+                 &MockVerletLists<autopas::Particle,
+                                  autopas::FullParticleCell<autopas::Particle>>::addHaloParticleVerletLists));
   // delegating to parent
   ON_CALL(mockVerletLists, updateContainer())
-      .WillByDefault(Invoke(
-          &mockVerletLists,
-          &MockVerletLists<autopas::Particle,
-                           autopas::FullParticleCell<autopas::Particle>>::updateContainerVerletLists));
+      .WillByDefault(
+          Invoke(&mockVerletLists,
+                 &MockVerletLists<autopas::Particle,
+                                  autopas::FullParticleCell<autopas::Particle>>::updateContainerVerletLists));
 
   MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
 

--- a/tests/testAutopas/VerletListsTest.cpp
+++ b/tests/testAutopas/VerletListsTest.cpp
@@ -492,7 +492,6 @@ TEST_F(VerletListsTest, LoadExtractSoA) {
 
   EXPECT_CALL(mockFunctor, SoALoaderVerlet(_, _, _)).Times(216);  // 6*6*6=216 cells
   EXPECT_CALL(mockFunctor, SoAExtractorVerlet(_, _, _)).Times(216);
-  EXPECT_CALL(mockFunctor, SoAFunctor(_, _, _, _)).Times(0);
   EXPECT_CALL(mockFunctor, SoAFunctor(_, _, _, _, _)).Times(1);
   verletLists.iteratePairwiseSoA(&mockFunctor, true);
 }

--- a/tests/testAutopas/VerletListsTest.cpp
+++ b/tests/testAutopas/VerletListsTest.cpp
@@ -39,7 +39,7 @@ TEST_F(VerletListsTest, testVerletListBuild) {
 
   MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, true)).Times(AtLeast(1));
-  verletLists.iteratePairwiseAoS2(&emptyFunctor, true);
+  verletLists.iteratePairwiseAoS(&emptyFunctor, true);
 
   auto& list = verletLists.getVerletListsAoS();
 
@@ -69,7 +69,7 @@ TEST_F(VerletListsTest, testVerletList) {
   using ::testing::_;  // anything is ok
   EXPECT_CALL(mockFunctor, AoSFunctor(_, _, true));
 
-  verletLists.iteratePairwiseAoS2(&mockFunctor, true);
+  verletLists.iteratePairwiseAoS(&mockFunctor, true);
 
   auto& list = verletLists.getVerletListsAoS();
 
@@ -99,7 +99,7 @@ TEST_F(VerletListsTest, testVerletListInSkin) {
   using ::testing::_;  // anything is ok
   EXPECT_CALL(mockFunctor, AoSFunctor(_, _, true));
 
-  verletLists.iteratePairwiseAoS2(&mockFunctor, true);
+  verletLists.iteratePairwiseAoS(&mockFunctor, true);
 
   auto& list = verletLists.getVerletListsAoS();
 
@@ -127,9 +127,9 @@ TEST_F(VerletListsTest, testVerletListBuildTwice) {
 
   MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, true)).Times(AtLeast(1));
-  verletLists.iteratePairwiseAoS2(&emptyFunctor, true);
+  verletLists.iteratePairwiseAoS(&emptyFunctor, true);
 
-  verletLists.iteratePairwiseAoS2(&emptyFunctor, true);
+  verletLists.iteratePairwiseAoS(&emptyFunctor, true);
 
   auto& list = verletLists.getVerletListsAoS();
 
@@ -162,7 +162,7 @@ TEST_F(VerletListsTest, testVerletListBuildFarAway) {
 
   MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, true)).Times(AtLeast(1));
-  verletLists.iteratePairwiseAoS2(&emptyFunctor, true);
+  verletLists.iteratePairwiseAoS(&emptyFunctor, true);
 
   auto& list = verletLists.getVerletListsAoS();
 
@@ -190,9 +190,9 @@ TEST_F(VerletListsTest, testVerletListBuildHalo) {
 
   MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, true)).Times(AtLeast(1));
-  verletLists.iteratePairwiseAoS2(&emptyFunctor, true);
+  verletLists.iteratePairwiseAoS(&emptyFunctor, true);
 
-  verletLists.iteratePairwiseAoS2(&emptyFunctor, true);
+  verletLists.iteratePairwiseAoS(&emptyFunctor, true);
 
   auto& list = verletLists.getVerletListsAoS();
 
@@ -211,10 +211,10 @@ TEST_F(VerletListsTest, testRebuildFrequencyAlways) {
 
   MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(4);
-  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);
-  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);
-  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);
-  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
 }
 
 TEST_F(VerletListsTest, testRebuildFrequencyEvery3) {
@@ -224,17 +224,17 @@ TEST_F(VerletListsTest, testRebuildFrequencyEvery3) {
   MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
 
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);  // 1
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);  // 1
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(0);
-  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);
-  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);  // 2
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);  // 2
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(0);
-  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);
-  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);  // 3
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);  // 3
 }
 
 TEST_F(VerletListsTest, testForceRebuild) {
@@ -263,33 +263,33 @@ TEST_F(VerletListsTest, testForceRebuild) {
 
   // check that the second call does not need a rebuild
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor,
-                                      true);  // rebuild happens here
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor,
+                                     true);  // rebuild happens here
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(0);
-  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
 
   // check that updateContainer() requires a rebuild
   EXPECT_CALL(mockVerletLists, updateContainer());
   mockVerletLists.updateContainer();
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor,
-                                      true);  // rebuild happens here
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor,
+                                     true);  // rebuild happens here
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(0);
-  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
 
   // check that adding particles requires a rebuild
   autopas::Particle p({1.1, 1.1, 1.1}, {0., 0., 0.}, 1);
   EXPECT_CALL(mockVerletLists, addParticle(_));
   mockVerletLists.addParticle(p);
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor,
-                                      true);  // rebuild happens here
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor,
+                                     true);  // rebuild happens here
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(0);
-  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);
-  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor,
-                                      true);  // rebuild happens here
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor,
+                                     true);  // rebuild happens here
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(0);
 
   // check that adding halo particles requires a rebuild
@@ -297,8 +297,8 @@ TEST_F(VerletListsTest, testForceRebuild) {
   EXPECT_CALL(mockVerletLists, addHaloParticle(_));
   mockVerletLists.addHaloParticle(p2);
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor,
-                                      true);  // rebuild happens here
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor,
+                                     true);  // rebuild happens here
 
   // check that deleting particles requires a rebuild
   /// @todo: reenable once implemented
@@ -307,14 +307,14 @@ TEST_F(VerletListsTest, testForceRebuild) {
     iterator.deleteCurrentParticle();
   }
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor,
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor,
                                      true);  // rebuild happens here
 */
   // check that deleting halo particles requires a rebuild
   mockVerletLists.deleteHaloParticles();
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS2(&emptyFunctor,
-                                      true);  // rebuild happens here
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor,
+                                     true);  // rebuild happens here
 }
 
 TEST_F(VerletListsTest, testCheckNeighborListsAreValidAfterBuild) {
@@ -330,7 +330,7 @@ TEST_F(VerletListsTest, testCheckNeighborListsAreValidAfterBuild) {
   verletLists.addParticle(p2);
 
   // this will build the verlet list
-  verletLists.iteratePairwiseAoS2(&emptyFunctor);
+  verletLists.iteratePairwiseAoS(&emptyFunctor);
 
   // check validity - should return true
   EXPECT_TRUE(verletLists.checkNeighborListsAreValid());
@@ -348,7 +348,7 @@ TEST_F(VerletListsTest, testCheckNeighborListsAreValidAfterSmallMove) {
   verletLists.addParticle(p2);
 
   // this will build the verlet list
-  verletLists.iteratePairwiseAoS2(&emptyFunctor);
+  verletLists.iteratePairwiseAoS(&emptyFunctor);
 
   for (auto iter = verletLists.begin(); iter.isValid(); ++iter) {
     if (iter->getID() == 1) {
@@ -372,7 +372,7 @@ TEST_F(VerletListsTest, testCheckNeighborListsAreInvalidAfterMoveLarge) {
   verletLists.addParticle(p2);
 
   // this will build the verlet list
-  verletLists.iteratePairwiseAoS2(&emptyFunctor);
+  verletLists.iteratePairwiseAoS(&emptyFunctor);
 
   for (auto iter = verletLists.begin(); iter.isValid(); ++iter) {
     if (iter->getID() == 1) {
@@ -396,7 +396,7 @@ TEST_F(VerletListsTest, testCheckNeighborListsInvalidMoveFarOutsideCell) {
   verletLists.addParticle(p2);
 
   // this will build the verlet list
-  verletLists.iteratePairwiseAoS2(&emptyFunctor);
+  verletLists.iteratePairwiseAoS(&emptyFunctor);
 
   for (auto iter = verletLists.begin(); iter.isValid(); ++iter) {
     if (iter->getID() == 1) {
@@ -421,7 +421,7 @@ TEST_F(VerletListsTest, testCheckNeighborListsValidMoveLittleOutsideCell) {
   verletLists.addParticle(p2);
 
   // this will build the verlet list
-  verletLists.iteratePairwiseAoS2(&emptyFunctor);
+  verletLists.iteratePairwiseAoS(&emptyFunctor);
 
   for (auto iter = verletLists.begin(); iter.isValid(); ++iter) {
     if (iter->getID() == 1) {
@@ -505,7 +505,7 @@ TEST_F(VerletListsTest, LoadExtractSoA) {
   EXPECT_CALL(mockFunctor, SoAExtractorVerlet(_, _, _)).Times(216);
   EXPECT_CALL(mockFunctor, SoAFunctor(_, _, _, _)).Times(0);
   EXPECT_CALL(mockFunctor, SoAFunctor(_, _, _, _, _)).Times(1);
-  verletLists.iteratePairwiseSoA2(&mockFunctor, true);
+  verletLists.iteratePairwiseSoA(&mockFunctor, true);
 }
 
 TEST_F(VerletListsTest, LoadExtractSoALJ) {
@@ -516,7 +516,7 @@ TEST_F(VerletListsTest, LoadExtractSoALJ) {
 
   autopas::LJFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> ljFunctor;
 
-  verletLists.iteratePairwiseSoA2(&ljFunctor, true);
+  verletLists.iteratePairwiseSoA(&ljFunctor, true);
 }
 
 TEST_F(VerletListsTest, SoAvsAoSLJ) {
@@ -531,8 +531,8 @@ TEST_F(VerletListsTest, SoAvsAoSLJ) {
   autopas::LJFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> ljFunctor;
   ljFunctor.setGlobals(cutoff, 1, 1, 0);
 
-  verletLists1.iteratePairwiseAoS2(&ljFunctor);
-  verletLists2.iteratePairwiseSoA2(&ljFunctor);
+  verletLists1.iteratePairwiseAoS(&ljFunctor);
+  verletLists2.iteratePairwiseSoA(&ljFunctor);
 
   auto iter1 = verletLists1.begin();
   auto iter2 = verletLists2.begin();

--- a/tests/testAutopas/mocks/MockFunctor.h
+++ b/tests/testAutopas/mocks/MockFunctor.h
@@ -20,29 +20,21 @@
 template <class Particle, class ParticleCell>
 class MockFunctor : public autopas::Functor<Particle, ParticleCell> {
  public:
-  // virtual void AoSFunctor(Particle &i, Particle &j, bool newton3 = true) {}
-  MOCK_METHOD2_T(AoSFunctor, void(Particle &i, Particle &j));
+  // virtual void AoSFunctor(Particle &i, Particle &j, bool newton3)
   MOCK_METHOD3_T(AoSFunctor, void(Particle &i, Particle &j, bool newton3));
 
-  // virtual void SoAFunctor(SoA &soa, bool newton3 = true) {}
-  MOCK_METHOD1_T(SoAFunctor, void(autopas::SoA<typename Particle::SoAArraysType> &soa));
+  // virtual void SoAFunctor(SoA &soa, bool newton3)
   MOCK_METHOD2_T(SoAFunctor, void(autopas::SoA<typename Particle::SoAArraysType> &soa, bool newton3));
 
-  // virtual void SoAFunctor(SoA &soa1, SoA &soa2, bool newton3 = true) {}
-  MOCK_METHOD2_T(SoAFunctor, void(autopas::SoA<typename Particle::SoAArraysType> &soa,
-                                  autopas::SoA<typename Particle::SoAArraysType> &soa2));
+  // virtual void SoAFunctor(SoA &soa1, SoA &soa2, bool newton3)
   MOCK_METHOD3_T(SoAFunctor, void(autopas::SoA<typename Particle::SoAArraysType> &soa,
                                   autopas::SoA<typename Particle::SoAArraysType> &soa2, bool newton3));
 
   // virtual void SoAFunctor(SoA &soa, const std::vector<std::vector<size_t,
-  // AlignedAllocator<size_t>>> &neighborList, size_t iFrom, size_t iTo, bool
-  // newton3 = true{})
-  MOCK_METHOD4_T(SoAFunctor,
-                 void(autopas::SoA<typename Particle::SoAArraysType> &soa,
-                      const std::vector<std::vector<size_t, autopas::AlignedAllocator<size_t>>> &, size_t, size_t));
+  // AlignedAllocator<size_t>>> &neighborList, size_t iFrom, size_t iTo, bool newton3)
   MOCK_METHOD5_T(SoAFunctor, void(autopas::SoA<typename Particle::SoAArraysType> &soa,
                                   const std::vector<std::vector<size_t, autopas::AlignedAllocator<size_t>>> &, size_t,
-                                  size_t, bool));
+                                  size_t, bool newton3));
 
   // virtual void SoALoader(ParticleCell &cell, autopas::SoA &soa, size_t
   // offset=0) {}

--- a/tests/testAutopas/mocks/MockFunctor.h
+++ b/tests/testAutopas/mocks/MockFunctor.h
@@ -8,6 +8,7 @@
 
 #include <gmock/gmock.h>
 #include "autopasIncludes.h"
+#include "containers/VerletListHelpers.h"
 
 // gmock does not write overrides, so we suppress that warning here!
 #if __GNUC__ >= 5
@@ -28,8 +29,10 @@ class MockFunctor : public autopas::Functor<Particle, ParticleCell> {
   MOCK_METHOD2_T(SoAFunctor, void(autopas::SoA<typename Particle::SoAArraysType> &soa, bool newton3));
 
   // virtual void SoAFunctor(SoA &soa1, SoA &soa2, bool newton3 = true) {}
-  MOCK_METHOD2_T(SoAFunctor, void(autopas::SoA<typename Particle::SoAArraysType> &soa, autopas::SoA<typename Particle::SoAArraysType> &soa2));
-  MOCK_METHOD3_T(SoAFunctor, void(autopas::SoA<typename Particle::SoAArraysType> &soa, autopas::SoA<typename Particle::SoAArraysType> &soa2, bool newton3));
+  MOCK_METHOD2_T(SoAFunctor, void(autopas::SoA<typename Particle::SoAArraysType> &soa,
+                                  autopas::SoA<typename Particle::SoAArraysType> &soa2));
+  MOCK_METHOD3_T(SoAFunctor, void(autopas::SoA<typename Particle::SoAArraysType> &soa,
+                                  autopas::SoA<typename Particle::SoAArraysType> &soa2, bool newton3));
 
   // virtual void SoAFunctor(SoA &soa, const std::vector<std::vector<size_t,
   // AlignedAllocator<size_t>>> &neighborList, size_t iFrom, size_t iTo, bool
@@ -44,12 +47,36 @@ class MockFunctor : public autopas::Functor<Particle, ParticleCell> {
   // virtual void SoALoader(ParticleCell &cell, autopas::SoA &soa, size_t
   // offset=0) {}
   MOCK_METHOD2_T(SoALoader, void(ParticleCell &cell, autopas::SoA<typename Particle::SoAArraysType> &soa));
-  MOCK_METHOD3_T(SoALoader, void(ParticleCell &cell, autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset));
+  MOCK_METHOD3_T(SoALoader,
+                 void(ParticleCell &cell, autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset));
+
+  MOCK_METHOD3_T(SoALoaderVerlet, void(typename autopas::VerletListHelpers<Particle>::VerletListParticleCellType &cell,
+                                       autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset));
+
+  template <typename /*dummy*/ = void,
+            typename = std::enable_if_t<not std::is_same<
+                typename autopas::VerletListHelpers<Particle>::VerletListParticleCellType, ParticleCell>::value>>
+  void SoALoader(typename autopas::VerletListHelpers<Particle>::VerletListParticleCellType &cell,
+                 autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset = 0) {
+    SoALoaderVerlet(cell, soa, offset);
+  }
 
   // virtual void SoAExtractor(ParticleCell &cell, autopas::SoA &soa, size_t
   // offset=0) {}
   MOCK_METHOD2_T(SoAExtractor, void(ParticleCell &cell, autopas::SoA<typename Particle::SoAArraysType> &soa));
-  MOCK_METHOD3_T(SoAExtractor, void(ParticleCell &cell, autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset));
+  MOCK_METHOD3_T(SoAExtractor,
+                 void(ParticleCell &cell, autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset));
+
+  MOCK_METHOD3_T(SoAExtractorVerlet, void(typename autopas::VerletListHelpers<Particle>::VerletListParticleCellType &cell,
+                                          autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset));
+
+  template <typename /*dummy*/ = void,
+            typename = std::enable_if_t<not std::is_same<
+                typename autopas::VerletListHelpers<Particle>::VerletListParticleCellType, ParticleCell>::value>>
+  void SoAExtractor(typename autopas::VerletListHelpers<Particle>::VerletListParticleCellType &cell,
+                    autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset = 0) {
+    SoAExtractorVerlet(cell, soa, offset);
+  }
 
   // virtual bool allowsNewton3() { return true; }
   MOCK_METHOD0(allowsNewton3, bool());

--- a/tests/testAutopas/mocks/MockFunctor.h
+++ b/tests/testAutopas/mocks/MockFunctor.h
@@ -24,32 +24,32 @@ class MockFunctor : public autopas::Functor<Particle, ParticleCell> {
   MOCK_METHOD3_T(AoSFunctor, void(Particle &i, Particle &j, bool newton3));
 
   // virtual void SoAFunctor(SoA &soa, bool newton3 = true) {}
-  MOCK_METHOD1_T(SoAFunctor, void(autopas::SoA<Particle> &soa));
-  MOCK_METHOD2_T(SoAFunctor, void(autopas::SoA<Particle> &soa, bool newton3));
+  MOCK_METHOD1_T(SoAFunctor, void(autopas::SoA<typename Particle::SoAArraysType> &soa));
+  MOCK_METHOD2_T(SoAFunctor, void(autopas::SoA<typename Particle::SoAArraysType> &soa, bool newton3));
 
   // virtual void SoAFunctor(SoA &soa1, SoA &soa2, bool newton3 = true) {}
-  MOCK_METHOD2_T(SoAFunctor, void(autopas::SoA<Particle> &soa, autopas::SoA<Particle> &soa2));
-  MOCK_METHOD3_T(SoAFunctor, void(autopas::SoA<Particle> &soa, autopas::SoA<Particle> &soa2, bool newton3));
+  MOCK_METHOD2_T(SoAFunctor, void(autopas::SoA<typename Particle::SoAArraysType> &soa, autopas::SoA<typename Particle::SoAArraysType> &soa2));
+  MOCK_METHOD3_T(SoAFunctor, void(autopas::SoA<typename Particle::SoAArraysType> &soa, autopas::SoA<typename Particle::SoAArraysType> &soa2, bool newton3));
 
   // virtual void SoAFunctor(SoA &soa, const std::vector<std::vector<size_t,
   // AlignedAllocator<size_t>>> &neighborList, size_t iFrom, size_t iTo, bool
   // newton3 = true{})
   MOCK_METHOD4_T(SoAFunctor,
-                 void(autopas::SoA<Particle> &soa,
+                 void(autopas::SoA<typename Particle::SoAArraysType> &soa,
                       const std::vector<std::vector<size_t, autopas::AlignedAllocator<size_t>>> &, size_t, size_t));
-  MOCK_METHOD5_T(SoAFunctor, void(autopas::SoA<Particle> &soa,
+  MOCK_METHOD5_T(SoAFunctor, void(autopas::SoA<typename Particle::SoAArraysType> &soa,
                                   const std::vector<std::vector<size_t, autopas::AlignedAllocator<size_t>>> &, size_t,
                                   size_t, bool));
 
   // virtual void SoALoader(ParticleCell &cell, autopas::SoA &soa, size_t
   // offset=0) {}
-  MOCK_METHOD2_T(SoALoader, void(ParticleCell &cell, autopas::SoA<Particle> &soa));
-  MOCK_METHOD3_T(SoALoader, void(ParticleCell &cell, autopas::SoA<Particle> &soa, size_t offset));
+  MOCK_METHOD2_T(SoALoader, void(ParticleCell &cell, autopas::SoA<typename Particle::SoAArraysType> &soa));
+  MOCK_METHOD3_T(SoALoader, void(ParticleCell &cell, autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset));
 
   // virtual void SoAExtractor(ParticleCell &cell, autopas::SoA &soa, size_t
   // offset=0) {}
-  MOCK_METHOD2_T(SoAExtractor, void(ParticleCell &cell, autopas::SoA<Particle> &soa));
-  MOCK_METHOD3_T(SoAExtractor, void(ParticleCell &cell, autopas::SoA<Particle> &soa, size_t offset));
+  MOCK_METHOD2_T(SoAExtractor, void(ParticleCell &cell, autopas::SoA<typename Particle::SoAArraysType> &soa));
+  MOCK_METHOD3_T(SoAExtractor, void(ParticleCell &cell, autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset));
 
   // virtual bool allowsNewton3() { return true; }
   MOCK_METHOD0(allowsNewton3, bool());

--- a/tests/testAutopas/mocks/MockFunctor.h
+++ b/tests/testAutopas/mocks/MockFunctor.h
@@ -63,8 +63,7 @@ class MockFunctor : public autopas::Functor<Particle, ParticleCell> {
                  void(typename autopas::VerletListHelpers<Particle>::VerletListParticleCellType &cell,
                       autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset));
 
-  template <typename /*dummy*/ = void,
-            typename = std::enable_if_t<not std::is_same<
+  template <typename = std::enable_if_t<not std::is_same<
                 typename autopas::VerletListHelpers<Particle>::VerletListParticleCellType, ParticleCell>::value>>
   void SoAExtractor(typename autopas::VerletListHelpers<Particle>::VerletListParticleCellType &cell,
                     autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset = 0) {

--- a/tests/testAutopas/mocks/MockFunctor.h
+++ b/tests/testAutopas/mocks/MockFunctor.h
@@ -67,8 +67,9 @@ class MockFunctor : public autopas::Functor<Particle, ParticleCell> {
   MOCK_METHOD3_T(SoAExtractor,
                  void(ParticleCell &cell, autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset));
 
-  MOCK_METHOD3_T(SoAExtractorVerlet, void(typename autopas::VerletListHelpers<Particle>::VerletListParticleCellType &cell,
-                                          autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset));
+  MOCK_METHOD3_T(SoAExtractorVerlet,
+                 void(typename autopas::VerletListHelpers<Particle>::VerletListParticleCellType &cell,
+                      autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset));
 
   template <typename /*dummy*/ = void,
             typename = std::enable_if_t<not std::is_same<

--- a/tests/testAutopas/mocks/MockVerletLists.h
+++ b/tests/testAutopas/mocks/MockVerletLists.h
@@ -16,12 +16,13 @@
 #pragma GCC diagnostic ignored "-Wsuggest-override"
 #endif
 
-template <typename Particle, typename ParticleCell>
-class MockVerletLists : public autopas::VerletLists<Particle, ParticleCell> {
+template <typename Particle>
+class MockVerletLists : public autopas::VerletLists<Particle> {
  public:
   MockVerletLists(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, double cutoff, double skin,
                   unsigned int rebuildFrequency = 1)
-      : autopas::VerletLists<Particle, ParticleCell>(boxMin, boxMax, cutoff, skin, rebuildFrequency) {}
+      : autopas::VerletLists<Particle>(boxMin, boxMax, cutoff, skin, rebuildFrequency) {}
+
   // MOCK_METHOD2_T(iteratePairwiseAoS, void(Functor, bool));  // we are not
   // allowed to mock this! We also don't want to! as this is exactly the
   // function we want to test
@@ -34,9 +35,9 @@ class MockVerletLists : public autopas::VerletLists<Particle, ParticleCell> {
  protected:
   MOCK_METHOD1(updateVerletListsAoS, void(bool));
 
-  void addParticleVerletLists(Particle& p) { autopas::VerletLists<Particle, ParticleCell>::addParticle(p); }
-  void addHaloParticleVerletLists(Particle& p) { autopas::VerletLists<Particle, ParticleCell>::addHaloParticle(p); }
-  void updateContainerVerletLists() { autopas::VerletLists<Particle, ParticleCell>::updateContainer(); }
+  void addParticleVerletLists(Particle& p) { autopas::VerletLists<Particle>::addParticle(p); }
+  void addHaloParticleVerletLists(Particle& p) { autopas::VerletLists<Particle>::addHaloParticle(p); }
+  void updateContainerVerletLists() { autopas::VerletLists<Particle>::updateContainer(); }
 
   friend class VerletListsTest_testRebuildFrequencyAlways_Test;
   friend class VerletListsTest_testRebuildFrequencyEvery3_Test;


### PR DESCRIPTION
**Features:**
- [x] fixes #61
- [x] fixes #52

**Details:**
- VerletLists now uses delegation for the usage of linked cells
- VerletLists' LinkedCells' SoAs are now only id + position
- this required the removal of some functions in functor, thus also implemented and fixed #52:
  - iteratePairwiseSoA2/*AoS2 is now always called, iteratePairwiseSoA/AoS are completely removed
  - static type is deduced using macro. see AutoPas.h or StaticSelectorMacros


**Todo:**
- [x] documentation
- cleanup:
   - [x] rename iteratePairwiseSoA2/AoS2 -> without 2
   - [x] remove useNewton3's default parameter in functor
   - [x] remove second template parameter from verlet list (if it is still there)
   - [x] remove 3rd template argument from FlopCounterFunctor, SPHCalcDensityFunctor, SPHCalcHydroForceFunctor