### PR TITLE
Selector strategies

### DIFF
--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -22,7 +22,7 @@ enum DataLayoutOption { aos, soa };
 
 /**
  * Possible choices for the auto tuner.
- * @TODO: implement more options and then use this enum! :D
+ * @todo: implement more options and then use this enum! :D
  */
 enum TuningStrategy {
   /**
@@ -30,7 +30,6 @@ enum TuningStrategy {
    */
   timeMeasuring
 };
-
 
 /**
  * Automated tuner for optimal iteration performance.

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -16,9 +16,21 @@
 namespace autopas {
 
 /**
- * Possible Choices for the particle data layout.
+ * Possible choices for the particle data layout.
  */
 enum DataLayoutOption { aos, soa };
+
+/**
+ * Possible choices for the auto tuner.
+ * @TODO: implement more options and then use this enum! :D
+ */
+enum TuningStrategy {
+  /**
+   * Test all allowed configurations and select the best.
+   */
+  timeMeasuring
+};
+
 
 /**
  * Automated tuner for optimal iteration performance.
@@ -54,7 +66,9 @@ class AutoTuner {
                            allowedTraversalOptions),
         _allowedTraversalOptions(allowedTraversalOptions),
         _maxSamples(maxSamples),
-        _numSamples(maxSamples) {}
+        _numSamples(maxSamples),
+        _containerSelectorStrategy(SelectorStrategy::fastestAbs),
+        _traversalSelectorStrategy(SelectorStrategy::fastestAbs) {}
 
   /**
    * Getter for the optimal container.
@@ -106,6 +120,9 @@ class AutoTuner {
    * Initialize with max value to start tuning at start of simulation.
    */
   size_t _numSamples;
+
+  SelectorStrategy _containerSelectorStrategy;
+  SelectorStrategy _traversalSelectorStrategy;
 };
 
 template <class Particle, class ParticleCell>
@@ -211,7 +228,8 @@ bool AutoTuner<Particle, ParticleCell>::tune(PairwiseFunctor &pairwiseFunctor) {
     } else {
       _containerSelector.selectOptimalContainer();
       _traversalSelectors[getContainer()->getContainerType()]
-          .template selectOptimalTraversal<PairwiseFunctor, useSoA, useNewton3>(pairwiseFunctor);
+          .template selectOptimalTraversal<PairwiseFunctor, useSoA, useNewton3>(_traversalSelectorStrategy,
+                                                                                pairwiseFunctor);
       _iterationsSinceTuning = 0;
       return false;
     }

--- a/src/autopas/selectors/ContainerSelector.h
+++ b/src/autopas/selectors/ContainerSelector.h
@@ -139,9 +139,6 @@ ContainerSelector<Particle, ParticleCell>::generateContainer(ContainerOptions co
     }
   }
 
-  // Build verlet lists now such that the rebuild time does not count into the measured traversal time.
-  if (containerChoice == verletLists) ((VerletLists<Particle> *)container.get())->rebuild();
-
   return container;
 }
 

