### PR TITLE
Faster region iterators

### DIFF
--- a/examples/sph-mpi/sph-main-mpi.cpp
+++ b/examples/sph-mpi/sph-main-mpi.cpp
@@ -40,7 +40,7 @@ void SetupIC(Container& sphSystem, double* end_time, const std::array<double, 3>
         // ith.eng = 2.5;
         // ith.id = i++;
         // ith.smth = 0.012;
-        if (autopas::inBox(ith.getR(), sphSystem.getBoxMin(), sphSystem.getBoxMax())) {
+        if (autopas::utils::inBox(ith.getR(), sphSystem.getBoxMin(), sphSystem.getBoxMax())) {
           sphSystem.addParticle(ith);
         }
       }
@@ -62,7 +62,7 @@ void SetupIC(Container& sphSystem, double* end_time, const std::array<double, 3>
         // ith.eng = 2.5;
         // ith.id = i++;
         // ith.smth = 0.012;
-        if (autopas::inBox(ith.getR(), sphSystem.getBoxMin(), sphSystem.getBoxMax())) {
+        if (autopas::utils::inBox(ith.getR(), sphSystem.getBoxMin(), sphSystem.getBoxMax())) {
           sphSystem.addParticle(ith);
         }
       }

--- a/examples/sph/sph-main.cpp
+++ b/examples/sph/sph-main.cpp
@@ -267,7 +267,7 @@ void densityPressureHydroForce(Container& sphSystem) {
   std::cout << "haloparticles... ";
   int haloparts = 0, innerparts = 0;
   for (auto part = sphSystem.begin(); part.isValid(); ++part) {
-    if (not autopas::inBox(part->getR(), sphSystem.getBoxMin(), sphSystem.getBoxMax())) {
+    if (not autopas::utils::inBox(part->getR(), sphSystem.getBoxMin(), sphSystem.getBoxMax())) {
       haloparts++;
     } else {
       innerparts++;
@@ -301,7 +301,7 @@ void densityPressureHydroForce(Container& sphSystem) {
   std::cout << "haloparticles... ";
   haloparts = 0, innerparts = 0;
   for (auto part = sphSystem.begin(); part.isValid(); ++part) {
-    if (not autopas::inBox(part->getR(), sphSystem.getBoxMin(), sphSystem.getBoxMax())) {
+    if (not autopas::utils::inBox(part->getR(), sphSystem.getBoxMin(), sphSystem.getBoxMax())) {
       haloparts++;
     } else {
       innerparts++;

--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -403,6 +403,6 @@ inline typename CellBlock3D<ParticleCell>::index_t CellBlock3D<ParticleCell>::in
 
 template <class ParticleCell>
 bool CellBlock3D<ParticleCell>::checkInHalo(std::array<double, 3> position) const {
-  return autopas::inBox(position, _haloBoxMin, _haloBoxMax) && autopas::notInBox(position, _boxMin, _boxMax);
+  return autopas::utils::inBox(position, _haloBoxMin, _haloBoxMax) && autopas::utils::notInBox(position, _boxMin, _boxMax);
 }
 }  // namespace autopas

--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -403,6 +403,7 @@ inline typename CellBlock3D<ParticleCell>::index_t CellBlock3D<ParticleCell>::in
 
 template <class ParticleCell>
 bool CellBlock3D<ParticleCell>::checkInHalo(std::array<double, 3> position) const {
-  return autopas::utils::inBox(position, _haloBoxMin, _haloBoxMax) && autopas::utils::notInBox(position, _boxMin, _boxMax);
+  return autopas::utils::inBox(position, _haloBoxMin, _haloBoxMax) &&
+         autopas::utils::notInBox(position, _boxMin, _boxMax);
 }
 }  // namespace autopas

--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -392,13 +392,13 @@ inline ParticleCell &CellBlock3D<ParticleCell>::getCell(const std::array<index_t
 template <class ParticleCell>
 inline std::array<typename CellBlock3D<ParticleCell>::index_t, 3> CellBlock3D<ParticleCell>::index3D(
     index_t index1d) const {
-  return ThreeDimensionalMapping::oneToThreeD(index1d, _cellsPerDimensionWithHalo);
+  return utils::ThreeDimensionalMapping::oneToThreeD(index1d, _cellsPerDimensionWithHalo);
 }
 
 template <class ParticleCell>
 inline typename CellBlock3D<ParticleCell>::index_t CellBlock3D<ParticleCell>::index1D(
     const std::array<index_t, 3> &index3d) const {
-  return ThreeDimensionalMapping::threeToOneD(index3d, _cellsPerDimensionWithHalo);
+  return utils::ThreeDimensionalMapping::threeToOneD(index3d, _cellsPerDimensionWithHalo);
 }
 
 template <class ParticleCell>

--- a/src/autopas/containers/CellBorderAndFlagManager.h
+++ b/src/autopas/containers/CellBorderAndFlagManager.h
@@ -8,30 +8,30 @@
 
 namespace autopas {
 /**
- * interface class to handle cell borders and cell types of cells.
+ * Interface class to handle cell borders and cell types of cells.
  * @todo: add cell border handling
  */
 class CellBorderAndFlagManager {
   /**
-   * the index type to access the particle cells
+   * The index type to access the particle cells.
    */
   typedef std::size_t index_t;
 
  public:
   /**
-   * destructor
+   * Cestructor
    */
   virtual ~CellBorderAndFlagManager() = default;
 
   /**
-   * checks if the cell with the one-dimensional index index1d is a halocell.
+   * Checks if the cell with the one-dimensional index index1d is a halocell.
    * @param index1d the one-dimensional index of the cell that should be checked
    * @return true if the cell is a halo cell
    */
   virtual bool isHaloCell(index_t index1d) const = 0;
 
   /**
-   * checks if the cell with the one-dimensional index index1d is owned by this
+   * Checks if the cell with the one-dimensional index index1d is owned by this
    * process, i.e. it is NOT a halo cell.
    * @param index1d the one-dimensional index of the cell that should be checked
    * @return true if the cell is owned by the current process.

--- a/src/autopas/containers/DirectSum.h
+++ b/src/autopas/containers/DirectSum.h
@@ -43,7 +43,7 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
   ContainerOptions getContainerType() override { return ContainerOptions::directSum; }
 
   void addParticle(Particle &p) override {
-    if (inBox(p.getR(), this->getBoxMin(), this->getBoxMax())) {
+    if (utils::inBox(p.getR(), this->getBoxMin(), this->getBoxMax())) {
       getCell()->addParticle(p);
     } else {
       utils::ExceptionHandler::exception("DirectSum: trying to add particle that is not in the bounding box.\n" +
@@ -52,7 +52,7 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
   }
 
   void addHaloParticle(Particle &p) override {
-    if (notInBox(p.getR(), this->getBoxMin(), this->getBoxMax())) {
+    if (utils::notInBox(p.getR(), this->getBoxMin(), this->getBoxMax())) {
       getHaloCell()->addParticle(p);
     } else {  // particle is not outside of own box
       utils::ExceptionHandler::exception(
@@ -113,7 +113,7 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
 #pragma omp parallel shared(outlierFound)  // if (this->_cells.size() / omp_get_max_threads() > ???)
 #endif
     for (auto iter = this->begin(); iter.isValid() && (not outlierFound); ++iter) {
-      if (notInBox(iter->getR(), this->getBoxMin(), this->getBoxMax())) {
+      if (utils::notInBox(iter->getR(), this->getBoxMin(), this->getBoxMax())) {
         outlierFound = true;
       }
     }

--- a/src/autopas/containers/DirectSum.h
+++ b/src/autopas/containers/DirectSum.h
@@ -109,7 +109,7 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
           getHaloCell()->numParticles());
     }
     for (auto iter = getCell()->begin(); iter.isValid(); ++iter) {
-      if (notInBox(iter->getR(), this->getBoxMin(), this->getBoxMax())) {
+      if (utils::notInBox(iter->getR(), this->getBoxMin(), this->getBoxMax())) {
         addHaloParticle(*iter);
         iter.deleteCurrentParticle();
       }

--- a/src/autopas/containers/DirectSum.h
+++ b/src/autopas/containers/DirectSum.h
@@ -43,8 +43,7 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
   ContainerOptions getContainerType() override { return ContainerOptions::directSum; }
 
   void addParticle(Particle &p) override {
-    bool inBox = autopas::inBox(p.getR(), this->getBoxMin(), this->getBoxMax());
-    if (inBox) {
+    if (inBox(p.getR(), this->getBoxMin(), this->getBoxMax())) {
       getCell()->addParticle(p);
     } else {
       utils::ExceptionHandler::exception("DirectSum: trying to add particle that is not in the bounding box.\n" +
@@ -53,8 +52,7 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
   }
 
   void addHaloParticle(Particle &p) override {
-    bool inBox = autopas::inBox(p.getR(), this->getBoxMin(), this->getBoxMax());
-    if (not inBox) {
+    if (notInBox(p.getR(), this->getBoxMin(), this->getBoxMax())) {
       getHaloCell()->addParticle(p);
     } else {  // particle is not outside of own box
       utils::ExceptionHandler::exception(
@@ -115,7 +113,7 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
 #pragma omp parallel shared(outlierFound)  // if (this->_cells.size() / omp_get_max_threads() > ???)
 #endif
     for (auto iter = this->begin(); iter.isValid() && (not outlierFound); ++iter) {
-      if (not iter->inBox(this->getBoxMin(), this->getBoxMax())) {
+      if (notInBox(iter->getR(), this->getBoxMin(), this->getBoxMax())) {
         outlierFound = true;
       }
     }

--- a/src/autopas/containers/DirectSum.h
+++ b/src/autopas/containers/DirectSum.h
@@ -140,9 +140,10 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
         new internal::ParticleIterator<Particle, ParticleCell>(&this->_cells, 0, &_cellBorderFlagManager, behavior));
   }
 
-  ParticleIteratorWrapper<Particle> getRegionIterator(
-      std::array<double, 3> lowerCorner, std::array<double, 3> higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
+  ParticleIteratorWrapper<Particle> getRegionIterator(std::array<double, 3> lowerCorner,
+                                                      std::array<double, 3> higherCorner,
+                                                      IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
+                                                      bool incSearchRegion = false) override {
     std::vector<size_t> cellsOfInterest;
 
     switch (behavior) {

--- a/src/autopas/containers/DirectSum.h
+++ b/src/autopas/containers/DirectSum.h
@@ -127,14 +127,14 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
 
   ParticleIteratorWrapper<Particle> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
     return ParticleIteratorWrapper<Particle>(
-        new internal::ParticleIterator<Particle, ParticleCell>(&this->_cells, &_cellBorderFlagManager, behavior));
+        new internal::ParticleIterator<Particle, ParticleCell>(&this->_cells, 0, &_cellBorderFlagManager, behavior));
   }
 
   ParticleIteratorWrapper<Particle> getRegionIterator(
       std::array<double, 3> lowerCorner, std::array<double, 3> higherCorner,
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
     return ParticleIteratorWrapper<Particle>(new internal::RegionParticleIterator<Particle, ParticleCell>(
-        &this->_cells, lowerCorner, higherCorner, &_cellBorderFlagManager, behavior));
+        &this->_cells, {1, 1, 1}, lowerCorner, higherCorner, 0, 1, &_cellBorderFlagManager, behavior));
   }
 
  private:

--- a/src/autopas/containers/DirectSum.h
+++ b/src/autopas/containers/DirectSum.h
@@ -133,8 +133,23 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
   ParticleIteratorWrapper<Particle> getRegionIterator(
       std::array<double, 3> lowerCorner, std::array<double, 3> higherCorner,
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
+    std::vector<size_t> cellsOfInterest;
+
+    switch (behavior) {
+      case IteratorBehavior::haloOnly:
+        cellsOfInterest.push_back(1);
+        break;
+      case IteratorBehavior::ownedOnly:
+        cellsOfInterest.push_back(0);
+        break;
+      case IteratorBehavior::haloAndOwned:
+        cellsOfInterest.push_back(0);
+        cellsOfInterest.push_back(1);
+        break;
+    }
+
     return ParticleIteratorWrapper<Particle>(new internal::RegionParticleIterator<Particle, ParticleCell>(
-        &this->_cells, {1, 1, 1}, lowerCorner, higherCorner, 0, 1, &_cellBorderFlagManager, behavior));
+        &this->_cells, lowerCorner, higherCorner, cellsOfInterest, &_cellBorderFlagManager, behavior));
   }
 
  private:

--- a/src/autopas/containers/LinkedCells.h
+++ b/src/autopas/containers/LinkedCells.h
@@ -203,10 +203,10 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
       // getBox does not account for halo. Therefore subtract two cells per dim.
       cellWidthPerDim[i] = (this->getBoxMax()[i] - this->getBoxMin()[i]) / (cellsPerDim[i] - 2);
       boxMinWithHalo[i] = this->getBoxMin()[i] - cellWidthPerDim[i];
-      boxMaxWithHalo[i] = this->getBoxMax()[i] - cellWidthPerDim[i];
+      boxMaxWithHalo[i] = this->getBoxMax()[i] + cellWidthPerDim[i];
       // implicit floor
-      startIndex3D[i] = lowerCorner[i] - boxMinWithHalo[i] / cellWidthPerDim[i];
-      stopIndex3D[i] = std::ceil(boxMaxWithHalo[i] - boxMinWithHalo[i] / cellWidthPerDim[i]);
+      startIndex3D[i] = (lowerCorner[i] - boxMinWithHalo[i]) / cellWidthPerDim[i];
+      stopIndex3D[i] = std::ceil((higherCorner[i] - boxMinWithHalo[i]) / cellWidthPerDim[i]);
     }
 
     auto startIndex = ThreeDimensionalMapping::threeToOneD(startIndex3D, cellsPerDim);

--- a/src/autopas/containers/LinkedCells.h
+++ b/src/autopas/containers/LinkedCells.h
@@ -207,6 +207,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
       // implicit floor
       startIndex3D[i] = (lowerCorner[i] - boxMinWithHalo[i]) / cellWidthPerDim[i];
       stopIndex3D[i] = std::ceil((higherCorner[i] - boxMinWithHalo[i]) / cellWidthPerDim[i]);
+      stopIndex3D[i] = std::min(stopIndex3D[i], cellsPerDim[i] - 1);
     }
 
     auto startIndex = utils::ThreeDimensionalMapping::threeToOneD(startIndex3D, cellsPerDim);

--- a/src/autopas/containers/LinkedCells.h
+++ b/src/autopas/containers/LinkedCells.h
@@ -197,21 +197,9 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
       std::array<double, 3> lowerCorner, std::array<double, 3> higherCorner,
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
     auto cellsPerDim = this->_cellBlock.getCellsPerDimensionWithHalo();
-    std::array<double, 3> cellWidthPerDim, boxMinWithHalo, boxMaxWithHalo;
-    std::array<size_t, 3> startIndex3D, stopIndex3D;
-    for (int i = 0; i < 3; ++i) {
-      // getBox does not account for halo. Therefore subtract two cells per dim.
-      cellWidthPerDim[i] = (this->getBoxMax()[i] - this->getBoxMin()[i]) / (cellsPerDim[i] - 2);
-      boxMinWithHalo[i] = this->getBoxMin()[i] - cellWidthPerDim[i];
-      boxMaxWithHalo[i] = this->getBoxMax()[i] + cellWidthPerDim[i];
-      // implicit floor
-      startIndex3D[i] = (lowerCorner[i] - boxMinWithHalo[i]) / cellWidthPerDim[i];
-      stopIndex3D[i] = std::ceil((higherCorner[i] - boxMinWithHalo[i]) / cellWidthPerDim[i]);
-      stopIndex3D[i] = std::min(stopIndex3D[i], cellsPerDim[i] - 1);
-    }
 
-    auto startIndex = utils::ThreeDimensionalMapping::threeToOneD(startIndex3D, cellsPerDim);
-    auto stopIndex = utils::ThreeDimensionalMapping::threeToOneD(stopIndex3D, cellsPerDim);
+    auto startIndex = this->_cellBlock.get1DIndexOfPosition(lowerCorner);
+    auto stopIndex = this->_cellBlock.get1DIndexOfPosition(higherCorner);
 
     return ParticleIteratorWrapper<Particle>(new internal::RegionParticleIterator<Particle, ParticleCell>(
         &this->_cells, cellsPerDim, lowerCorner, higherCorner, startIndex, stopIndex, &_cellBlock, behavior));

--- a/src/autopas/containers/LinkedCells.h
+++ b/src/autopas/containers/LinkedCells.h
@@ -56,7 +56,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
   ContainerOptions getContainerType() override { return ContainerOptions::linkedCells; }
 
   void addParticle(Particle &p) override {
-    bool inBox = autopas::inBox(p.getR(), this->getBoxMin(), this->getBoxMax());
+    bool inBox = autopas::utils::inBox(p.getR(), this->getBoxMin(), this->getBoxMax());
     if (inBox) {
       ParticleCell &cell = _cellBlock.getContainingCell(p.getR());
       cell.addParticle(p);
@@ -138,7 +138,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
 
         for (auto &&pIter = this->getCells()[cellId].begin(); pIter.isValid(); ++pIter) {
           // if not in cell
-          if (notInBox(pIter->getR(), cellLowerCorner, cellUpperCorner)) {
+          if (utils::notInBox(pIter->getR(), cellLowerCorner, cellUpperCorner)) {
             myInvalidParticles.push_back(*pIter);
             pIter.deleteCurrentParticle();
           }
@@ -150,7 +150,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
       // this loop is executed for every thread
       for (auto &&p : myInvalidParticles)
         // if not in halo
-        if (inBox(p.getR(), this->getBoxMin(), this->getBoxMax()))
+        if (utils::inBox(p.getR(), this->getBoxMin(), this->getBoxMax()))
           addParticle(p);
         else
           addHaloParticle(p);
@@ -172,7 +172,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
       _cellBlock.getCellBoundingBox(cellIndex1d, boxmin, boxmax);
 
       for (auto iter = this->_cells[cellIndex1d].begin(); iter.isValid(); ++iter) {
-        if (not inBox(iter->getR(), boxmin, boxmax)) {
+        if (not utils::inBox(iter->getR(), boxmin, boxmax)) {
           outlierFound = true;  // we need an update
           break;
         }

--- a/src/autopas/containers/LinkedCells.h
+++ b/src/autopas/containers/LinkedCells.h
@@ -209,8 +209,8 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
       stopIndex3D[i] = std::ceil((higherCorner[i] - boxMinWithHalo[i]) / cellWidthPerDim[i]);
     }
 
-    auto startIndex = ThreeDimensionalMapping::threeToOneD(startIndex3D, cellsPerDim);
-    auto stopIndex = ThreeDimensionalMapping::threeToOneD(stopIndex3D, cellsPerDim);
+    auto startIndex = utils::ThreeDimensionalMapping::threeToOneD(startIndex3D, cellsPerDim);
+    auto stopIndex = utils::ThreeDimensionalMapping::threeToOneD(stopIndex3D, cellsPerDim);
 
     return ParticleIteratorWrapper<Particle>(new internal::RegionParticleIterator<Particle, ParticleCell>(
         &this->_cells, cellsPerDim, lowerCorner, higherCorner, startIndex, stopIndex, &_cellBlock, behavior));

--- a/src/autopas/containers/LinkedCells.h
+++ b/src/autopas/containers/LinkedCells.h
@@ -193,10 +193,22 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
         new internal::ParticleIterator<Particle, ParticleCell>(&this->_cells, 0, &_cellBlock, behavior));
   }
 
-  ParticleIteratorWrapper<Particle> getRegionIterator(
-      std::array<double, 3> lowerCorner, std::array<double, 3> higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
-    auto startIndex = this->_cellBlock.get1DIndexOfPosition(lowerCorner);
+  ParticleIteratorWrapper<Particle> getRegionIterator(std::array<double, 3> lowerCorner,
+                                                      std::array<double, 3> higherCorner,
+                                                      IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
+                                                      bool incSearchRegion = false) override {
+    size_t startIndex;
+    // this is needed when used through verlet lists since particles can move over cell borders.
+    // only lower corner needed since we increase the upper corner anyways.
+    if (incSearchRegion) {
+      startIndex = this->_cellBlock.get1DIndexOfPosition({
+          lowerCorner[0] - 1,
+          lowerCorner[1] - 1,
+          lowerCorner[2] - 1,
+      });
+    } else {
+      startIndex = this->_cellBlock.get1DIndexOfPosition(lowerCorner);
+    }
     auto stopIndex = this->_cellBlock.get1DIndexOfPosition(higherCorner);
 
     auto startIndex3D =

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -105,11 +105,12 @@ class ParticleContainerInterface {
    * @param lowerCorner Lower corner of the region
    * @param higherCorner Higher corner of the region
    * @param behavior The behavior of the iterator (shall it iterate over halo particles as well?).
+   * @param incSearchRegion Weather to increase the search space (e.g. include more cells)
    * @return Iterator to iterate over all particles in a specific region.
    */
   virtual ParticleIteratorWrapper<Particle> getRegionIterator(
       std::array<double, 3> lowerCorner, std::array<double, 3> higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) = 0;
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool incSearchRegion = false) = 0;
 
   /**
    * Get the upper corner of the container.

--- a/src/autopas/containers/VerletLists.h
+++ b/src/autopas/containers/VerletLists.h
@@ -279,10 +279,11 @@ class VerletLists : public ParticleContainer<Particle, autopas::FullParticleCell
     return _linkedCells.begin(behavior);
   }
 
-  ParticleIteratorWrapper<Particle> getRegionIterator(
-      std::array<double, 3> lowerCorner, std::array<double, 3> higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
-    return _linkedCells.getRegionIterator(lowerCorner, higherCorner, behavior);
+  ParticleIteratorWrapper<Particle> getRegionIterator(std::array<double, 3> lowerCorner,
+                                                      std::array<double, 3> higherCorner,
+                                                      IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
+                                                      bool incSearchRegion = false) override {
+    return _linkedCells.getRegionIterator(lowerCorner, higherCorner, behavior, true);
   }
 
  protected:

--- a/src/autopas/containers/VerletLists.h
+++ b/src/autopas/containers/VerletLists.h
@@ -215,7 +215,7 @@ class VerletLists : public ParticleContainer<Particle, autopas::FullParticleCell
       boxmin = ArrayMath::addScalar(boxmin, -_skin / 2.);
       boxmax = ArrayMath::addScalar(boxmax, +_skin / 2.);
       for (auto iter = _linkedCells.getCells()[cellIndex1d].begin(); iter.isValid(); ++iter) {
-        if (notInBox(iter->getR(), boxmin, boxmax)) {
+        if (utils::notInBox(iter->getR(), boxmin, boxmax)) {
           outlierFound = true;  // we need an update
           break;
         }

--- a/src/autopas/containers/VerletLists.h
+++ b/src/autopas/containers/VerletLists.h
@@ -204,7 +204,7 @@ class VerletLists : public ParticleContainer<Particle, autopas::FullParticleCell
       boxmin = ArrayMath::addScalar(boxmin, -_skin / 2.);
       boxmax = ArrayMath::addScalar(boxmax, +_skin / 2.);
       for (auto iter = _linkedCells.getCells()[cellIndex1d].begin(); iter.isValid(); ++iter) {
-        if (not iter->inBox(boxmin, boxmax)) {
+        if (notInBox(iter->getR(), boxmin, boxmax)) {
           outlierFound = true;  // we need an update
           break;
         }

--- a/src/autopas/containers/cellPairTraversals/C08BasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/C08BasedTraversal.h
@@ -140,5 +140,4 @@ inline void C08BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>
   _cellOffsets[i++] = xz;
   _cellOffsets[i++] = xyz;
 }
-
 }  // namespace autopas

--- a/src/autopas/containers/cellPairTraversals/C08BasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/C08BasedTraversal.h
@@ -99,7 +99,7 @@ inline void C08BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>
 template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3>
 inline void C08BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>::computeOffsets() {
   using std::make_pair;
-  typedef ThreeDimensionalMapping TDM;
+  typedef utils::ThreeDimensionalMapping TDM;
 
   unsigned long o = TDM::threeToOneD(0ul, 0ul, 0ul, this->_cellsPerDimension);  // origin
   unsigned long x = TDM::threeToOneD(1ul, 0ul, 0ul, this->_cellsPerDimension);  // displacement to the right

--- a/src/autopas/containers/cellPairTraversals/C08BasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/C08BasedTraversal.h
@@ -99,16 +99,17 @@ inline void C08BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>
 template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3>
 inline void C08BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>::computeOffsets() {
   using std::make_pair;
-  typedef utils::ThreeDimensionalMapping TDM;
 
-  unsigned long o = TDM::threeToOneD(0ul, 0ul, 0ul, this->_cellsPerDimension);  // origin
-  unsigned long x = TDM::threeToOneD(1ul, 0ul, 0ul, this->_cellsPerDimension);  // displacement to the right
-  unsigned long y = TDM::threeToOneD(0ul, 1ul, 0ul, this->_cellsPerDimension);  // displacement ...
-  unsigned long z = TDM::threeToOneD(0ul, 0ul, 1ul, this->_cellsPerDimension);
-  unsigned long xy = TDM::threeToOneD(1ul, 1ul, 0ul, this->_cellsPerDimension);
-  unsigned long yz = TDM::threeToOneD(0ul, 1ul, 1ul, this->_cellsPerDimension);
-  unsigned long xz = TDM::threeToOneD(1ul, 0ul, 1ul, this->_cellsPerDimension);
-  unsigned long xyz = TDM::threeToOneD(1ul, 1ul, 1ul, this->_cellsPerDimension);
+  // origin
+  unsigned long o = utils::ThreeDimensionalMapping::threeToOneD(0ul, 0ul, 0ul, this->_cellsPerDimension);
+  // displacement to right ...
+  unsigned long x = utils::ThreeDimensionalMapping::threeToOneD(1ul, 0ul, 0ul, this->_cellsPerDimension);
+  unsigned long y = utils::ThreeDimensionalMapping::threeToOneD(0ul, 1ul, 0ul, this->_cellsPerDimension);
+  unsigned long z = utils::ThreeDimensionalMapping::threeToOneD(0ul, 0ul, 1ul, this->_cellsPerDimension);
+  unsigned long xy = utils::ThreeDimensionalMapping::threeToOneD(1ul, 1ul, 0ul, this->_cellsPerDimension);
+  unsigned long yz = utils::ThreeDimensionalMapping::threeToOneD(0ul, 1ul, 1ul, this->_cellsPerDimension);
+  unsigned long xz = utils::ThreeDimensionalMapping::threeToOneD(1ul, 0ul, 1ul, this->_cellsPerDimension);
+  unsigned long xyz = utils::ThreeDimensionalMapping::threeToOneD(1ul, 1ul, 1ul, this->_cellsPerDimension);
 
   int i = 0;
   // if incrementing along X, the following order will be more cache-efficient:

--- a/src/autopas/containers/cellPairTraversals/C08Traversal.h
+++ b/src/autopas/containers/cellPairTraversals/C08Traversal.h
@@ -59,7 +59,7 @@ inline void C08Traversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>::tra
 #endif
   {
     for (unsigned long col = 0; col < 8; ++col) {
-      std::array<unsigned long, 3> start = ThreeDimensionalMapping::oneToThreeD(col, stride);
+      std::array<unsigned long, 3> start = utils::ThreeDimensionalMapping::oneToThreeD(col, stride);
 
       // intel compiler demands following:
       const unsigned long start_x = start[0], start_y = start[1], start_z = start[2];
@@ -72,7 +72,7 @@ inline void C08Traversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>::tra
       for (unsigned long z = start_z; z < end_z; z += stride_z) {
         for (unsigned long y = start_y; y < end_y; y += stride_y) {
           for (unsigned long x = start_x; x < end_x; x += stride_x) {
-            unsigned long baseIndex = ThreeDimensionalMapping::threeToOneD(x, y, z, this->_cellsPerDimension);
+            unsigned long baseIndex = utils::ThreeDimensionalMapping::threeToOneD(x, y, z, this->_cellsPerDimension);
             this->processBaseCell(cells, baseIndex);
           }
         }

--- a/src/autopas/containers/cellPairTraversals/SlicedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/SlicedTraversal.h
@@ -137,7 +137,7 @@ inline void SlicedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>::
           idArray[_dimsPerLength[0]] = dimSlice;
           idArray[_dimsPerLength[1]] = dimMedium;
           idArray[_dimsPerLength[2]] = dimShort;
-          auto id = ThreeDimensionalMapping::threeToOneD(idArray, this->_cellsPerDimension);
+          auto id = utils::ThreeDimensionalMapping::threeToOneD(idArray, this->_cellsPerDimension);
           this->processBaseCell(cells, id);
         }
       }

--- a/src/autopas/iterators/ParticleIterator.h
+++ b/src/autopas/iterators/ParticleIterator.h
@@ -26,6 +26,15 @@ namespace internal {
  */
 template <class Particle, class ParticleCell>
 class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle> {
+ protected:
+  explicit ParticleIterator(std::vector<ParticleCell>* cont, CellBorderAndFlagManager* flagManager,
+                            IteratorBehavior behavior)
+      : _vectorOfCells(cont),
+        _iteratorAcrossCells(cont->begin()),
+        _iteratorWithinOneCell(cont->begin()->begin()),
+        _flagManager(flagManager),
+        _behavior(behavior) {}
+
  public:
   /**
    * Constructor of the ParticleIterator class.
@@ -170,7 +179,6 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle> {
    */
   SingleCellIteratorWrapper<Particle> _iteratorWithinOneCell;
 
- private:
   CellBorderAndFlagManager* _flagManager;
   IteratorBehavior _behavior;
 };

--- a/src/autopas/iterators/ParticleIterator.h
+++ b/src/autopas/iterators/ParticleIterator.h
@@ -51,7 +51,7 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle> {
         _iteratorWithinOneCell(cont->begin()->begin()),
         _flagManager(flagManager),
         _behavior(behavior) {
-    size_t myThreadId = autopas_get_thread_num();
+    auto myThreadId = autopas_get_thread_num();
     offset += myThreadId;
     if (offset < cont->size()) {
       _iteratorAcrossCells += offset;

--- a/src/autopas/iterators/ParticleIterator.h
+++ b/src/autopas/iterators/ParticleIterator.h
@@ -35,13 +35,16 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle> {
    * and iterate in a round robin fashion. If there are more threads than cells
    * surplus iterators are directly set to cont->end().
    *
-   * @param cont linear data vector of ParticleCells
-   * @param flagManager the CellBorderAndFlagManager that shall be used to
-   * query the cell types. Can be nullptr if the behavior is haloAndOwned
-   * @param behavior the IteratorBehavior that specifies which type of cells
+   * @param cont Linear data vector of ParticleCells.
+   * @param offset Number of cells to skip before starting to iterate.
+   * @param flagManager The CellBorderAndFlagManager that shall be used to.
+   * query the cell types. Can be nullptr if the behavior is haloAndOwned.
+   * @param behavior The IteratorBehavior that specifies which type of cells.
    * shall be iterated through.
    */
-  explicit ParticleIterator(std::vector<ParticleCell>* cont, CellBorderAndFlagManager* flagManager = nullptr,
+  explicit ParticleIterator(std::vector<ParticleCell> *cont,
+                            size_t offset = 0,
+                            CellBorderAndFlagManager *flagManager = nullptr,
                             IteratorBehavior behavior = haloAndOwned)
       : _vectorOfCells(cont),
         _iteratorAcrossCells(cont->begin()),
@@ -49,8 +52,9 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle> {
         _flagManager(flagManager),
         _behavior(behavior) {
     size_t myThreadId = autopas_get_thread_num();
-    if (myThreadId < cont->size()) {
-      _iteratorAcrossCells += myThreadId;
+    offset += myThreadId;
+    if (offset < cont->size()) {
+      _iteratorAcrossCells += offset;
       _iteratorWithinOneCell = _iteratorAcrossCells->begin();
     } else {
       _iteratorAcrossCells = cont->end();

--- a/src/autopas/iterators/ParticleIterator.h
+++ b/src/autopas/iterators/ParticleIterator.h
@@ -20,10 +20,9 @@ namespace internal {
 /**
  * ParticleIterator class to access particles inside of a container.
  * The particles can be accessed using "iterator->" or "*iterator". The next
- * particle using the ++operator, e.g. "++iterator"
- * @tparam Particle type of the particle that is accessed
- * @tparam ParticleCell type of the cell of the underlying data structure of the
- * container
+ * particle using the ++operator, e.g. "++iterator".
+ * @tparam Particle Type of the particle that is accessed.
+ * @tparam ParticleCell Type of the cell of the underlying data structure of the container.
  */
 template <class Particle, class ParticleCell>
 class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle> {
@@ -37,10 +36,9 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle> {
    *
    * @param cont Linear data vector of ParticleCells.
    * @param offset Number of cells to skip before starting to iterate.
-   * @param flagManager The CellBorderAndFlagManager that shall be used to.
-   * query the cell types. Can be nullptr if the behavior is haloAndOwned.
-   * @param behavior The IteratorBehavior that specifies which type of cells.
-   * shall be iterated through.
+   * @param flagManager The CellBorderAndFlagManager that shall be used to query the cell types.
+   * Can be nullptr if the behavior is haloAndOwned.
+   * @param behavior The IteratorBehavior that specifies which type of cells shall be iterated through.
    */
   explicit ParticleIterator(std::vector<ParticleCell>* cont, size_t offset = 0,
                             CellBorderAndFlagManager* flagManager = nullptr, IteratorBehavior behavior = haloAndOwned)

--- a/src/autopas/iterators/ParticleIterator.h
+++ b/src/autopas/iterators/ParticleIterator.h
@@ -124,7 +124,7 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle> {
   /**
    * Moves the iterator to the next non-empty cell with respect to the stride.
    */
-  void next_non_empty_cell() {
+  virtual void next_non_empty_cell() {
     // find the next non-empty cell
     const int stride = autopas_get_num_threads();  // num threads
     for (_iteratorAcrossCells += stride; _iteratorAcrossCells < _vectorOfCells->end(); _iteratorAcrossCells += stride) {
@@ -159,10 +159,20 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle> {
    */
   size_t getCurrentCellId() { return _iteratorAcrossCells - _vectorOfCells->begin(); }
 
- private:
+  /**
+   * Pointer to the cell vector.
+   */
   std::vector<ParticleCell>* _vectorOfCells;
+  /**
+   * Iterator for traversing the cell vector.
+   */
   typename std::vector<ParticleCell>::iterator _iteratorAcrossCells;
+  /**
+   * Particle iterator for a single cell.
+   */
   SingleCellIteratorWrapper<Particle> _iteratorWithinOneCell;
+
+ private:
   CellBorderAndFlagManager* _flagManager;
   IteratorBehavior _behavior;
 };

--- a/src/autopas/iterators/ParticleIterator.h
+++ b/src/autopas/iterators/ParticleIterator.h
@@ -42,10 +42,8 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle> {
    * @param behavior The IteratorBehavior that specifies which type of cells.
    * shall be iterated through.
    */
-  explicit ParticleIterator(std::vector<ParticleCell> *cont,
-                            size_t offset = 0,
-                            CellBorderAndFlagManager *flagManager = nullptr,
-                            IteratorBehavior behavior = haloAndOwned)
+  explicit ParticleIterator(std::vector<ParticleCell>* cont, size_t offset = 0,
+                            CellBorderAndFlagManager* flagManager = nullptr, IteratorBehavior behavior = haloAndOwned)
       : _vectorOfCells(cont),
         _iteratorAcrossCells(cont->begin()),
         _iteratorWithinOneCell(cont->begin()->begin()),

--- a/src/autopas/iterators/ParticleIterator.h
+++ b/src/autopas/iterators/ParticleIterator.h
@@ -153,6 +153,12 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle> {
     }
   }
 
+  /**
+   * Get the 1D index of the cell the iterator currently is in.
+   * @return Index of current cell.
+   */
+  size_t getCurrentCellId() { return _iteratorAcrossCells - _vectorOfCells->begin(); }
+
  private:
   std::vector<ParticleCell>* _vectorOfCells;
   typename std::vector<ParticleCell>::iterator _iteratorAcrossCells;

--- a/src/autopas/iterators/ParticleIterator.h
+++ b/src/autopas/iterators/ParticleIterator.h
@@ -27,6 +27,15 @@ namespace internal {
 template <class Particle, class ParticleCell>
 class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle> {
  protected:
+  /**
+   * Simple constructor without major calculation overhead for internal use.
+   * ATTENTION: This Iterator might be invalid after construction!
+   *
+   * @param cont Linear data vector of ParticleCells.
+   * @param flagManager The CellBorderAndFlagManager that shall be used to query the cell types.
+   * Can be nullptr if the behavior is haloAndOwned.
+   * @param behavior The IteratorBehavior that specifies which type of cells shall be iterated through.
+   */
   explicit ParticleIterator(std::vector<ParticleCell>* cont, CellBorderAndFlagManager* flagManager,
                             IteratorBehavior behavior)
       : _vectorOfCells(cont),
@@ -179,7 +188,14 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle> {
    */
   SingleCellIteratorWrapper<Particle> _iteratorWithinOneCell;
 
+  /**
+   * Manager providing info if cell is in halo.
+   */
   CellBorderAndFlagManager* _flagManager;
+
+  /**
+   * The behavior of the iterator.
+   */
   IteratorBehavior _behavior;
 };
 }  // namespace internal

--- a/src/autopas/iterators/ParticleIterator.h
+++ b/src/autopas/iterators/ParticleIterator.h
@@ -108,7 +108,7 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle> {
   }
 
   /**
-   * Check whether the iterator is valid
+   * Check whether the iterator currently points to a valid particle.
    * @return returns whether the iterator is valid
    */
   bool isValid() const override {
@@ -122,7 +122,7 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle> {
 
  protected:
   /**
-   * the next non-empty cell is selected
+   * Moves the iterator to the next non-empty cell with respect to the stride.
    */
   void next_non_empty_cell() {
     // find the next non-empty cell

--- a/src/autopas/iterators/RegionParticleIterator.h
+++ b/src/autopas/iterators/RegionParticleIterator.h
@@ -26,12 +26,15 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell> {
   /**
    * Constructor of the RegionParticleIterator.
    *
-   * @param cont container of particle cells
-   * @param startRegion lower corner of the region to iterate over
-   * @param endRegion top corner of the region to iterate over
-   * @param flagManager the CellBorderAndFlagManager that shall be used to
-   * query the cell types. Can be nullptr if the behavior is haloAndOwned
-   * @param behavior the IteratorBehavior that specifies which type of cells
+   * @param cont Container of particle cells.
+   * @param cellsPerDimension Total number of cells along each dimension.
+   * @param startRegion Lower corner of the region to iterate over.
+   * @param endRegion Top corner of the region to iterate over.
+   * @param startIndex Index of the first cell in the region of interest.
+   * @param endIndex Index of the last cell in the region of interest.
+   * @param flagManager The CellBorderAndFlagManager that shall be used to
+   * query the cell types. Can be nullptr if the behavior is haloAndOwned.
+   * @param behavior The IteratorBehavior that specifies which type of cells
    * shall be iterated through.
    */
   explicit RegionParticleIterator(std::vector<ParticleCell> *cont, const std::array<size_t, 3> cellsPerDimension,

--- a/src/autopas/iterators/RegionParticleIterator.h
+++ b/src/autopas/iterators/RegionParticleIterator.h
@@ -34,9 +34,7 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell> {
    * @param behavior the IteratorBehavior that specifies which type of cells
    * shall be iterated through.
    */
-#define newVersion
-#ifdef newVersion
-  explicit RegionParticleIterator(std::vector<ParticleCell> *cont,const std::array<size_t, 3> cellsPerDimension,
+  explicit RegionParticleIterator(std::vector<ParticleCell> *cont, const std::array<size_t, 3> cellsPerDimension,
                                   std::array<double, 3> startRegion, std::array<double, 3> endRegion, size_t startIndex,
                                   size_t endIndex, CellBorderAndFlagManager *flagManager = nullptr,
                                   IteratorBehavior behavior = haloAndOwned)
@@ -46,14 +44,6 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell> {
         _endRegion(endRegion),
         _startIndex(startIndex),
         _endIndex(endIndex) {
-#else
-  explicit RegionParticleIterator(std::vector<ParticleCell> *cont, std::array<double, 3> startRegion,
-                                  std::array<double, 3> endRegion, CellBorderAndFlagManager *flagManager = nullptr,
-                                  IteratorBehavior behavior = haloAndOwned)
-      : ParticleIterator<Particle, ParticleCell>(cont, flagManager, behavior),
-        _startRegion(startRegion),
-        _endRegion(endRegion) {
-#endif
     // ParticleIterator's constructor will initialize the Iterator, such that it
     // points to the first particle if one is found, otherwise the pointer is
     // not valid
@@ -82,16 +72,11 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell> {
   }
 
  private:
-#ifdef newVersion
   std::array<size_t, 3> _cellsPerDim;
   std::array<double, 3> _startRegion;
   std::array<double, 3> _endRegion;
   size_t _startIndex;
   size_t _endIndex;
-#else
-  std::array<double, 3> _startRegion;
-  std::array<double, 3> _endRegion;
-#endif
 };
 }  // namespace internal
 }  // namespace autopas

--- a/src/autopas/iterators/RegionParticleIterator.h
+++ b/src/autopas/iterators/RegionParticleIterator.h
@@ -119,7 +119,15 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell> {
   std::array<size_t, 3> _endIndex3D;
   size_t _startIndex;
   size_t _endIndex;
+  /**
+   * When the iterator passes _endIndex3D[0] this is the jump distance to increase y by 1 and setting x to
+   * _startIndex3D[0] (or behind this depending on the stride).
+   */
   size_t _shortJump;
+  /**
+   * When the iterator passes _endIndex3D[1] this is the jump distance to increase z by 1 and setting y to
+   * _startIndex3D[1] (or behind this depending on the stride).
+   */
   size_t _longJump;
 };
 }  // namespace internal

--- a/src/autopas/iterators/RegionParticleIterator.h
+++ b/src/autopas/iterators/RegionParticleIterator.h
@@ -34,12 +34,26 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell> {
    * @param behavior the IteratorBehavior that specifies which type of cells
    * shall be iterated through.
    */
+#define newVersion
+#ifdef newVersion
+  explicit RegionParticleIterator(std::vector<ParticleCell> *cont,const std::array<size_t, 3> cellsPerDimension,
+                                  std::array<double, 3> startRegion, std::array<double, 3> endRegion, size_t startIndex,
+                                  size_t endIndex, CellBorderAndFlagManager *flagManager = nullptr,
+                                  IteratorBehavior behavior = haloAndOwned)
+      : ParticleIterator<Particle, ParticleCell>(cont, startIndex, flagManager, behavior),
+        _cellsPerDim(cellsPerDimension),
+        _startRegion(startRegion),
+        _endRegion(endRegion),
+        _startIndex(startIndex),
+        _endIndex(endIndex) {
+#else
   explicit RegionParticleIterator(std::vector<ParticleCell> *cont, std::array<double, 3> startRegion,
                                   std::array<double, 3> endRegion, CellBorderAndFlagManager *flagManager = nullptr,
                                   IteratorBehavior behavior = haloAndOwned)
       : ParticleIterator<Particle, ParticleCell>(cont, flagManager, behavior),
         _startRegion(startRegion),
         _endRegion(endRegion) {
+#endif
     // ParticleIterator's constructor will initialize the Iterator, such that it
     // points to the first particle if one is found, otherwise the pointer is
     // not valid
@@ -68,8 +82,16 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell> {
   }
 
  private:
+#ifdef newVersion
+  std::array<size_t, 3> _cellsPerDim;
   std::array<double, 3> _startRegion;
   std::array<double, 3> _endRegion;
+  size_t _startIndex;
+  size_t _endIndex;
+#else
+  std::array<double, 3> _startRegion;
+  std::array<double, 3> _endRegion;
+#endif
 };
 }  // namespace internal
 }  // namespace autopas

--- a/src/autopas/iterators/RegionParticleIterator.h
+++ b/src/autopas/iterators/RegionParticleIterator.h
@@ -58,7 +58,7 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell> {
     // not valid
     if (ParticleIterator<Particle, ParticleCell>::isValid()) {  // if there is NO particle, we can not dereference it,
                                                                 // so we need a check.
-      if (notInBox(this->operator*().getR(), _startRegion, _endRegion)) {
+      if (utils::notInBox(this->operator*().getR(), _startRegion, _endRegion)) {
         operator++();
       }
     }
@@ -71,13 +71,13 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell> {
     do {
       ParticleIterator<Particle, ParticleCell>::operator++();
     } while (ParticleIterator<Particle, ParticleCell>::isValid() &&
-             notInBox(this->operator*().getR(), _startRegion, _endRegion) && this->getCurrentCellId() <= _endIndex);
+             utils::notInBox(this->operator*().getR(), _startRegion, _endRegion) && this->getCurrentCellId() <= _endIndex);
     return *this;
   }
 
   bool isValid() const override {
     return ParticleIterator<Particle, ParticleCell>::isValid() &&
-           inBox(this->operator*().getR(), _startRegion, _endRegion);
+           utils::inBox(this->operator*().getR(), _startRegion, _endRegion);
   }
 
   // @todo add test of clone

--- a/src/autopas/iterators/RegionParticleIterator.h
+++ b/src/autopas/iterators/RegionParticleIterator.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <autopas/utils/inBox.h>
 #include <array>
 #include <vector>
 #include "autopas/iterators/ParticleIterator.h"
@@ -43,7 +44,7 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell> {
     // points to the first particle if one is found, otherwise the pointer is
     // not valid
     if (this->isValid()) {  // if there is NO particle, we can not dereference it, so we need a check.
-      if (not(this->operator*()).inBox(_startRegion, _endRegion)) {
+      if (notInBox(this->operator*().getR(), _startRegion, _endRegion)) {
         operator++();
       }
     }
@@ -57,7 +58,7 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell> {
     do {
       ParticleIterator<Particle, ParticleCell>::operator++();
     } while (ParticleIterator<Particle, ParticleCell>::isValid() &&
-             !(this->operator*()).inBox(_startRegion, _endRegion));
+             notInBox(this->operator*().getR(), _startRegion, _endRegion));
     return *this;
   }
 

--- a/src/autopas/iterators/RegionParticleIterator.h
+++ b/src/autopas/iterators/RegionParticleIterator.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
-#include <autopas/utils/inBox.h>
 #include <array>
 #include <vector>
 #include "autopas/iterators/ParticleIterator.h"
+#include "autopas/utils/inBox.h"
 
 namespace autopas {
 namespace internal {
@@ -45,7 +45,6 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell> {
         _cellsPerDim(cellsPerDimension),
         _startRegion(startRegion),
         _endRegion(endRegion),
-        _startIndex(startIndex),
         _endIndex(endIndex) {
     // ParticleIterator's constructor will initialize the Iterator, such that it
     // points to the first particle if one is found, otherwise the pointer is
@@ -59,14 +58,18 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell> {
 
   /**
    * @copydoc ParticleIteratorInterface::operator++
-   * @todo optimize! this version is currently very slow
    */
   inline RegionParticleIterator<Particle, ParticleCell> &operator++() override {
     do {
       ParticleIterator<Particle, ParticleCell>::operator++();
     } while (ParticleIterator<Particle, ParticleCell>::isValid() &&
-             notInBox(this->operator*().getR(), _startRegion, _endRegion));
+             notInBox(this->operator*().getR(), _startRegion, _endRegion) && this->getCurrentCellId() <= _endIndex);
     return *this;
+  }
+
+  bool isValid() const override {
+    return ParticleIterator<Particle, ParticleCell>::isValid() &&
+           inBox(this->operator*().getR(), _startRegion, _endRegion);
   }
 
   // @todo add test of clone
@@ -78,7 +81,7 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell> {
   std::array<size_t, 3> _cellsPerDim;
   std::array<double, 3> _startRegion;
   std::array<double, 3> _endRegion;
-  size_t _startIndex;
+  //  size_t _startIndex;
   size_t _endIndex;
 };
 }  // namespace internal

--- a/src/autopas/iterators/RegionParticleIterator.h
+++ b/src/autopas/iterators/RegionParticleIterator.h
@@ -33,10 +33,9 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell> {
    * @param endRegion Top corner of the region to iterate over.
    * @param startIndex Index of the first cell in the region of interest.
    * @param endIndex Index of the last cell in the region of interest.
-   * @param flagManager The CellBorderAndFlagManager that shall be used to
-   * query the cell types. Can be nullptr if the behavior is haloAndOwned.
-   * @param behavior The IteratorBehavior that specifies which type of cells
-   * shall be iterated through.
+   * @param flagManager The CellBorderAndFlagManager that shall be used to query the cell types.
+   * Can be nullptr if the behavior is haloAndOwned.
+   * @param behavior The IteratorBehavior that specifies which type of cells shall be iterated through.
    */
   explicit RegionParticleIterator(std::vector<ParticleCell> *cont, const std::array<size_t, 3> cellsPerDimension,
                                   std::array<double, 3> startRegion, std::array<double, 3> endRegion, size_t startIndex,

--- a/src/autopas/iterators/RegionParticleIterator.h
+++ b/src/autopas/iterators/RegionParticleIterator.h
@@ -46,7 +46,7 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell> {
         _cellsPerDim(cellsPerDimension),
         _startRegion(startRegion),
         _endRegion(endRegion),
-        _startIndex(startIndex),  // @todo: maybe pass 3D indices since they are calculated right before
+        _startIndex(startIndex),
         _endIndex(endIndex) {
     _startIndex3D = utils::ThreeDimensionalMapping::oneToThreeD(_startIndex, _cellsPerDim);
     _endIndex3D = utils::ThreeDimensionalMapping::oneToThreeD(_endIndex, _cellsPerDim);

--- a/src/autopas/iterators/RegionParticleIterator.h
+++ b/src/autopas/iterators/RegionParticleIterator.h
@@ -28,11 +28,9 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell> {
    * Constructor of the RegionParticleIterator.
    *
    * @param cont Container of particle cells.
-   * @param cellsPerDimension Total number of cells along each dimension.
    * @param startRegion Lower corner of the region to iterate over.
    * @param endRegion Top corner of the region to iterate over.
-   * @param startIndex Index of the first cell in the region of interest.
-   * @param endIndex Index of the last cell in the region of interest.
+   * @param indicesInRegion List of indices all threads will iterate over.
    * @param flagManager The CellBorderAndFlagManager that shall be used to query the cell types.
    * Can be nullptr if the behavior is haloAndOwned.
    * @param behavior The IteratorBehavior that specifies which type of cells shall be iterated through.

--- a/src/autopas/particles/Particle.h
+++ b/src/autopas/particles/Particle.h
@@ -91,21 +91,6 @@ class Particle {
   void addR(const std::array<double, 3> &r) { _r = ArrayMath::add(_r, r); }
 
   /**
-   * Checks whether the particle is within a cuboidal box specified by rmin and
-   * rmax
-   * @param rmin lower corner of the box
-   * @param rmax higher corner of the box
-   * @return true if the particle is in the box, false otherwise
-   */
-  bool inBox(const std::array<double, 3> &rmin, const std::array<double, 3> &rmax) const {
-    bool in = true;
-    for (int d = 0; d < 3; ++d) {
-      in &= (_r[d] >= rmin[d] and _r[d] < rmax[d]);
-    }
-    return in;
-  }
-
-  /**
    * Get the velocity of the particle
    * @return current velocity
    */

--- a/src/autopas/utils/ThreeDimensionalMapping.h
+++ b/src/autopas/utils/ThreeDimensionalMapping.h
@@ -13,6 +13,7 @@ namespace autopas {
 namespace utils {
 /**
  * Class to handle the conversion between one dimensional and three dimensional indices.
+ * The running index is x.
  */
 class ThreeDimensionalMapping {
  public:

--- a/src/autopas/utils/ThreeDimensionalMapping.h
+++ b/src/autopas/utils/ThreeDimensionalMapping.h
@@ -16,48 +16,48 @@ namespace utils {
  * The running index is x.
  */
 namespace ThreeDimensionalMapping {
-  /**
-   * Convert a 3d index to a 1d index.
-   * @tparam T type of the indices
-   * @param x x index of the 3d index
-   * @param y y index of the 3d index
-   * @param z z index of the 3d index
-   * @param dims the total dimensions of the index space
-   * @return the 1d index
-   */
-  template <typename T>
-  static T threeToOneD(T x, T y, T z, const std::array<T, 3> dims) {
-    return (z * dims[1] + y) * dims[0] + x;
-  }
+/**
+ * Convert a 3d index to a 1d index.
+ * @tparam T type of the indices
+ * @param x x index of the 3d index
+ * @param y y index of the 3d index
+ * @param z z index of the 3d index
+ * @param dims the total dimensions of the index space
+ * @return the 1d index
+ */
+template <typename T>
+static T threeToOneD(T x, T y, T z, const std::array<T, 3> dims) {
+  return (z * dims[1] + y) * dims[0] + x;
+}
 
-  /**
-   * Convert a 3d index to a 1d index
-   * @tparam T type of the indices
-   * @param index3d the 3d index
-   * @param dims the total dimensions of the index space
-   * @return the 1d index
-   */
-  template <typename T>
-  static T threeToOneD(const std::array<T, 3> &index3d, const std::array<T, 3> dims) {
-    return (index3d[2] * dims[1] + index3d[1]) * dims[0] + index3d[0];
-  }
+/**
+ * Convert a 3d index to a 1d index
+ * @tparam T type of the indices
+ * @param index3d the 3d index
+ * @param dims the total dimensions of the index space
+ * @return the 1d index
+ */
+template <typename T>
+static T threeToOneD(const std::array<T, 3> &index3d, const std::array<T, 3> dims) {
+  return (index3d[2] * dims[1] + index3d[1]) * dims[0] + index3d[0];
+}
 
-  /**
-   * Convert a 1d index to a 3d index
-   * @tparam T type of the indices
-   * @param ind the 1d index
-   * @param dims the total dimensions of the index space
-   * @return the 3d index
-   */
-  template <typename T>
-  static std::array<T, 3> oneToThreeD(T ind, const std::array<T, 3> dims) {
-    std::array<T, 3> pos;
-    pos[2] = ind / (dims[0] * dims[1]);
-    pos[1] = (ind - pos[2] * dims[0] * dims[1]) / dims[0];
-    pos[0] = ind - dims[0] * (pos[1] + dims[1] * pos[2]);
-    return pos;
-  }
+/**
+ * Convert a 1d index to a 3d index
+ * @tparam T type of the indices
+ * @param ind the 1d index
+ * @param dims the total dimensions of the index space
+ * @return the 3d index
+ */
+template <typename T>
+static std::array<T, 3> oneToThreeD(T ind, const std::array<T, 3> dims) {
+  std::array<T, 3> pos;
+  pos[2] = ind / (dims[0] * dims[1]);
+  pos[1] = (ind - pos[2] * dims[0] * dims[1]) / dims[0];
+  pos[0] = ind - dims[0] * (pos[1] + dims[1] * pos[2]);
+  return pos;
+}
 
-};  // class ThreeDimensionalMapping
+};  // namespace ThreeDimensionalMapping
 }  // namespace utils
 }  // namespace autopas

--- a/src/autopas/utils/ThreeDimensionalMapping.h
+++ b/src/autopas/utils/ThreeDimensionalMapping.h
@@ -15,8 +15,7 @@ namespace utils {
  * Class to handle the conversion between one dimensional and three dimensional indices.
  * The running index is x.
  */
-class ThreeDimensionalMapping {
- public:
+namespace ThreeDimensionalMapping {
   /**
    * Convert a 3d index to a 1d index.
    * @tparam T type of the indices

--- a/src/autopas/utils/ThreeDimensionalMapping.h
+++ b/src/autopas/utils/ThreeDimensionalMapping.h
@@ -10,6 +10,7 @@
 #include <array>
 
 namespace autopas {
+namespace utils {
 /**
  * Class to handle the conversion between one dimensional and three dimensional indices.
  */
@@ -58,4 +59,5 @@ class ThreeDimensionalMapping {
   }
 
 };  // class ThreeDimensionalMapping
+}  // namespace utils
 }  // namespace autopas

--- a/src/autopas/utils/inBox.h
+++ b/src/autopas/utils/inBox.h
@@ -11,7 +11,7 @@
 #include <type_traits>
 
 namespace autopas {
-
+namespace utils {
 /**
  * Checks if position is inside of a box defined by low and high.
  * The lower corner is included in, the upper is excluded from the box.
@@ -52,4 +52,5 @@ bool notInBox(const std::array<T, 3> &position, const std::array<T, 3> &low, con
   return not(inBox(position, low, high));
 }
 
+}  // namespace utils
 }  // namespace autopas

--- a/tests/testAutopas/InBoxTest.cpp
+++ b/tests/testAutopas/InBoxTest.cpp
@@ -18,7 +18,7 @@ TEST(InBoxTest, testInBox) {
         inside &= y >= 0. and y < 2. / 3.;
         inside &= z >= 2. / 3. and z < 1.;
         const std::array<double, 3> position{x, y, z};
-        EXPECT_EQ(inside, autopas::inBox(position, lowCorner, highCorner));
+        EXPECT_EQ(inside, autopas::utils::inBox(position, lowCorner, highCorner));
       }
     }
   }
@@ -35,7 +35,7 @@ TEST(InBoxTest, testNotInBox) {
         inside &= y >= 0. and y < 2. / 3.;
         inside &= z >= 2. / 3. and z < 1.;
         const std::array<double, 3> position{x, y, z};
-        EXPECT_EQ(not inside, autopas::notInBox(position, lowCorner, highCorner));
+        EXPECT_EQ(not inside, autopas::utils::notInBox(position, lowCorner, highCorner));
       }
     }
   }

--- a/tests/testAutopas/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/RegionParticleIteratorTest.cpp
@@ -25,7 +25,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIterator) {
   for (size_t cellId = 0; cellId < lcContainer.getCells().size(); ++cellId) {
     auto cellId3D = utils::ThreeDimensionalMapping::oneToThreeD(cellId, {7, 7, 7});
     for (auto pIter = lcContainer.getCells()[cellId].begin(); pIter.isValid(); ++pIter) {
-      EXPECT_EQ(inBox(pIter->getR(), _regionMin, _regionMax) ? 1 : 0, pIter->getNumTouched())
+      EXPECT_EQ(utils::inBox(pIter->getR(), _regionMin, _regionMax) ? 1 : 0, pIter->getNumTouched())
           << "at: [" << pIter->getR()[0] << ", " << pIter->getR()[1] << ", " << pIter->getR()[2] << "]" << std::endl
           << "in cell: " << cellId << " [" << cellId3D[0] << " | " << cellId3D[1] << " | " << cellId3D[2] << "]";
     }
@@ -55,7 +55,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehavior
     //         << ", " << iterator->getR()[1] << ", " << iterator->getR()[2]
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
-    ASSERT_EQ(inBox(iterator->getR(), _boxMin, _regionMax) ? 1 : 0, iterator->getNumTouched());
+    ASSERT_EQ(utils::inBox(iterator->getR(), _boxMin, _regionMax) ? 1 : 0, iterator->getNumTouched());
   }
 }
 
@@ -82,8 +82,8 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehavior
     //         << ", " << iterator->getR()[1] << ", " << iterator->getR()[2]
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
-    ASSERT_EQ(inBox(iterator->getR(), ArrayMath::addScalar(_boxMin, -_cutoff * 0.5), _regionMax)
-                  ? (inBox(iterator->getR(), _boxMin, _regionMax) ? 0 : 1)
+    ASSERT_EQ(utils::inBox(iterator->getR(), ArrayMath::addScalar(_boxMin, -_cutoff * 0.5), _regionMax)
+                  ? (utils::inBox(iterator->getR(), _boxMin, _regionMax) ? 0 : 1)
                   : 0,
               iterator->getNumTouched());
   }
@@ -108,7 +108,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorEmpty) {
     //         << ", " << iterator->getR()[1] << ", " << iterator->getR()[2]
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
-    ASSERT_EQ(inBox(iterator->getR(), _regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched());
+    ASSERT_EQ(utils::inBox(iterator->getR(), _regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched());
     i++;
   }
   ASSERT_EQ(i, 0);
@@ -135,7 +135,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorCopyCons
     //         << ", " << iterator->getR()[1] << ", " << iterator->getR()[2]
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
-    ASSERT_EQ(inBox(iterator->getR(), _regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched());
+    ASSERT_EQ(utils::inBox(iterator->getR(), _regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched());
   }
 }
 
@@ -170,7 +170,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorCopyAssi
     //         << ", " << iterator->getR()[1] << ", " << iterator->getR()[2]
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
-    ASSERT_EQ(inBox(iterator->getR(), _regionMin, _regionMax) ? 3 : 0, iterator->getNumTouched());
+    ASSERT_EQ(utils::inBox(iterator->getR(), _regionMin, _regionMax) ? 3 : 0, iterator->getNumTouched());
   }
 }
 
@@ -218,7 +218,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorSparseDo
 
   int particlesChecked = 0;
   for (auto iterator = lcContainer.begin(); iterator.isValid(); ++iterator) {
-    EXPECT_EQ(inBox(iterator->getR(), regionOfInterstMin, regionOfInterstMax) ? 1 : 0, iterator->getNumTouched());
+    EXPECT_EQ(utils::inBox(iterator->getR(), regionOfInterstMin, regionOfInterstMax) ? 1 : 0, iterator->getNumTouched());
     ++particlesChecked;
   }
   EXPECT_EQ(particlesChecked, idShouldTouch + idShouldNotTouch - idOffset);
@@ -267,7 +267,7 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorSparseDoma
 
   int particlesChecked = 0;
   for (auto iterator = dsContainer.begin(); iterator.isValid(); ++iterator) {
-    EXPECT_EQ(inBox(iterator->getR(), regionOfInterstMin, regionOfInterstMax) ? 1 : 0, iterator->getNumTouched());
+    EXPECT_EQ(utils::inBox(iterator->getR(), regionOfInterstMin, regionOfInterstMax) ? 1 : 0, iterator->getNumTouched());
     ++particlesChecked;
   }
   EXPECT_EQ(particlesChecked, idShouldTouch + idShouldNotTouch - idOffset);
@@ -292,7 +292,7 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIterator) {
     //         << ", " << iterator->getR()[1] << ", " << iterator->getR()[2]
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
-    ASSERT_EQ(inBox(iterator->getR(), _regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched())
+    ASSERT_EQ(utils::inBox(iterator->getR(), _regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched())
         << "at: [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]";
   }
 }
@@ -320,7 +320,7 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorBehaviorOw
     //         << ", " << iterator->getR()[1] << ", " << iterator->getR()[2]
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
-    ASSERT_EQ(inBox(iterator->getR(), _boxMin, _regionMax) ? 1 : 0, iterator->getNumTouched());
+    ASSERT_EQ(utils::inBox(iterator->getR(), _boxMin, _regionMax) ? 1 : 0, iterator->getNumTouched());
   }
 }
 
@@ -347,8 +347,8 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorBehaviorHa
     //         << ", " << iterator->getR()[1] << ", " << iterator->getR()[2]
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
-    ASSERT_EQ(inBox(iterator->getR(), ArrayMath::addScalar(_boxMin, -_cutoff * 0.5), _regionMax)
-                  ? (inBox(iterator->getR(), _boxMin, _regionMax) ? 0 : 1)
+    ASSERT_EQ(utils::inBox(iterator->getR(), ArrayMath::addScalar(_boxMin, -_cutoff * 0.5), _regionMax)
+                  ? (utils::inBox(iterator->getR(), _boxMin, _regionMax) ? 0 : 1)
                   : 0,
               iterator->getNumTouched());
   }
@@ -373,7 +373,7 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorEmpty) {
     //         << ", " << iterator->getR()[1] << ", " << iterator->getR()[2]
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
-    ASSERT_EQ(inBox(iterator->getR(), _regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched());
+    ASSERT_EQ(utils::inBox(iterator->getR(), _regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched());
     i++;
   }
   ASSERT_EQ(i, 0);
@@ -400,7 +400,7 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorCopyConstr
     //         << ", " << iterator->getR()[1] << ", " << iterator->getR()[2]
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
-    ASSERT_EQ(inBox(iterator->getR(), _regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched());
+    ASSERT_EQ(utils::inBox(iterator->getR(), _regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched());
   }
 }
 
@@ -435,6 +435,6 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorCopyAssign
     //         << ", " << iterator->getR()[1] << ", " << iterator->getR()[2]
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
-    ASSERT_EQ(inBox(iterator->getR(), _regionMin, _regionMax) ? 3 : 0, iterator->getNumTouched());
+    ASSERT_EQ(utils::inBox(iterator->getR(), _regionMin, _regionMax) ? 3 : 0, iterator->getNumTouched());
   }
 }

--- a/tests/testAutopas/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/RegionParticleIteratorTest.cpp
@@ -19,14 +19,14 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIterator) {
     iterator->touch();
   }
 
-  // check the touch using the normal iterator
-  for (auto iterator = lcContainer.begin(); iterator.isValid(); ++iterator) {
-    //  std::cout << "id: " << iterator->getID() << " at [" <<
-    //  iterator->getR()[0]
-    //         << ", " << iterator->getR()[1] << ", " << iterator->getR()[2]
-    //              << "] touched:" << iterator->getNumTouched() << std::endl;
-
-    ASSERT_EQ(inBox(iterator->getR(), _regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched());
+  // check the touch. Iterating over cells provides more debug info than normal iterator.
+  for (size_t cellId = 0; cellId < lcContainer.getCells().size(); ++cellId) {
+    auto cellId3D = utils::ThreeDimensionalMapping::oneToThreeD(cellId, {7, 7, 7});
+    for (auto pIter = lcContainer.getCells()[cellId].begin(); pIter.isValid(); ++pIter) {
+      EXPECT_EQ(inBox(pIter->getR(), _regionMin, _regionMax) ? 1 : 0, pIter->getNumTouched())
+          << "at: [" << pIter->getR()[0] << ", " << pIter->getR()[1] << ", " << pIter->getR()[2] << "]" << std::endl
+          << "in cell: " << cellId << " [" << cellId3D[0] << " | " << cellId3D[1] << " | " << cellId3D[2] << "]";
+    }
   }
 }
 

--- a/tests/testAutopas/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/RegionParticleIteratorTest.cpp
@@ -26,7 +26,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIterator) {
     //         << ", " << iterator->getR()[1] << ", " << iterator->getR()[2]
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
-    ASSERT_EQ(iterator->inBox(_regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched());
+    ASSERT_EQ(inBox(iterator->getR(), _regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched());
   }
 }
 
@@ -53,7 +53,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehavior
     //         << ", " << iterator->getR()[1] << ", " << iterator->getR()[2]
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
-    ASSERT_EQ(iterator->inBox(_boxMin, _regionMax) ? 1 : 0, iterator->getNumTouched());
+    ASSERT_EQ(inBox(iterator->getR(), _boxMin, _regionMax) ? 1 : 0, iterator->getNumTouched());
   }
 }
 
@@ -80,8 +80,8 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehavior
     //         << ", " << iterator->getR()[1] << ", " << iterator->getR()[2]
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
-    ASSERT_EQ(iterator->inBox(ArrayMath::addScalar(_boxMin, -_cutoff * 0.5), _regionMax)
-                  ? (iterator->inBox(_boxMin, _regionMax) ? 0 : 1)
+    ASSERT_EQ(inBox(iterator->getR(), ArrayMath::addScalar(_boxMin, -_cutoff * 0.5), _regionMax)
+                  ? (inBox(iterator->getR(), _boxMin, _regionMax) ? 0 : 1)
                   : 0,
               iterator->getNumTouched());
   }
@@ -106,7 +106,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorEmpty) {
     //         << ", " << iterator->getR()[1] << ", " << iterator->getR()[2]
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
-    ASSERT_EQ(iterator->inBox(_regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched());
+    ASSERT_EQ(inBox(iterator->getR(), _regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched());
     i++;
   }
   ASSERT_EQ(i, 0);
@@ -133,7 +133,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorCopyCons
     //         << ", " << iterator->getR()[1] << ", " << iterator->getR()[2]
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
-    ASSERT_EQ(iterator->inBox(_regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched());
+    ASSERT_EQ(inBox(iterator->getR(), _regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched());
   }
 }
 
@@ -168,6 +168,6 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorCopyAssi
     //         << ", " << iterator->getR()[1] << ", " << iterator->getR()[2]
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
-    ASSERT_EQ(iterator->inBox(_regionMin, _regionMax) ? 3 : 0, iterator->getNumTouched());
+    ASSERT_EQ(inBox(iterator->getR(), _regionMin, _regionMax) ? 3 : 0, iterator->getNumTouched());
   }
 }

--- a/tests/testAutopas/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/RegionParticleIteratorTest.cpp
@@ -214,7 +214,6 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorSparseDo
   }
   EXPECT_EQ(particlesTouched, idShouldTouch);
 
-
   int particlesChecked = 0;
   for (auto iterator = lcContainer.begin(); iterator.isValid(); ++iterator) {
     EXPECT_EQ(inBox(iterator->getR(), regionOfInterstMin, regionOfInterstMax) ? 1 : 0, iterator->getNumTouched());

--- a/tests/testAutopas/RegionParticleIteratorTest.h
+++ b/tests/testAutopas/RegionParticleIteratorTest.h
@@ -24,6 +24,8 @@ class TouchableParticle : public autopas::Particle {
 
 class RegionParticleIteratorTest : public AutoPasTestBase {
  public:
+  typedef autopas::LinkedCells<TouchableParticle, autopas::FullParticleCell<TouchableParticle>> LCTouch;
+
   RegionParticleIteratorTest()
       : _boxMin{0., 0., 0.}, _boxMax{5., 5., 5.}, _regionMin{1., 1., 1.}, _regionMax{3., 3., 3.}, _cutoff{.9} {}
 
@@ -32,6 +34,15 @@ class RegionParticleIteratorTest : public AutoPasTestBase {
   void TearDown() override{};
 
   ~RegionParticleIteratorTest() override = default;
+
+  /**
+   * Checks if all particles in the given region of a Lined Cells container are touched exactly once and provides debug
+   * output.
+   * @param lcContainer
+   * @param regionMin
+   * @param regionMax
+   */
+  void checkTouches(LCTouch &lcContainer, std::array<double, 3> &regionMin, std::array<double, 3> &regionMax);
 
  protected:
   // needs to be protected, because the test fixtures generate a derived class

--- a/tests/testAutopas/testingHelpers/GaussianGenerator.h
+++ b/tests/testAutopas/testingHelpers/GaussianGenerator.h
@@ -21,7 +21,7 @@ class GaussianGenerator {
     for (size_t id = 0; id < numParticles;) {
       std::array<double, 3> position = {distribution(generator), distribution(generator), distribution(generator)};
       // only increment loop var (and place particle) if position is valid
-      if (not autopas::inBox(position, {0, 0, 0}, autoPas.getBoxMax())) continue;
+      if (not autopas::utils::inBox(position, {0, 0, 0}, autoPas.getBoxMax())) continue;
       Particle p(defaultParicle);
       p.setR(position);
       p.setID(id++);

--- a/tests/testAutopas/testingHelpers/RandomGenerator.h
+++ b/tests/testAutopas/testingHelpers/RandomGenerator.h
@@ -60,7 +60,7 @@ class RandomGenerator {
       Particle particle = defaultParticle;
       auto pos = randomPosition(haloBoxMax, haloBoxMax);
       // we only want  to add particles not in the actual box
-      if (autopas::inBox(pos, container.getBoxMin(), container.getBoxMax())) continue;
+      if (autopas::utils::inBox(pos, container.getBoxMin(), container.getBoxMax())) continue;
       particle.setR(pos);
       particle.setID(i);
       container.addHaloParticle(particle);


### PR DESCRIPTION
The region iterator now...
- [x] starts directly at the region of interest.
- [x] stops directly after the region of interest.
- [x] jumps over uninteresting parts of the cell vector instead of testing all cells.
- [x] test for regioniterator in direct sum
- [x] works with >1 thread
- [x] clean up region iterator tests

This PR aims to close #2 

Tests:
- Domain 10x10x10 + Halo (size: 0.2)
- Cutoff / cell length: 0.2
- Number of cells: 140608 (52x52x52)
- 1 million particles uniformly randomly distributed.
- Time in ms
- T = Number of threads

Description | Region    | Old (T=1) | New (T=1) | Old (T=8) | New (T=8) | Comment
------------ | ------------ | ------------ | ------------ | ------------ | ------------ | ------------ 
~6.4% of domain | [5 5 5] to [9 9 9]                     | 31 | 3 | 10 | 2 |probably realistic case
Full domain | [-0.2 -0.2 -0.2] to [10.2 10.2 10.2]  | 37 | 45 | 9 | 13 | Here the normal iterator should be used wich needs ~18 ms (T=1)
Full domain w/o halo | [0 0 0] to [10 10 10]         | 39 | 46 | 9 | 12 | Here the normal iterator should be used wich needs ~20 ms (T=1)
One halo side | [-0.2 -0.2 -0.2] to [10.2 10.2 0]   | 3 | <1 | 1 | <1 |
Half halo  | [-0.2 -0.2 -0.2] to [10.2 5 10.2]          | 3 | 2 | 1 | 1 |
