### PR TITLE
Faster update container

### DIFF
--- a/src/autopas/cells/FullParticleCell.h
+++ b/src/autopas/cells/FullParticleCell.h
@@ -25,19 +25,10 @@ class FullParticleCell : public ParticleCell<Particle> {
 
   ~FullParticleCell() { autopas_destroy_lock(&particlesLock); }
 
-/**
- * Switch for enabling thread safety
- */
-#define uselocks 1
-
   void addParticle(Particle &m) override {
-#if uselocks == 1
     autopas_set_lock(&particlesLock);
-#endif
     _particles.push_back(m);
-#if uselocks == 1
     autopas_unset_lock(&particlesLock);
-#endif
   }
 
   virtual SingleCellIteratorWrapper<Particle> begin() override {
@@ -51,18 +42,14 @@ class FullParticleCell : public ParticleCell<Particle> {
   void clear() override { _particles.clear(); }
 
   void deleteByIndex(size_t index) override {
-#if uselocks == 1
     autopas_set_lock(&particlesLock);
-#endif
     assert(index < numParticles());
 
     if (index < numParticles() - 1) {
       std::swap(_particles[index], _particles[numParticles() - 1]);
     }
     _particles.pop_back();
-#if uselocks == 1
     autopas_unset_lock(&particlesLock);
-#endif
   }
 
   /**

--- a/src/autopas/cells/FullParticleCell.h
+++ b/src/autopas/cells/FullParticleCell.h
@@ -21,8 +21,7 @@ namespace autopas {
 template <class Particle, class SoAArraysType = typename Particle::SoAArraysType>
 class FullParticleCell : public ParticleCell<Particle> {
  public:
-  FullParticleCell() {
-    autopas_init_lock(&addParticleLock); }
+  FullParticleCell() { autopas_init_lock(&addParticleLock); }
 
   ~FullParticleCell() { autopas_destroy_lock(&addParticleLock); }
 

--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -237,6 +237,18 @@ class CellBlock3D : public CellBorderAndFlagManager {
     return closeHaloCells;
   }
 
+  /**
+   * Get the lower corner of the halo region.
+   * @return Coordinates of the lower corner.
+   */
+  std::array<double, 3> getHaloBoxMin() { return _haloBoxMin; }
+
+  /**
+   * Get the upper corner of the halo region.
+   * @return Coordinates of the upper corner.
+   */
+  std::array<double, 3> getHaloBoxMax() { return _haloBoxMax; }
+
  private:
   std::array<index_t, 3> index3D(index_t index1d) const;
   index_t index1D(const std::array<index_t, 3> &index3d) const;

--- a/src/autopas/containers/LinkedCells.h
+++ b/src/autopas/containers/LinkedCells.h
@@ -112,7 +112,6 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
   }
 
   void updateContainer() override {
-    // @todo optimize
     std::vector<Particle> invalidParticles;
 // custom reduction with templates not supported
 //#pragma omp parallel reduction(vecMerge: invalidParticles)

--- a/src/autopas/containers/LinkedCells.h
+++ b/src/autopas/containers/LinkedCells.h
@@ -112,6 +112,13 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
   }
 
   void updateContainer() override {
+    auto haloIter = this->getRegionIterator(this->_cellBlock.getHaloBoxMin(), this->_cellBlock.getHaloBoxMax(),
+                                            IteratorBehavior::haloOnly);
+    if (haloIter.isValid()) {
+      utils::ExceptionHandler::exception(
+          "Linked Cells: Halo particles still present when updateContainer was called. First particle found:\n" +
+          haloIter->toString());
+    }
 #ifdef AUTOPAS_OPENMP
 #pragma omp parallel for
 #endif  // AUTOPAS_OPENMP

--- a/src/autopas/containers/LinkedCells.h
+++ b/src/autopas/containers/LinkedCells.h
@@ -178,12 +178,12 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
       // if empty
       if (not this->getCells()[cellId].isNotEmpty()) continue;
 
-      std::array<double, 3> cellLoweCorner, cellUpperCorner;
-      this->getCellBlock().getCellBoundingBox(cellId, cellLoweCorner, cellUpperCorner);
+      std::array<double, 3> cellLowerCorner, cellUpperCorner;
+      this->getCellBlock().getCellBoundingBox(cellId, cellLowerCorner, cellUpperCorner);
 
       for (auto &&pIter = this->getCells()[cellId].begin(); pIter.isValid(); ++pIter) {
         // if not in cell
-        if (notInBox(pIter->getR(), cellLoweCorner, cellUpperCorner)) {
+        if (notInBox(pIter->getR(), cellLowerCorner, cellUpperCorner)) {
           // if not in halo
           if (inBox(pIter->getR(), this->getBoxMin(), this->getBoxMax()))
             addParticle(*pIter);
@@ -219,12 +219,12 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
         // if empty
         if (not this->getCells()[cellId].isNotEmpty()) continue;
 
-        std::array<double, 3> cellLoweCorner, cellUpperCorner;
-        this->getCellBlock().getCellBoundingBox(cellId, cellLoweCorner, cellUpperCorner);
+        std::array<double, 3> cellLowerCorner, cellUpperCorner;
+        this->getCellBlock().getCellBoundingBox(cellId, cellLowerCorner, cellUpperCorner);
 
         for (auto &&pIter = this->getCells()[cellId].begin(); pIter.isValid(); ++pIter) {
           // if not in cell
-          if (notInBox(pIter->getR(), cellLoweCorner, cellUpperCorner)) {
+          if (notInBox(pIter->getR(), cellLowerCorner, cellUpperCorner)) {
             myInvalidParticles.push_back(*pIter);
             pIter.deleteCurrentParticle();
           }

--- a/src/autopas/containers/LinkedCells.h
+++ b/src/autopas/containers/LinkedCells.h
@@ -120,13 +120,12 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
  * 3 = add-barrier-delete: first check all particles fully parallel and delete invalid then after a barrier add with
  * locks
  */
-#define variant 3
+#define variant 2
 
 #if variant == 1
   // old variant
   void updateContainer() override {
-    auto haloIter = this->getRegionIterator(this->_cellBlock.getHaloBoxMin(), this->_cellBlock.getHaloBoxMax(),
-                                            IteratorBehavior::haloOnly);
+    auto haloIter = this->begin(IteratorBehavior::haloOnly);
     if (haloIter.isValid()) {
       utils::ExceptionHandler::exception(
           "Linked Cells: Halo particles still present when updateContainer was called. First particle found:\n" +
@@ -164,8 +163,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
 
   // new with locking
   void updateContainer() override {
-    auto haloIter = this->getRegionIterator(this->_cellBlock.getHaloBoxMin(), this->_cellBlock.getHaloBoxMax(),
-                                            IteratorBehavior::haloOnly);
+    auto haloIter = this->begin(IteratorBehavior::haloOnly);
     if (haloIter.isValid()) {
       utils::ExceptionHandler::exception(
           "Linked Cells: Halo particles still present when updateContainer was called. First particle found:\n" +
@@ -199,8 +197,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
 
   // new with barrier
   void updateContainer() override {
-    auto haloIter = this->getRegionIterator(this->_cellBlock.getHaloBoxMin(), this->_cellBlock.getHaloBoxMax(),
-                                            IteratorBehavior::haloOnly);
+    auto haloIter = this->begin(IteratorBehavior::haloOnly);
     if (haloIter.isValid()) {
       utils::ExceptionHandler::exception(
           "Linked Cells: Halo particles still present when updateContainer was called. First particle found:\n" +

--- a/src/autopas/utils/WrapOpenMP.h
+++ b/src/autopas/utils/WrapOpenMP.h
@@ -119,6 +119,7 @@ inline void autopas_set_lock(autopas_lock_t *l) {
  */
 inline void autopas_init_lock(autopas_lock_t *l) {
   assert(l != nullptr);  // @todo: customize asserts
+  *l = 0;
 }
 
 /**

--- a/tests/testAutopas/LinkedCellsTest.cpp
+++ b/tests/testAutopas/LinkedCellsTest.cpp
@@ -155,7 +155,7 @@ TEST_F(LinkedCellsTest, testUpdateContainer) {
       EXPECT_EQ(linkedCells.getCells()[i].numParticles(), 2);
       auto pIter = linkedCells.getCells()[i].begin();
       auto ids = {pIter->getID(), (++pIter)->getID()};
-      EXPECT_THAT(ids, testing::UnorderedElementsAre(0,4));
+      EXPECT_THAT(ids, testing::UnorderedElementsAre(0, 4));
     } else if (i == 38) {
       EXPECT_EQ(linkedCells.getCells()[i].numParticles(), 1);
       EXPECT_EQ(linkedCells.getCells()[i].begin()->getID(), 1);
@@ -166,4 +166,17 @@ TEST_F(LinkedCellsTest, testUpdateContainer) {
       EXPECT_FALSE(linkedCells.getCells()[i].isNotEmpty());
     }
   }
+}
+
+TEST_F(LinkedCellsTest, testUpdateContainerHalo) {
+  autopas::LinkedCells<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> linkedCells({0., 0., 0.},
+                                                                                                    {3., 3., 3.}, 1.);
+
+  autopas::Particle p({-0.5, -0.5, -0.5}, {0, 0, 0}, 42);
+  linkedCells.addHaloParticle(p);
+
+  EXPECT_EQ(linkedCells.getCells()[0].numParticles(), 1);
+  EXPECT_EQ(linkedCells.getCells()[0].begin()->getID(), 42);
+
+  EXPECT_THROW(linkedCells.updateContainer();, autopas::utils::ExceptionHandler::AutoPasException);
 }

--- a/tests/testAutopas/LinkedCellsTest.cpp
+++ b/tests/testAutopas/LinkedCellsTest.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "LinkedCellsTest.h"
+#include <gmock/gmock-generated-matchers.h>
 
 TEST_F(LinkedCellsTest, testParticleAdding) {
   autopas::LinkedCells<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> linkedCells(
@@ -152,8 +153,9 @@ TEST_F(LinkedCellsTest, testUpdateContainer) {
       EXPECT_EQ(linkedCells.getCells()[i].begin()->getID(), 3);
     } else if (i == 32) {
       EXPECT_EQ(linkedCells.getCells()[i].numParticles(), 2);
-      EXPECT_EQ(linkedCells.getCells()[i].begin()->getID(), 0);
-      EXPECT_EQ((++(linkedCells.getCells()[i].begin()))->getID(), 4);
+      auto pIter = linkedCells.getCells()[i].begin();
+      auto ids = {pIter->getID(), (++pIter)->getID()};
+      EXPECT_THAT(ids, testing::UnorderedElementsAre(0,4));
     } else if (i == 38) {
       EXPECT_EQ(linkedCells.getCells()[i].numParticles(), 1);
       EXPECT_EQ(linkedCells.getCells()[i].begin()->getID(), 1);

--- a/tests/testAutopas/LinkedCellsTest.cpp
+++ b/tests/testAutopas/LinkedCellsTest.cpp
@@ -81,7 +81,7 @@ TEST_F(LinkedCellsTest, testCheckUpdateContainerNeededNoMove) {
   }
 }
 
-TEST_F(LinkedCellsTest, testIsContainerNeeded) {
+TEST_F(LinkedCellsTest, testIsContainerUpdateNeeded) {
   std::array<double, 3> boxMin{0, 0, 0};
   std::array<double, 3> boxMax{10, 10, 10};
   double cutoff = 1.;
@@ -100,4 +100,68 @@ TEST_F(LinkedCellsTest, testIsContainerNeeded) {
   // Particle moves to halo cell -> needs update
   container.begin()->setR({-1, -1, -1});
   EXPECT_TRUE(container.isContainerUpdateNeeded());
+}
+
+TEST_F(LinkedCellsTest, testUpdateContainer) {
+  autopas::LinkedCells<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> linkedCells({0., 0., 0.},
+                                                                                                    {3., 3., 3.}, 1.);
+
+  autopas::Particle p1({0.5, 0.5, 0.5}, {0, 0, 0}, 0);
+  autopas::Particle p2({1.5, 1.5, 1.5}, {0, 0, 0}, 1);
+  autopas::Particle p3({1.6, 1.5, 1.5}, {0, 0, 0}, 2);
+  autopas::Particle p4({2.5, 1.5, 1.5}, {0, 0, 0}, 3);
+  autopas::Particle p5({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
+
+  linkedCells.addParticle(p1);
+  linkedCells.addParticle(p2);
+  linkedCells.addParticle(p3);
+  linkedCells.addParticle(p4);
+  linkedCells.addParticle(p5);
+
+  // check particles are where we expect them to be (and nothing else)
+  for (size_t i = 0; i < linkedCells.getCells().size(); ++i) {
+    if (i == 31) {
+      EXPECT_EQ(linkedCells.getCells()[i].numParticles(), 1);
+      EXPECT_EQ(linkedCells.getCells()[i].begin()->getID(), 0);
+    } else if (i == 62) {
+      EXPECT_EQ(linkedCells.getCells()[i].numParticles(), 2);
+      EXPECT_EQ(linkedCells.getCells()[i].begin()->getID(), 1);
+      EXPECT_EQ((++(linkedCells.getCells()[i].begin()))->getID(), 2);
+    } else if (i == 63) {
+      EXPECT_EQ(linkedCells.getCells()[i].numParticles(), 1);
+      EXPECT_EQ(linkedCells.getCells()[i].begin()->getID(), 3);
+    } else if (i == 93) {
+      EXPECT_EQ(linkedCells.getCells()[i].numParticles(), 1);
+      EXPECT_EQ(linkedCells.getCells()[i].begin()->getID(), 4);
+    } else {
+      EXPECT_FALSE(linkedCells.getCells()[i].isNotEmpty());
+    }
+  }
+
+  // new locations for particles
+  linkedCells.getCells()[31].begin()->setR({1.5, 0.5, 0.5});
+  linkedCells.getCells()[62].begin()->setR({2.5, 1.5, 0.5});
+  linkedCells.getCells()[63].begin()->setR({-0.5, -0.5, -0.5});
+  linkedCells.getCells()[93].begin()->setR({1.6, 0.5, 0.5});
+  linkedCells.updateContainer();
+
+  // verify particles are in correct new cells (and nowhere else
+  for (size_t i = 0; i < linkedCells.getCells().size(); ++i) {
+    if (i == 0) {
+      EXPECT_EQ(linkedCells.getCells()[i].numParticles(), 1);
+      EXPECT_EQ(linkedCells.getCells()[i].begin()->getID(), 3);
+    } else if (i == 32) {
+      EXPECT_EQ(linkedCells.getCells()[i].numParticles(), 2);
+      EXPECT_EQ(linkedCells.getCells()[i].begin()->getID(), 0);
+      EXPECT_EQ((++(linkedCells.getCells()[i].begin()))->getID(), 4);
+    } else if (i == 38) {
+      EXPECT_EQ(linkedCells.getCells()[i].numParticles(), 1);
+      EXPECT_EQ(linkedCells.getCells()[i].begin()->getID(), 1);
+    } else if (i == 62) {
+      EXPECT_EQ(linkedCells.getCells()[i].numParticles(), 1);
+      EXPECT_EQ(linkedCells.getCells()[i].begin()->getID(), 2);
+    } else {
+      EXPECT_FALSE(linkedCells.getCells()[i].isNotEmpty());
+    }
+  }
 }


### PR DESCRIPTION
Faster and more parallel implementation of `LinkedCells::updateContainer()`

- [x] locking mechanism for `FullParticleCell::addParticle()`
- [x] full parallel implementation of `LinkedCells::updateContainer()`
- [x] unit tests for `LinkedCells::updateContainer()`
- [x] resolves #72 
- [x] resolves #26  


Tested on my machine (i7-7700 8x3.6GHz)
- 1,000,000 Particles (uniform random distribution)
- 52x 52 x 52 Cells
- random = particle jumps to a complete random location in the domain
- realistic = particle jumps to a random neighbor cell
- omitting locks (= allowing data races) has no significant impact

Particle relocations [ms] |  no | random 50%  | random 100% | realistic 5% | realistic 10%
------------ | ------------- | ------------- | ------------- | ------------- | -------------
old                         | 180 | 285 | 285 | 185 | 190
lock everything      |   30 | 240 | 250 |   42 | 50
add-barrier-delete |   35 | 250 | 288 |   47 | 58

Versions can be compared in 2330c573c0dde6b5da3b1a1eec670edf915ccf0f