--- a/src/autopas/selectors/TraversalSelector.h
+++ b/src/autopas/selectors/TraversalSelector.h
@@ -294,13 +294,14 @@ template <class ParticleCell>
 void TraversalSelector<ParticleCell>::findFastestMeanTraversal() {
   // choose the fastest traversal and reset timings
   // reorder measurements
-  // TODO: maybe directly save measurements in this way?
+  // @todo: maybe directly save measurements in this way?
   std::unordered_map<TraversalOptions, std::vector<long>, TrivialHash> measurementsMap;
   for (auto &&t : _traversalTimes) {
     measurementsMap[t.traversal].push_back(t.time);
   }
 
   long optimalTraversalTime = std::numeric_limits<long>::max();
+  // @todo: when verlet list traversals are here apply weights to measurement w/ or w/o vl rebuild
   for (auto &&m : measurementsMap) {
     long meanTime = std::accumulate(m.second.begin(), m.second.end(), 0l) / m.second.size();
     if (meanTime < optimalTraversalTime) {
@@ -319,7 +320,7 @@ template <class ParticleCell>
 void TraversalSelector<ParticleCell>::findFastestMedianTraversal() {
   // choose the fastest traversal and reset timings
   // reorder measurements
-  // TODO: maybe directly save measurements in this way?
+  // todo: maybe directly save measurements in this way?
   std::unordered_map<TraversalOptions, std::vector<long>, TrivialHash> measurementsMap;
   for (auto &&t : _traversalTimes) {
     measurementsMap[t.traversal].push_back(t.time);

--- a/src/autopas/selectors/TraversalSelector.h
+++ b/src/autopas/selectors/TraversalSelector.h
@@ -296,7 +296,7 @@ void TraversalSelector<ParticleCell>::findFastestMeanTraversal() {
   // choose the fastest traversal and reset timings
   // reorder measurements
   // TODO: maybe directly save measurements in this way?
-  std::unordered_map<TraversalOptions, std::vector<long>> measurementsMap;
+  std::map<TraversalOptions, std::vector<long>> measurementsMap;
   for (auto &&t : _traversalTimes) {
     measurementsMap[t.traversal].push_back(t.time);
   }

--- a/src/autopas/selectors/TraversalSelector.h
+++ b/src/autopas/selectors/TraversalSelector.h
@@ -6,18 +6,19 @@
 
 #pragma once
 
-#include <autopas/containers/cellPairTraversals/DummyTraversal.h>
 #include <array>
 #include <numeric>
+#include <unordered_map>
 #include <vector>
 #include "autopas/containers/cellPairTraversals/C08Traversal.h"
 #include "autopas/containers/cellPairTraversals/CellPairTraversal.h"
 #include "autopas/containers/cellPairTraversals/CellPairTraversalInterface.h"
+#include "autopas/containers/cellPairTraversals/DummyTraversal.h"
 #include "autopas/containers/cellPairTraversals/SlicedTraversal.h"
 #include "autopas/pairwiseFunctors/CellFunctor.h"
-//#include "autopas/selectors/AutoTuner.h"
 #include "autopas/utils/ExceptionHandler.h"
 #include "autopas/utils/Logger.h"
+#include "autopas/utils/TrivialHash.h"
 
 namespace autopas {
 
@@ -189,7 +190,6 @@ template <class ParticleCell>
 template <class PairwiseFunctor, bool useSoA, bool useNewton3>
 std::unique_ptr<CellPairTraversal<ParticleCell>> TraversalSelector<ParticleCell>::selectOptimalTraversal(
     SelectorStrategy strategy, PairwiseFunctor &pairwiseFunctor) {
-
   // Time measure strategy
   if (_traversalTimes.empty()) {
     utils::ExceptionHandler::exception("TraversalSelector: Trying to determine fastest traversal before measuring!");
@@ -292,11 +292,10 @@ void TraversalSelector<ParticleCell>::findFastestAbsTraversal() {
 
 template <class ParticleCell>
 void TraversalSelector<ParticleCell>::findFastestMeanTraversal() {
-
   // choose the fastest traversal and reset timings
   // reorder measurements
   // TODO: maybe directly save measurements in this way?
-  std::map<TraversalOptions, std::vector<long>> measurementsMap;
+  std::unordered_map<TraversalOptions, std::vector<long>, TrivialHash> measurementsMap;
   for (auto &&t : _traversalTimes) {
     measurementsMap[t.traversal].push_back(t.time);
   }
@@ -321,7 +320,7 @@ void TraversalSelector<ParticleCell>::findFastestMedianTraversal() {
   // choose the fastest traversal and reset timings
   // reorder measurements
   // TODO: maybe directly save measurements in this way?
-  std::unordered_map<TraversalOptions, std::vector<long>> measurementsMap;
+  std::unordered_map<TraversalOptions, std::vector<long>, TrivialHash> measurementsMap;
   for (auto &&t : _traversalTimes) {
     measurementsMap[t.traversal].push_back(t.time);
   }

--- a/src/autopas/utils/TrivialHash.h
+++ b/src/autopas/utils/TrivialHash.h
@@ -11,7 +11,16 @@
 
 namespace autopas {
 
+/**
+ * Trivial hash for enums.
+ */
 struct TrivialHash {
+  /**
+   * Trivial hash function
+   * @tparam T
+   * @param t
+   * @return Integer representation of t
+   */
   template <typename T>
   std::size_t operator()(T t) const {
     return static_cast<std::size_t>(t);

--- a/src/autopas/utils/TrivialHash.h
+++ b/src/autopas/utils/TrivialHash.h
@@ -1,0 +1,21 @@
+/**
+ * @file TrivialHash.h
+ * @author F. Gratl
+ * @date 11/23/18
+ */
+
+#pragma once
+
+// for std::size_t
+#include <cstddef>
+
+namespace autopas {
+
+struct TrivialHash {
+  template <typename T>
+  std::size_t operator()(T t) const {
+    return static_cast<std::size_t>(t);
+  }
+};
+
+}  // namespace autopas

--- a/tests/testAutopas/TraversalSelectorTest.cpp
+++ b/tests/testAutopas/TraversalSelectorTest.cpp
@@ -83,12 +83,12 @@ TEST_F(TraversalSelectorTest, testNextTraversal) {
 TEST_F(TraversalSelectorTest, testSelectOptimalTraversalFastestAbs) {
   auto strategy = autopas::SelectorStrategy::fastestAbs;
 
-  std::unordered_map<autopas::TraversalOptions, std::vector<long>> measurements;
+  mapOptionsTime measurements;
 
   measurements[autopas::TraversalOptions::c08] = {22, 14};
   measurements[autopas::TraversalOptions::sliced] = {30, 10};
 
-  std::unordered_map<autopas::TraversalOptions, std::vector<long>> ignoredMeasurements;
+  mapOptionsTime ignoredMeasurements;
   ignoredMeasurements[autopas::TraversalOptions::c08] = {1};
 
   testFastest(strategy, measurements, autopas::TraversalOptions::sliced, ignoredMeasurements);
@@ -97,7 +97,7 @@ TEST_F(TraversalSelectorTest, testSelectOptimalTraversalFastestAbs) {
 TEST_F(TraversalSelectorTest, testSelectOptimalTraversalFastestMean) {
   auto strategy = autopas::SelectorStrategy::fastestMean;
 
-  std::unordered_map<autopas::TraversalOptions, std::vector<long>> measurements;
+  mapOptionsTime measurements;
 
   measurements[autopas::TraversalOptions::c08] = {2, 20};
   measurements[autopas::TraversalOptions::sliced] = {5, 7};
@@ -108,7 +108,7 @@ TEST_F(TraversalSelectorTest, testSelectOptimalTraversalFastestMean) {
 TEST_F(TraversalSelectorTest, testSelectOptimalTraversalFastestMedian) {
   auto strategy = autopas::SelectorStrategy::fastestMedian;
 
-  std::unordered_map<autopas::TraversalOptions, std::vector<long>> measurements;
+  mapOptionsTime measurements;
 
   measurements[autopas::TraversalOptions::c08] = {4, 1, 5};
   measurements[autopas::TraversalOptions::sliced] = {2, 3, 3, 100};
@@ -116,10 +116,8 @@ TEST_F(TraversalSelectorTest, testSelectOptimalTraversalFastestMedian) {
   testFastest(strategy, measurements, autopas::TraversalOptions::sliced);
 }
 
-void TraversalSelectorTest::testFastest(
-    autopas::SelectorStrategy strategy, std::unordered_map<autopas::TraversalOptions, std::vector<long>> measurements,
-    autopas::TraversalOptions expectedBest,
-    std::unordered_map<autopas::TraversalOptions, std::vector<long>> ignoredMeasurements) {
+void TraversalSelectorTest::testFastest(autopas::SelectorStrategy strategy, mapOptionsTime measurements,
+                                        autopas::TraversalOptions expectedBest, mapOptionsTime ignoredMeasurements) {
   MFunctor functor;
 
   std::vector<autopas::TraversalOptions> optionVector;

--- a/tests/testAutopas/TraversalSelectorTest.cpp
+++ b/tests/testAutopas/TraversalSelectorTest.cpp
@@ -80,8 +80,10 @@ TEST_F(TraversalSelectorTest, testNextTraversal) {
   }
 }
 
-TEST_F(TraversalSelectorTest, testSelectOptimalTraversal) {
+TEST_F(TraversalSelectorTest, testSelectOptimalTraversalFastestAbs) {
   MFunctor functor;
+
+  auto strategy = autopas::SelectorStrategy::fastestAbs;
 
   std::vector<autopas::TraversalOptions> optionVector = {autopas::TraversalOptions::sliced,
                                                          autopas::TraversalOptions::c08};
@@ -89,9 +91,7 @@ TEST_F(TraversalSelectorTest, testSelectOptimalTraversal) {
   constexpr size_t domainSize = 1000;
   autopas::TraversalSelector<FPCell> traversalSelector({domainSize, domainSize, domainSize}, optionVector);
 
-  EXPECT_THROW(
-      (traversalSelector.selectOptimalTraversal<MFunctor, true, true>(autopas::SelectorStrategy::fastestAbs, functor)),
-      std::exception);
+  EXPECT_THROW((traversalSelector.selectOptimalTraversal<MFunctor, true, true>(strategy, functor)), std::exception);
 
   EXPECT_CALL(functor, isRelevantForTuning()).WillRepeatedly(Return(true));
   traversalSelector.addTimeMeasurement(functor, optionVector[0], 20);
@@ -103,12 +103,64 @@ TEST_F(TraversalSelectorTest, testSelectOptimalTraversal) {
   EXPECT_CALL(functor, isRelevantForTuning()).WillOnce(Return(false));
   traversalSelector.addTimeMeasurement(functor, optionVector[0], 1);
 
-  auto traversal =
-      traversalSelector.selectOptimalTraversal<MFunctor, true, true>(autopas::SelectorStrategy::fastestAbs, functor);
+  auto traversal = traversalSelector.selectOptimalTraversal<MFunctor, true, true>(strategy, functor);
   EXPECT_EQ(optionVector[1], traversal->getTraversalType());
 
   // select optimal traversal should delete all measurements
-  EXPECT_THROW(
-      (traversalSelector.selectOptimalTraversal<MFunctor, true, true>(autopas::SelectorStrategy::fastestAbs, functor)),
-      std::exception);
+  EXPECT_THROW((traversalSelector.selectOptimalTraversal<MFunctor, true, true>(strategy, functor)), std::exception);
+}
+
+TEST_F(TraversalSelectorTest, testSelectOptimalTraversalFastestMean) {
+  MFunctor functor;
+
+  auto strategy = autopas::SelectorStrategy::fastestMean;
+
+  std::vector<autopas::TraversalOptions> optionVector = {autopas::TraversalOptions::sliced,
+                                                         autopas::TraversalOptions::c08};
+
+  constexpr size_t domainSize = 1000;
+  autopas::TraversalSelector<FPCell> traversalSelector({domainSize, domainSize, domainSize}, optionVector);
+
+  EXPECT_THROW((traversalSelector.selectOptimalTraversal<MFunctor, true, true>(strategy, functor)), std::exception);
+
+  EXPECT_CALL(functor, isRelevantForTuning()).WillRepeatedly(Return(true));
+  traversalSelector.addTimeMeasurement(functor, optionVector[0], 2);
+  traversalSelector.addTimeMeasurement(functor, optionVector[0], 20);
+  traversalSelector.addTimeMeasurement(functor, optionVector[1], 5);
+  traversalSelector.addTimeMeasurement(functor, optionVector[1], 7);
+
+  auto traversal = traversalSelector.selectOptimalTraversal<MFunctor, true, true>(strategy, functor);
+  EXPECT_EQ(optionVector[1], traversal->getTraversalType());
+
+  // select optimal traversal should delete all measurements
+  EXPECT_THROW((traversalSelector.selectOptimalTraversal<MFunctor, true, true>(strategy, functor)), std::exception);
+}
+
+TEST_F(TraversalSelectorTest, testSelectOptimalTraversalFastestMedian) {
+  MFunctor functor;
+
+  auto strategy = autopas::SelectorStrategy::fastestMedian;
+
+  std::vector<autopas::TraversalOptions> optionVector = {autopas::TraversalOptions::sliced,
+                                                         autopas::TraversalOptions::c08};
+
+  constexpr size_t domainSize = 1000;
+  autopas::TraversalSelector<FPCell> traversalSelector({domainSize, domainSize, domainSize}, optionVector);
+
+  EXPECT_THROW((traversalSelector.selectOptimalTraversal<MFunctor, true, true>(strategy, functor)), std::exception);
+
+  EXPECT_CALL(functor, isRelevantForTuning()).WillRepeatedly(Return(true));
+  traversalSelector.addTimeMeasurement(functor, optionVector[0], 1);
+  traversalSelector.addTimeMeasurement(functor, optionVector[0], 4);
+  traversalSelector.addTimeMeasurement(functor, optionVector[0], 5);
+  traversalSelector.addTimeMeasurement(functor, optionVector[1], 2);
+  traversalSelector.addTimeMeasurement(functor, optionVector[1], 3);
+  traversalSelector.addTimeMeasurement(functor, optionVector[1], 4);
+  traversalSelector.addTimeMeasurement(functor, optionVector[1], 100);
+
+  auto traversal = traversalSelector.selectOptimalTraversal<MFunctor, true, true>(strategy, functor);
+  EXPECT_EQ(optionVector[1], traversal->getTraversalType());
+
+  // select optimal traversal should delete all measurements
+  EXPECT_THROW((traversalSelector.selectOptimalTraversal<MFunctor, true, true>(strategy, functor)), std::exception);
 }

--- a/tests/testAutopas/TraversalSelectorTest.cpp
+++ b/tests/testAutopas/TraversalSelectorTest.cpp
@@ -89,7 +89,9 @@ TEST_F(TraversalSelectorTest, testSelectOptimalTraversal) {
   constexpr size_t domainSize = 1000;
   autopas::TraversalSelector<FPCell> traversalSelector({domainSize, domainSize, domainSize}, optionVector);
 
-  EXPECT_THROW((traversalSelector.selectOptimalTraversal<MFunctor, true, true>(functor)), std::exception);
+  EXPECT_THROW(
+      (traversalSelector.selectOptimalTraversal<MFunctor, true, true>(autopas::SelectorStrategy::fastestAbs, functor)),
+      std::exception);
 
   EXPECT_CALL(functor, isRelevantForTuning()).WillRepeatedly(Return(true));
   traversalSelector.addTimeMeasurement(functor, optionVector[0], 20);
@@ -101,9 +103,12 @@ TEST_F(TraversalSelectorTest, testSelectOptimalTraversal) {
   EXPECT_CALL(functor, isRelevantForTuning()).WillOnce(Return(false));
   traversalSelector.addTimeMeasurement(functor, optionVector[0], 1);
 
-  auto traversal = traversalSelector.selectOptimalTraversal<MFunctor, true, true>(functor);
+  auto traversal =
+      traversalSelector.selectOptimalTraversal<MFunctor, true, true>(autopas::SelectorStrategy::fastestAbs, functor);
   EXPECT_EQ(optionVector[1], traversal->getTraversalType());
 
   // select optimal traversal should delete all measurements
-  EXPECT_THROW((traversalSelector.selectOptimalTraversal<MFunctor, true, true>(functor)), std::exception);
+  EXPECT_THROW(
+      (traversalSelector.selectOptimalTraversal<MFunctor, true, true>(autopas::SelectorStrategy::fastestAbs, functor)),
+      std::exception);
 }

--- a/tests/testAutopas/TraversalSelectorTest.h
+++ b/tests/testAutopas/TraversalSelectorTest.h
@@ -17,4 +17,9 @@ class TraversalSelectorTest : public AutoPasTestBase {
  public:
   TraversalSelectorTest() = default;
   ~TraversalSelectorTest() override = default;
+
+  void testFastest(autopas::SelectorStrategy strategy,
+                   std::unordered_map<autopas::TraversalOptions, std::vector<long>> measurements,
+                   autopas::TraversalOptions expectedBest,
+                   std::unordered_map<autopas::TraversalOptions, std::vector<long>> ignoredMeasurements = {});
 };

--- a/tests/testAutopas/TraversalSelectorTest.h
+++ b/tests/testAutopas/TraversalSelectorTest.h
@@ -18,8 +18,8 @@ class TraversalSelectorTest : public AutoPasTestBase {
   TraversalSelectorTest() = default;
   ~TraversalSelectorTest() override = default;
 
-  void testFastest(autopas::SelectorStrategy strategy,
-                   std::unordered_map<autopas::TraversalOptions, std::vector<long>> measurements,
-                   autopas::TraversalOptions expectedBest,
-                   std::unordered_map<autopas::TraversalOptions, std::vector<long>> ignoredMeasurements = {});
+  using mapOptionsTime = std::unordered_map<autopas::TraversalOptions, std::vector<long>, autopas::TrivialHash>;
+
+  void testFastest(autopas::SelectorStrategy strategy, mapOptionsTime measurements,
+                   autopas::TraversalOptions expectedBest, mapOptionsTime ignoredMeasurements = {});
 };


### PR DESCRIPTION
# Description

Introducing swappable strategies for the tuner classes.

- [x] averaging time samples
- [x] median of time samples
- [x] trivial hash struct/function for maps with enums

## ~Related Pull Requests~

## Resolved Issues # (issue)

- [x] #120 (Do not ignore Verlet rebuild time)
- [x] #120 (Average time samples)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Tests for average
- [x] Tests for median
