### PR TITLE
Simple auto tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,17 @@ as long as particles move not more than a skin radius.
 	clang-format-6.0 
 	(Version is important since formatting is not consistent)
 
+## Logging
+AutoPas has its own logger based on [spdlog](https://github.com/gabime/spdlog) which can be used after the initialization of an AutoPas object via:
+```
+AutoPasLogger->warn("Hello {}", name);
+```
+The global log level can be set at runtime with:
+```
+AutoPasLogger->set_level(spdlog::level::debug);
+```
+Possible log levels are:`trace`, `debug`, `info`, `warn`, `err`, `critical`, `off`,
+
 ## Acknowledgements
 * TaLPas BMBF
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The particle can be accesses using `iter->` (`*iter` is also possible).
 When created inside a OpenMP parallel region, work is automatically spread over all iterators.
 ```C++
 #pragma omp parallel
-for(auto iter = container.begin(), iter.isValid(); ++iter) {
+for(auto iter = container.begin(); iter.isValid(); ++iter) {
   // user code:
   auto position = iter->getR();
 }

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ make
 
 
 ## Testing
+### Running Tests
 to run tests:
 ```
 make test
@@ -82,7 +83,15 @@ or `ctest` arguments like `-R` (run tests matching regex) and `-D` (exclude test
 ```
 ctest -R 'Array.*testAdd' -E `Double'
 ```
-
+### Debugging Tests
+Find out the command to start your desired test with `-N` aka. `--show-only`:
+```
+ctest -R 'Array.*testAdd' -N
+```
+Start the test with `gdb`
+```
+gdb --args ${TestCommand}
+```
 
 ## Examples
 As AutoPas is only a library for particle simulations it itself is not able to run simulations.

--- a/examples/md-flexible/MDFlexParser.cpp
+++ b/examples/md-flexible/MDFlexParser.cpp
@@ -24,6 +24,7 @@ bool MDFlexParser::parseInput(int argc, char **argv) {
                                          {"particle-spacing", required_argument, nullptr, 's'},
                                          {"traversal", required_argument, nullptr, 't'},
                                          {"tuning-interval", required_argument, nullptr, 'I'},
+                                         {"log-level", required_argument, nullptr, 'l'},
                                          {"verlet-rebuild-frequency", required_argument, nullptr, 'v'},
                                          {"verlet-skin-radius", required_argument, nullptr, 'r'},
                                          {"vtk", required_argument, nullptr, 'w'},
@@ -124,6 +125,44 @@ bool MDFlexParser::parseInput(int argc, char **argv) {
         } catch (const exception &) {
           cerr << "Error parsing tuning interval: " << optarg << endl;
           displayHelp = true;
+        }
+        break;
+      }
+      case 'l': {
+        switch (strArg[0]) {
+          case 't': {
+            logLevel = spdlog::level::trace;
+            break;
+          }
+          case 'd': {
+            logLevel = spdlog::level::debug;
+            break;
+          }
+          case 'i': {
+            logLevel = spdlog::level::info;
+            break;
+          }
+          case 'w': {
+            logLevel = spdlog::level::warn;
+            break;
+          }
+          case 'e': {
+            logLevel = spdlog::level::err;
+            break;
+          }
+          case 'c': {
+            logLevel = spdlog::level::critical;
+            break;
+          }
+          case 'o': {
+            logLevel = spdlog::level::off;
+            break;
+          }
+          default: {
+            cerr << "Unknown Log Level : " << strArg << endl;
+            cerr << "Please use 'trace', 'debug', 'info', 'warning', 'error', 'critical' or 'off'." << endl;
+            displayHelp = true;
+          }
         }
         break;
       }
@@ -358,3 +397,5 @@ double MDFlexParser::getBoxLength() const {
 bool MDFlexParser::getMeasureFlops() const { return measureFlops; }
 
 unsigned int MDFlexParser::getTuningInterval() const { return tuningInterval; }
+
+spdlog::level::level_enum MDFlexParser::getLogLevel() const { return logLevel; }

--- a/examples/md-flexible/MDFlexParser.cpp
+++ b/examples/md-flexible/MDFlexParser.cpp
@@ -23,6 +23,7 @@ bool MDFlexParser::parseInput(int argc, char **argv) {
                                          {"particles-per-dimension", required_argument, nullptr, 'n'},
                                          {"particle-spacing", required_argument, nullptr, 's'},
                                          {"traversal", required_argument, nullptr, 't'},
+                                         {"tuning-interval", required_argument, nullptr, 'I'},
                                          {"verlet-rebuild-frequency", required_argument, nullptr, 'v'},
                                          {"verlet-skin-radius", required_argument, nullptr, 'r'},
                                          {"vtk", required_argument, nullptr, 'w'},
@@ -113,6 +114,15 @@ bool MDFlexParser::parseInput(int argc, char **argv) {
           iterations = stoul(strArg);
         } catch (const exception &) {
           cerr << "Error parsing number of iterations: " << optarg << endl;
+          displayHelp = true;
+        }
+        break;
+      }
+      case 'I': {
+        try {
+          tuningInterval = (unsigned int)stoul(strArg);
+        } catch (const exception &) {
+          cerr << "Error parsing tuning interval: " << optarg << endl;
           displayHelp = true;
         }
         break;
@@ -308,6 +318,8 @@ void MDFlexParser::printConfig() {
 
   cout << setw(valueOffset) << left << "Iterations"
        << ":  " << iterations << endl;
+  cout << setw(valueOffset) << left << "Tuning Interval"
+       << ":  " << tuningInterval << endl;
 }
 
 autopas::ContainerOptions MDFlexParser::getContainerOption() const { return containerOption; }
@@ -344,3 +356,5 @@ double MDFlexParser::getBoxLength() const {
 }
 
 bool MDFlexParser::getMeasureFlops() const { return measureFlops; }
+
+unsigned int MDFlexParser::getTuningInterval() const { return tuningInterval; }

--- a/examples/md-flexible/MDFlexParser.cpp
+++ b/examples/md-flexible/MDFlexParser.cpp
@@ -18,6 +18,7 @@ bool MDFlexParser::parseInput(int argc, char **argv) {
                                          {"functor", required_argument, nullptr, 'f'},
                                          {"help", no_argument, nullptr, 'h'},
                                          {"iterations", required_argument, nullptr, 'i'},
+                                         {"no-flops", no_argument, nullptr, 'F'},
                                          {"particles-generator", required_argument, nullptr, 'g'},
                                          {"particles-per-dimension", required_argument, nullptr, 'n'},
                                          {"particle-spacing", required_argument, nullptr, 's'},
@@ -85,6 +86,10 @@ bool MDFlexParser::parseInput(int argc, char **argv) {
           cerr << "Please use 'Lennard-Jones', you have no options here :P" << endl;
           displayHelp = true;
         }
+        break;
+      }
+      case 'F': {
+        measureFlops = false;
         break;
       }
       case 'g': {
@@ -336,4 +341,8 @@ string MDFlexParser::getWriteVTK() const { return writeVTK; }
 double MDFlexParser::getBoxLength() const {
   if (boxLength == -1) return ceil(2 * distributionMean);
   return boxLength;
+}
+
+bool MDFlexParser::getMeasureFlops() const {
+  return measureFlops;
 }

--- a/examples/md-flexible/MDFlexParser.cpp
+++ b/examples/md-flexible/MDFlexParser.cpp
@@ -343,6 +343,4 @@ double MDFlexParser::getBoxLength() const {
   return boxLength;
 }
 
-bool MDFlexParser::getMeasureFlops() const {
-  return measureFlops;
-}
+bool MDFlexParser::getMeasureFlops() const { return measureFlops; }

--- a/examples/md-flexible/MDFlexParser.h
+++ b/examples/md-flexible/MDFlexParser.h
@@ -33,12 +33,14 @@ class MDFlexParser {
   bool getMeasureFlops() const;
   double getParticleSpacing() const;
   size_t getParticlesPerDim() const;
+  unsigned int getTuningInterval() const;
   string getWriteVTK() const;
   const vector<autopas::TraversalOptions> &getTraversalOptions() const;
   size_t getVerletRebuildFrequency() const;
   double getVerletSkinRadius() const;
   bool parseInput(int argc, char **argv);
   void printConfig();
+  ;
 
  private:
   static constexpr size_t valueOffset = 32;
@@ -58,6 +60,7 @@ class MDFlexParser {
   bool measureFlops = true;
   size_t particlesPerDim = 20;
   double particleSpacing = .4;
+  unsigned int tuningInterval = 100;
   string writeVTK = "";
   size_t verletRebuildFrequency = 5;
   double verletSkinRadius = .2;

--- a/examples/md-flexible/MDFlexParser.h
+++ b/examples/md-flexible/MDFlexParser.h
@@ -41,7 +41,6 @@ class MDFlexParser {
   double getVerletSkinRadius() const;
   bool parseInput(int argc, char **argv);
   void printConfig();
-  ;
 
  private:
   static constexpr size_t valueOffset = 32;

--- a/examples/md-flexible/MDFlexParser.h
+++ b/examples/md-flexible/MDFlexParser.h
@@ -31,6 +31,7 @@ class MDFlexParser {
   GeneratorOption getGeneratorOption() const;
   size_t getIterations() const;
   bool getMeasureFlops() const;
+  spdlog::level::level_enum getLogLevel() const;
   double getParticleSpacing() const;
   size_t getParticlesPerDim() const;
   unsigned int getTuningInterval() const;
@@ -57,6 +58,7 @@ class MDFlexParser {
   FunctorOption functorOption = FunctorOption::lj12_6;
   GeneratorOption generatorOption = GeneratorOption::grid;
   size_t iterations = 10;
+  spdlog::level::level_enum logLevel = spdlog::level::info;
   bool measureFlops = true;
   size_t particlesPerDim = 20;
   double particleSpacing = .4;
@@ -64,4 +66,5 @@ class MDFlexParser {
   string writeVTK = "";
   size_t verletRebuildFrequency = 5;
   double verletSkinRadius = .2;
+
 };

--- a/examples/md-flexible/MDFlexParser.h
+++ b/examples/md-flexible/MDFlexParser.h
@@ -30,6 +30,7 @@ class MDFlexParser {
   FunctorOption getFunctorOption() const;
   GeneratorOption getGeneratorOption() const;
   size_t getIterations() const;
+  bool getMeasureFlops() const;
   double getParticleSpacing() const;
   size_t getParticlesPerDim() const;
   string getWriteVTK() const;
@@ -54,6 +55,7 @@ class MDFlexParser {
   FunctorOption functorOption = FunctorOption::lj12_6;
   GeneratorOption generatorOption = GeneratorOption::grid;
   size_t iterations = 10;
+  bool measureFlops = true;
   size_t particlesPerDim = 20;
   double particleSpacing = .4;
   string writeVTK = "";

--- a/examples/md-flexible/MDFlexParser.h
+++ b/examples/md-flexible/MDFlexParser.h
@@ -66,5 +66,4 @@ class MDFlexParser {
   string writeVTK = "";
   size_t verletRebuildFrequency = 5;
   double verletSkinRadius = .2;
-
 };

--- a/examples/md-flexible/main.cpp
+++ b/examples/md-flexible/main.cpp
@@ -47,7 +47,8 @@ void initContainerGrid(autopas::ContainerOptions containerOption,
   std::array<double, 3> boxMax(
       {(particlesPerDim)*particelSpacing, (particlesPerDim)*particelSpacing, (particlesPerDim)*particelSpacing});
 
-  autopas.init(boxMax, cutoff, verletSkinRadius, verletRebuildFrequency, {containerOption}, traversalOptions, tuningInterval);
+  autopas.init(boxMax, cutoff, verletSkinRadius, verletRebuildFrequency, {containerOption}, traversalOptions,
+               tuningInterval);
 
   PrintableMolecule dummyParticle;
   GridGenerator::fillWithParticles(autopas, {particlesPerDim, particlesPerDim, particlesPerDim}, dummyParticle,
@@ -59,11 +60,13 @@ void initContainerGauss(autopas::ContainerOptions containerOption,
                         std::vector<autopas::TraversalOptions> traversalOptions,
                         autopas::AutoPas<PrintableMolecule, FullParticleCell<PrintableMolecule>> &autopas,
                         double boxLength, size_t numParticles, double distributionMean, double distributionStdDev,
-                        double cutoff, double verletSkinRadius, int verletRebuildFrequency, unsigned int tuningInterval) {
+                        double cutoff, double verletSkinRadius, int verletRebuildFrequency,
+                        unsigned int tuningInterval) {
   std::array<double, 3> boxMax({boxLength, boxLength, boxLength});
 
-  autopas.init(boxMax, cutoff, verletSkinRadius, verletRebuildFrequency, {containerOption}, traversalOptions,  tuningInterval);
-  
+  autopas.init(boxMax, cutoff, verletSkinRadius, verletRebuildFrequency, {containerOption}, traversalOptions,
+               tuningInterval);
+
   PrintableMolecule dummyParticle;
   GaussianGenerator::fillWithParticles(autopas, numParticles, dummyParticle, distributionMean, distributionStdDev);
 }

--- a/examples/md-flexible/main.cpp
+++ b/examples/md-flexible/main.cpp
@@ -117,7 +117,7 @@ int main(int argc, char **argv) {
 
   // Initialization
   autopas::AutoPas<PrintableMolecule, FullParticleCell<PrintableMolecule>> autopas;
-
+  AutoPasLogger->set_level(spdlog::level::debug);
   switch (generatorChoice) {
     case MDFlexParser::GeneratorOption::grid: {
       initContainerGrid(containerChoice, traversalOptions, autopas, particlesPerDim, particleSpacing, cutoff,

--- a/examples/md-flexible/main.cpp
+++ b/examples/md-flexible/main.cpp
@@ -169,6 +169,7 @@ int main(int argc, char **argv) {
   startCalc = std::chrono::high_resolution_clock::now();
   // Calculation
   for (unsigned int i = 0; i < numIterations; ++i) {
+    AutoPasLogger->debug("Iteration {}", i);
     autopas.iteratePairwise(&functor, dataLayoutChoice);
   }
   stopCalc = std::chrono::high_resolution_clock::now();

--- a/examples/md-flexible/main.cpp
+++ b/examples/md-flexible/main.cpp
@@ -105,6 +105,7 @@ int main(int argc, char **argv) {
   auto distributionMean(parser.getDistributionMean());
   auto distributionStdDev(parser.getDistributionStdDev());
   auto generatorChoice(parser.getGeneratorOption());
+  auto logLevel(parser.getLogLevel());
   auto measureFlops(parser.getMeasureFlops());
   auto numIterations(parser.getIterations());
   auto particleSpacing(parser.getParticleSpacing());
@@ -123,7 +124,7 @@ int main(int argc, char **argv) {
 
   // Initialization
   autopas::AutoPas<PrintableMolecule, FullParticleCell<PrintableMolecule>> autopas;
-  AutoPasLogger->set_level(spdlog::level::debug);
+  AutoPasLogger->set_level(logLevel);
   switch (generatorChoice) {
     case MDFlexParser::GeneratorOption::grid: {
       initContainerGrid(containerChoice, traversalOptions, autopas, particlesPerDim, particleSpacing, cutoff,

--- a/examples/md-flexible/main.cpp
+++ b/examples/md-flexible/main.cpp
@@ -171,16 +171,18 @@ int main(int argc, char **argv) {
   }
 
   cout << "Using " << autopas::autopas_get_max_threads() << " Threads" << endl;
-  cout << "Starting force calculation... " << flush;
+  cout << "Starting force calculation... " << endl;
   startCalc = std::chrono::high_resolution_clock::now();
   // Calculation
   for (unsigned int i = 0; i < numIterations; ++i) {
-    AutoPasLogger->debug("Iteration {}", i);
+    if (AutoPasLogger->level() <= spdlog::level::debug) {
+      cout << "Iteration " << i << endl;
+    }
     autopas.iteratePairwise(&functor, dataLayoutChoice);
   }
   stopCalc = std::chrono::high_resolution_clock::now();
   stopTotal = std::chrono::high_resolution_clock::now();
-  cout << "done!" << endl;
+  cout << "Force calculation done!" << endl;
 
   //  printMolecules(autopas);
 

--- a/examples/md-flexible/main.cpp
+++ b/examples/md-flexible/main.cpp
@@ -43,11 +43,11 @@ void initContainerGrid(autopas::ContainerOptions containerOption,
                        std::vector<autopas::TraversalOptions> traversalOptions,
                        autopas::AutoPas<PrintableMolecule, FullParticleCell<PrintableMolecule>> &autopas,
                        size_t particlesPerDim, double particelSpacing, double cutoff, double verletSkinRadius,
-                       int verletRebuildFrequency) {
+                       unsigned int verletRebuildFrequency, unsigned int tuningInterval) {
   std::array<double, 3> boxMax(
       {(particlesPerDim)*particelSpacing, (particlesPerDim)*particelSpacing, (particlesPerDim)*particelSpacing});
 
-  autopas.init(boxMax, cutoff, verletSkinRadius, verletRebuildFrequency, {containerOption}, traversalOptions);
+  autopas.init(boxMax, cutoff, verletSkinRadius, verletRebuildFrequency, {containerOption}, traversalOptions, tuningInterval);
 
   PrintableMolecule dummyParticle;
   GridGenerator::fillWithParticles(autopas, {particlesPerDim, particlesPerDim, particlesPerDim}, dummyParticle,
@@ -59,10 +59,11 @@ void initContainerGauss(autopas::ContainerOptions containerOption,
                         std::vector<autopas::TraversalOptions> traversalOptions,
                         autopas::AutoPas<PrintableMolecule, FullParticleCell<PrintableMolecule>> &autopas,
                         double boxLength, size_t numParticles, double distributionMean, double distributionStdDev,
-                        double cutoff, double verletSkinRadius, int verletRebuildFrequency) {
+                        double cutoff, double verletSkinRadius, int verletRebuildFrequency, unsigned int tuningInterval) {
   std::array<double, 3> boxMax({boxLength, boxLength, boxLength});
 
-  autopas.init(boxMax, cutoff, verletSkinRadius, verletRebuildFrequency, {containerOption}, traversalOptions);
+  autopas.init(boxMax, cutoff, verletSkinRadius, verletRebuildFrequency, {containerOption}, traversalOptions,  tuningInterval);
+  
   PrintableMolecule dummyParticle;
   GaussianGenerator::fillWithParticles(autopas, numParticles, dummyParticle, distributionMean, distributionStdDev);
 }
@@ -96,19 +97,20 @@ int main(int argc, char **argv) {
 
   auto boxLength(parser.getBoxLength());
   auto containerChoice(parser.getContainerOption());
-  auto dataLayoutChoice(parser.getDataLayoutOption());
-  auto particlesPerDim(parser.getParticlesPerDim());
   auto cutoff(parser.getCutoff());
-  auto numIterations(parser.getIterations());
-  auto particleSpacing(parser.getParticleSpacing());
-  auto traversalOptions(parser.getTraversalOptions());
-  auto verletRebuildFrequency(parser.getVerletRebuildFrequency());
-  auto verletSkinRadius(parser.getVerletSkinRadius());
-  auto generatorChoice(parser.getGeneratorOption());
+  auto dataLayoutChoice(parser.getDataLayoutOption());
   auto distributionMean(parser.getDistributionMean());
   auto distributionStdDev(parser.getDistributionStdDev());
-  auto vtkFilename(parser.getWriteVTK());
+  auto generatorChoice(parser.getGeneratorOption());
   auto measureFlops(parser.getMeasureFlops());
+  auto numIterations(parser.getIterations());
+  auto particleSpacing(parser.getParticleSpacing());
+  auto particlesPerDim(parser.getParticlesPerDim());
+  auto traversalOptions(parser.getTraversalOptions());
+  auto tuningInterval(parser.getTuningInterval());
+  auto verletRebuildFrequency(parser.getVerletRebuildFrequency());
+  auto verletSkinRadius(parser.getVerletSkinRadius());
+  auto vtkFilename(parser.getWriteVTK());
 
   parser.printConfig();
 
@@ -122,13 +124,13 @@ int main(int argc, char **argv) {
   switch (generatorChoice) {
     case MDFlexParser::GeneratorOption::grid: {
       initContainerGrid(containerChoice, traversalOptions, autopas, particlesPerDim, particleSpacing, cutoff,
-                        verletSkinRadius, verletRebuildFrequency);
+                        verletSkinRadius, verletRebuildFrequency, tuningInterval);
       break;
     }
     case MDFlexParser::GeneratorOption::gaussian: {
       initContainerGauss(containerChoice, traversalOptions, autopas, boxLength,
                          particlesPerDim * particlesPerDim * particlesPerDim, distributionMean, distributionStdDev,
-                         cutoff, verletSkinRadius, verletRebuildFrequency);
+                         cutoff, verletSkinRadius, verletRebuildFrequency, tuningInterval);
       break;
     }
     default:

--- a/examples/sph-verlet/sph-main-verlet.cpp
+++ b/examples/sph-verlet/sph-main-verlet.cpp
@@ -12,6 +12,9 @@
 #include "autopas/sph/autopassph.h"
 
 typedef autopas::VerletLists<autopas::sph::SPHParticle> Container;
+typedef autopas::C08Traversal<autopas::FullParticleCell<autopas::sph::SPHParticle>,
+                              autopas::sph::SPHCalcHydroForceFunctor, false, false>
+    DummyTraversal;
 
 std::map<std::array<int, 3>, std::vector<autopas::sph::SPHParticle*>> sph_verlet_particle_list;
 
@@ -272,7 +275,8 @@ void densityPressureHydroForce(Container& sphSystem) {
     part->setDensity(part->getDensity() / 2);
   }
   std::cout << "calculation of density... started" << std::endl;
-  sphSystem.iteratePairwiseAoS(&densityFunctor);
+  DummyTraversal dummyTraversal({0, 0, 0}, &hydroForceFunctor);
+  sphSystem.iteratePairwiseAoS(&densityFunctor, &dummyTraversal);
   std::cout << "calculation of density... completed" << std::endl;
   // 1.3 delete halo particles, as their values are no longer valid
   // deleteHaloParticles(sphSystem);
@@ -296,7 +300,7 @@ void densityPressureHydroForce(Container& sphSystem) {
     part->setEngDot(0.);
   }
   std::cout << "calculation of hydroforces... started" << std::endl;
-  sphSystem.iteratePairwiseAoS(&hydroForceFunctor);
+  sphSystem.iteratePairwiseAoS(&hydroForceFunctor, &dummyTraversal);
   std::cout << "calculation of hydroforces... completed" << std::endl;
   // 0.3.3 delete halo particles, as their values are no longer valid
   // deleteHaloParticles(sphSystem);

--- a/src/autopas/autopasIncludes.h
+++ b/src/autopas/autopasIncludes.h
@@ -17,6 +17,7 @@
 #include "autopas/utils/SoA.h"
 #include "autopas/utils/StaticSelectorMacros.h"
 #include "autopas/utils/Timer.h"
+#include "autopas/utils/WrapOpenMP.h"
 
 // particles
 #include "autopas/particles/MoleculeLJ.h"
@@ -32,6 +33,10 @@
 #include "autopas/iterators/ParticleIterator.h"
 #include "autopas/iterators/RegionParticleIterator.h"
 #include "autopas/iterators/SingleCellIterator.h"
+
+// traversals
+#include "autopas/containers/cellPairTraversals/C08Traversal.h"
+#include "autopas/containers/cellPairTraversals/SlicedTraversal.h"
 
 // containers
 #include "autopas/containers/CellBlock3D.h"

--- a/src/autopas/containers/DirectSum.h
+++ b/src/autopas/containers/DirectSum.h
@@ -40,6 +40,10 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
     this->_cells.resize(2);
   }
 
+  ContainerOptions getContainerType() override {
+    return ContainerOptions::directSum;
+  }
+
   void addParticle(Particle &p) override {
     bool inBox = autopas::inBox(p.getR(), this->getBoxMin(), this->getBoxMax());
     if (inBox) {

--- a/src/autopas/containers/DirectSum.h
+++ b/src/autopas/containers/DirectSum.h
@@ -40,9 +40,7 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
     this->_cells.resize(2);
   }
 
-  ContainerOptions getContainerType() override {
-    return ContainerOptions::directSum;
-  }
+  ContainerOptions getContainerType() override { return ContainerOptions::directSum; }
 
   void addParticle(Particle &p) override {
     bool inBox = autopas::inBox(p.getR(), this->getBoxMin(), this->getBoxMax());

--- a/src/autopas/containers/DirectSum.h
+++ b/src/autopas/containers/DirectSum.h
@@ -67,8 +67,8 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
   /**
    * @copydoc LinkedCells::iteratePairwiseAoS
    */
-  template <class ParticleFunctor>
-  void iteratePairwiseAoS(ParticleFunctor *f, bool useNewton3 = true) {
+  template <class ParticleFunctor, class Traversal>
+  void iteratePairwiseAoS(ParticleFunctor *f, Traversal *traversal, bool useNewton3 = true) {
     if (useNewton3) {
       CellFunctor<Particle, ParticleCell, ParticleFunctor, false, true> cellFunctor(f);
       cellFunctor.processCell(*getCell());
@@ -83,8 +83,8 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
   /**
    * @copydoc LinkedCells::iteratePairwiseSoA
    */
-  template <class ParticleFunctor>
-  void iteratePairwiseSoA(ParticleFunctor *f, bool useNewton3 = true) {
+  template <class ParticleFunctor, class Traversal>
+  void iteratePairwiseSoA(ParticleFunctor *f, Traversal *traversal, bool useNewton3 = true) {
     f->SoALoader(*getCell(), (*getCell())._particleSoABuffer);
     f->SoALoader(*getHaloCell(), (*getHaloCell())._particleSoABuffer);
 

--- a/src/autopas/containers/DirectSum.h
+++ b/src/autopas/containers/DirectSum.h
@@ -120,6 +120,11 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
     return outlierFound;
   }
 
+  TraversalSelector<ParticleCell> generateTraversalSelector(std::vector<TraversalOptions> traversalOptions) override {
+    // direct sum technically consists of two cells (owned + halo)
+    return TraversalSelector<ParticleCell>({2, 0, 0}, traversalOptions);
+  }
+
   ParticleIteratorWrapper<Particle> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
     return ParticleIteratorWrapper<Particle>(
         new internal::ParticleIterator<Particle, ParticleCell>(&this->_cells, &_cellBorderFlagManager, behavior));

--- a/src/autopas/containers/LinkedCells.h
+++ b/src/autopas/containers/LinkedCells.h
@@ -170,6 +170,10 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
     return outlierFound;
   }
 
+  TraversalSelector<ParticleCell> generateTraversalSelector(std::vector<TraversalOptions> traversalOptions) override {
+    return TraversalSelector<ParticleCell>(this->getCellBlock().getCellsPerDimensionWithHalo(), traversalOptions);
+  }
+
   ParticleIteratorWrapper<Particle> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
     return ParticleIteratorWrapper<Particle>(
         new internal::ParticleIterator<Particle, ParticleCell>(&this->_cells, &_cellBlock, behavior));

--- a/src/autopas/containers/LinkedCells.h
+++ b/src/autopas/containers/LinkedCells.h
@@ -106,6 +106,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
     } else {
       traversal = this->_traversalSelector->template getOptimalTraversal<ParticleFunctor, false, false>(*f);
     }
+    AutoPasLogger->debug("LinkedCells: using traversal {}", traversal->getTraversalType());
     auto start = std::chrono::high_resolution_clock::now();
     traversal->traverseCellPairs(this->_cells);
     auto stop = std::chrono::high_resolution_clock::now();

--- a/src/autopas/containers/LinkedCells.h
+++ b/src/autopas/containers/LinkedCells.h
@@ -173,7 +173,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
 #ifdef AUTOPAS_OPENMP
     // TODO: find a sensible value for magic number
     // numThreads should be at least 1 and maximal max_threads
-    int numThreads = std::max(1, std::min(omp_get_max_threads(),(int)(this->_cells.size() / 500)));
+    int numThreads = std::max(1, std::min(omp_get_max_threads(), (int)(this->_cells.size() / 500)));
     std::cout << numThreads << std::endl;
 #pragma omp parallel for shared(outlierFound) num_threads(numThreads)
 #endif

--- a/src/autopas/containers/LinkedCells.h
+++ b/src/autopas/containers/LinkedCells.h
@@ -63,6 +63,10 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
     return v;
   }
 
+  ContainerOptions getContainerType() override {
+    return ContainerOptions::linkedCells;
+  }
+
   void addParticle(Particle &p) override {
     bool inBox = autopas::inBox(p.getR(), this->getBoxMin(), this->getBoxMax());
     if (inBox) {

--- a/src/autopas/containers/LinkedCells.h
+++ b/src/autopas/containers/LinkedCells.h
@@ -171,8 +171,11 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
   bool isContainerUpdateNeeded() override {
     std::atomic<bool> outlierFound(false);
 #ifdef AUTOPAS_OPENMP
-    // TODO: find a sensible value for ???
-#pragma omp parallel for shared(outlierFound)  // if (this->_cells.size() / omp_get_max_threads() > ???)
+    // TODO: find a sensible value for magic number
+    // numThreads should be at least 1 and maximal max_threads
+    int numThreads = std::max(1, std::min(omp_get_max_threads(),(int)(this->_cells.size() / 500)));
+    std::cout << numThreads << std::endl;
+#pragma omp parallel for shared(outlierFound) num_threads(numThreads)
 #endif
     for (size_t cellIndex1d = 0; cellIndex1d < this->_cells.size(); ++cellIndex1d) {
       std::array<double, 3> boxmin{0., 0., 0.};

--- a/src/autopas/containers/LinkedCells.h
+++ b/src/autopas/containers/LinkedCells.h
@@ -63,9 +63,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
     return v;
   }
 
-  ContainerOptions getContainerType() override {
-    return ContainerOptions::linkedCells;
-  }
+  ContainerOptions getContainerType() override { return ContainerOptions::linkedCells; }
 
   void addParticle(Particle &p) override {
     bool inBox = autopas::inBox(p.getR(), this->getBoxMin(), this->getBoxMax());

--- a/src/autopas/containers/LinkedCells.h
+++ b/src/autopas/containers/LinkedCells.h
@@ -13,7 +13,6 @@
 #include "autopas/containers/cellPairTraversals/SlicedTraversal.h"
 #include "autopas/iterators/ParticleIterator.h"
 #include "autopas/iterators/RegionParticleIterator.h"
-#include "autopas/pairwiseFunctors/CellFunctor.h"
 #include "autopas/utils/WrapOpenMP.h"
 #include "autopas/utils/inBox.h"
 
@@ -37,22 +36,11 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
    * @param boxMin
    * @param boxMax
    * @param cutoff
-   * @param allowedTraversalOptions Traversal options from which the TraversalSelector shall choose.
    * By default all applicable traversals are allowed.
    */
-  LinkedCells(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
-              const std::vector<TraversalOptions> &allowedTraversalOptions = allLCApplicableTraversals())
+  LinkedCells(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff)
       : ParticleContainer<Particle, ParticleCell, SoAArraysType>(boxMin, boxMax, cutoff, allLCApplicableTraversals()),
-        _cellBlock(this->_cells, boxMin, boxMax, cutoff) {
-    // LC should only be instantiated with applicable traversals
-    if (not this->checkIfTraversalsAreApplicable(allowedTraversalOptions))
-      utils::ExceptionHandler::exception("LinkedCells: At least one non-applicable traversal option was passed.");
-    // LC should not bee instantiated without any traversals
-    if (allowedTraversalOptions.empty())
-      utils::ExceptionHandler::exception("LinkedCells: No traversal option was passed.");
-    this->_traversalSelector = std::make_unique<TraversalSelector<ParticleCell>>(
-        _cellBlock.getCellsPerDimensionWithHalo(), allowedTraversalOptions);
-  }
+        _cellBlock(this->_cells, boxMin, boxMax, cutoff) {}
 
   /**
    * Lists all traversal options applicable for the Linked Cells container.
@@ -96,45 +84,27 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
    * short-range interactions.
    * @tparam the type of ParticleFunctor
    * @param f functor that describes the pair-potential
-   * @param useNewton3 defines whether newton3 should be used
+   * @param traversal the traversal that will be used
    */
-  template <class ParticleFunctor>
-  void iteratePairwiseAoS(ParticleFunctor *f, bool useNewton3 = true) {
-    std::unique_ptr<CellPairTraversal<ParticleCell>> traversal;
-    if (useNewton3) {
-      traversal = this->_traversalSelector->template getOptimalTraversal<ParticleFunctor, false, true>(*f);
-    } else {
-      traversal = this->_traversalSelector->template getOptimalTraversal<ParticleFunctor, false, false>(*f);
-    }
-    AutoPasLogger->debug("LinkedCells: using traversal {}", traversal->getTraversalType());
-    auto start = std::chrono::high_resolution_clock::now();
+  template <class ParticleFunctor, class Traversal>
+  void iteratePairwiseAoS(ParticleFunctor *f, Traversal *traversal, bool useNewton3 = true) {
+    AutoPasLogger->debug("LinkedCells: using traversal {} with AoS", traversal->getTraversalType());
     traversal->traverseCellPairs(this->_cells);
-    auto stop = std::chrono::high_resolution_clock::now();
-    auto runtime = std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start).count();
-    this->_traversalSelector->addTimeMeasurement(*f, traversal->getTraversalType(), runtime);
   }
 
   /**
-   * setting. This function is often better vectorizable.
+   * Function to iterate over all pairs of particles in an structure of arrays setting. This function only handles
+   * short-range interactions. It is often better vectorizable than iteratePairwiseAoS.
    * @tparam ParticleFunctor
    * @param f functor that describes the pair-potential
-   * @param useNewton3 defines whether newton3 should be used
+   * @param traversal the traversal that will be used
    */
-  template <class ParticleFunctor>
-  void iteratePairwiseSoA(ParticleFunctor *f, bool useNewton3 = true) {
+  template <class ParticleFunctor, class Traversal>
+  void iteratePairwiseSoA(ParticleFunctor *f, Traversal *traversal, bool useNewton3 = true) {
+    AutoPasLogger->debug("LinkedCells: using traversal {} with SoA ", traversal->getTraversalType());
     loadSoAs(f);
 
-    std::unique_ptr<CellPairTraversal<ParticleCell>> traversal;
-    if (useNewton3) {
-      traversal = this->_traversalSelector->template getOptimalTraversal<ParticleFunctor, true, true>(*f);
-    } else {
-      traversal = this->_traversalSelector->template getOptimalTraversal<ParticleFunctor, true, false>(*f);
-    }
-    auto start = std::chrono::high_resolution_clock::now();
     traversal->traverseCellPairs(this->_cells);
-    auto stop = std::chrono::high_resolution_clock::now();
-    auto runtime = std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start).count();
-    this->_traversalSelector->addTimeMeasurement(*f, traversal->getTraversalType(), runtime);
 
     extractSoAs(f);
   }

--- a/src/autopas/containers/LinkedCells.h
+++ b/src/autopas/containers/LinkedCells.h
@@ -102,11 +102,9 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
   void iteratePairwiseAoS(ParticleFunctor *f, bool useNewton3 = true) {
     std::unique_ptr<CellPairTraversal<ParticleCell>> traversal;
     if (useNewton3) {
-      traversal =
-          this->_traversalSelector->template getOptimalTraversal<ParticleFunctor, false, true>(*f, this->_cells);
+      traversal = this->_traversalSelector->template getOptimalTraversal<ParticleFunctor, false, true>(*f);
     } else {
-      traversal =
-          this->_traversalSelector->template getOptimalTraversal<ParticleFunctor, false, false>(*f, this->_cells);
+      traversal = this->_traversalSelector->template getOptimalTraversal<ParticleFunctor, false, false>(*f);
     }
     auto start = std::chrono::high_resolution_clock::now();
     traversal->traverseCellPairs(this->_cells);
@@ -127,10 +125,9 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
 
     std::unique_ptr<CellPairTraversal<ParticleCell>> traversal;
     if (useNewton3) {
-      traversal = this->_traversalSelector->template getOptimalTraversal<ParticleFunctor, true, true>(*f, this->_cells);
+      traversal = this->_traversalSelector->template getOptimalTraversal<ParticleFunctor, true, true>(*f);
     } else {
-      traversal =
-          this->_traversalSelector->template getOptimalTraversal<ParticleFunctor, true, false>(*f, this->_cells);
+      traversal = this->_traversalSelector->template getOptimalTraversal<ParticleFunctor, true, false>(*f);
     }
     auto start = std::chrono::high_resolution_clock::now();
     traversal->traverseCellPairs(this->_cells);

--- a/src/autopas/containers/LinkedCells.h
+++ b/src/autopas/containers/LinkedCells.h
@@ -111,7 +111,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
     traversal->traverseCellPairs(this->_cells);
     auto stop = std::chrono::high_resolution_clock::now();
     auto runtime = std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start).count();
-    this->_traversalSelector->addTimeMeasurement(traversal->getTraversalType(), runtime);
+    this->_traversalSelector->addTimeMeasurement(*f, traversal->getTraversalType(), runtime);
   }
 
   /**
@@ -134,7 +134,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
     traversal->traverseCellPairs(this->_cells);
     auto stop = std::chrono::high_resolution_clock::now();
     auto runtime = std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start).count();
-    this->_traversalSelector->addTimeMeasurement(traversal->getTraversalType(), runtime);
+    this->_traversalSelector->addTimeMeasurement(*f, traversal->getTraversalType(), runtime);
 
     extractSoAs(f);
   }

--- a/src/autopas/containers/LinkedCells.h
+++ b/src/autopas/containers/LinkedCells.h
@@ -99,11 +99,11 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
   template <class ParticleFunctor>
   void iteratePairwiseAoS(ParticleFunctor *f, bool useNewton3 = true) {
     if (useNewton3) {
-      this->_traversalSelector->template getOptimalTraversal<ParticleFunctor, false, true>(*f)->traverseCellPairs(
-          this->_cells);
+      this->_traversalSelector->template getOptimalTraversal<ParticleFunctor, false, true>(*f, this->_cells)
+          ->traverseCellPairs(this->_cells);
     } else {
-      this->_traversalSelector->template getOptimalTraversal<ParticleFunctor, false, false>(*f)->traverseCellPairs(
-          this->_cells);
+      this->_traversalSelector->template getOptimalTraversal<ParticleFunctor, false, false>(*f, this->_cells)
+          ->traverseCellPairs(this->_cells);
     }
   }
 
@@ -118,11 +118,11 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
     loadSoAs(f);
 
     if (useNewton3) {
-      this->_traversalSelector->template getOptimalTraversal<ParticleFunctor, true, true>(*f)->traverseCellPairs(
-          this->_cells);
+      this->_traversalSelector->template getOptimalTraversal<ParticleFunctor, true, true>(*f, this->_cells)
+          ->traverseCellPairs(this->_cells);
     } else {
-      this->_traversalSelector->template getOptimalTraversal<ParticleFunctor, true, false>(*f)->traverseCellPairs(
-          this->_cells);
+      this->_traversalSelector->template getOptimalTraversal<ParticleFunctor, true, false>(*f, this->_cells)
+          ->traverseCellPairs(this->_cells);
     }
 
     extractSoAs(f);

--- a/src/autopas/containers/LinkedCells.h
+++ b/src/autopas/containers/LinkedCells.h
@@ -83,8 +83,10 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
    * Function to iterate over all pairs of particles in an array of structures setting. This function only handles
    * short-range interactions.
    * @tparam the type of ParticleFunctor
+   * @tparam Traversal
    * @param f functor that describes the pair-potential
    * @param traversal the traversal that will be used
+   * @param useNewton3 whether newton 3 optimization should be used
    */
   template <class ParticleFunctor, class Traversal>
   void iteratePairwiseAoS(ParticleFunctor *f, Traversal *traversal, bool useNewton3 = true) {
@@ -96,8 +98,10 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
    * Function to iterate over all pairs of particles in an structure of arrays setting. This function only handles
    * short-range interactions. It is often better vectorizable than iteratePairwiseAoS.
    * @tparam ParticleFunctor
+   * @tparam Traversal
    * @param f functor that describes the pair-potential
    * @param traversal the traversal that will be used
+   * @param useNewton3 whether newton 3 optimization should be used
    */
   template <class ParticleFunctor, class Traversal>
   void iteratePairwiseSoA(ParticleFunctor *f, Traversal *traversal, bool useNewton3 = true) {

--- a/src/autopas/containers/ParticleContainer.h
+++ b/src/autopas/containers/ParticleContainer.h
@@ -132,7 +132,7 @@ class ParticleContainer : public ParticleContainerInterface<Particle> {
   template <class PairwiseFunctor, bool useSoA, bool useNewton3>
   bool tuneTraversal(PairwiseFunctor &pairwiseFunctor) {
     if (_traversalSelector != nullptr)
-      return _traversalSelector->template tune<PairwiseFunctor, useSoA, useNewton3>(pairwiseFunctor, this->_cells);
+      return _traversalSelector->template tune<PairwiseFunctor, useSoA, useNewton3>(pairwiseFunctor);
     return false;
   }
 

--- a/src/autopas/containers/ParticleContainer.h
+++ b/src/autopas/containers/ParticleContainer.h
@@ -11,7 +11,6 @@
 #include <array>
 #include "autopas/containers/ParticleContainerInterface.h"
 #include "autopas/pairwiseFunctors/Functor.h"
-#include "autopas/selectors/TraversalSelector.h"
 
 namespace autopas {
 
@@ -45,12 +44,7 @@ class ParticleContainer : public ParticleContainerInterface<Particle> {
    */
   ParticleContainer(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
                     const std::vector<TraversalOptions> &applicableTraversals = DefaultApplicableTraversals())
-      : _cells(),
-        _traversalSelector(nullptr),  // needs to be instantiated by respective container.
-        _applicableTraversals(applicableTraversals),
-        _boxMin(boxMin),
-        _boxMax(boxMax),
-        _cutoff(cutoff) {}
+      : _cells(), _applicableTraversals(applicableTraversals), _boxMin(boxMin), _boxMax(boxMax), _cutoff(cutoff) {}
 
   /**
    * destructor of ParticleContainer
@@ -121,21 +115,6 @@ class ParticleContainer : public ParticleContainerInterface<Particle> {
     return true;
   }
 
-  /**
-   * Determine the optimal traversal for the current situation.
-   * @tparam PairwiseFunctor
-   * @tparam useSoA
-   * @tparam useNewton3
-   * @param pairwiseFunctor Functor to optimize for.
-   * @return true if still in traversal tuning phase
-   */
-  template <class PairwiseFunctor, bool useSoA, bool useNewton3>
-  bool tuneTraversal(PairwiseFunctor &pairwiseFunctor) {
-    if (_traversalSelector != nullptr)
-      return _traversalSelector->template tune<PairwiseFunctor, useSoA, useNewton3>(pairwiseFunctor);
-    return false;
-  }
-
  protected:
   /**
    * vector of particle cells.
@@ -143,10 +122,6 @@ class ParticleContainer : public ParticleContainerInterface<Particle> {
    * common vector for this purpose.
    */
   std::vector<ParticleCell> _cells;
-  /**
-   * Selector for traversal of the container.
-   */
-  std::unique_ptr<TraversalSelector<ParticleCell>> _traversalSelector;
   /**
    * Vector of all applicable traversal options for the container.
    */

--- a/src/autopas/containers/ParticleContainer.h
+++ b/src/autopas/containers/ParticleContainer.h
@@ -127,11 +127,13 @@ class ParticleContainer : public ParticleContainerInterface<Particle> {
    * @tparam useSoA
    * @tparam useNewton3
    * @param pairwiseFunctor Functor to optimize for.
+   * @return true if still in traversal tuning phase
    */
   template <class PairwiseFunctor, bool useSoA, bool useNewton3>
-  void tuneTraversal(PairwiseFunctor &pairwiseFunctor) {
+  bool tuneTraversal(PairwiseFunctor &pairwiseFunctor) {
     if (_traversalSelector != nullptr)
-      _traversalSelector->template tune<PairwiseFunctor, useSoA, useNewton3>(pairwiseFunctor, this->_cells);
+      return _traversalSelector->template tune<PairwiseFunctor, useSoA, useNewton3>(pairwiseFunctor, this->_cells);
+    return false;
   }
 
  protected:

--- a/src/autopas/containers/ParticleContainer.h
+++ b/src/autopas/containers/ParticleContainer.h
@@ -7,9 +7,9 @@
 
 #pragma once
 
-#include <autopas/containers/cellPairTraversals/CellPairTraversalInterface.h>
 #include <array>
 #include "autopas/containers/ParticleContainerInterface.h"
+#include "autopas/containers/cellPairTraversals/CellPairTraversalInterface.h"
 #include "autopas/pairwiseFunctors/Functor.h"
 
 namespace autopas {
@@ -22,7 +22,7 @@ namespace autopas {
  * @tparam ParticleCell Class for the particle cells
  */
 template <class Particle, class ParticleCell, class SoAArraysType = typename Particle::SoAArraysType>
-class ParticleContainer : public ParticleContainerInterface<Particle> {
+class ParticleContainer : public ParticleContainerInterface<Particle, ParticleCell> {
  private:
   static const std::vector<TraversalOptions> &DefaultApplicableTraversals() {
     static const std::vector<TraversalOptions> v{};

--- a/src/autopas/containers/ParticleContainer.h
+++ b/src/autopas/containers/ParticleContainer.h
@@ -131,7 +131,7 @@ class ParticleContainer : public ParticleContainerInterface<Particle> {
   template <class PairwiseFunctor, bool useSoA, bool useNewton3>
   void tuneTraversal(PairwiseFunctor &pairwiseFunctor) {
     if (_traversalSelector != nullptr)
-      _traversalSelector->template tune<PairwiseFunctor, useSoA, useNewton3>(pairwiseFunctor);
+      _traversalSelector->template tune<PairwiseFunctor, useSoA, useNewton3>(pairwiseFunctor, this->_cells);
   }
 
  protected:

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -55,13 +55,11 @@ class ParticleContainerInterface {
    */
   ParticleContainerInterface &operator=(const ParticleContainerInterface &other) = delete;
 
-
   /**
    * Return a enum representing the name of the container class.
    * @return Enum representing the container.
    */
   virtual ContainerOptions getContainerType() = 0;
-
 
   /**
    * adds a particle to the container

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <autopas/selectors/TraversalSelector.h>
 #include <array>
 
 #include "autopas/iterators/ParticleIteratorWrapper.h"
@@ -30,7 +31,7 @@ enum ContainerOptions {
  *
  * @tparam Particle Class for particles
  */
-template <class Particle>
+template <class Particle, class ParticleCell>
 class ParticleContainerInterface {
  public:
   ParticleContainerInterface() {}
@@ -149,6 +150,13 @@ class ParticleContainerInterface {
    * @return true if an update is needed, false otherwise
    */
   virtual bool isContainerUpdateNeeded() = 0;
+
+  /**
+   * Generates a traversal selector for this container type.
+   * @param traversalOptions vector of traversal options that shall be allowed.
+   * @return Traversal selector for this container type.
+   */
+  virtual TraversalSelector<ParticleCell> generateTraversalSelector(std::vector<TraversalOptions> traversalOptions) = 0;
 };
 
 }  // namespace autopas

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -13,6 +13,15 @@
 
 namespace autopas {
 
+/**
+ * Possible choices for the particle container type.
+ */
+enum ContainerOptions {
+  directSum = 0,
+  linkedCells = 1,
+  verletLists = 2,
+};
+
 // consider multiple inheritance or delegation to avoid virtual call to Functor
 /**
  * The ParticleContainerInterface class provides a basic interface for all Containers within AutoPas.
@@ -45,6 +54,14 @@ class ParticleContainerInterface {
    * @return
    */
   ParticleContainerInterface &operator=(const ParticleContainerInterface &other) = delete;
+
+
+  /**
+   * Return a enum representing the name of the container class.
+   * @return Enum representing the container.
+   */
+  virtual ContainerOptions getContainerType() = 0;
+
 
   /**
    * adds a particle to the container

--- a/src/autopas/containers/VerletLists.h
+++ b/src/autopas/containers/VerletLists.h
@@ -74,6 +74,10 @@ class VerletLists : public ParticleContainer<Particle, autopas::FullParticleCell
         _soa(),
         _buildVerletListType(buildVerletListType) {}
 
+  ContainerOptions getContainerType() override {
+    return ContainerOptions::verletLists;
+  }
+
   /**
    * @copydoc LinkedCells::iteratePairwiseAoS
    */

--- a/src/autopas/containers/VerletLists.h
+++ b/src/autopas/containers/VerletLists.h
@@ -74,9 +74,7 @@ class VerletLists : public ParticleContainer<Particle, autopas::FullParticleCell
         _soa(),
         _buildVerletListType(buildVerletListType) {}
 
-  ContainerOptions getContainerType() override {
-    return ContainerOptions::verletLists;
-  }
+  ContainerOptions getContainerType() override { return ContainerOptions::verletLists; }
 
   /**
    * @copydoc LinkedCells::iteratePairwiseAoS

--- a/src/autopas/containers/VerletLists.h
+++ b/src/autopas/containers/VerletLists.h
@@ -218,6 +218,11 @@ class VerletLists : public ParticleContainer<Particle, autopas::FullParticleCell
     return outlierFound;
   }
 
+  TraversalSelector<ParticleCell> generateTraversalSelector(std::vector<TraversalOptions> traversalOptions) override {
+    // at the moment this is just a dummy
+    return TraversalSelector<ParticleCell>({0, 0, 0}, traversalOptions);
+  }
+
   /**
    * specifies whether the neighbor lists need to be rebuild
    * @return true if the neighbor lists need to be rebuild, false otherwise

--- a/src/autopas/containers/cellPairTraversals/CellPairTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/CellPairTraversal.h
@@ -10,8 +10,6 @@
 #include <array>
 #include <vector>
 #include "autopas/containers/cellPairTraversals/CellPairTraversalInterface.h"
-#include "autopas/selectors/TraversalSelector.h"
-//#include "CellPairTraversalInterface.h"
 
 namespace autopas {
 

--- a/src/autopas/containers/cellPairTraversals/SlicedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/SlicedTraversal.h
@@ -9,7 +9,6 @@
 
 #include <algorithm>
 #include "autopas/containers/cellPairTraversals/C08BasedTraversal.h"
-#include "autopas/selectors/TraversalSelector.h"
 #include "autopas/utils/ThreeDimensionalMapping.h"
 #include "autopas/utils/WrapOpenMP.h"
 

--- a/src/autopas/iterators/ParticleIterator.h
+++ b/src/autopas/iterators/ParticleIterator.h
@@ -13,6 +13,7 @@
 #include "autopas/iterators/SingleCellIterator.h"
 #include "autopas/iterators/SingleCellIteratorWrapper.h"
 #include "autopas/utils/ExceptionHandler.h"
+#include "autopas/utils/WrapOpenMP.h"
 
 namespace autopas {
 namespace internal {

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -74,6 +74,8 @@ class AutoTuner {
 
   unsigned int _tuningInterval, _iterationsSinceTuning;
   ContainerSelector<Particle, ParticleCell> _containerSelector;
+  bool _isTuningTraversals = false;
+  bool _isTuningContainers = false;
 };
 template <class Particle, class ParticleCell>
 template <class ParticleFunctor>
@@ -127,9 +129,15 @@ void AutoTuner<Particle, ParticleCell>::iteratePairwise(ParticleFunctor *f, Data
 template <class Particle, class ParticleCell>
 template <class PairwiseFunctor, bool useSoA, bool useNewton3>
 void AutoTuner<Particle, ParticleCell>::tune(PairwiseFunctor &pairwiseFunctor) {
-  _containerSelector.tune();
-  _containerSelector.getOptimalContainer()->template tuneTraversal<PairwiseFunctor, useSoA, useNewton3>(
-      pairwiseFunctor);
-  _iterationsSinceTuning = 0;
+  if (not _isTuningTraversals) {
+    _isTuningContainers = _containerSelector.tune();
+  };
+
+  _isTuningTraversals =
+      _containerSelector.getOptimalContainer()->template tuneTraversal<PairwiseFunctor, useSoA, useNewton3>(
+          pairwiseFunctor);
+
+  // reset counter only if all tuning phases are done
+  if (not _isTuningTraversals and not _isTuningContainers) _iterationsSinceTuning = 0;
 }
 }  // namespace autopas

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <array>
 #include <gtest/gtest_prod.h>
+#include <array>
 #include "autopas/autopasIncludes.h"
 #include "autopas/pairwiseFunctors/Functor.h"
 #include "autopas/selectors/ContainerSelector.h"

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <gtest/gtest_prod.h>
 #include <array>
 #include "autopas/autopasIncludes.h"
 #include "autopas/pairwiseFunctors/Functor.h"

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -61,12 +61,10 @@ class AutoTuner {
     auto container = _containerSelector.getOptimalContainer();
     // if the container is new create a new traversal selector for it
     if (_traversalSelectors.find(container->getContainerType()) == _traversalSelectors.end()) {
+      // @todo as soon as all containers work with traversalselectors this if can be removed
       if (container->getContainerType() == ContainerOptions::linkedCells) {
-        auto lc = dynamic_cast<LinkedCells<Particle, ParticleCell> *>(container.get());
-        _traversalSelectors.insert(
-            std::make_pair(container->getContainerType(),
-                           TraversalSelector<ParticleCell>(lc->getCellBlock().getCellsPerDimensionWithHalo(),
-                                                           _allowedTraversalOptions)));
+        _traversalSelectors.insert(std::make_pair(container->getContainerType(),
+                                                  container->generateTraversalSelector(_allowedTraversalOptions)));
         // @todo think about how to handle traversal selectors for other containers (dedicated selector types?)
         //      } else {
       }

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -106,6 +106,7 @@ bool AutoTuner<Particle, ParticleCell>::iteratePairwise(ParticleFunctor *f, Data
         }
       }
       auto container = _containerSelector.getOptimalContainer();
+      AutoPasLogger->debug("AutoTuner: Using container {}", container->getContainerType());
       auto start = std::chrono::high_resolution_clock::now();
       WithStaticContainerType(container, container->iteratePairwiseSoA(f, useNewton3););
       auto stop = std::chrono::high_resolution_clock::now();

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -105,7 +105,11 @@ void AutoTuner<Particle, ParticleCell>::iteratePairwise(ParticleFunctor *f, Data
         }
       }
       auto container = _containerSelector.getOptimalContainer();
+      auto start = std::chrono::high_resolution_clock::now();
       WithStaticContainerType(container, container->iteratePairwiseSoA(f, useNewton3););
+      auto stop = std::chrono::high_resolution_clock::now();
+      auto runtime = std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start).count();
+      _containerSelector.addTimeMeasurement(container->getContainerType(), runtime);
       break;
     }
     case autopas::aos: {
@@ -119,7 +123,11 @@ void AutoTuner<Particle, ParticleCell>::iteratePairwise(ParticleFunctor *f, Data
         }
       }
       auto container = _containerSelector.getOptimalContainer();
+      auto start = std::chrono::high_resolution_clock::now();
       WithStaticContainerType(container, container->iteratePairwiseAoS(f, useNewton3););
+      auto stop = std::chrono::high_resolution_clock::now();
+      auto runtime = std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start).count();
+      _containerSelector.addTimeMeasurement(container->getContainerType(), runtime);
       break;
     }
   }

--- a/src/autopas/selectors/ContainerSelector.h
+++ b/src/autopas/selectors/ContainerSelector.h
@@ -145,7 +145,6 @@ ContainerSelector<Particle, ParticleCell>::generateContainers() {
 template <class Particle, class ParticleCell>
 bool ContainerSelector<Particle, ParticleCell>::chooseOptimalContainer(
     std::vector<std::unique_ptr<autopas::ParticleContainer<Particle, ParticleCell>>> containers) {
-  // TODO: Autotuning goes here
   size_t bestContainerID = 0;
 
   // Test all options to find the fastest
@@ -186,12 +185,12 @@ bool ContainerSelector<Particle, ParticleCell>::chooseOptimalContainer(
                                      }) -
                         containers.begin();
       _containerTimes.clear();
-
-      _optimalContainer = std::move(containers[bestContainerID]);
-      AutoPasLogger->debug("Selected container {}", _optimalContainer->getContainerType());
     }
+
+    _optimalContainer = std::move(containers[bestContainerID]);
+    AutoPasLogger->debug("Selected container {}", _optimalContainer->getContainerType());
   }
-  return false;
+  return _currentlyTuning;
 }
 
 template <class Particle, class ParticleCell>
@@ -202,6 +201,7 @@ ContainerSelector<Particle, ParticleCell>::getOptimalContainer() {
 }
 template <class Particle, class ParticleCell>
 bool ContainerSelector<Particle, ParticleCell>::tune() {
+  _currentlyTuning = true;
   return chooseOptimalContainer(generateContainers());
 }
 

--- a/src/autopas/selectors/ContainerSelector.h
+++ b/src/autopas/selectors/ContainerSelector.h
@@ -148,8 +148,8 @@ bool ContainerSelector<Particle, ParticleCell>::chooseOptimalContainer(
   size_t bestContainerID = 0;
 
   // Test all options to find the fastest
-  // If there is no container chosen yet choose the first
-  if (_optimalContainer == nullptr) {
+  // If there is no container chosen yet or no measurements were made by now choose the first
+  if (_optimalContainer == nullptr || _containerTimes.size() == 0) {
     _optimalContainer = std::move(containers.front());
   } else if (_currentlyTuning) {
     // if we are in tuning state just select next container

--- a/src/autopas/selectors/ContainerSelector.h
+++ b/src/autopas/selectors/ContainerSelector.h
@@ -169,7 +169,7 @@ bool ContainerSelector<Particle, ParticleCell>::chooseOptimalContainer() {
       }
       // sanity check
       if (fastestTime == std::numeric_limits<long>::max()) {
-        utils::ExceptionHandler::exception("ContainerSelector: nothing was faster than max long oO");
+        utils::ExceptionHandler::exception("ContainerSelector: nothing was faster than max long! o_O");
       }
 
       // find id of fastest container in passed container list

--- a/src/autopas/selectors/ContainerSelector.h
+++ b/src/autopas/selectors/ContainerSelector.h
@@ -72,12 +72,19 @@ class ContainerSelector {
 
   /**
    * Evaluates the optimal container option.
+   * @return true if still in tuning phase
    */
-  void tune();
+  bool tune();
 
  private:
   std::vector<std::unique_ptr<autopas::ParticleContainer<Particle, ParticleCell>>> generateContainers();
-  void chooseOptimalContainer(
+
+  /**
+   * Chooses the optimal container from a given list.
+   * @param containers
+   * @return true if still in tuning phase
+   */
+  bool chooseOptimalContainer(
       std::vector<std::unique_ptr<autopas::ParticleContainer<Particle, ParticleCell>>> containers);
 
   std::array<double, 3> _boxMin, _boxMax;
@@ -134,10 +141,11 @@ ContainerSelector<Particle, ParticleCell>::generateContainers() {
 }
 
 template <class Particle, class ParticleCell>
-void ContainerSelector<Particle, ParticleCell>::chooseOptimalContainer(
+bool ContainerSelector<Particle, ParticleCell>::chooseOptimalContainer(
     std::vector<std::unique_ptr<autopas::ParticleContainer<Particle, ParticleCell>>> containers) {
   // TODO: Autotuning goes here
   _optimalContainer = std::move(containers.front());
+  return false;
 }
 
 template <class Particle, class ParticleCell>
@@ -147,7 +155,7 @@ ContainerSelector<Particle, ParticleCell>::getOptimalContainer() {
   return _optimalContainer;
 }
 template <class Particle, class ParticleCell>
-void ContainerSelector<Particle, ParticleCell>::tune() {
-  chooseOptimalContainer(generateContainers());
+bool ContainerSelector<Particle, ParticleCell>::tune() {
+  return chooseOptimalContainer(generateContainers());
 }
 }  // namespace autopas

--- a/src/autopas/selectors/ContainerSelector.h
+++ b/src/autopas/selectors/ContainerSelector.h
@@ -160,9 +160,9 @@ bool ContainerSelector<Particle, ParticleCell>::chooseOptimalContainer() {
       _currentlyTuning = false;
       ContainerOptions fastestContainer;
       long fastestTime = std::numeric_limits<long>::max();
-      AutoPasLogger->debug("ContainerSelector: Collected containers:");
+      AutoPasLogger->debug("ContainerSelector.tune(): ContainerSelector: Collected containers:");
       for (auto &&c : _containerTimes) {
-        AutoPasLogger->debug("Container {} took {} nanoseconds:", c.first, c.second);
+        AutoPasLogger->debug("ContainerSelector.tune(): Container {} took {} nanoseconds:", c.first, c.second);
         if (c.second < fastestTime) {
           fastestContainer = c.first;
           fastestTime = c.second;
@@ -180,8 +180,8 @@ bool ContainerSelector<Particle, ParticleCell>::chooseOptimalContainer() {
     }
 
     _optimalContainer = std::move(generateContainer(_allowedContainerOptions[bestContainerID]));
-    AutoPasLogger->debug("Selected container {}", _optimalContainer->getContainerType());
   }
+  AutoPasLogger->debug("ContainerSelector.tune(): Selected container {}", _optimalContainer->getContainerType());
   return _currentlyTuning;
 }
 

--- a/src/autopas/selectors/ContainerSelector.h
+++ b/src/autopas/selectors/ContainerSelector.h
@@ -16,15 +16,6 @@
 namespace autopas {
 
 /**
- * Possible choices for the particle container type.
- */
-enum ContainerOptions {
-  directSum = 0,
-  linkedCells = 1,
-  verletLists = 2,
-};
-
-/**
  * Provides a way to iterate over the possible choices of ContainerOption.
  */
 static std::vector<ContainerOptions> allContainerOptions = {ContainerOptions::directSum, ContainerOptions::linkedCells,

--- a/src/autopas/selectors/ContainerSelector.h
+++ b/src/autopas/selectors/ContainerSelector.h
@@ -113,8 +113,7 @@ ContainerSelector<Particle, ParticleCell>::generateContainer(ContainerOptions co
       break;
     }
     case linkedCells: {
-      container =
-          std::make_unique<LinkedCells<Particle, ParticleCell>>(_boxMin, _boxMax, _cutoff, _allowedTraversalOptions);
+      container = std::make_unique<LinkedCells<Particle, ParticleCell>>(_boxMin, _boxMax, _cutoff);
       break;
     }
     case verletLists: {

--- a/src/autopas/selectors/TraversalSelector.h
+++ b/src/autopas/selectors/TraversalSelector.h
@@ -52,7 +52,7 @@ class TraversalSelector {
   std::unique_ptr<CellPairTraversal<ParticleCell>> getOptimalTraversal(PairwiseFunctor &pairwiseFunctor);
 
   /**
-   * Evaluates to optimal traversal based on a given cell functor.
+   * Evaluates to optimal traversal based on a given functor.
    * @tparam PairwiseFunctor The functor that defines the interaction of two particles.
    * @tparam useSoA
    * @tparam useNewton3

--- a/src/autopas/selectors/TraversalSelector.h
+++ b/src/autopas/selectors/TraversalSelector.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <autopas/containers/cellPairTraversals/CellPairTraversalInterface.h>
 #include <array>
 #include <vector>
 #include "autopas/containers/cellPairTraversals/C08Traversal.h"
@@ -31,6 +30,10 @@ static std::vector<TraversalOptions> allTraversalOptions = {TraversalOptions::c0
 template <class ParticleCell>
 class TraversalSelector {
  public:
+  /**
+   * Dummy constructor s.th. this class can be used in maps
+   */
+  TraversalSelector() : _dims({0, 0, 0}), _allowedTraversalOptions({}) {}
   /**
    * Constructor of the TraversalSelector class.
    * @param dims Array with the dimension lengths of the domain.

--- a/src/autopas/selectors/TraversalSelector.h
+++ b/src/autopas/selectors/TraversalSelector.h
@@ -128,8 +128,8 @@ std::unique_ptr<CellPairTraversal<ParticleCell>> TraversalSelector<ParticleCell>
   auto functorHash = typeid(PairwiseFunctor).hash_code();
   size_t bestTraversal = 0;
   // Test all options to find the fastest
-  // If functor is unknown we start with the first traversal
-  if (_optimalTraversalOptions.find(functorHash) == _optimalTraversalOptions.end()) {
+  // If functor is unknown or no measurements were made by now we start with the first traversal
+  if (_traversalTimes.empty() || _optimalTraversalOptions.find(functorHash) == _optimalTraversalOptions.end()) {
     bestTraversal = 0;
   } else if (_currentlyTuning) {
     // if we are in tuning state just select next traversal

--- a/src/autopas/selectors/TraversalSelector.h
+++ b/src/autopas/selectors/TraversalSelector.h
@@ -145,9 +145,9 @@ std::unique_ptr<CellPairTraversal<ParticleCell>> TraversalSelector<ParticleCell>
       _currentlyTuning = false;
       TraversalOptions fastestTraversal;
       long fastestTime = std::numeric_limits<long>::max();
-      AutoPasLogger->debug("TraversalSelector: Collected traversals:");
+      AutoPasLogger->debug("TraversalSelector.tune(): TraversalSelector: Collected traversals:");
       for (auto &&t : _traversalTimes) {
-        AutoPasLogger->debug("Traversal {} took {} nanoseconds:", t.first, t.second);
+        AutoPasLogger->debug("TraversalSelector.tune(): Traversal {} took {} nanoseconds:", t.first, t.second);
         if (t.second < fastestTime) {
           fastestTraversal = t.first;
           fastestTime = t.second;
@@ -173,7 +173,7 @@ std::unique_ptr<CellPairTraversal<ParticleCell>> TraversalSelector<ParticleCell>
       dynamic_cast<CellPairTraversal<ParticleCell> *>(traversals[bestTraversal].release()));
 
   _optimalTraversalOptions[functorHash] = optimalTraversal->getTraversalType();
-  AutoPasLogger->debug("Selected traversal {}", optimalTraversal->getTraversalType());
+  AutoPasLogger->debug("TraversalSelector.tune(): Selected traversal {}", optimalTraversal->getTraversalType());
 
   return optimalTraversal;
 }

--- a/src/autopas/selectors/TraversalSelector.h
+++ b/src/autopas/selectors/TraversalSelector.h
@@ -63,6 +63,11 @@ class TraversalSelector {
   template <class PairwiseFunctor, bool useSoA, bool useNewton3>
   bool tune(PairwiseFunctor &pairwiseFunctor, std::vector<ParticleCell> &cells);
 
+  /**
+   * Save the runtime of a given traversal
+   * @param traversal
+   * @param time
+   */
   void addTimeMeasurement(TraversalOptions traversal, long time) {
     _traversalTimes.push_back(std::make_pair(traversal, time));
   }
@@ -149,10 +154,12 @@ std::unique_ptr<CellPairTraversal<ParticleCell>> TraversalSelector<ParticleCell>
           fastestTime = t.second;
         }
       }
+      // sanity check
       if (fastestTime == std::numeric_limits<long>::max()) {
         utils::ExceptionHandler::exception("TraversalSelector: nothing was faster than max long oO");
       }
 
+      // find id of fastest traversal in passed traversal list
       bestTraversal = std::find_if(traversals.begin(), traversals.end(),
                                    [&](const std::unique_ptr<CellPairTraversalInterface> &a) {
                                      return a->getTraversalType() == fastestTraversal;

--- a/src/autopas/selectors/TraversalSelector.h
+++ b/src/autopas/selectors/TraversalSelector.h
@@ -67,8 +67,6 @@ class TraversalSelector {
     _traversalTimes.push_back(std::make_pair(traversal, time));
   }
 
-  bool isCurrentlyTuning() const;
-
  private:
   template <class PairwiseFunctor, bool useSoA, bool useNewton3>
   std::vector<std::unique_ptr<CellPairTraversalInterface>> generateTraversals(PairwiseFunctor &pairwiseFunctor);
@@ -214,9 +212,4 @@ bool TraversalSelector<ParticleCell>::tune(PairwiseFunctor &pairwiseFunctor, std
 
   return _currentlyTuning;
 }
-template <class ParticleCell>
-bool TraversalSelector<ParticleCell>::isCurrentlyTuning() const {
-  return _currentlyTuning;
-}
-
 }  // namespace autopas

--- a/src/autopas/selectors/TraversalSelector.h
+++ b/src/autopas/selectors/TraversalSelector.h
@@ -134,6 +134,11 @@ std::unique_ptr<CellPairTraversal<ParticleCell>> TraversalSelector<ParticleCell>
   }
 
   // reset forces
+  // omp parallelization seems only beneficial for really large systems
+  // TODO: find good threshold when to activate OMP here
+  //#ifdef AUTOPAS_OPENMP
+  //#pragma omp parallel for
+  //#endif
   for (size_t i = 0; i < cells.size(); ++i) {
     for (size_t j = 0; j < cells[i]._particles.size(); ++j) {
       cells[i]._particles[j].setF({0, 0, 0});

--- a/src/autopas/selectors/TraversalSelector.h
+++ b/src/autopas/selectors/TraversalSelector.h
@@ -66,13 +66,13 @@ class TraversalSelector {
   bool tune(PairwiseFunctor &pairwiseFunctor);
 
   /**
-   * Save the runtime of a given traversal with a given functor
+   * Save the runtime of a given traversal with a given functor.
    * @param functor
    * @param traversal
    * @param time
    */
   template <class PairwiseFunctor>
-  void addTimeMeasurement(PairwiseFunctor &f, TraversalOptions traversal, long time) {
+  void addTimeMeasurement(PairwiseFunctor &functor, TraversalOptions traversal, long time) {
     auto functorHash = typeid(PairwiseFunctor).hash_code();
     struct TimeMeasurement measurement = {functorHash, traversal, time};
     _traversalTimes.push_back(measurement);

--- a/src/autopas/selectors/TraversalSelector.h
+++ b/src/autopas/selectors/TraversalSelector.h
@@ -144,12 +144,11 @@ std::unique_ptr<CellPairTraversal<ParticleCell>> TraversalSelector<ParticleCell>
     bestTraversal = 0;
   } else if (_currentlyTuning) {
     // if we are in tuning state just select next traversal
-    for (size_t i = 0; i < traversals.size(); ++i) {
-      if (traversals[i]->getTraversalType() == _optimalTraversalOptions[functorHash]) {
-        bestTraversal = i;
-        break;
-      }
-    }
+    bestTraversal = std::find_if(traversals.begin(), traversals.end(),
+                                 [&](const std::unique_ptr<CellPairTraversalInterface> &a) {
+                                   return a->getTraversalType() == _optimalTraversalOptions[functorHash];
+                                 }) -
+                    traversals.begin();
     ++bestTraversal;
     // if the last possible traversal has already been tested choose fastest one and reset timings
     if (bestTraversal >= traversals.size()) {

--- a/src/autopas/selectors/TraversalSelector.h
+++ b/src/autopas/selectors/TraversalSelector.h
@@ -31,7 +31,7 @@ template <class ParticleCell>
 class TraversalSelector {
  public:
   /**
-   * Dummy constructor s.th. this class can be used in maps
+   * Dummy constructor such that this class can be used in maps
    */
   TraversalSelector() : _dims({0, 0, 0}), _allowedTraversalOptions({}) {}
   /**

--- a/tests/testAutopas/AutoTunerTest.cpp
+++ b/tests/testAutopas/AutoTunerTest.cpp
@@ -22,6 +22,7 @@ TEST_F(AutoTunerTest, testTune) {
   autopas::AutoTuner<Particle, FPCell> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkin, verletRebuildFrequency,
                                                  containers, traversals, 100);
 
+  std::shared_ptr<autopas::ParticleContainer<Particle, FPCell>> fastestContainer;
   bool stillTuning = true;
   int i = 0;
   for (; stillTuning; ++i) {
@@ -45,9 +46,9 @@ TEST_F(AutoTunerTest, testTune) {
         break;
       }
       case 4: {
-        // direct sum should be the fastest since it has the least overhead
-        EXPECT_TRUE((dynamic_cast<autopas::DirectSum<Particle, FPCell>*>(container.get())))
-            << "tune() selected the wrong container after collecting all timings";
+        // the fastest container might be nondeterministic here due to hardware constrains so just remember it
+        // and check if the selector returns the same later
+        fastestContainer = container;
         EXPECT_FALSE(stillTuning) << "tune() returns true(=still tuning) after checking all options!";
         break;
       }
@@ -59,6 +60,6 @@ TEST_F(AutoTunerTest, testTune) {
   EXPECT_EQ(i, 5) << "Too unexpected number of tuning iterations!";
 
   auto container = autoTuner.getContainer();
-  EXPECT_TRUE((dynamic_cast<autopas::DirectSum<Particle, FPCell>*>(container.get())))
+  EXPECT_EQ(fastestContainer->getContainerType(), container->getContainerType())
       << "tune() returned the wrong container after tuning phase";
 }

--- a/tests/testAutopas/AutoTunerTest.cpp
+++ b/tests/testAutopas/AutoTunerTest.cpp
@@ -23,9 +23,11 @@ TEST_F(AutoTunerTest, testTune) {
                                                  containers, traversals, 100);
 
   std::shared_ptr<autopas::ParticleContainer<Particle, FPCell>> fastestContainer;
+  AutoPasLogger->set_level(spdlog::level::debug);
   bool stillTuning = true;
   int i = 0;
   for (; stillTuning; ++i) {
+    AutoPasLogger->debug("AutoTunerTest: Iteration {}", i);
     stillTuning = autoTuner.iteratePairwise(&functor, autopas::DataLayoutOption::aos);
 
     auto container = autoTuner.getContainer();

--- a/tests/testAutopas/AutoTunerTest.cpp
+++ b/tests/testAutopas/AutoTunerTest.cpp
@@ -15,7 +15,7 @@ TEST_F(AutoTunerTest, testTune) {
   std::vector<autopas::TraversalOptions> traversals = {autopas::TraversalOptions::sliced,
                                                        autopas::TraversalOptions::c08};
 
-  std::array<double, 3> bBoxMin = {0, 0, 0}, bBoxMax = {10, 10, 10};
+  std::array<double, 3> bBoxMin = {0, 0, 0}, bBoxMax = {10, 10, 100};
   const double cutoff = 1;
   const double verletSkin = 0;
   const unsigned int verletRebuildFrequency = 1;
@@ -43,11 +43,12 @@ TEST_F(AutoTunerTest, testTune) {
       }
       // only here both traversals are checked
       case 2:
-      case 3: {
+      case 3:
+      case 4: {
         EXPECT_TRUE((dynamic_cast<autopas::LinkedCells<Particle, FPCell>*>(container.get())));
         break;
       }
-      case 4: {
+      case 5: {
         // the fastest container might be nondeterministic here due to hardware constrains so just remember it
         // and check if the selector returns the same later
         fastestContainer = container;
@@ -59,7 +60,7 @@ TEST_F(AutoTunerTest, testTune) {
     }
   }
 
-  EXPECT_EQ(i, 5) << "Too unexpected number of tuning iterations!";
+  EXPECT_EQ(i, 6) << "Too unexpected number of tuning iterations!";
 
   auto container = autoTuner.getContainer();
   EXPECT_EQ(fastestContainer->getContainerType(), container->getContainerType())

--- a/tests/testAutopas/AutoTunerTest.cpp
+++ b/tests/testAutopas/AutoTunerTest.cpp
@@ -1,0 +1,64 @@
+/**
+ * @file AutoTunerTest.cpp
+ * @author F. Gratl
+ * @date 8/10/18
+ */
+
+#include "AutoTunerTest.h"
+#include <autopas/selectors/AutoTuner.h>
+
+TEST_F(AutoTunerTest, testTune) {
+  autopas::LJFunctor<Particle, FPCell> functor;
+  std::vector<autopas::ContainerOptions> containers = {autopas::ContainerOptions::verletLists,
+                                                       autopas::ContainerOptions::directSum,
+                                                       autopas::ContainerOptions::linkedCells};
+  std::vector<autopas::TraversalOptions> traversals = {autopas::TraversalOptions::sliced,
+                                                       autopas::TraversalOptions::c08};
+
+  std::array<double, 3> bBoxMin = {0, 0, 0}, bBoxMax = {10, 10, 10};
+  const double cutoff = 1;
+  const double verletSkin = 0;
+  const unsigned int verletRebuildFrequency = 1;
+  autopas::AutoTuner<Particle, FPCell> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkin, verletRebuildFrequency,
+                                                 containers, traversals, 100);
+
+  bool stillTuning = true;
+  int i = 0;
+  for (; stillTuning; ++i) {
+    stillTuning = autoTuner.iteratePairwise(&functor, autopas::DataLayoutOption::aos);
+
+    auto container = autoTuner.getContainer();
+
+    switch (i) {
+      case 0: {
+        EXPECT_TRUE((dynamic_cast<autopas::VerletLists<Particle>*>(container.get())));
+        break;
+      }
+      case 1: {
+        EXPECT_TRUE((dynamic_cast<autopas::DirectSum<Particle, FPCell>*>(container.get())));
+        break;
+      }
+      // only here both traversals are checked
+      case 2:
+      case 3: {
+        EXPECT_TRUE((dynamic_cast<autopas::LinkedCells<Particle, FPCell>*>(container.get())));
+        break;
+      }
+      case 4: {
+        // direct sum should be the fastest since it has the least overhead
+        EXPECT_TRUE((dynamic_cast<autopas::DirectSum<Particle, FPCell>*>(container.get())))
+            << "tune() selected the wrong container after collecting all timings";
+        EXPECT_FALSE(stillTuning) << "tune() returns true(=still tuning) after checking all options!";
+        break;
+      }
+      default:
+        FAIL() << "Tuning took more iterations than expected!";
+    }
+  }
+
+  EXPECT_EQ(i, 5) << "Too unexpected number of tuning iterations!";
+
+  auto container = autoTuner.getContainer();
+  EXPECT_TRUE((dynamic_cast<autopas::DirectSum<Particle, FPCell>*>(container.get())))
+            << "tune() returned the wrong container after tuning phase";
+}

--- a/tests/testAutopas/AutoTunerTest.cpp
+++ b/tests/testAutopas/AutoTunerTest.cpp
@@ -32,6 +32,14 @@ TEST_F(AutoTunerTest, testTune) {
 
     auto container = autoTuner.getContainer();
 
+    // tuning phases:
+    // 0 -> test verlet
+    // 1 -> test directSum
+    // 2 -> test linked with sliced
+    // 3 -> test linked with c08
+    // 4 -> choose best lc traversal -> traversal tuning finished
+    // 5 -> choose best container -> tuning finished
+    // 6 -> normal iteration using optimal combination
     switch (i) {
       case 0: {
         EXPECT_TRUE((dynamic_cast<autopas::VerletLists<Particle>*>(container.get())));

--- a/tests/testAutopas/AutoTunerTest.cpp
+++ b/tests/testAutopas/AutoTunerTest.cpp
@@ -27,7 +27,7 @@ TEST_F(AutoTunerTest, testTune) {
   bool stillTuning = true;
   int i = 0;
   for (; stillTuning; ++i) {
-    AutoPasLogger->debug("AutoTunerTest: Iteration {}", i);
+    // AutoPasLogger->debug("AutoTunerTest: Iteration {}", i);
     stillTuning = autoTuner.iteratePairwise(&functor, autopas::DataLayoutOption::aos);
 
     auto container = autoTuner.getContainer();

--- a/tests/testAutopas/AutoTunerTest.cpp
+++ b/tests/testAutopas/AutoTunerTest.cpp
@@ -68,7 +68,7 @@ TEST_F(AutoTunerTest, testTune) {
     }
   }
 
-  EXPECT_EQ(i, 6) << "Too unexpected number of tuning iterations!";
+  EXPECT_EQ(i, 6) << "Unexpected number of tuning iterations!";
 
   auto container = autoTuner.getContainer();
   EXPECT_EQ(fastestContainer->getContainerType(), container->getContainerType())

--- a/tests/testAutopas/AutoTunerTest.cpp
+++ b/tests/testAutopas/AutoTunerTest.cpp
@@ -60,5 +60,5 @@ TEST_F(AutoTunerTest, testTune) {
 
   auto container = autoTuner.getContainer();
   EXPECT_TRUE((dynamic_cast<autopas::DirectSum<Particle, FPCell>*>(container.get())))
-            << "tune() returned the wrong container after tuning phase";
+      << "tune() returned the wrong container after tuning phase";
 }

--- a/tests/testAutopas/AutoTunerTest.h
+++ b/tests/testAutopas/AutoTunerTest.h
@@ -1,0 +1,17 @@
+/**
+ * @file AutoTunerTest.h
+ * @author F. Gratl
+ * @date 8/10/18
+ */
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include "AutoPasTestBase.h"
+#include "testingHelpers/commonTypedefs.h"
+
+class AutoTunerTest : public AutoPasTestBase {
+ public:
+  AutoTunerTest() = default;
+  ~AutoTunerTest() = default;
+};

--- a/tests/testAutopas/ContainerSelectorTest.cpp
+++ b/tests/testAutopas/ContainerSelectorTest.cpp
@@ -49,7 +49,8 @@ TEST_F(ContainerSelectorTest, testTune) {
                                                                  verletRebuildFrequency, containers, traversals);
 
   bool stillTuning = true;
-  for (int i = 0; stillTuning; ++i) {
+  int i = 0;
+  for (; stillTuning; ++i) {
     stillTuning = containerSelector.tune();
 
     auto container = containerSelector.getOptimalContainer();
@@ -61,17 +62,17 @@ TEST_F(ContainerSelectorTest, testTune) {
         break;
       }
       case 1: {
-        EXPECT_TRUE((dynamic_cast<autopas::DirectSum<Particle, FPCell>*>(container.get())));
+        EXPECT_TRUE((dynamic_cast<autopas::VerletLists<Particle>*>(container.get())));
         containerSelector.addTimeMeasurement(autopas::ContainerOptions::verletLists, 30);
         break;
       }
       case 2: {
-        EXPECT_TRUE((dynamic_cast<autopas::DirectSum<Particle, FPCell>*>(container.get())));
+        EXPECT_TRUE((dynamic_cast<autopas::LinkedCells<Particle, FPCell>*>(container.get())));
         containerSelector.addTimeMeasurement(autopas::ContainerOptions::linkedCells, 10);
         break;
       }
       case 3: {
-        EXPECT_TRUE((dynamic_cast<autopas::DirectSum<Particle, FPCell>*>(container.get())))
+        EXPECT_TRUE((dynamic_cast<autopas::LinkedCells<Particle, FPCell>*>(container.get())))
             << "tune() selected the wrong container after collecting all timings";
         EXPECT_FALSE(stillTuning) << "tune() returns true(=still tuning) after checking all options!";
         break;
@@ -81,7 +82,9 @@ TEST_F(ContainerSelectorTest, testTune) {
     }
   }
 
+  EXPECT_EQ(i, 4) << "Too unexpected number of tuning iterations!";
+
   auto container = containerSelector.getOptimalContainer();
-  EXPECT_TRUE((dynamic_cast<autopas::DirectSum<Particle, FPCell>*>(container.get())))
-            << "tune() returned the wrong traversal tuning phase";
+  EXPECT_TRUE((dynamic_cast<autopas::LinkedCells<Particle, FPCell>*>(container.get())))
+            << "tune() returned the wrong container after tuning phase";
 }

--- a/tests/testAutopas/ContainerSelectorTest.cpp
+++ b/tests/testAutopas/ContainerSelectorTest.cpp
@@ -33,3 +33,55 @@ TEST_F(ContainerSelectorTest, testGetOptimalContainerOneOption) {
   EXPECT_TRUE((dynamic_cast<autopas::LinkedCells<Particle, FPCell>*>(containerLC.get())));
   EXPECT_TRUE((dynamic_cast<autopas::VerletLists<Particle>*>(containerVerlet.get())));
 }
+
+TEST_F(ContainerSelectorTest, testTune) {
+  std::vector<autopas::ContainerOptions> containers = {autopas::ContainerOptions::directSum,
+                                                       autopas::ContainerOptions::verletLists,
+                                                       autopas::ContainerOptions::linkedCells};
+  std::vector<autopas::TraversalOptions> traversals = {autopas::TraversalOptions::c08,
+                                                       autopas::TraversalOptions::sliced};
+
+  std::array<double, 3> bBoxMin = {0, 0, 0}, bBoxMax = {10, 10, 10};
+  const double cutoff = 1;
+  const double verletSkin = 0;
+  const unsigned int verletRebuildFrequency = 1;
+  autopas::ContainerSelector<Particle, FPCell> containerSelector(bBoxMin, bBoxMax, cutoff, verletSkin,
+                                                                 verletRebuildFrequency, containers, traversals);
+
+  bool stillTuning = true;
+  for (int i = 0; stillTuning; ++i) {
+    stillTuning = containerSelector.tune();
+
+    auto container = containerSelector.getOptimalContainer();
+
+    switch (i) {
+      case 0: {
+        EXPECT_TRUE((dynamic_cast<autopas::DirectSum<Particle, FPCell>*>(container.get())));
+        containerSelector.addTimeMeasurement(autopas::ContainerOptions::directSum, 20);
+        break;
+      }
+      case 1: {
+        EXPECT_TRUE((dynamic_cast<autopas::DirectSum<Particle, FPCell>*>(container.get())));
+        containerSelector.addTimeMeasurement(autopas::ContainerOptions::verletLists, 30);
+        break;
+      }
+      case 2: {
+        EXPECT_TRUE((dynamic_cast<autopas::DirectSum<Particle, FPCell>*>(container.get())));
+        containerSelector.addTimeMeasurement(autopas::ContainerOptions::linkedCells, 10);
+        break;
+      }
+      case 3: {
+        EXPECT_TRUE((dynamic_cast<autopas::DirectSum<Particle, FPCell>*>(container.get())))
+            << "tune() selected the wrong container after collecting all timings";
+        EXPECT_FALSE(stillTuning) << "tune() returns true(=still tuning) after checking all options!";
+        break;
+      }
+      default:
+        FAIL() << "Tuning took more turns than expected!";
+    }
+  }
+
+  auto container = containerSelector.getOptimalContainer();
+  EXPECT_TRUE((dynamic_cast<autopas::DirectSum<Particle, FPCell>*>(container.get())))
+            << "tune() returned the wrong traversal tuning phase";
+}

--- a/tests/testAutopas/ContainerSelectorTest.cpp
+++ b/tests/testAutopas/ContainerSelectorTest.cpp
@@ -86,5 +86,5 @@ TEST_F(ContainerSelectorTest, testTune) {
 
   auto container = containerSelector.getOptimalContainer();
   EXPECT_TRUE((dynamic_cast<autopas::LinkedCells<Particle, FPCell>*>(container.get())))
-            << "tune() returned the wrong container after tuning phase";
+      << "tune() returned the wrong container after tuning phase";
 }

--- a/tests/testAutopas/ForceCalculationTest.cpp
+++ b/tests/testAutopas/ForceCalculationTest.cpp
@@ -15,8 +15,9 @@ void ForceCalculationTest::testLJ(double particleSpacing, double cutoff, autopas
   std::array<double, 3> boxMin = {0., 0., 0.};
   std::array<double, 3> boxMax = {3., 3., 3.};
 
-  autoPas.init(boxMin, boxMax, cutoff, 0, 1, {autopas::ContainerOptions::linkedCells});
-
+  //@todo test this with all containers and traversals
+  autoPas.init(boxMin, boxMax, cutoff, 0, 1, {autopas::ContainerOptions::linkedCells},
+               {autopas::TraversalOptions::c08});
   autopas::MoleculeLJ defaultParticle;
 
   GridGenerator::fillWithParticles(autoPas, {2, 2, 1}, defaultParticle,
@@ -33,9 +34,9 @@ void ForceCalculationTest::testLJ(double particleSpacing, double cutoff, autopas
 
   for (auto p = autoPas.begin(); p.isValid(); ++p) {
     auto id = p->getID();
-    ASSERT_NEAR(expectedForces[id][0], p->getF()[0], tolerance);
-    ASSERT_NEAR(expectedForces[id][1], p->getF()[1], tolerance);
-    ASSERT_NEAR(expectedForces[id][2], p->getF()[2], tolerance);
+    EXPECT_NEAR(expectedForces[id][0], p->getF()[0], tolerance) << "ParticleID: " << id;
+    EXPECT_NEAR(expectedForces[id][1], p->getF()[1], tolerance) << "ParticleID: " << id;
+    EXPECT_NEAR(expectedForces[id][2], p->getF()[2], tolerance) << "ParticleID: " << id;
   }
 }
 

--- a/tests/testAutopas/LinkedCellsVersusDirectSumTest.h
+++ b/tests/testAutopas/LinkedCellsVersusDirectSumTest.h
@@ -10,6 +10,7 @@
 #include <cstdlib>
 #include "AutoPasTestBase.h"
 #include "autopas/autopasIncludes.h"
+#include "testingHelpers/commonTypedefs.h"
 
 class LinkedCellsVersusDirectSumTest : public AutoPasTestBase {
  public:

--- a/tests/testAutopas/LinkedCellsVersusVerletListsTest.h
+++ b/tests/testAutopas/LinkedCellsVersusVerletListsTest.h
@@ -11,6 +11,7 @@
 #include "AutoPasTestBase.h"
 #include "autopas/autopasIncludes.h"
 #include "testingHelpers/RandomGenerator.h"
+#include "testingHelpers/commonTypedefs.h"
 
 class LinkedCellsVersusVerletListsTest : public AutoPasTestBase {
  public:

--- a/tests/testAutopas/SPHTest.cpp
+++ b/tests/testAutopas/SPHTest.cpp
@@ -636,10 +636,19 @@ TEST_F(SPHTest, testSPHCalcHydroForceFunctorNewton3OnOff) {
     }                                                                                                                  \
                                                                                                                        \
     autopas::sph::functor fnctr;                                                                                       \
+    if (strcmp(#mode, "AoS") == 0) {                                                                                   \
+      autopas::C08Traversal<autopas::FullParticleCell<SPHParticle>, autopas::sph::functor, false, true> traversalLJ(   \
+          _linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), &fnctr);                                         \
                                                                                                                        \
-    _verletLists.iteratePairwise##mode(&fnctr);                                                                        \
-    _linkedCells.iteratePairwise##mode(&fnctr);                                                                        \
+      _verletLists.iteratePairwise##mode(&fnctr, &traversalLJ);                                                        \
+      _linkedCells.iteratePairwise##mode(&fnctr, &traversalLJ);                                                        \
+    } else {                                                                                                           \
+      autopas::C08Traversal<autopas::FullParticleCell<SPHParticle>, autopas::sph::functor, true, true> traversalLJ(    \
+          _linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), &fnctr);                                         \
                                                                                                                        \
+      _verletLists.iteratePairwise##mode(&fnctr, &traversalLJ);                                                        \
+      _linkedCells.iteratePairwise##mode(&fnctr, &traversalLJ);                                                        \
+    }                                                                                                                  \
     check;                                                                                                             \
   }
 

--- a/tests/testAutopas/TraversalSelectorTest.cpp
+++ b/tests/testAutopas/TraversalSelectorTest.cpp
@@ -28,7 +28,7 @@ TEST(TraversalSelectorTest, testGetOptimalTraversalOneOption) {
   EXPECT_TRUE((dynamic_cast<autopas::SlicedTraversal<FPCell, MFunctor, false, true> *>(traversalSlice.get())))
       << "Is the domain size large enough for the processors' thread count?";
 }
-
+// TODO check repeated call
 TEST(TraversalSelectorTest, testGetOptimalTraversalBadFirstOption) {
   MFunctor functor;
 

--- a/tests/testAutopas/TraversalSelectorTest.cpp
+++ b/tests/testAutopas/TraversalSelectorTest.cpp
@@ -92,7 +92,7 @@ TEST_F(TraversalSelectorTest, testTune) {
     }
   }
 
-  EXPECT_EQ(i, 3) << "Too unexpected number of tuning iterations!";
+  EXPECT_EQ(i, 3) << "Unexpected number of tuning iterations!";
 
   auto traversal = traversalSelector.getOptimalTraversal<MFunctor, false, true>(functor);
   EXPECT_TRUE((dynamic_cast<autopas::C08Traversal<FPCell, MFunctor, false, true> *>(traversal.get())))

--- a/tests/testAutopas/TraversalSelectorTest.cpp
+++ b/tests/testAutopas/TraversalSelectorTest.cpp
@@ -9,7 +9,7 @@
 /**
  * Check if the only allowed traversal is returned
  */
-TEST(TraversalSelectorTest, testGetOptimalTraversalOneOption) {
+TEST_F(TraversalSelectorTest, testGetOptimalTraversalOneOption) {
   MFunctor functor;
 
   std::vector<autopas::TraversalOptions> optionVectorC08 = {autopas::TraversalOptions::c08};
@@ -29,7 +29,7 @@ TEST(TraversalSelectorTest, testGetOptimalTraversalOneOption) {
       << "Is the domain size large enough for the processors' thread count?";
 }
 // TODO check repeated call
-TEST(TraversalSelectorTest, testGetOptimalTraversalBadFirstOption) {
+TEST_F(TraversalSelectorTest, testGetOptimalTraversalBadFirstOption) {
   MFunctor functor;
 
   std::vector<autopas::TraversalOptions> optionVector = {autopas::TraversalOptions::sliced,

--- a/tests/testAutopas/TraversalSelectorTest.cpp
+++ b/tests/testAutopas/TraversalSelectorTest.cpp
@@ -73,12 +73,12 @@ TEST_F(TraversalSelectorTest, testTune) {
     switch (i) {
       case 0: {
         EXPECT_TRUE((dynamic_cast<autopas::SlicedTraversal<FPCell, MFunctor, false, true> *>(traversal.get())));
-        traversalSelector.addTimeMeasurement(autopas::TraversalOptions::sliced, 20);
+        traversalSelector.addTimeMeasurement(functor, autopas::TraversalOptions::sliced, 20);
         break;
       }
       case 1: {
         EXPECT_TRUE((dynamic_cast<autopas::C08Traversal<FPCell, MFunctor, false, true> *>(traversal.get())));
-        traversalSelector.addTimeMeasurement(autopas::TraversalOptions::c08, 10);
+        traversalSelector.addTimeMeasurement(functor, autopas::TraversalOptions::c08, 10);
         break;
       }
       case 2: {

--- a/tests/testAutopas/TraversalSelectorTest.cpp
+++ b/tests/testAutopas/TraversalSelectorTest.cpp
@@ -96,5 +96,5 @@ TEST_F(TraversalSelectorTest, testTune) {
 
   auto traversal = traversalSelector.getOptimalTraversal<MFunctor, false, true>(functor);
   EXPECT_TRUE((dynamic_cast<autopas::C08Traversal<FPCell, MFunctor, false, true> *>(traversal.get())))
-            << "tune() returned the wrong traversal tuning phase";
+      << "tune() returned the wrong traversal tuning phase";
 }

--- a/tests/testAutopas/TraversalSelectorTest.cpp
+++ b/tests/testAutopas/TraversalSelectorTest.cpp
@@ -65,7 +65,8 @@ TEST_F(TraversalSelectorTest, testTune) {
   autopas::TraversalSelector<FPCell> traversalSelector({domainSize, domainSize, domainSize}, optionVector);
 
   bool stillTuning = true;
-  for (int i = 0; stillTuning; ++i) {
+  int i = 0;
+  for (; stillTuning; ++i) {
     stillTuning = traversalSelector.tune<MFunctor, false, false>(functor);
     auto traversal = traversalSelector.getOptimalTraversal<MFunctor, false, true>(functor);
 
@@ -90,6 +91,8 @@ TEST_F(TraversalSelectorTest, testTune) {
         FAIL() << "Tuning took more turns than expected!";
     }
   }
+
+  EXPECT_EQ(i, 3) << "Too unexpected number of tuning iterations!";
 
   auto traversal = traversalSelector.getOptimalTraversal<MFunctor, false, true>(functor);
   EXPECT_TRUE((dynamic_cast<autopas::C08Traversal<FPCell, MFunctor, false, true> *>(traversal.get())))

--- a/tests/testAutopas/TraversalSelectorTest.cpp
+++ b/tests/testAutopas/TraversalSelectorTest.cpp
@@ -27,8 +27,17 @@ TEST_F(TraversalSelectorTest, testGetOptimalTraversalOneOption) {
   EXPECT_TRUE((dynamic_cast<autopas::C08Traversal<FPCell, MFunctor, false, true> *>(traversalC08.get())));
   EXPECT_TRUE((dynamic_cast<autopas::SlicedTraversal<FPCell, MFunctor, false, true> *>(traversalSlice.get())))
       << "Is the domain size large enough for the processors' thread count?";
+
+  // now that the functor is known check if still the same is returned
+  traversalC08 = traversalSelectorC08.getOptimalTraversal<MFunctor, false, true>(functor);
+  traversalSlice = traversalSelectorSlice.getOptimalTraversal<MFunctor, false, true>(functor);
+  // check that traversals are of the expected type
+  EXPECT_TRUE((dynamic_cast<autopas::C08Traversal<FPCell, MFunctor, false, true> *>(traversalC08.get())))
+      << "Repeated call for c08 failed";
+  EXPECT_TRUE((dynamic_cast<autopas::SlicedTraversal<FPCell, MFunctor, false, true> *>(traversalSlice.get())))
+      << "Repeated call for sliced failed";
 }
-// TODO check repeated call
+
 TEST_F(TraversalSelectorTest, testGetOptimalTraversalBadFirstOption) {
   MFunctor functor;
 
@@ -39,5 +48,9 @@ TEST_F(TraversalSelectorTest, testGetOptimalTraversalBadFirstOption) {
   auto traversal = traversalSelectorC08.getOptimalTraversal<MFunctor, false, true>(functor);
 
   // check that traversals are of the expected type
+  EXPECT_TRUE((dynamic_cast<autopas::C08Traversal<FPCell, MFunctor, false, true> *>(traversal.get())));
+
+  // also after the functor is known
+  traversal = traversalSelectorC08.getOptimalTraversal<MFunctor, false, true>(functor);
   EXPECT_TRUE((dynamic_cast<autopas::C08Traversal<FPCell, MFunctor, false, true> *>(traversal.get())));
 }

--- a/tests/testAutopas/TraversalSelectorTest.h
+++ b/tests/testAutopas/TraversalSelectorTest.h
@@ -15,6 +15,6 @@
 
 class TraversalSelectorTest : public AutoPasTestBase {
  public:
-  TraversalSelectorTest();
-  ~TraversalSelectorTest();
+  TraversalSelectorTest() = default;
+  ~TraversalSelectorTest() override = default;
 };

--- a/tests/testAutopas/VerletListsTest.cpp
+++ b/tests/testAutopas/VerletListsTest.cpp
@@ -15,7 +15,7 @@ TEST_F(VerletListsTest, VerletListConstructor) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skin = 0.2;
-  autopas::VerletLists<autopas::Particle> verletLists(min, max, cutoff, skin);
+  autopas::VerletLists<Particle> verletLists(min, max, cutoff, skin);
 }
 
 TEST_F(VerletListsTest, testVerletListBuild) {
@@ -23,18 +23,20 @@ TEST_F(VerletListsTest, testVerletListBuild) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skin = 0.2;
-  autopas::VerletLists<autopas::Particle> verletLists(min, max, cutoff, skin);
+  autopas::VerletLists<Particle> verletLists(min, max, cutoff, skin);
 
   std::array<double, 3> r = {2, 2, 2};
-  autopas::Particle p(r, {0., 0., 0.}, 0);
+  Particle p(r, {0., 0., 0.}, 0);
   verletLists.addParticle(p);
   std::array<double, 3> r2 = {1.5, 2, 2};
-  autopas::Particle p2(r2, {0., 0., 0.}, 1);
+  Particle p2(r2, {0., 0., 0.}, 1);
   verletLists.addParticle(p2);
 
-  MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
+  MockFunctor<Particle, FPCell> emptyFunctor;
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, true)).Times(AtLeast(1));
-  verletLists.iteratePairwiseAoS(&emptyFunctor, true);
+
+  autopas::C08Traversal<FPCell, MFunctor, false, true> dummyTraversal({0, 0, 0}, &emptyFunctor);
+  verletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal, true);
 
   auto& list = verletLists.getVerletListsAoS();
 
@@ -51,20 +53,21 @@ TEST_F(VerletListsTest, testVerletList) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skin = 0.2;
-  autopas::VerletLists<autopas::Particle> verletLists(min, max, cutoff, skin);
+  autopas::VerletLists<Particle> verletLists(min, max, cutoff, skin);
 
   std::array<double, 3> r = {2, 2, 2};
-  autopas::Particle p(r, {0., 0., 0.}, 0);
+  Particle p(r, {0., 0., 0.}, 0);
   verletLists.addParticle(p);
   std::array<double, 3> r2 = {1.5, 2, 2};
-  autopas::Particle p2(r2, {0., 0., 0.}, 1);
+  Particle p2(r2, {0., 0., 0.}, 1);
   verletLists.addParticle(p2);
 
-  MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> mockFunctor;
+  MockFunctor<Particle, FPCell> mockFunctor;
   using ::testing::_;  // anything is ok
   EXPECT_CALL(mockFunctor, AoSFunctor(_, _, true));
 
-  verletLists.iteratePairwiseAoS(&mockFunctor, true);
+  autopas::C08Traversal<FPCell, MFunctor, false, true> dummyTraversal({0, 0, 0}, &mockFunctor);
+  verletLists.iteratePairwiseAoS(&mockFunctor, &dummyTraversal, true);
 
   auto& list = verletLists.getVerletListsAoS();
 
@@ -81,20 +84,21 @@ TEST_F(VerletListsTest, testVerletListInSkin) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skin = 0.2;
-  autopas::VerletLists<autopas::Particle> verletLists(min, max, cutoff, skin);
+  autopas::VerletLists<Particle> verletLists(min, max, cutoff, skin);
 
   std::array<double, 3> r = {1.4, 2, 2};
-  autopas::Particle p(r, {0., 0., 0.}, 0);
+  Particle p(r, {0., 0., 0.}, 0);
   verletLists.addParticle(p);
   std::array<double, 3> r2 = {2.5, 2, 2};
-  autopas::Particle p2(r2, {0., 0., 0.}, 1);
+  Particle p2(r2, {0., 0., 0.}, 1);
   verletLists.addParticle(p2);
 
-  MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> mockFunctor;
+  MockFunctor<Particle, FPCell> mockFunctor;
   using ::testing::_;  // anything is ok
   EXPECT_CALL(mockFunctor, AoSFunctor(_, _, true));
 
-  verletLists.iteratePairwiseAoS(&mockFunctor, true);
+  autopas::C08Traversal<FPCell, MFunctor, false, true> dummyTraversal({0, 0, 0}, &mockFunctor);
+  verletLists.iteratePairwiseAoS(&mockFunctor, &dummyTraversal, true);
 
   auto& list = verletLists.getVerletListsAoS();
 
@@ -111,20 +115,22 @@ TEST_F(VerletListsTest, testVerletListBuildTwice) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skin = 0.2;
-  autopas::VerletLists<autopas::Particle> verletLists(min, max, cutoff, skin);
+  autopas::VerletLists<Particle> verletLists(min, max, cutoff, skin);
 
   std::array<double, 3> r = {2, 2, 2};
-  autopas::Particle p(r, {0., 0., 0.}, 0);
+  Particle p(r, {0., 0., 0.}, 0);
   verletLists.addParticle(p);
   std::array<double, 3> r2 = {1.5, 2, 2};
-  autopas::Particle p2(r2, {0., 0., 0.}, 1);
+  Particle p2(r2, {0., 0., 0.}, 1);
   verletLists.addParticle(p2);
 
-  MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
+  MockFunctor<Particle, FPCell> emptyFunctor;
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, true)).Times(AtLeast(1));
-  verletLists.iteratePairwiseAoS(&emptyFunctor, true);
 
-  verletLists.iteratePairwiseAoS(&emptyFunctor, true);
+  autopas::C08Traversal<FPCell, MFunctor, false, true> dummyTraversal({0, 0, 0}, &emptyFunctor);
+  verletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal, true);
+
+  verletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal, true);
 
   auto& list = verletLists.getVerletListsAoS();
 
@@ -141,23 +147,24 @@ TEST_F(VerletListsTest, testVerletListBuildFarAway) {
   std::array<double, 3> max = {5, 5, 5};
   double cutoff = 1.;
   double skin = 0.2;
-  autopas::VerletLists<autopas::Particle> verletLists(min, max, cutoff, skin);
+  autopas::VerletLists<Particle> verletLists(min, max, cutoff, skin);
 
   std::array<double, 3> r = {2, 2, 2};
-  autopas::Particle p(r, {0., 0., 0.}, 0);
+  Particle p(r, {0., 0., 0.}, 0);
   verletLists.addParticle(p);
 
   std::array<double, 3> r2 = {1.5, 2, 2};
-  autopas::Particle p2(r2, {0., 0., 0.}, 1);
+  Particle p2(r2, {0., 0., 0.}, 1);
   verletLists.addParticle(p2);
 
   std::array<double, 3> r3 = {4.5, 4.5, 4.5};
-  autopas::Particle p3(r3, {0., 0., 0.}, 2);
+  Particle p3(r3, {0., 0., 0.}, 2);
   verletLists.addParticle(p3);
 
-  MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
+  MockFunctor<Particle, FPCell> emptyFunctor;
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, true)).Times(AtLeast(1));
-  verletLists.iteratePairwiseAoS(&emptyFunctor, true);
+  autopas::C08Traversal<FPCell, MFunctor, false, true> dummyTraversal({0, 0, 0}, &emptyFunctor);
+  verletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal, true);
 
   auto& list = verletLists.getVerletListsAoS();
 
@@ -174,20 +181,21 @@ TEST_F(VerletListsTest, testVerletListBuildHalo) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skin = 0.2;
-  autopas::VerletLists<autopas::Particle> verletLists(min, max, cutoff, skin);
+  autopas::VerletLists<Particle> verletLists(min, max, cutoff, skin);
 
   std::array<double, 3> r = {0.9, 0.9, 0.9};
-  autopas::Particle p(r, {0., 0., 0.}, 0);
+  Particle p(r, {0., 0., 0.}, 0);
   verletLists.addHaloParticle(p);
   std::array<double, 3> r2 = {1.1, 1.1, 1.1};
-  autopas::Particle p2(r2, {0., 0., 0.}, 1);
+  Particle p2(r2, {0., 0., 0.}, 1);
   verletLists.addParticle(p2);
 
-  MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
+  MockFunctor<Particle, FPCell> emptyFunctor;
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, true)).Times(AtLeast(1));
-  verletLists.iteratePairwiseAoS(&emptyFunctor, true);
+  autopas::C08Traversal<FPCell, MFunctor, false, true> dummyTraversal({0, 0, 0}, &emptyFunctor);
+  verletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal, true);
 
-  verletLists.iteratePairwiseAoS(&emptyFunctor, true);
+  verletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal, true);
 
   auto& list = verletLists.getVerletListsAoS();
 
@@ -201,87 +209,89 @@ TEST_F(VerletListsTest, testVerletListBuildHalo) {
 }
 
 TEST_F(VerletListsTest, testRebuildFrequencyAlways) {
-  MockVerletLists<autopas::Particle> mockVerletLists({0., 0., 0.}, {10., 10., 10.}, 1., 0.3, 1);
+  MockVerletLists<Particle> mockVerletLists({0., 0., 0.}, {10., 10., 10.}, 1., 0.3, 1);
 
-  MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
+  MockFunctor<Particle, FPCell> emptyFunctor;
+  autopas::C08Traversal<FPCell, MFunctor, false, true> dummyTraversal({0, 0, 0}, &emptyFunctor);
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(4);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal, true);
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal, true);
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal, true);
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal, true);
 }
 
 TEST_F(VerletListsTest, testRebuildFrequencyEvery3) {
-  MockVerletLists<autopas::Particle> mockVerletLists({0., 0., 0.}, {10., 10., 10.}, 1., 0.3, 3);
+  MockVerletLists<Particle> mockVerletLists({0., 0., 0.}, {10., 10., 10.}, 1., 0.3, 3);
 
-  MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
+  MockFunctor<Particle, FPCell> emptyFunctor;
+  autopas::C08Traversal<FPCell, MFunctor, false, true> dummyTraversal({0, 0, 0}, &emptyFunctor);
 
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);  // 1
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal, true);  // 1
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(0);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal, true);
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal, true);
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);  // 2
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal, true);  // 2
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(0);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal, true);
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal, true);
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);  // 3
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal, true);  // 3
 }
 
 TEST_F(VerletListsTest, testForceRebuild) {
   // generate Velet list with rebuild frequency of 3
-  MockVerletLists<autopas::Particle> mockVerletLists({0., 0., 0.}, {10., 10., 10.}, 1., 0.3, 3);
+  MockVerletLists<Particle> mockVerletLists({0., 0., 0.}, {10., 10., 10.}, 1., 0.3, 3);
   // delegating to parent
   ON_CALL(mockVerletLists, addParticle(_))
-      .WillByDefault(Invoke(&mockVerletLists, &MockVerletLists<autopas::Particle>::addParticleVerletLists));
+      .WillByDefault(Invoke(&mockVerletLists, &MockVerletLists<Particle>::addParticleVerletLists));
   // delegating to parent
   ON_CALL(mockVerletLists, addHaloParticle(_))
-      .WillByDefault(Invoke(&mockVerletLists, &MockVerletLists<autopas::Particle>::addHaloParticleVerletLists));
+      .WillByDefault(Invoke(&mockVerletLists, &MockVerletLists<Particle>::addHaloParticleVerletLists));
   // delegating to parent
   ON_CALL(mockVerletLists, updateContainer())
-      .WillByDefault(Invoke(&mockVerletLists, &MockVerletLists<autopas::Particle>::updateContainerVerletLists));
+      .WillByDefault(Invoke(&mockVerletLists, &MockVerletLists<Particle>::updateContainerVerletLists));
 
-  MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
-
+  MockFunctor<Particle, FPCell> emptyFunctor;
+  autopas::C08Traversal<FPCell, MFunctor, false, true> dummyTraversal({0, 0, 0}, &emptyFunctor);
   // check that the second call does not need a rebuild
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor,
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal,
                                      true);  // rebuild happens here
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(0);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal, true);
 
   // check that updateContainer() requires a rebuild
   EXPECT_CALL(mockVerletLists, updateContainer());
   mockVerletLists.updateContainer();
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor,
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal,
                                      true);  // rebuild happens here
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(0);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal, true);
 
   // check that adding particles requires a rebuild
-  autopas::Particle p({1.1, 1.1, 1.1}, {0., 0., 0.}, 1);
+  Particle p({1.1, 1.1, 1.1}, {0., 0., 0.}, 1);
   EXPECT_CALL(mockVerletLists, addParticle(_));
   mockVerletLists.addParticle(p);
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor,
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal,
                                      true);  // rebuild happens here
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(0);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, true);
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal, true);
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal, true);
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor,
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal,
                                      true);  // rebuild happens here
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(0);
 
   // check that adding halo particles requires a rebuild
-  autopas::Particle p2({-0.1, 1.2, 1.1}, {0., 0., 0.}, 2);
+  Particle p2({-0.1, 1.2, 1.1}, {0., 0., 0.}, 2);
   EXPECT_CALL(mockVerletLists, addHaloParticle(_));
   mockVerletLists.addHaloParticle(p2);
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor,
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal,
                                      true);  // rebuild happens here
 
   // check that deleting particles requires a rebuild
@@ -291,48 +301,50 @@ TEST_F(VerletListsTest, testForceRebuild) {
     iterator.deleteCurrentParticle();
   }
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor,
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor,&dummyTraversal,
                                      true);  // rebuild happens here
 */
   // check that deleting halo particles requires a rebuild
   mockVerletLists.deleteHaloParticles();
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwiseAoS(&emptyFunctor,
+  mockVerletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal,
                                      true);  // rebuild happens here
 }
 
 TEST_F(VerletListsTest, testCheckNeighborListsAreValidAfterBuild) {
-  autopas::VerletLists<autopas::Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
+  autopas::VerletLists<Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
 
-  MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
+  MockFunctor<Particle, FPCell> emptyFunctor;
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, true)).Times(AtLeast(1));
 
   // addtwo particles in proper distance
-  autopas::Particle p({1.1, 1.1, 1.1}, {0., 0., 0.}, 1);
+  Particle p({1.1, 1.1, 1.1}, {0., 0., 0.}, 1);
   verletLists.addParticle(p);
-  autopas::Particle p2({3.1, 1.1, 1.1}, {0., 0., 0.}, 1);
+  Particle p2({3.1, 1.1, 1.1}, {0., 0., 0.}, 1);
   verletLists.addParticle(p2);
 
+  autopas::C08Traversal<FPCell, MFunctor, false, true> dummyTraversal({0, 0, 0}, &emptyFunctor);
   // this will build the verlet list
-  verletLists.iteratePairwiseAoS(&emptyFunctor);
+  verletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal);
 
   // check validity - should return true
   EXPECT_TRUE(verletLists.checkNeighborListsAreValid());
 }
 
 TEST_F(VerletListsTest, testCheckNeighborListsAreValidAfterSmallMove) {
-  autopas::VerletLists<autopas::Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
+  autopas::VerletLists<Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
 
-  MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
+  MockFunctor<Particle, FPCell> emptyFunctor;
 
   // addtwo particles in proper distance
-  autopas::Particle p({1.1, 1.1, 1.1}, {0., 0., 0.}, 1);
+  Particle p({1.1, 1.1, 1.1}, {0., 0., 0.}, 1);
   verletLists.addParticle(p);
-  autopas::Particle p2({3.5, 1.1, 1.1}, {0., 0., 0.}, 2);
+  Particle p2({3.5, 1.1, 1.1}, {0., 0., 0.}, 2);
   verletLists.addParticle(p2);
 
+  autopas::C08Traversal<FPCell, MFunctor, false, true> dummyTraversal({0, 0, 0}, &emptyFunctor);
   // this will build the verlet list
-  verletLists.iteratePairwiseAoS(&emptyFunctor);
+  verletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal);
 
   for (auto iter = verletLists.begin(); iter.isValid(); ++iter) {
     if (iter->getID() == 1) {
@@ -345,18 +357,19 @@ TEST_F(VerletListsTest, testCheckNeighborListsAreValidAfterSmallMove) {
 }
 
 TEST_F(VerletListsTest, testCheckNeighborListsAreInvalidAfterMoveLarge) {
-  autopas::VerletLists<autopas::Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
+  autopas::VerletLists<Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
 
-  MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
+  MockFunctor<Particle, FPCell> emptyFunctor;
 
   // addtwo particles in proper distance
-  autopas::Particle p({1.1, 1.1, 1.1}, {0., 0., 0.}, 1);
+  Particle p({1.1, 1.1, 1.1}, {0., 0., 0.}, 1);
   verletLists.addParticle(p);
-  autopas::Particle p2({3.5, 1.1, 1.1}, {0., 0., 0.}, 2);
+  Particle p2({3.5, 1.1, 1.1}, {0., 0., 0.}, 2);
   verletLists.addParticle(p2);
 
+  autopas::C08Traversal<FPCell, MFunctor, false, true> dummyTraversal({0, 0, 0}, &emptyFunctor);
   // this will build the verlet list
-  verletLists.iteratePairwiseAoS(&emptyFunctor);
+  verletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal);
 
   for (auto iter = verletLists.begin(); iter.isValid(); ++iter) {
     if (iter->getID() == 1) {
@@ -369,18 +382,19 @@ TEST_F(VerletListsTest, testCheckNeighborListsAreInvalidAfterMoveLarge) {
 }
 
 TEST_F(VerletListsTest, testCheckNeighborListsInvalidMoveFarOutsideCell) {
-  autopas::VerletLists<autopas::Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
+  autopas::VerletLists<Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
 
-  MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
+  MockFunctor<Particle, FPCell> emptyFunctor;
 
   // addtwo particles in proper distance
-  autopas::Particle p({1.1, 1.1, 1.1}, {0., 0., 0.}, 1);
+  Particle p({1.1, 1.1, 1.1}, {0., 0., 0.}, 1);
   verletLists.addParticle(p);
-  autopas::Particle p2({7.5, 1.1, 1.1}, {0., 0., 0.}, 2);
+  Particle p2({7.5, 1.1, 1.1}, {0., 0., 0.}, 2);
   verletLists.addParticle(p2);
 
+  autopas::C08Traversal<FPCell, MFunctor, false, true> dummyTraversal({0, 0, 0}, &emptyFunctor);
   // this will build the verlet list
-  verletLists.iteratePairwiseAoS(&emptyFunctor);
+  verletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal);
 
   for (auto iter = verletLists.begin(); iter.isValid(); ++iter) {
     if (iter->getID() == 1) {
@@ -394,18 +408,19 @@ TEST_F(VerletListsTest, testCheckNeighborListsInvalidMoveFarOutsideCell) {
 }
 
 TEST_F(VerletListsTest, testCheckNeighborListsValidMoveLittleOutsideCell) {
-  autopas::VerletLists<autopas::Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
+  autopas::VerletLists<Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
 
-  MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> emptyFunctor;
+  MockFunctor<Particle, FPCell> emptyFunctor;
 
   // add two particles in proper distance
-  autopas::Particle p({1.1, 1.1, 1.1}, {0., 0., 0.}, 1);
+  Particle p({1.1, 1.1, 1.1}, {0., 0., 0.}, 1);
   verletLists.addParticle(p);
-  autopas::Particle p2({7.5, 1.1, 1.1}, {0., 0., 0.}, 2);
+  Particle p2({7.5, 1.1, 1.1}, {0., 0., 0.}, 2);
   verletLists.addParticle(p2);
 
+  autopas::C08Traversal<FPCell, MFunctor, false, true> dummyTraversal({0, 0, 0}, &emptyFunctor);
   // this will build the verlet list
-  verletLists.iteratePairwiseAoS(&emptyFunctor);
+  verletLists.iteratePairwiseAoS(&emptyFunctor, &dummyTraversal);
 
   for (auto iter = verletLists.begin(); iter.isValid(); ++iter) {
     if (iter->getID() == 1) {
@@ -432,9 +447,9 @@ void moveUpdateAndExpectEqual(Container& container, Particle& particle, std::arr
 };
 
 TEST_F(VerletListsTest, testUpdateHaloParticle) {
-  autopas::VerletLists<autopas::Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
+  autopas::VerletLists<Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
 
-  autopas::Particle p({-.1, 10.1, -.1}, {0., 0., 0.}, 1);
+  Particle p({-.1, 10.1, -.1}, {0., 0., 0.}, 1);
   verletLists.addHaloParticle(p);
 
   // test same position, change velocity
@@ -459,20 +474,20 @@ TEST_F(VerletListsTest, testUpdateHaloParticle) {
   EXPECT_NO_THROW(moveUpdateAndExpectEqual(verletLists, p, {.05, 9.95, .05}));
 
   // check for particle with wrong id
-  autopas::Particle p2({-.1, -.1, -.1}, {0., 0., 0.}, 2);
+  Particle p2({-.1, -.1, -.1}, {0., 0., 0.}, 2);
   EXPECT_ANY_THROW(verletLists.updateHaloParticle(p2));
 
   // test move far, expect throw
   EXPECT_ANY_THROW(moveUpdateAndExpectEqual(verletLists, p, {3, 3, 3}););
 
   // test particles at intermediate positions (not at corners)
-  autopas::Particle p3({-1., 4., 2.}, {0., 0., 0.}, 3);
+  Particle p3({-1., 4., 2.}, {0., 0., 0.}, 3);
   verletLists.addHaloParticle(p3);
   EXPECT_NO_THROW(verletLists.updateHaloParticle(p3));
-  autopas::Particle p4({4., 10.2, 2.}, {0., 0., 0.}, 4);
+  Particle p4({4., 10.2, 2.}, {0., 0., 0.}, 4);
   verletLists.addHaloParticle(p4);
   EXPECT_NO_THROW(verletLists.updateHaloParticle(p4));
-  autopas::Particle p5({5., 4., 10.2}, {0., 0., 0.}, 3);
+  Particle p5({5., 4., 10.2}, {0., 0., 0.}, 3);
   verletLists.addHaloParticle(p5);
   EXPECT_NO_THROW(verletLists.updateHaloParticle(p5));
 }
@@ -500,44 +515,48 @@ TEST_F(VerletListsTest, testIsContainerNeeded) {
 }
 
 TEST_F(VerletListsTest, LoadExtractSoA) {
-  autopas::VerletLists<autopas::Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
+  autopas::VerletLists<Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
 
-  autopas::Particle p({-.1, 10.1, -.1}, {0., 0., 0.}, 1);
+  Particle p({-.1, 10.1, -.1}, {0., 0., 0.}, 1);
   verletLists.addHaloParticle(p);
 
-  MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> mockFunctor;
+  MockFunctor<Particle, FPCell> mockFunctor;
+  autopas::C08Traversal<FPCell, MFunctor, false, true> dummyTraversal({0, 0, 0}, &mockFunctor);
 
   EXPECT_CALL(mockFunctor, SoALoaderVerlet(_, _, _)).Times(216);  // 6*6*6=216 cells
   EXPECT_CALL(mockFunctor, SoAExtractorVerlet(_, _, _)).Times(216);
   EXPECT_CALL(mockFunctor, SoAFunctor(_, _, _, _, _)).Times(1);
-  verletLists.iteratePairwiseSoA(&mockFunctor, true);
+  verletLists.iteratePairwiseSoA(&mockFunctor, &dummyTraversal, true);
 }
 
 TEST_F(VerletListsTest, LoadExtractSoALJ) {
-  autopas::VerletLists<autopas::Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
+  autopas::VerletLists<Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 3);
 
-  autopas::Particle p({-.1, 10.1, -.1}, {0., 0., 0.}, 1);
+  Particle p({-.1, 10.1, -.1}, {0., 0., 0.}, 1);
   verletLists.addHaloParticle(p);
 
-  autopas::LJFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> ljFunctor;
-
-  verletLists.iteratePairwiseSoA(&ljFunctor, true);
+  autopas::LJFunctor<Particle, FPCell> ljFunctor;
+  autopas::C08Traversal<FPCell, autopas::LJFunctor<Particle, FPCell>, false, true> dummyTraversal({0, 0, 0},
+                                                                                                  &ljFunctor);
+  verletLists.iteratePairwiseSoA(&ljFunctor, &dummyTraversal, true);
 }
 
 TEST_F(VerletListsTest, SoAvsAoSLJ) {
   double cutoff = 2.;
-  autopas::VerletLists<autopas::Particle> verletLists1({0., 0., 0.}, {10., 10., 10.}, cutoff, 0.3, 3);
+  autopas::VerletLists<Particle> verletLists1({0., 0., 0.}, {10., 10., 10.}, cutoff, 0.3, 3);
 
-  autopas::VerletLists<autopas::Particle> verletLists2({0., 0., 0.}, {10., 10., 10.}, cutoff, 0.3, 3);
+  autopas::VerletLists<Particle> verletLists2({0., 0., 0.}, {10., 10., 10.}, cutoff, 0.3, 3);
 
-  RandomGenerator::fillWithParticles(verletLists1, autopas::Particle({0., 0., 0.}, {0., 0., 0.}, 0), 100);
-  RandomGenerator::fillWithParticles(verletLists2, autopas::Particle({0., 0., 0.}, {0., 0., 0.}, 0), 100);
+  RandomGenerator::fillWithParticles(verletLists1, Particle({0., 0., 0.}, {0., 0., 0.}, 0), 100);
+  RandomGenerator::fillWithParticles(verletLists2, Particle({0., 0., 0.}, {0., 0., 0.}, 0), 100);
 
-  autopas::LJFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> ljFunctor;
+  autopas::LJFunctor<Particle, FPCell> ljFunctor;
   ljFunctor.setGlobals(cutoff, 1, 1, 0);
+  autopas::C08Traversal<FPCell, autopas::LJFunctor<Particle, FPCell>, false, true> dummyTraversal({0, 0, 0},
+                                                                                                  &ljFunctor);
 
-  verletLists1.iteratePairwiseAoS(&ljFunctor);
-  verletLists2.iteratePairwiseSoA(&ljFunctor);
+  verletLists1.iteratePairwiseAoS(&ljFunctor, &dummyTraversal);
+  verletLists2.iteratePairwiseSoA(&ljFunctor, &dummyTraversal);
 
   auto iter1 = verletLists1.begin();
   auto iter2 = verletLists2.begin();

--- a/tests/testAutopas/testingHelpers/commonTypedefs.h
+++ b/tests/testAutopas/testingHelpers/commonTypedefs.h
@@ -12,8 +12,10 @@
 // a place for typedefs that are commonly used in tests
 
 typedef autopas::Particle Particle;
-
 typedef autopas::FullParticleCell<autopas::Particle> FPCell;
+
+typedef autopas::MoleculeLJ Molecule;
+typedef autopas::FullParticleCell<autopas::MoleculeLJ> FMCell;
 
 // M prefix for mocks
 typedef MockFunctor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> MFunctor;


### PR DESCRIPTION
A simple version of auto-tuning.
When the tuning interval is reached (or at the start of the simulation) in every iteration a new container/traversal is selected and measured. When all options are tested the fastest combination is selected and used until the next tuning phase.
This implementation resolves #71 in the sense that tune just selects a combination but does not change any forces (described there as alternative 2).

- [x] tuning traversals
- [x] tuning containers
- [x] add option to md-flex to control tuning cycles
- [x] fix tests
- [x] test TraversalSelector
- [x] test ContainerSelector
- [x] test AutoTuner
- [x] resolve #83
- [x] move traversal selectors to AutoTuner