### PR TITLE
AoS performance improvements

### DIFF
--- a/examples/md/measurePerf.sh
+++ b/examples/md/measurePerf.sh
@@ -10,12 +10,12 @@ do
 	# iterate over molecules with the correct repetition
 	echo -e "Number of Molecules\tNumber of Force updates\tElapsed time\tMFUPS\tFLOPs\thit rate\tGFLOP/sec" > output-${iCont}.txt
 	for i in {0..8}; do ./md-main ${iCont} ${Mols[$i]} ${Reps[$i]}; done >> output-${iCont}.txt
-done
+	echo Container ${iCont} soa:
 
-echo "Container 0 soa:"
-iCont=0
-    echo -e "Number of Molecules\tNumber of Force updates\tElapsed time\tMFUPS\tFLOPs\thit rate\tGFLOP/sec" > output-${iCont}-soa.txt
+	echo -e "Number of Molecules\tNumber of Force updates\tElapsed time\tMFUPS\tFLOPs\thit rate\tGFLOP/sec" > output-${iCont}-soa.txt
     for i in {0..8}; do ./md-main ${iCont} ${Mols[$i]} ${Reps[$i]} soa; done >> output-${iCont}-soa.txt
+
+done
 
 
 # verlet
@@ -31,7 +31,7 @@ iCont=2;
     echo -e "Number of Molecules\tNumber of Force updates\tElapsed time\tMFUPS\tFLOPs\thit rate\tGFLOP/sec" > output-${iCont}-verlet-20-0.3.txt
 	for i in {0..8}; do ./md-main ${iCont} ${Mols[$i]} ${Reps[$i]} 20 0.3; done >> output-${iCont}-verlet-20-0.3.txt
 
-	echo "Container ${iCont}, soa:"
+	echo "Container ${iCont} soa:"
     echo -e "Number of Molecules\tNumber of Force updates\tElapsed time\tMFUPS\tFLOPs\thit rate\tGFLOP/sec" > output-${iCont}-verlet-1-0.0-soa.txt
 	for i in {0..8}; do ./md-main ${iCont} ${Mols[$i]} ${Reps[$i]} 1 0. soa; done >> output-${iCont}-verlet-1-0.0-soa.txt
     echo -e "Number of Molecules\tNumber of Force updates\tElapsed time\tMFUPS\tFLOPs\thit rate\tGFLOP/sec" > output-${iCont}-verlet-5-0.1-soa.txt

