### PR TITLE
Feature/flopcounter fix openmp

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -252,14 +252,14 @@ pipeline{
                         githubNotify context: 'checkExamples', description: 'checking examples in progress...',  status: 'PENDING', targetUrl: currentBuild.absoluteUrl
                         container('autopas-gcc7-cmake-make') {
                             dir("build/examples") {
-                                sh 'ctest -C checkExamples -j8'
+                                sh 'ctest -C checkExamples -j8 --verbose'
                             }
                         }
                     },
                     "gcc openmp": {
                         container('autopas-gcc7-cmake-make') {
                             dir("build-openmp/examples") {
-                                sh 'ctest -C checkExamples -j8'
+                                sh 'ctest -C checkExamples -j8 --verbose'
                             }
                         }
                     },
@@ -273,63 +273,63 @@ pipeline{
                     /*"address sanitizer": {
                         container('autopas-gcc7-cmake-make') {
                             dir("build-addresssanitizer/examples"){
-                                sh 'ctest -C checkExamples -j8'
+                                sh 'ctest -C checkExamples -j8 --verbose'
                             }
                         }
                     },*/
                     /*"address sanitizer release": {
                         container('autopas-gcc7-cmake-make') {
                             dir("build-addresssanitizer-release/examples"){
-                                sh 'ctest -C checkExamples -j8'
+                                sh 'ctest -C checkExamples -j8 --verbose'
                             }
                         }
                     },*/
                     /*"thread sanitizer": {
                         container('autopas-gcc7-cmake-make') {
                             dir("build-threadsanitizer/examples"){
-                                sh 'ctest -C checkExamples -j8'
+                                sh 'ctest -C checkExamples -j8 --verbose'
                             }
                         }
                     },*/
                     "clang openmp": {
                         container('autopas-clang6-cmake-ninja-make'){
                             dir("build-clang-ninja-openmp/examples"){
-                                sh 'ctest -C checkExamples -j8'
+                                sh 'ctest -C checkExamples -j8 --verbose'
                             }
                         }
                     },
                     /*"clang ninja address sanitizer": {
                         container('autopas-clang6-cmake-ninja-make'){
                             dir("build-clang-ninja-addresssanitizer-debug/examples"){
-                                sh 'ctest -C checkExamples -j8'
+                                sh 'ctest -C checkExamples -j8 --verbose'
                             }
                         }
                     },*/
                     "clang ninja address sanitizer release": {
                         container('autopas-clang6-cmake-ninja-make'){
                             dir("build-clang-ninja-addresssanitizer-release/examples"){
-                                sh 'ctest -C checkExamples -j8'
+                                sh 'ctest -C checkExamples -j8 --verbose'
                             }
                         }
                     },
                     "archer": {
                         container('autopas-archer'){
                             dir("build-archer/examples"){
-                                sh 'export TSAN_OPTIONS="ignore_noninstrumented_modules=1" && ctest -C checkExamples -j8'
+                                sh 'export TSAN_OPTIONS="ignore_noninstrumented_modules=1" && ctest -C checkExamples -j8 --verbose'
                             }
                         }
                     },
                     "intel": {
                         container('autopas-intel18'){
                             dir("build-intel/examples"){
-                                sh "bash -i -c 'ctest -C checkExamples -j8'"
+                                sh "bash -i -c 'ctest -C checkExamples -j8 --verbose'"
                             }
                         }
                     },
                     "intel openmp": {
                         container('autopas-intel18'){
                             dir("build-intel-ninja-openmp/examples"){
-                                sh "bash -i -c 'ctest -C checkExamples -j8'"
+                                sh "bash -i -c 'ctest -C checkExamples -j8 --verbose'"
                             }
                         }
                     }

--- a/src/autopas/pairwiseFunctors/FlopCounterFunctor.h
+++ b/src/autopas/pairwiseFunctors/FlopCounterFunctor.h
@@ -81,9 +81,13 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell> {
 
         if (dr2 <= _cutoffSquare) ++kernelCallsAcc;
       }
-
-      _distanceCalculations += distanceCalculationsAcc;
-      _kernelCalls += kernelCallsAcc;
+#ifdef AUTOPAS_OPENMP
+#pragma omp critical
+#endif
+      {
+        _distanceCalculations += distanceCalculationsAcc;
+        _kernelCalls += kernelCallsAcc;
+      }
     }
   }
 
@@ -119,8 +123,13 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell> {
           ++kernelCallsAcc;
         }
       }
-      _distanceCalculations += distanceCalculationsAcc;
-      _kernelCalls += kernelCallsAcc;
+#ifdef AUTOPAS_OPENMP
+#pragma omp critical
+#endif
+      {
+        _distanceCalculations += distanceCalculationsAcc;
+        _kernelCalls += kernelCallsAcc;
+      }
     }
   }
 
@@ -199,9 +208,13 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell> {
 
             kernelCallsAcc += mask;
           }
-
-          _distanceCalculations += distanceCalculationsAcc;
-          _kernelCalls += kernelCallsAcc;
+#ifdef AUTOPAS_OPENMP
+#pragma omp critical
+#endif
+          {
+            _distanceCalculations += distanceCalculationsAcc;
+            _kernelCalls += kernelCallsAcc;
+          }
         }
       }
       unsigned long distanceCalculationsAcc = 0;
@@ -226,8 +239,13 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell> {
           ++kernelCallsAcc;
         }
       }
-      _distanceCalculations += distanceCalculationsAcc;
-      _kernelCalls += kernelCallsAcc;
+#ifdef AUTOPAS_OPENMP
+#pragma omp critical
+#endif
+      {
+        _distanceCalculations += distanceCalculationsAcc;
+        _kernelCalls += kernelCallsAcc;
+      }
     }
   }
 

--- a/tests/testAutopas/FlopCounterTest.cpp
+++ b/tests/testAutopas/FlopCounterTest.cpp
@@ -172,6 +172,4 @@ TEST_F(FlopCounterTest, testFlopCounterSoAOpenMP) {
       functor.SoAFunctor(cell3._particleSoABuffer, cell4._particleSoABuffer, newton3);
     }
   }
-
-
 }


### PR DESCRIPTION
# Description

Fixes data races in FlopCounter's SoA functors. Using openmp critical for now.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Added unit tests to check SoA and AoS functors - the SoA version was failing.
- [x] Fixed the code to satisfy the SoA unit-test version.
