### PR TITLE
Smarter sliced

### DIFF
--- a/src/autopas/containers/cellPairTraversals/SlicedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/SlicedTraversal.h
@@ -67,7 +67,7 @@ inline TraversalOptions SlicedTraversal<ParticleCell, PairwiseFunctor, useSoA, u
 
 template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3>
 inline bool SlicedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>::isApplicable() {
-  return this->_cellsPerDimension[_dimsPerLength[0]] / this->_sliceThickness.size() >= 2;
+  return this->_sliceThickness.size() > 0;
 }
 
 template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3>
@@ -83,14 +83,24 @@ inline void SlicedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>::
 
   // split domain across its longest dimension
 
-  auto numSlices = autopas_get_max_threads();
-  // find dimension with most cells
+  auto numSlices = (size_t)autopas_get_max_threads();
+  auto minSliceThickness = this->_cellsPerDimension[_dimsPerLength[0]] / numSlices;
+  if(minSliceThickness < 2) {
+    AutoPasLog(debug, "Sliced travesal only using {} threads because number of cells is too small.", numSlices)
+    minSliceThickness = 2;
+    numSlices = this->_cellsPerDimension[_dimsPerLength[0]] / minSliceThickness;
+  }
+
   _sliceThickness.clear();
-  _sliceThickness.insert(_sliceThickness.begin(), numSlices, this->_cellsPerDimension[_dimsPerLength[0]] / numSlices);
+
+  // abort if domain is too small -> cleared _sliceThickness array indicates non applicability
+  if(numSlices < 1)
+    return;
+
+  _sliceThickness.insert(_sliceThickness.begin(), numSlices, minSliceThickness);
   auto rest = this->_cellsPerDimension[_dimsPerLength[0]] - _sliceThickness[0] * numSlices;
   for (size_t i = 0; i < rest; ++i) ++_sliceThickness[i];
-  // decreases last _sliceThickness by one to account for the way we handle base
-  // cells
+  // decreases last _sliceThickness by one to account for the way we handle base cells
   --*--_sliceThickness.end();
 
   locks.resize(numSlices);
@@ -110,9 +120,8 @@ inline void SlicedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>::
   }
 
 #ifdef AUTOPAS_OPENMP
-// although every thread gets exactly one iteration (=slice) this is faster than
-// a normal parallel region
-#pragma omp parallel for schedule(static, 1)
+// although every thread gets exactly one iteration (=slice) this is faster than a normal parallel region
+#pragma omp parallel for schedule(static, 1) num_threads(numSlices)
 #endif
   for (size_t slice = 0; slice < numSlices; ++slice) {
     array<unsigned long, 3> myStartArray{0, 0, 0};

--- a/src/autopas/containers/cellPairTraversals/SlicedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/SlicedTraversal.h
@@ -86,9 +86,9 @@ inline void SlicedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>::
   auto numSlices = (size_t)autopas_get_max_threads();
   auto minSliceThickness = this->_cellsPerDimension[_dimsPerLength[0]] / numSlices;
   if (minSliceThickness < 2) {
-    AutoPasLog(debug, "Sliced travesal only using {} threads because number of cells is too small.", numSlices)
-        minSliceThickness = 2;
+    minSliceThickness = 2;
     numSlices = this->_cellsPerDimension[_dimsPerLength[0]] / minSliceThickness;
+    AutoPasLog(debug, "Sliced traversal only using {} threads because the number of cells is too small.", numSlices);
   }
 
   _sliceThickness.clear();

--- a/src/autopas/containers/cellPairTraversals/SlicedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/SlicedTraversal.h
@@ -85,17 +85,16 @@ inline void SlicedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>::
 
   auto numSlices = (size_t)autopas_get_max_threads();
   auto minSliceThickness = this->_cellsPerDimension[_dimsPerLength[0]] / numSlices;
-  if(minSliceThickness < 2) {
+  if (minSliceThickness < 2) {
     AutoPasLog(debug, "Sliced travesal only using {} threads because number of cells is too small.", numSlices)
-    minSliceThickness = 2;
+        minSliceThickness = 2;
     numSlices = this->_cellsPerDimension[_dimsPerLength[0]] / minSliceThickness;
   }
 
   _sliceThickness.clear();
 
   // abort if domain is too small -> cleared _sliceThickness array indicates non applicability
-  if(numSlices < 1)
-    return;
+  if (numSlices < 1) return;
 
   _sliceThickness.insert(_sliceThickness.begin(), numSlices, minSliceThickness);
   auto rest = this->_cellsPerDimension[_dimsPerLength[0]] - _sliceThickness[0] * numSlices;

--- a/tests/testAutopas/C08TraversalTest.h
+++ b/tests/testAutopas/C08TraversalTest.h
@@ -8,10 +8,10 @@
 
 #include <gtest/gtest.h>
 #include <testingHelpers/commonTypedefs.h>
+#include "AutoPasTestBase.h"
 #include "autopas/AutoPas.h"
 #include "mocks/MockFunctor.h"
 #include "testingHelpers/GridGenerator.h"
-#include "AutoPasTestBase.h"
 
 #ifdef AUTOPAS_OPENMP
 #include <omp.h>

--- a/tests/testAutopas/C08TraversalTest.h
+++ b/tests/testAutopas/C08TraversalTest.h
@@ -11,14 +11,15 @@
 #include "autopas/AutoPas.h"
 #include "mocks/MockFunctor.h"
 #include "testingHelpers/GridGenerator.h"
+#include "AutoPasTestBase.h"
 
 #ifdef AUTOPAS_OPENMP
 #include <omp.h>
 #endif
 
-class C08TraversalTest : public testing::Test {
+class C08TraversalTest : public AutoPasTestBase {
  public:
   C08TraversalTest() = default;
 
-  ~C08TraversalTest() = default;
+  ~C08TraversalTest() override = default;
 };

--- a/tests/testAutopas/SlicedTraversalTest.h
+++ b/tests/testAutopas/SlicedTraversalTest.h
@@ -7,10 +7,10 @@
 #pragma once
 
 #include <gtest/gtest.h>
+#include "AutoPasTestBase.h"
 #include "autopas/AutoPas.h"
 #include "mocks/MockFunctor.h"
 #include "testingHelpers/commonTypedefs.h"
-#include "AutoPasTestBase.h"
 
 #ifdef AUTOPAS_OPENMP
 #include <omp.h>

--- a/tests/testAutopas/SlicedTraversalTest.h
+++ b/tests/testAutopas/SlicedTraversalTest.h
@@ -10,12 +10,13 @@
 #include "autopas/AutoPas.h"
 #include "mocks/MockFunctor.h"
 #include "testingHelpers/commonTypedefs.h"
+#include "AutoPasTestBase.h"
 
 #ifdef AUTOPAS_OPENMP
 #include <omp.h>
 #endif
 
-class SlicedTraversalTest : public testing::Test {
+class SlicedTraversalTest : public AutoPasTestBase {
  public:
   SlicedTraversalTest() = default;
 


### PR DESCRIPTION
# Description

- [x] Sliced traversal can use fewer threads if the domain is too small. This leads to a wider applicability of this traversal.

## ~Related Pull Requests~

## Resolved Issues # (issue)

- [x] fixes #84 

# How Has This Been Tested?

- [x] testTraversalCubeShrink
- [x] testIsApplicableTooSmall
- [x] testIsApplicableShrinkable