--- a/src/iterators/SingleCellIterator.h
+++ b/src/iterators/SingleCellIterator.h
@@ -42,7 +42,7 @@ class SingleCellIterator : public SingleCellIteratorInterfaceImpl<Particle> {
    * this is the indirection operator
    * @return current particle
    */
-  Particle &operator*() const override {
+  inline Particle &operator*() const override {
     Particle *ptr = nullptr;
     //_cell->particleAt(_index, ptr);
     ptr = &(_cell->_particles.at(_index));
@@ -53,7 +53,7 @@ class SingleCellIterator : public SingleCellIteratorInterfaceImpl<Particle> {
    * increment operator to get the next particle
    * @return the next particle, usually ignored
    */
-  SingleCellIterator &operator++() override {
+  inline SingleCellIterator &operator++() override {
     if (not _deleted) ++_index;
     _deleted = false;
     return *this;
@@ -67,7 +67,7 @@ class SingleCellIterator : public SingleCellIteratorInterfaceImpl<Particle> {
    * @return true if the iterators point to the same particle (in the same
    * cell), false otherwise
    */
-  bool operator==(const SingleCellIteratorInterface<Particle> &rhs) const override {
+  inline bool operator==(const SingleCellIteratorInterface<Particle> &rhs) const override {
     if (auto other = dynamic_cast<const SingleCellIterator<Particle, ParticleCell> *>(&rhs)) {
       return (not rhs.isValid() and not this->isValid()) or (_cell == other->_cell && _index == other->_index);
     } else {
@@ -81,28 +81,28 @@ class SingleCellIterator : public SingleCellIteratorInterfaceImpl<Particle> {
    * @param rhs
    * @return
    */
-  bool operator!=(const SingleCellIteratorInterface<Particle> &rhs) const override { return !(rhs == *this); }
+  inline bool operator!=(const SingleCellIteratorInterface<Particle> &rhs) const override { return !(rhs == *this); }
   /**
    * Check whether the iterator is valid
    * @return returns whether the iterator is valid
    */
-  bool isValid() const override { return _cell != nullptr and _index < _cell->numParticles(); }
+  inline bool isValid() const override { return _cell != nullptr and _index < _cell->numParticles(); }
 
   /**
    * Get the index of the particle in the cell
    * @return index of the current particle
    */
-  size_t getIndex() const override { return _index; }
+  inline size_t getIndex() const override { return _index; }
 
   /**
    * Deletes the current particle
    */
-  void deleteCurrentParticle() override {
+  inline void deleteCurrentParticle() override {
     _cell->deleteByIndex(_index);
     _deleted = true;
   }
 
-  SingleCellIteratorInterfaceImpl<Particle> *clone() const override {
+  inline SingleCellIteratorInterfaceImpl<Particle> *clone() const override {
     return new SingleCellIterator<Particle, ParticleCell>(*this);
   }
 

--- a/src/iterators/SingleCellIteratorInterface.h
+++ b/src/iterators/SingleCellIteratorInterface.h
@@ -71,7 +71,6 @@ class SingleCellIteratorInterfaceImpl : public SingleCellIteratorInterface<Parti
 }  // namespace internal
 }  // namespace autopas
 
-
 /**
  * gets a static cell iterator from an iteratorwrapper of a cell.
  * @param iter the iterator to be defined

--- a/src/iterators/SingleCellIteratorInterface.h
+++ b/src/iterators/SingleCellIteratorInterface.h
@@ -70,3 +70,26 @@ class SingleCellIteratorInterfaceImpl : public SingleCellIteratorInterface<Parti
 };
 }  // namespace internal
 }  // namespace autopas
+
+
+/**
+ * gets a static cell iterator from an iteratorwrapper of a cell.
+ * @param iter the iterator to be defined
+ * @param cell the cell for which the iterator should be get
+ * @param body the body to be executed with the static iterator
+ */
+#define WITH_STATIC_CELL_ITER(iter, cell, body)                                                                       \
+  auto __wrapper = cell.begin();                                                                                      \
+  auto __ptr = __wrapper.get();                                                                                       \
+  {                                                                                                                   \
+    if (auto __##iter##ptr = dynamic_cast<                                                                            \
+            internal::SingleCellIterator<Particle, typename std::remove_reference<decltype(cell)>::type> *>(__ptr)) { \
+      auto iter = *__##iter##ptr;                                                                                     \
+      body                                                                                                            \
+    } else if (auto __##iter##ptr = dynamic_cast<RMMParticleCellIterator<Particle> *>(__ptr)) {                       \
+      auto iter = *__##iter##ptr;                                                                                     \
+      body                                                                                                            \
+    } else {                                                                                                          \
+      autopas::utils::ExceptionHandler::exception("unknown iteratortype in WITH_STATIC_CELL_ITER");                   \
+    }                                                                                                                 \
+  }

--- a/src/iterators/SingleCellIteratorWrapper.h
+++ b/src/iterators/SingleCellIteratorWrapper.h
@@ -59,21 +59,23 @@ class SingleCellIteratorWrapper : public SingleCellIteratorInterface<Particle> {
     return *this;
   }
 
-  Particle& operator*() const override final { return _particleIterator->operator*(); }
+  inline Particle& operator*() const override final { return _particleIterator->operator*(); }
 
-  void deleteCurrentParticle() override final { _particleIterator->deleteCurrentParticle(); }
+  inline void deleteCurrentParticle() override final { _particleIterator->deleteCurrentParticle(); }
 
-  bool isValid() const override final { return _particleIterator->isValid(); }
+  inline bool isValid() const override final { return _particleIterator->isValid(); }
 
-  bool operator==(const SingleCellIteratorInterface<Particle>& rhs) const override final {
+  inline bool operator==(const SingleCellIteratorInterface<Particle>& rhs) const override final {
     return _particleIterator->operator==(rhs);
   }
 
-  bool operator!=(const SingleCellIteratorInterface<Particle>& rhs) const override final {
+  inline bool operator!=(const SingleCellIteratorInterface<Particle>& rhs) const override final {
     return _particleIterator->operator!=(rhs);
   }
 
-  size_t getIndex() const override final { return _particleIterator->getIndex(); }
+  inline size_t getIndex() const override final { return _particleIterator->getIndex(); }
+
+  inline SingleCellIteratorInterface<Particle>* get() const { return _particleIterator.get(); }
 
  private:
   std::unique_ptr<internal::SingleCellIteratorInterfaceImpl<Particle>> _particleIterator;

--- a/src/iterators/SingleCellIteratorWrapper.h
+++ b/src/iterators/SingleCellIteratorWrapper.h
@@ -75,6 +75,10 @@ class SingleCellIteratorWrapper : public SingleCellIteratorInterface<Particle> {
 
   inline size_t getIndex() const override final { return _particleIterator->getIndex(); }
 
+  /**
+   * Returns the stored single cell iterator.
+   * @return
+   */
   inline SingleCellIteratorInterface<Particle>* get() const { return _particleIterator.get(); }
 
  private:

--- a/src/pairwiseFunctors/CellFunctor.h
+++ b/src/pairwiseFunctors/CellFunctor.h
@@ -82,28 +82,6 @@ class CellFunctor {
     }
   }
 
-  /**
-   * gets a static cell iterator from an iteratorwrapper of a cell.
-   * @param iter the iterator to be defined
-   * @param cell the cell for which the iterator should be get
-   * @param body the body to be executed with the static iterator
-   */
-#define WITH_STATIC_CELL_ITER(iter, cell, body)                                                                       \
-  auto __wrapper = cell.begin();                                                                                      \
-  auto __ptr = __wrapper.get();                                                                                       \
-  {                                                                                                                   \
-    if (auto __##iter##ptr = dynamic_cast<                                                                            \
-            internal::SingleCellIterator<Particle, typename std::remove_reference<decltype(cell)>::type> *>(__ptr)) { \
-      auto iter = *__##iter##ptr;                                                                                     \
-      body                                                                                                            \
-    } else if (auto __##iter##ptr = dynamic_cast<RMMParticleCellIterator<Particle> *>(__ptr)) {                       \
-      auto iter = *__##iter##ptr;                                                                                     \
-      body                                                                                                            \
-    } else {                                                                                                          \
-      autopas::utils::ExceptionHandler::exception("unknown iteratortype in WITH_STATIC_CELL_ITER");                   \
-    }                                                                                                                 \
-  }
-
  private:
   /**
    * Applies the functor to all particle pairs exploiting newtons third law of

--- a/src/pairwiseFunctors/CellFunctor.h
+++ b/src/pairwiseFunctors/CellFunctor.h
@@ -7,9 +7,9 @@
 
 #pragma once
 
+#include "cells/RMMParticleCell2T.h"
 #include "iterators/SingleCellIterator.h"
 #include "utils/ExceptionHandler.h"
-#include "cells/RMMParticleCell2T.h"
 
 namespace autopas {
 
@@ -39,6 +39,9 @@ class CellFunctor {
    * calculated
    */
   void processCell(ParticleCell &cell) {
+    if (cell.numParticles() == 0) {
+      return;
+    }
     if (useSoA) {
       if (useNewton3) {
         processCellSoAN3(cell);
@@ -61,6 +64,9 @@ class CellFunctor {
    * @param cell2
    */
   void processCellPair(ParticleCell &cell1, ParticleCell &cell2) {
+    if (cell1.numParticles() == 0 || cell2.numParticles() == 0) {
+      return;
+    }
     if (useSoA) {
       if (useNewton3) {
         processCellPairSoAN3(cell1, cell2);


### PR DESCRIPTION
Problem:
ParticleIteratorWrappers were decreasing performance of AoS functors.
See these plots (orange and blue solid lines):
### Before Wrappers:
![image](https://user-images.githubusercontent.com/38119442/42015854-03558326-7ae4-11e8-9167-18000119b365.png)

### After Wrappers:
![image](https://user-images.githubusercontent.com/38119442/42015863-0d3590a2-7ae4-11e8-9dbc-540dfcc46a14.png)

### With the improvements made here:
![image](https://user-images.githubusercontent.com/38119442/42015872-17843950-7ae4-11e8-881b-af02b03f00a7.png)

### Speedup now vs. before wrappers:
![image](https://user-images.githubusercontent.com/38119442/42016178-8d7debf0-7ae5-11e8-88dc-4465b1e37bd6.png)
notes:
* (without the linked-cells soa version, as this is sort of totally different and the previous performance was very bad)
* verlet lists: for very few particles (less than 0.1 particles per cell), they are slower than before. not entirely sure why this happens.
* linked cells: slower than before up to 0.5 particles per cell. this most likely stems from the overhead of the wrappers, i.e. having additional `new` calls, etc.. This is probably also the reason for the decreased performance of the verlet lists.
* some of the speedup comes from new return statements inside the CellFunctors.


@FG-TUM In theory we can remove the wrapper for the SingleCellIterators, as they are anyways internal only, so not visible to the outside. What is your opinion?