### PR TITLE
RegionParticleIterator tests now openmp + bugfix

### DIFF
--- a/src/autopas/containers/CellBorderAndFlagManager.h
+++ b/src/autopas/containers/CellBorderAndFlagManager.h
@@ -5,6 +5,7 @@
  */
 
 #pragma once
+#include <cstdlib>
 
 namespace autopas {
 /**

--- a/src/autopas/iterators/ParticleIteratorWrapper.h
+++ b/src/autopas/iterators/ParticleIteratorWrapper.h
@@ -6,6 +6,7 @@
  */
 #pragma once
 
+#include <memory>
 #include "autopas/iterators/ParticleIteratorInterface.h"
 
 namespace autopas {

--- a/src/autopas/iterators/RegionParticleIterator.h
+++ b/src/autopas/iterators/RegionParticleIterator.h
@@ -45,7 +45,7 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell> {
         _indicesInRegion(indicesInRegion),
         _currentRegionIndex(autopas_get_thread_num()) {
     this->_vectorOfCells = cont;
-    if (_indicesInRegion.size() >= (size_t)autopas_get_num_threads()) {
+    if (_indicesInRegion.size() > (size_t)autopas_get_thread_num()) {
       this->_iteratorAcrossCells = cont->begin() + _indicesInRegion[autopas_get_thread_num()];
       this->_iteratorWithinOneCell = this->_iteratorAcrossCells->begin();
     } else {

--- a/tests/testAutopas/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/RegionParticleIteratorTest.cpp
@@ -197,7 +197,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorSparseDo
 
   int particlesTouched = 0;
 #ifdef AUTOPAS_OPENMP
-#pragma omp parallel reduction(+: particlesTouched)
+#pragma omp parallel reduction(+ : particlesTouched)
 #endif
   for (auto iterator = lcContainer.getRegionIterator(regionOfInterstMin, regionOfInterstMax); iterator.isValid();
        ++iterator) {
@@ -251,7 +251,7 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorSparseDoma
 
   int particlesTouched = 0;
 #ifdef AUTOPAS_OPENMP
-#pragma omp parallel reduction(+: particlesTouched)
+#pragma omp parallel reduction(+ : particlesTouched)
 #endif
   for (auto iterator = dsContainer.getRegionIterator(regionOfInterstMin, regionOfInterstMax); iterator.isValid();
        ++iterator) {
@@ -367,7 +367,7 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorEmpty) {
   int i = 0;
   // touch them using the regionIterator
 #ifdef AUTOPAS_OPENMP
-#pragma omp parallel reduction(+: i)
+#pragma omp parallel reduction(+ : i)
 #endif
   for (auto iterator = container.getRegionIterator(_regionMin, _regionMax); iterator.isValid(); ++iterator) {
     iterator->touch();
@@ -492,7 +492,7 @@ TEST_F(RegionParticleIteratorTest, testVerletRegionParticleIteratorSparseDomain)
 
   int particlesTouched = 0;
 #ifdef AUTOPAS_OPENMP
-#pragma omp parallel reduction(+: particlesTouched)
+#pragma omp parallel reduction(+ : particlesTouched)
 #endif
   for (auto iterator = vlContainer.getRegionIterator(regionOfInterstMin, regionOfInterstMax); iterator.isValid();
        ++iterator) {

--- a/tests/testAutopas/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/RegionParticleIteratorTest.cpp
@@ -15,7 +15,9 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIterator) {
 
   // add a number of particles
   RandomGenerator::fillWithParticles(lcContainer, TouchableParticle({0., 0., 0.}, 0));
-
+#ifdef AUTOPAS_OPENMP
+#pragma omp parallel
+#endif
   // touch them using the regionIterator
   for (auto iterator = lcContainer.getRegionIterator(_regionMin, _regionMax); iterator.isValid(); ++iterator) {
     iterator->touch();
@@ -35,6 +37,9 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehavior
 
   // touch them using the regionIterator
   auto testRegionMin = ArrayMath::addScalar(_boxMin, -_cutoff * 0.5);
+#ifdef AUTOPAS_OPENMP
+#pragma omp parallel
+#endif
   for (auto iterator = lcContainer.getRegionIterator(testRegionMin, _regionMax, autopas::IteratorBehavior::ownedOnly);
        iterator.isValid(); ++iterator) {
     iterator->touch();
@@ -54,6 +59,9 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehavior
 
   auto testRegionMin = ArrayMath::addScalar(_boxMin, -_cutoff * 0.5);
   // touch them using the regionIterator
+#ifdef AUTOPAS_OPENMP
+#pragma omp parallel
+#endif
   for (auto iterator = lcContainer.getRegionIterator(testRegionMin, _regionMax, autopas::IteratorBehavior::haloOnly);
        iterator.isValid(); ++iterator) {
     iterator->touch();
@@ -79,6 +87,9 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorEmpty) {
   // add no particles
 
   // touch them using the regionIterator
+#ifdef AUTOPAS_OPENMP
+#pragma omp parallel
+#endif
   for (auto iterator = lcContainer.getRegionIterator(_regionMin, _regionMax); iterator.isValid(); ++iterator) {
     iterator->touch();
   }
@@ -185,6 +196,9 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorSparseDo
   std::array<double, 3> regionOfInterstMax = {3, 4, 4};
 
   int particlesTouched = 0;
+#ifdef AUTOPAS_OPENMP
+#pragma omp parallel reduction(+: particlesTouched)
+#endif
   for (auto iterator = lcContainer.getRegionIterator(regionOfInterstMin, regionOfInterstMax); iterator.isValid();
        ++iterator) {
     iterator->touch();
@@ -193,6 +207,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorSparseDo
   EXPECT_EQ(particlesTouched, idShouldTouch);
 
   int particlesChecked = 0;
+  // no openmp for check!
   for (auto iterator = lcContainer.begin(); iterator.isValid(); ++iterator) {
     EXPECT_EQ(utils::inBox(iterator->getR(), regionOfInterstMin, regionOfInterstMax) ? 1 : 0,
               iterator->getNumTouched());
@@ -235,6 +250,9 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorSparseDoma
   std::array<double, 3> regionOfInterstMax = {3, 4, 4};
 
   int particlesTouched = 0;
+#ifdef AUTOPAS_OPENMP
+#pragma omp parallel reduction(+: particlesTouched)
+#endif
   for (auto iterator = dsContainer.getRegionIterator(regionOfInterstMin, regionOfInterstMax); iterator.isValid();
        ++iterator) {
     iterator->touch();
@@ -258,6 +276,9 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIterator) {
   RandomGenerator::fillWithParticles(container, TouchableParticle({0., 0., 0.}, 0));
 
   // touch them using the regionIterator
+#ifdef AUTOPAS_OPENMP
+#pragma omp parallel
+#endif
   for (auto iterator = container.getRegionIterator(_regionMin, _regionMax); iterator.isValid(); ++iterator) {
     iterator->touch();
   }
@@ -285,6 +306,9 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorBehaviorOw
   container.addHaloParticle(part);
 
   // touch them using the regionIterator
+#ifdef AUTOPAS_OPENMP
+#pragma omp parallel
+#endif
   for (auto iterator = container.getRegionIterator(ArrayMath::addScalar(_boxMin, -_cutoff * 0.5), _regionMax,
                                                    autopas::IteratorBehavior::ownedOnly);
        iterator.isValid(); ++iterator) {
@@ -312,6 +336,9 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorBehaviorHa
   container.addHaloParticle(part);
 
   // touch them using the regionIterator
+#ifdef AUTOPAS_OPENMP
+#pragma omp parallel
+#endif
   for (auto iterator = container.getRegionIterator(ArrayMath::addScalar(_boxMin, -_cutoff * 0.5), _regionMax,
                                                    autopas::IteratorBehavior::haloOnly);
        iterator.isValid(); ++iterator) {
@@ -339,6 +366,9 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorEmpty) {
 
   int i = 0;
   // touch them using the regionIterator
+#ifdef AUTOPAS_OPENMP
+#pragma omp parallel reduction(+: i)
+#endif
   for (auto iterator = container.getRegionIterator(_regionMin, _regionMax); iterator.isValid(); ++iterator) {
     iterator->touch();
     i++;
@@ -439,6 +469,9 @@ TEST_F(RegionParticleIteratorTest, testVerletRegionParticleIteratorSparseDomain)
   vlContainer.addParticle(p);
 
   // move stuff
+#ifdef AUTOPAS_OPENMP
+#pragma omp parallel
+#endif
   for (auto pIter = vlContainer.begin(); pIter.isValid(); ++pIter) {
     switch (pIter->getID()) {
       case 0: {
@@ -458,6 +491,9 @@ TEST_F(RegionParticleIteratorTest, testVerletRegionParticleIteratorSparseDomain)
   std::array<double, 3> regionOfInterstMax = {2.5, 2.5, 2.5};
 
   int particlesTouched = 0;
+#ifdef AUTOPAS_OPENMP
+#pragma omp parallel reduction(+: particlesTouched)
+#endif
   for (auto iterator = vlContainer.getRegionIterator(regionOfInterstMin, regionOfInterstMax); iterator.isValid();
        ++iterator) {
     iterator->touch();


### PR DESCRIPTION
# Description

Makes the Tests for the RegionParticleIterator use OpenMP.
Discovered and fixed one bug (See below)

## Related Pull Requests

- #PR

## Resolved Issues # (issue)

- [x] #125 As soon as numthreads > numcells for a specific region, the RegionParticleIterator was always invalid.