### PR TITLE
fix sph vectorization

### DIFF
--- a/cmake/modules/other-compileroptions.cmake
+++ b/cmake/modules/other-compileroptions.cmake
@@ -1,3 +1,6 @@
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-math-errno")
+message(STATUS "fno-math-errno set. This is needed to vectorize, e.g., sqrt().")
+
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Weffc++")
 if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.1)
     #Wsuggest-override only exists for g++ starting at version 5.1
@@ -21,6 +24,8 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Intel")
         message(STATUS "fast-math disabled using -fp-model precise (intel)")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fp-model precise")
     endif ()
+else()
+    message(WARNING "for this compiler fast math is unknown")
 endif ()
 
 SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g -DNDEBUG")

--- a/src/autopas/sph/SPHCalcDensityFunctor.h
+++ b/src/autopas/sph/SPHCalcDensityFunctor.h
@@ -72,7 +72,7 @@ class SPHCalcDensityFunctor : public Functor<SPHParticle, FullParticleCell<SPHPa
     double *const __restrict__ densityptr = soa.template begin<Particle::AttributeNames::density>();
     double *const __restrict__ smthptr = soa.template begin<Particle::AttributeNames::smth>();
     double *const __restrict__ massptr = soa.template begin<Particle::AttributeNames::mass>();
-    size_t numParticles =  soa.getNumParticles();
+    size_t numParticles = soa.getNumParticles();
     for (unsigned int i = 0; i < numParticles; ++i) {
       double densacc = 0.;
 
@@ -126,10 +126,10 @@ class SPHCalcDensityFunctor : public Functor<SPHParticle, FullParticleCell<SPHPa
     double *const __restrict__ smthptr2 = soa2.begin<Particle::AttributeNames::smth>();
     double *const __restrict__ massptr2 = soa2.begin<Particle::AttributeNames::mass>();
 
-    size_t numParticlesi =  soa1.getNumParticles();
+    size_t numParticlesi = soa1.getNumParticles();
     for (unsigned int i = 0; i < numParticlesi; ++i) {
       double densacc = 0.;
-      size_t numParticlesj =  soa2.getNumParticles();
+      size_t numParticlesj = soa2.getNumParticles();
 // icpc vectorizes this.
 // g++ only with -ffast-math or -funsafe-math-optimizations
 #pragma omp simd reduction(+ : densacc)
@@ -176,7 +176,7 @@ class SPHCalcDensityFunctor : public Functor<SPHParticle, FullParticleCell<SPHPa
     double *const __restrict__ smthptr = soa.template begin<Particle::AttributeNames::smth>();
     double *const __restrict__ massptr = soa.template begin<Particle::AttributeNames::mass>();
 
-    size_t numParticlesi =  soa.getNumParticles();
+    size_t numParticlesi = soa.getNumParticles();
     for (unsigned int i = 0; i < numParticlesi; ++i) {
       double densacc = 0;
       auto &currentList = neighborList[i];

--- a/src/autopas/sph/SPHCalcDensityFunctor.h
+++ b/src/autopas/sph/SPHCalcDensityFunctor.h
@@ -72,14 +72,14 @@ class SPHCalcDensityFunctor : public Functor<SPHParticle, FullParticleCell<SPHPa
     double *const __restrict__ densityptr = soa.template begin<Particle::AttributeNames::density>();
     double *const __restrict__ smthptr = soa.template begin<Particle::AttributeNames::smth>();
     double *const __restrict__ massptr = soa.template begin<Particle::AttributeNames::mass>();
-
-    for (unsigned int i = 0; i < soa.getNumParticles(); ++i) {
-      double densacc = 0;
+    size_t numParticles =  soa.getNumParticles();
+    for (unsigned int i = 0; i < numParticles; ++i) {
+      double densacc = 0.;
 
 // icpc vectorizes this.
 // g++ only with -ffast-math or -funsafe-math-optimizations
 #pragma omp simd reduction(+ : densacc)
-      for (unsigned int j = i + 1; j < soa.getNumParticles(); ++j) {
+      for (unsigned int j = i + 1; j < numParticles; ++j) {
         const double drx = xptr[i] - xptr[j];
         const double dry = yptr[i] - yptr[j];
         const double drz = zptr[i] - zptr[j];
@@ -126,13 +126,14 @@ class SPHCalcDensityFunctor : public Functor<SPHParticle, FullParticleCell<SPHPa
     double *const __restrict__ smthptr2 = soa2.begin<Particle::AttributeNames::smth>();
     double *const __restrict__ massptr2 = soa2.begin<Particle::AttributeNames::mass>();
 
-    for (unsigned int i = 0; i < soa1.getNumParticles(); ++i) {
-      double densacc = 0;
-
+    size_t numParticlesi =  soa1.getNumParticles();
+    for (unsigned int i = 0; i < numParticlesi; ++i) {
+      double densacc = 0.;
+      size_t numParticlesj =  soa2.getNumParticles();
 // icpc vectorizes this.
 // g++ only with -ffast-math or -funsafe-math-optimizations
 #pragma omp simd reduction(+ : densacc)
-      for (unsigned int j = 0; j < soa2.getNumParticles(); ++j) {
+      for (unsigned int j = 0; j < numParticlesj; ++j) {
         const double drx = xptr1[i] - xptr2[j];
         const double dry = yptr1[i] - yptr2[j];
         const double drz = zptr1[i] - zptr2[j];
@@ -175,7 +176,8 @@ class SPHCalcDensityFunctor : public Functor<SPHParticle, FullParticleCell<SPHPa
     double *const __restrict__ smthptr = soa.template begin<Particle::AttributeNames::smth>();
     double *const __restrict__ massptr = soa.template begin<Particle::AttributeNames::mass>();
 
-    for (unsigned int i = 0; i < soa.getNumParticles(); ++i) {
+    size_t numParticlesi =  soa.getNumParticles();
+    for (unsigned int i = 0; i < numParticlesi; ++i) {
       double densacc = 0;
       auto &currentList = neighborList[i];
       size_t listSize = currentList.size();


### PR DESCRIPTION
closes #110 

**The Bug**
sph functions weren't properly vectorized anymore

**The possibilities**
either enable `-ffast-math`
or
enable `-fno-math-errno`

**The fix**
The latter seemed the better alternative, so I enabled for all configurations. `-fno-math-errno` also exists for all tested compilers (i.e. clang, gnu, intel)