### PR TITLE
show build errors correctly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,7 +77,7 @@ pipeline{
                     "clang ninja address sanitizer": {
                         container('autopas-clang6-cmake-ninja-make'){
                             dir("build-clang-ninja-addresssanitizer-debug"){
-                                sh "CC=clang CXX=clang++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DENABLE_ADDRESS_SANITIZER=ON .."
+                                sh "CC=clang CXX=clang++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DENABLE_ADDRESS_SANITIZER=ON -Wno-pass-failed .."
                                 sh "ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
                             }
                         }
@@ -85,7 +85,7 @@ pipeline{
                     "clang ninja address sanitizer release": {
                         container('autopas-clang6-cmake-ninja-make'){
                             dir("build-clang-ninja-addresssanitizer-release"){
-                                sh "CC=clang CXX=clang++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_ADDRESS_SANITIZER=ON .."
+                                sh "CC=clang CXX=clang++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_ADDRESS_SANITIZER=ON -Wno-pass-failed .."
                                 sh "ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
                             }
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline{
                         container('autopas-gcc7-cmake-make') {
                             dir("build"){
                                 sh "cmake .."
-                                sh "bash -i -c 'make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)'"
+                                sh "make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)"
                             }
                         }
                     },
@@ -29,7 +29,7 @@ pipeline{
                         container('autopas-gcc7-cmake-make') {
                             dir("build-openmp"){
                                 sh "cmake -DOPENMP=ON .."
-                                sh "bash -i -c 'make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)'"
+                                sh "make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)"
                             }
                         }
                     },
@@ -37,7 +37,7 @@ pipeline{
                         container('autopas-gcc7-cmake-make') {
                             dir("build-openmp-address-sanitizer"){
                                 sh "cmake -DOPENMP=ON -DCMAKE_BUILD_TYPE=Debug -DENABLE_ADDRESS_SANITIZER=ON .."
-                                sh "bash -i -c 'make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)'"
+                                sh "make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)"
                             }
                         }
                     },
@@ -45,7 +45,7 @@ pipeline{
                         container('autopas-gcc7-cmake-make') {
                             dir("build-addresssanitizer"){
                                 sh "cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_ADDRESS_SANITIZER=ON .."
-                                sh "bash -i -c 'make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)'"
+                                sh "make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)"
                             }
                         }
                     },
@@ -53,7 +53,7 @@ pipeline{
                         container('autopas-gcc7-cmake-make') {
                             dir("build-addresssanitizer-release"){
                                 sh "cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_ADDRESS_SANITIZER=ON .."
-                                sh "bash -i -c 'make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)'"
+                                sh "make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)"
                             }
                         }
                     },
@@ -62,7 +62,7 @@ pipeline{
                             dir("build-threadsanitizer"){
                                 // this is for simple testing of our threading libraries.
                                 sh "cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_THREAD_SANITIZER=ON .."
-                                sh "bash -i -c 'make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)'"
+                                sh "make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)"
                             }
                         }
                     },
@@ -70,7 +70,7 @@ pipeline{
                         container('autopas-clang6-cmake-ninja-make'){
                             dir("build-clang-ninja-openmp"){
                                 sh "CC=clang CXX=clang++ cmake -G Ninja -DOPENMP=ON .."
-                                sh "bash -i -c 'ninja -j 4 &> buildlog_clang.txt || (cat buildlog_clang.txt && exit 1)'"
+                                sh "ninja -j 4 &> buildlog_clang.txt || (cat buildlog_clang.txt && exit 1)"
                             }
                         }
                     },
@@ -78,7 +78,7 @@ pipeline{
                         container('autopas-clang6-cmake-ninja-make'){
                             dir("build-clang-ninja-addresssanitizer-debug"){
                                 sh "CC=clang CXX=clang++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DENABLE_ADDRESS_SANITIZER=ON .."
-                                sh "bash -i -c 'ninja -j 4 &> buildlog_clang.txt || (cat buildlog_clang.txt && exit 1)'"
+                                sh "ninja -j 4 &> buildlog_clang.txt || (cat buildlog_clang.txt && exit 1)"
                             }
                         }
                     },
@@ -86,7 +86,7 @@ pipeline{
                         container('autopas-clang6-cmake-ninja-make'){
                             dir("build-clang-ninja-addresssanitizer-release"){
                                 sh "CC=clang CXX=clang++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_ADDRESS_SANITIZER=ON .."
-                                sh "bash -i -c 'ninja -j 4 &> buildlog_clang.txt || (cat buildlog_clang.txt && exit 1)'"
+                                sh "ninja -j 4 &> buildlog_clang.txt || (cat buildlog_clang.txt && exit 1)"
                             }
                         }
                     },
@@ -94,7 +94,7 @@ pipeline{
                         container('autopas-archer'){
                             dir("build-archer"){
                                 sh "CC=clang-archer CXX=clang-archer++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DUSE_VECTORIZATION=OFF .."
-                                sh "bash -i -c 'ninja -j 4 &> buildlog_clang.txt || (cat buildlog_clang.txt && exit 1)'"
+                                sh "ninja -j 4 &> buildlog_clang.txt || (cat buildlog_clang.txt && exit 1)"
                             }
                         }
                     },

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,7 +102,7 @@ pipeline{
                         container('autopas-intel18'){
                             dir("build-intel"){
                                 sh "bash -i -c 'which icc && CC=`which icc` CXX=`which icpc` cmake -DOPENMP=OFF ..'"
-                                sh "bash -i -c 'make -j 8 > buildlog_intel.txt || (cat buildlog_intel.txt && exit 1)'"
+                                sh "bash -i -c 'make -j 8 > buildlog_intel.txt 2>&1 || (cat buildlog_intel.txt && exit 1)'"
                             }
                         }
                     },
@@ -110,7 +110,7 @@ pipeline{
                         container('autopas-intel18'){
                             dir("build-intel-ninja-openmp"){
                                 sh "bash -i -c 'which icc && CC=`which icc` CXX=`which icpc` cmake -G Ninja -DOPENMP=ON ..'"
-                                sh "bash -i -c 'ninja -j 8 > buildlog_intel.txt || (cat buildlog_intel.txt && exit 1)'"
+                                sh "bash -i -c 'ninja -j 8 > buildlog_intel.txt 2>&1 || (cat buildlog_intel.txt && exit 1)'"
                             }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,7 +102,7 @@ pipeline{
                         container('autopas-intel18'){
                             dir("build-intel"){
                                 sh "bash -i -c 'which icc && CC=`which icc` CXX=`which icpc` cmake -DOPENMP=OFF ..'"
-                                sh "bash -i -c 'make -j 4 > buildlog_intel.txt || (cat buildlog_intel.txt && exit 1)'"
+                                sh "bash -i -c 'make -j 8 > buildlog_intel.txt || (cat buildlog_intel.txt && exit 1)'"
                             }
                         }
                     },
@@ -110,7 +110,7 @@ pipeline{
                         container('autopas-intel18'){
                             dir("build-intel-ninja-openmp"){
                                 sh "bash -i -c 'which icc && CC=`which icc` CXX=`which icpc` cmake -G Ninja -DOPENMP=ON ..'"
-                                sh "bash -i -c 'ninja -j 4 > buildlog_intel.txt || (cat buildlog_intel.txt && exit 1)'"
+                                sh "bash -i -c 'ninja -j 8 > buildlog_intel.txt || (cat buildlog_intel.txt && exit 1)'"
                             }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline{
                         container('autopas-gcc7-cmake-make') {
                             dir("build"){
                                 sh "cmake .."
-                                sh "make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)"
+                                sh "bash -i -c 'make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)'"
                             }
                         }
                     },
@@ -29,7 +29,7 @@ pipeline{
                         container('autopas-gcc7-cmake-make') {
                             dir("build-openmp"){
                                 sh "cmake -DOPENMP=ON .."
-                                sh "make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)"
+                                sh "bash -i -c 'make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)'"
                             }
                         }
                     },
@@ -37,7 +37,7 @@ pipeline{
                         container('autopas-gcc7-cmake-make') {
                             dir("build-openmp-address-sanitizer"){
                                 sh "cmake -DOPENMP=ON -DCMAKE_BUILD_TYPE=Debug -DENABLE_ADDRESS_SANITIZER=ON .."
-                                sh "make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)"
+                                sh "bash -i -c 'make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)'"
                             }
                         }
                     },
@@ -45,7 +45,7 @@ pipeline{
                         container('autopas-gcc7-cmake-make') {
                             dir("build-addresssanitizer"){
                                 sh "cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_ADDRESS_SANITIZER=ON .."
-                                sh "make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)"
+                                sh "bash -i -c 'make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)'"
                             }
                         }
                     },
@@ -53,7 +53,7 @@ pipeline{
                         container('autopas-gcc7-cmake-make') {
                             dir("build-addresssanitizer-release"){
                                 sh "cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_ADDRESS_SANITIZER=ON .."
-                                sh "make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)"
+                                sh "bash -i -c 'make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)'"
                             }
                         }
                     },
@@ -62,7 +62,7 @@ pipeline{
                             dir("build-threadsanitizer"){
                                 // this is for simple testing of our threading libraries.
                                 sh "cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_THREAD_SANITIZER=ON .."
-                                sh "make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)"
+                                sh "bash -i -c 'make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)'"
                             }
                         }
                     },
@@ -70,7 +70,7 @@ pipeline{
                         container('autopas-clang6-cmake-ninja-make'){
                             dir("build-clang-ninja-openmp"){
                                 sh "CC=clang CXX=clang++ cmake -G Ninja -DOPENMP=ON .."
-                                sh "ninja -j 4 &> buildlog_clang.txt || (cat buildlog_clang.txt && exit 1)"
+                                sh "bash -i -c 'ninja -j 4 &> buildlog_clang.txt || (cat buildlog_clang.txt && exit 1)'"
                             }
                         }
                     },
@@ -78,7 +78,7 @@ pipeline{
                         container('autopas-clang6-cmake-ninja-make'){
                             dir("build-clang-ninja-addresssanitizer-debug"){
                                 sh "CC=clang CXX=clang++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DENABLE_ADDRESS_SANITIZER=ON .."
-                                sh "ninja -j 4 &> buildlog_clang.txt || (cat buildlog_clang.txt && exit 1)"
+                                sh "bash -i -c 'ninja -j 4 &> buildlog_clang.txt || (cat buildlog_clang.txt && exit 1)'"
                             }
                         }
                     },
@@ -86,7 +86,7 @@ pipeline{
                         container('autopas-clang6-cmake-ninja-make'){
                             dir("build-clang-ninja-addresssanitizer-release"){
                                 sh "CC=clang CXX=clang++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_ADDRESS_SANITIZER=ON .."
-                                sh "ninja -j 4 &> buildlog_clang.txt || (cat buildlog_clang.txt && exit 1)"
+                                sh "bash -i -c 'ninja -j 4 &> buildlog_clang.txt || (cat buildlog_clang.txt && exit 1)'"
                             }
                         }
                     },
@@ -94,7 +94,7 @@ pipeline{
                         container('autopas-archer'){
                             dir("build-archer"){
                                 sh "CC=clang-archer CXX=clang-archer++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DUSE_VECTORIZATION=OFF .."
-                                sh "ninja -j 4 &> buildlog_clang.txt || (cat buildlog_clang.txt && exit 1)"
+                                sh "bash -i -c 'ninja -j 4 &> buildlog_clang.txt || (cat buildlog_clang.txt && exit 1)'"
                             }
                         }
                     },

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline{
                         container('autopas-gcc7-cmake-make') {
                             dir("build"){
                                 sh "cmake .."
-                                sh "make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)"
+                                sh "make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
                             }
                         }
                     },
@@ -29,7 +29,7 @@ pipeline{
                         container('autopas-gcc7-cmake-make') {
                             dir("build-openmp"){
                                 sh "cmake -DOPENMP=ON .."
-                                sh "make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)"
+                                sh "make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
                             }
                         }
                     },
@@ -37,7 +37,7 @@ pipeline{
                         container('autopas-gcc7-cmake-make') {
                             dir("build-openmp-address-sanitizer"){
                                 sh "cmake -DOPENMP=ON -DCMAKE_BUILD_TYPE=Debug -DENABLE_ADDRESS_SANITIZER=ON .."
-                                sh "make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)"
+                                sh "make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
                             }
                         }
                     },
@@ -45,7 +45,7 @@ pipeline{
                         container('autopas-gcc7-cmake-make') {
                             dir("build-addresssanitizer"){
                                 sh "cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_ADDRESS_SANITIZER=ON .."
-                                sh "make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)"
+                                sh "make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
                             }
                         }
                     },
@@ -53,7 +53,7 @@ pipeline{
                         container('autopas-gcc7-cmake-make') {
                             dir("build-addresssanitizer-release"){
                                 sh "cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_ADDRESS_SANITIZER=ON .."
-                                sh "make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)"
+                                sh "make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
                             }
                         }
                     },
@@ -62,7 +62,7 @@ pipeline{
                             dir("build-threadsanitizer"){
                                 // this is for simple testing of our threading libraries.
                                 sh "cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_THREAD_SANITIZER=ON .."
-                                sh "make -j 4 &> buildlog.txt || (cat buildlog.txt && exit 1)"
+                                sh "make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
                             }
                         }
                     },
@@ -70,7 +70,7 @@ pipeline{
                         container('autopas-clang6-cmake-ninja-make'){
                             dir("build-clang-ninja-openmp"){
                                 sh "CC=clang CXX=clang++ cmake -G Ninja -DOPENMP=ON .."
-                                sh "ninja -j 4 &> buildlog_clang.txt || (cat buildlog_clang.txt && exit 1)"
+                                sh "ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
                             }
                         }
                     },
@@ -78,7 +78,7 @@ pipeline{
                         container('autopas-clang6-cmake-ninja-make'){
                             dir("build-clang-ninja-addresssanitizer-debug"){
                                 sh "CC=clang CXX=clang++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DENABLE_ADDRESS_SANITIZER=ON .."
-                                sh "ninja -j 4 &> buildlog_clang.txt || (cat buildlog_clang.txt && exit 1)"
+                                sh "ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
                             }
                         }
                     },
@@ -86,7 +86,7 @@ pipeline{
                         container('autopas-clang6-cmake-ninja-make'){
                             dir("build-clang-ninja-addresssanitizer-release"){
                                 sh "CC=clang CXX=clang++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_ADDRESS_SANITIZER=ON .."
-                                sh "ninja -j 4 &> buildlog_clang.txt || (cat buildlog_clang.txt && exit 1)"
+                                sh "ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
                             }
                         }
                     },
@@ -94,7 +94,7 @@ pipeline{
                         container('autopas-archer'){
                             dir("build-archer"){
                                 sh "CC=clang-archer CXX=clang-archer++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DUSE_VECTORIZATION=OFF .."
-                                sh "ninja -j 4 &> buildlog_clang.txt || (cat buildlog_clang.txt && exit 1)"
+                                sh "ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
                             }
                         }
                     },
@@ -102,7 +102,7 @@ pipeline{
                         container('autopas-intel18'){
                             dir("build-intel"){
                                 sh "bash -i -c 'which icc && CC=`which icc` CXX=`which icpc` cmake -DOPENMP=OFF ..'"
-                                sh "bash -i -c 'make -j 4 &> buildlog_intel.txt || (cat buildlog_intel.txt && exit 1)'"
+                                sh "bash -i -c 'make -j 4 > buildlog_intel.txt || (cat buildlog_intel.txt && exit 1)'"
                             }
                         }
                     },
@@ -110,7 +110,7 @@ pipeline{
                         container('autopas-intel18'){
                             dir("build-intel-ninja-openmp"){
                                 sh "bash -i -c 'which icc && CC=`which icc` CXX=`which icpc` cmake -G Ninja -DOPENMP=ON ..'"
-                                sh "bash -i -c 'ninja -j 4 &> buildlog_intel.txt || (cat buildlog_intel.txt && exit 1)'"
+                                sh "bash -i -c 'ninja -j 4 > buildlog_intel.txt || (cat buildlog_intel.txt && exit 1)'"
                             }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,7 +93,7 @@ pipeline{
                     "archer": {
                         container('autopas-archer'){
                             dir("build-archer"){
-                                sh "CC=clang-archer CXX=clang-archer++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DUSE_VECTORIZATION=OFF .."
+                                sh "CC=clang-archer CXX=clang-archer++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DUSE_VECTORIZATION=OFF -Wno-pass-failed .."
                                 sh "ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
                             }
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,7 +77,7 @@ pipeline{
                     "clang ninja address sanitizer": {
                         container('autopas-clang6-cmake-ninja-make'){
                             dir("build-clang-ninja-addresssanitizer-debug"){
-                                sh "CC=clang CXX=clang++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DENABLE_ADDRESS_SANITIZER=ON -Wno-pass-failed .."
+                                sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DENABLE_ADDRESS_SANITIZER=ON .."
                                 sh "ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
                             }
                         }
@@ -85,7 +85,7 @@ pipeline{
                     "clang ninja address sanitizer release": {
                         container('autopas-clang6-cmake-ninja-make'){
                             dir("build-clang-ninja-addresssanitizer-release"){
-                                sh "CC=clang CXX=clang++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_ADDRESS_SANITIZER=ON -Wno-pass-failed .."
+                                sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_ADDRESS_SANITIZER=ON .."
                                 sh "ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
                             }
                         }
@@ -93,7 +93,7 @@ pipeline{
                     "archer": {
                         container('autopas-archer'){
                             dir("build-archer"){
-                                sh "CC=clang-archer CXX=clang-archer++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DUSE_VECTORIZATION=OFF -Wno-pass-failed .."
+                                sh "CXXFLAGS=-Wno-pass-failed CC=clang-archer CXX=clang-archer++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DUSE_VECTORIZATION=OFF .."
                                 sh "ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
                             }
                         }


### PR DESCRIPTION
build errors were not correctly shown.
also shows warnings correctly now.

**the error:**
redirecting using
```
cmd &> file
``` 
is not supported in the normal shell.
**fix:**
used
```
cmd > file 2>&1
```
instead

fixes #107 