### PR TITLE
fixes RegionParticleIterator when using a non-default IteratorBehavior

### DIFF
--- a/src/autopas/iterators/RegionParticleIterator.h
+++ b/src/autopas/iterators/RegionParticleIterator.h
@@ -104,11 +104,6 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell> {
 
     for (this->_iteratorAcrossCells += iteratorInc; this->getCurrentCellId() <= *(_indicesInRegion.end() - 1);
          this->_iteratorAcrossCells += iteratorInc) {
-      //#pragma omp critical
-      //      std::cout << "Thread [" << autopas_get_thread_num() << "] currentCellIndex= " <<
-      //      (this->getCurrentCellId())
-      //      << " currentRegionIndex= " << _currentRegionIndex
-      //      << " iteratorInc= " << iteratorInc << std::endl;
       _currentRegionIndex += stride;
 
       if (this->_iteratorAcrossCells < this->_vectorOfCells->end() and this->_iteratorAcrossCells->isNotEmpty() and

--- a/src/autopas/iterators/RegionParticleIterator.h
+++ b/src/autopas/iterators/RegionParticleIterator.h
@@ -59,7 +59,7 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell> {
     // not valid
     if (ParticleIterator<Particle, ParticleCell>::isValid()) {  // if there is NO particle, we can not dereference
                                                                 // it, so we need a check.
-      if (utils::notInBox(this->operator*().getR(), _startRegion, _endRegion)) {
+      if (utils::notInBox(this->operator*().getR(), _startRegion, _endRegion) or not this->isCellTypeBehaviorCorrect()) {
         operator++();
       }
     } else if (this->_iteratorAcrossCells != cont->end()) {

--- a/src/autopas/iterators/RegionParticleIterator.h
+++ b/src/autopas/iterators/RegionParticleIterator.h
@@ -56,9 +56,6 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell> {
     this->_behavior = behavior;
 
     if (not this->isCellTypeBehaviorCorrect()) {
-      if (omp_get_thread_num() == 32) {
-        std::cout << "next_non_empty_cell at constructor" << std::endl;
-      }
       this->next_non_empty_cell();
     }
 

--- a/src/autopas/iterators/RegionParticleIterator.h
+++ b/src/autopas/iterators/RegionParticleIterator.h
@@ -103,6 +103,8 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell> {
     // find the next non-empty cell
     const int stride = autopas_get_num_threads();  // num threads
     if (_currentRegionIndex + stride >= _indicesInRegion.size()) {
+      // make the iterator invalid!
+      this->_iteratorAcrossCells = this->_vectorOfCells->end();
       return;
     }
     size_t iteratorInc = _indicesInRegion[_currentRegionIndex + stride] - _indicesInRegion[_currentRegionIndex];

--- a/tests/testAutopas/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/RegionParticleIteratorTest.cpp
@@ -26,7 +26,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIterator) {
   checkTouches(lcContainer, _regionMin, _regionMax);
 }
 
-void RegionParticleIteratorTest::testLinkedCellsRegionParticleIteratorBehaviorOwned(){
+void RegionParticleIteratorTest::testLinkedCellsRegionParticleIteratorBehaviorOwned() {
   LinkedCells<TouchableParticle, FullParticleCell<TouchableParticle>> lcContainer(_boxMin, _boxMax, _cutoff);
 
   // add a number of particles
@@ -86,7 +86,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehavior
 }
 #endif
 
-void RegionParticleIteratorTest::testLinkedCellsRegionParticleIteratorBehaviorHalo(){
+void RegionParticleIteratorTest::testLinkedCellsRegionParticleIteratorBehaviorHalo() {
   LinkedCells<TouchableParticle, FullParticleCell<TouchableParticle>> lcContainer(_boxMin, _boxMax, _cutoff);
 
   // add a number of particles
@@ -104,10 +104,10 @@ void RegionParticleIteratorTest::testLinkedCellsRegionParticleIteratorBehaviorHa
        iterator.isValid(); ++iterator) {
     iterator->touch();
     EXPECT_TRUE(utils::inBox(iterator->getR(), testRegionMin, _regionMax)
-                ? (utils::inBox(iterator->getR(), _boxMin, _boxMax) ? 0 : 1)
-                : 0)
-              << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
-              << " in thread: " << autopas_get_thread_num() << std::endl;
+                    ? (utils::inBox(iterator->getR(), _boxMin, _boxMax) ? 0 : 1)
+                    : 0)
+        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
+        << " in thread: " << autopas_get_thread_num() << std::endl;
   }
 
   // check the touch using the normal iterator
@@ -115,11 +115,11 @@ void RegionParticleIteratorTest::testLinkedCellsRegionParticleIteratorBehaviorHa
     // this is a test for halo only! so we first check whether it's within our region of interest and then whether it's
     // not in the halo
     EXPECT_EQ(utils::inBox(iterator->getR(), testRegionMin, _regionMax)
-              ? (utils::inBox(iterator->getR(), _boxMin, _boxMax) ? 0 : 1)
-              : 0,
+                  ? (utils::inBox(iterator->getR(), _boxMin, _boxMax) ? 0 : 1)
+                  : 0,
               iterator->getNumTouched())
-              << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
-              << std::endl;
+        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
+        << std::endl;
   }
 }
 

--- a/tests/testAutopas/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/RegionParticleIteratorTest.cpp
@@ -3,11 +3,8 @@
  * @author seckler
  * @date 03.04.18
  */
-#ifdef AUTOPAS_OPENMP
-#include <omp.h>
-#endif
-
 #include "RegionParticleIteratorTest.h"
+#include "autopas/utils/WrapOpenMP.h"
 
 using namespace autopas;
 
@@ -72,10 +69,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehavior
                     ? (utils::inBox(iterator->getR(), _boxMin, _boxMax) ? 0 : 1)
                     : 0)
         << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
-#ifdef AUTOPAS_OPENMP
-        << " in thread: " << omp_get_thread_num()
-#endif
-        << std::endl;
+        << " in thread: " << autopas_get_thread_num() << std::endl;
   }
 
   // check the touch using the normal iterator

--- a/tests/testAutopas/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/RegionParticleIteratorTest.cpp
@@ -48,7 +48,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehavior
   checkTouches(lcContainer, testRegionMin, _regionMax);
 }
 
-TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehaviorHalo) {
+void RegionParticleIteratorTest::testLinkedCellsRegionParticleIteratorBehaviorHalo(){
   LinkedCells<TouchableParticle, FullParticleCell<TouchableParticle>> lcContainer(_boxMin, _boxMax, _cutoff);
 
   // add a number of particles
@@ -66,10 +66,10 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehavior
        iterator.isValid(); ++iterator) {
     iterator->touch();
     EXPECT_TRUE(utils::inBox(iterator->getR(), testRegionMin, _regionMax)
-                    ? (utils::inBox(iterator->getR(), _boxMin, _boxMax) ? 0 : 1)
-                    : 0)
-        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
-        << " in thread: " << autopas_get_thread_num() << std::endl;
+                ? (utils::inBox(iterator->getR(), _boxMin, _boxMax) ? 0 : 1)
+                : 0)
+              << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
+              << " in thread: " << autopas_get_thread_num() << std::endl;
   }
 
   // check the touch using the normal iterator
@@ -77,13 +77,33 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehavior
     // this is a test for halo only! so we first check whether it's within our region of interest and then whether it's
     // not in the halo
     EXPECT_EQ(utils::inBox(iterator->getR(), testRegionMin, _regionMax)
-                  ? (utils::inBox(iterator->getR(), _boxMin, _boxMax) ? 0 : 1)
-                  : 0,
+              ? (utils::inBox(iterator->getR(), _boxMin, _boxMax) ? 0 : 1)
+              : 0,
               iterator->getNumTouched())
-        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
-        << std::endl;
+              << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
+              << std::endl;
   }
 }
+
+TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehaviorHalo) {
+  testLinkedCellsRegionParticleIteratorBehaviorHalo();
+}
+
+#ifdef AUTOPAS_OPENMP
+TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehaviorHalo32Threads) {
+  omp_set_num_threads(32);
+  testLinkedCellsRegionParticleIteratorBehaviorHalo();
+}
+
+TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehaviorHalo50Threads) {
+  omp_set_num_threads(50);
+  testLinkedCellsRegionParticleIteratorBehaviorHalo();
+}
+TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehaviorHalo240Threads) {
+  omp_set_num_threads(240);
+  testLinkedCellsRegionParticleIteratorBehaviorHalo();
+}
+#endif
 
 TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorEmpty) {
   LinkedCells<TouchableParticle, FullParticleCell<TouchableParticle>> lcContainer(_boxMin, _boxMax, _cutoff);

--- a/tests/testAutopas/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/RegionParticleIteratorTest.cpp
@@ -26,7 +26,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIterator) {
   checkTouches(lcContainer, _regionMin, _regionMax);
 }
 
-TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehaviorOwned) {
+void RegionParticleIteratorTest::testLinkedCellsRegionParticleIteratorBehaviorOwned(){
   LinkedCells<TouchableParticle, FullParticleCell<TouchableParticle>> lcContainer(_boxMin, _boxMax, _cutoff);
 
   // add a number of particles
@@ -47,6 +47,43 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehavior
 
   checkTouches(lcContainer, testRegionMin, _regionMax);
 }
+
+TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehaviorOwned1Thread) {
+#ifdef AUTOPAS_OPENMP
+  int before = omp_get_max_threads();
+  omp_set_num_threads(1);
+#endif
+  testLinkedCellsRegionParticleIteratorBehaviorOwned();
+#ifdef AUTOPAS_OPENMP
+  omp_set_num_threads(before);
+#endif
+}
+#ifdef AUTOPAS_OPENMP
+TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehaviorOwned16Thread) {
+  int before = omp_get_max_threads();
+  omp_set_num_threads(16);
+  testLinkedCellsRegionParticleIteratorBehaviorOwned();
+  omp_set_num_threads(before);
+}
+TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehaviorOwned32Thread) {
+  int before = omp_get_max_threads();
+  omp_set_num_threads(32);
+  testLinkedCellsRegionParticleIteratorBehaviorOwned();
+  omp_set_num_threads(before);
+}
+TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehaviorOwned50Thread) {
+  int before = omp_get_max_threads();
+  omp_set_num_threads(50);
+  testLinkedCellsRegionParticleIteratorBehaviorOwned();
+  omp_set_num_threads(before);
+}
+TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehaviorOwned240Thread) {
+  int before = omp_get_max_threads();
+  omp_set_num_threads(240);
+  testLinkedCellsRegionParticleIteratorBehaviorOwned();
+  omp_set_num_threads(before);
+}
+#endif
 
 void RegionParticleIteratorTest::testLinkedCellsRegionParticleIteratorBehaviorHalo(){
   LinkedCells<TouchableParticle, FullParticleCell<TouchableParticle>> lcContainer(_boxMin, _boxMax, _cutoff);
@@ -85,23 +122,43 @@ void RegionParticleIteratorTest::testLinkedCellsRegionParticleIteratorBehaviorHa
   }
 }
 
-TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehaviorHalo) {
+TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehaviorHalo1Thread) {
+#ifdef AUTOPAS_OPENMP
+  int before = omp_get_max_threads();
+  omp_set_num_threads(1);
+#endif
   testLinkedCellsRegionParticleIteratorBehaviorHalo();
+#ifdef AUTOPAS_OPENMP
+  omp_set_num_threads(before);
+#endif
 }
 
 #ifdef AUTOPAS_OPENMP
+TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehaviorHalo16Threads) {
+  int before = omp_get_max_threads();
+  omp_set_num_threads(16);
+  testLinkedCellsRegionParticleIteratorBehaviorHalo();
+  omp_set_num_threads(before);
+}
+
 TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehaviorHalo32Threads) {
+  int before = omp_get_max_threads();
   omp_set_num_threads(32);
   testLinkedCellsRegionParticleIteratorBehaviorHalo();
+  omp_set_num_threads(before);
 }
 
 TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehaviorHalo50Threads) {
+  int before = omp_get_max_threads();
   omp_set_num_threads(50);
   testLinkedCellsRegionParticleIteratorBehaviorHalo();
+  omp_set_num_threads(before);
 }
 TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehaviorHalo240Threads) {
+  int before = omp_get_max_threads();
   omp_set_num_threads(240);
   testLinkedCellsRegionParticleIteratorBehaviorHalo();
+  omp_set_num_threads(before);
 }
 #endif
 

--- a/tests/testAutopas/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/RegionParticleIteratorTest.cpp
@@ -69,15 +69,14 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehavior
 
   // check the touch using the normal iterator
   for (auto iterator = lcContainer.begin(); iterator.isValid(); ++iterator) {
-    //  std::cout << "id: " << iterator->getID() << " at [" <<
-    //  iterator->getR()[0]
-    //         << ", " << iterator->getR()[1] << ", " << iterator->getR()[2]
-    //              << "] touched:" << iterator->getNumTouched() << std::endl;
-
+    // this is a test for halo only! so we first check whether it's within our region of interest and then whether it's
+    // not in the halo
     EXPECT_EQ(utils::inBox(iterator->getR(), testRegionMin, _regionMax)
-                  ? (utils::inBox(iterator->getR(), _boxMin, _regionMax) ? 0 : 1)
+                  ? (utils::inBox(iterator->getR(), _boxMin, _boxMax) ? 0 : 1)
                   : 0,
-              iterator->getNumTouched());
+              iterator->getNumTouched())
+        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
+        << std::endl;
   }
 }
 
@@ -122,7 +121,9 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorCopyCons
     //         << ", " << iterator->getR()[1] << ", " << iterator->getR()[2]
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
-    EXPECT_EQ(utils::inBox(iterator->getR(), _regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched());
+    EXPECT_EQ(utils::inBox(iterator->getR(), _regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched())
+        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
+        << std::endl;
   }
 }
 
@@ -157,7 +158,9 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorCopyAssi
     //         << ", " << iterator->getR()[1] << ", " << iterator->getR()[2]
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
-    EXPECT_EQ(utils::inBox(iterator->getR(), _regionMin, _regionMax) ? 3 : 0, iterator->getNumTouched());
+    EXPECT_EQ(utils::inBox(iterator->getR(), _regionMin, _regionMax) ? 3 : 0, iterator->getNumTouched())
+        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
+        << std::endl;
   }
 }
 
@@ -209,8 +212,9 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorSparseDo
   int particlesChecked = 0;
   // no openmp for check!
   for (auto iterator = lcContainer.begin(); iterator.isValid(); ++iterator) {
-    EXPECT_EQ(utils::inBox(iterator->getR(), regionOfInterstMin, regionOfInterstMax) ? 1 : 0,
-              iterator->getNumTouched());
+    EXPECT_EQ(utils::inBox(iterator->getR(), regionOfInterstMin, regionOfInterstMax) ? 1 : 0, iterator->getNumTouched())
+        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
+        << std::endl;
     ++particlesChecked;
   }
   EXPECT_EQ(particlesChecked, idShouldTouch + idShouldNotTouch - idOffset);
@@ -262,8 +266,9 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorSparseDoma
 
   int particlesChecked = 0;
   for (auto iterator = dsContainer.begin(); iterator.isValid(); ++iterator) {
-    EXPECT_EQ(utils::inBox(iterator->getR(), regionOfInterstMin, regionOfInterstMax) ? 1 : 0,
-              iterator->getNumTouched());
+    EXPECT_EQ(utils::inBox(iterator->getR(), regionOfInterstMin, regionOfInterstMax) ? 1 : 0, iterator->getNumTouched())
+        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
+        << std::endl;
     ++particlesChecked;
   }
   EXPECT_EQ(particlesChecked, idShouldTouch + idShouldNotTouch - idOffset);
@@ -322,7 +327,9 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorBehaviorOw
     //         << ", " << iterator->getR()[1] << ", " << iterator->getR()[2]
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
-    EXPECT_EQ(utils::inBox(iterator->getR(), _boxMin, _regionMax) ? 1 : 0, iterator->getNumTouched());
+    EXPECT_EQ(utils::inBox(iterator->getR(), _boxMin, _regionMax) ? 1 : 0, iterator->getNumTouched())
+        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
+        << std::endl;
   }
 }
 
@@ -355,7 +362,9 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorBehaviorHa
     EXPECT_EQ(utils::inBox(iterator->getR(), ArrayMath::addScalar(_boxMin, -_cutoff * 0.5), _regionMax)
                   ? (utils::inBox(iterator->getR(), _boxMin, _regionMax) ? 0 : 1)
                   : 0,
-              iterator->getNumTouched());
+              iterator->getNumTouched())
+        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
+        << std::endl;
   }
 }
 
@@ -381,7 +390,9 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorEmpty) {
     //         << ", " << iterator->getR()[1] << ", " << iterator->getR()[2]
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
-    EXPECT_EQ(utils::inBox(iterator->getR(), _regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched());
+    EXPECT_EQ(utils::inBox(iterator->getR(), _regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched())
+        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
+        << std::endl;
     i++;
   }
   EXPECT_EQ(i, 0);
@@ -408,7 +419,9 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorCopyConstr
     //         << ", " << iterator->getR()[1] << ", " << iterator->getR()[2]
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
-    EXPECT_EQ(utils::inBox(iterator->getR(), _regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched());
+    EXPECT_EQ(utils::inBox(iterator->getR(), _regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched())
+        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
+        << std::endl;
   }
 }
 
@@ -443,7 +456,9 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorCopyAssign
     //         << ", " << iterator->getR()[1] << ", " << iterator->getR()[2]
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
-    EXPECT_EQ(utils::inBox(iterator->getR(), _regionMin, _regionMax) ? 3 : 0, iterator->getNumTouched());
+    EXPECT_EQ(utils::inBox(iterator->getR(), _regionMin, _regionMax) ? 3 : 0, iterator->getNumTouched())
+        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
+        << std::endl;
   }
 }
 
@@ -503,8 +518,9 @@ TEST_F(RegionParticleIteratorTest, testVerletRegionParticleIteratorSparseDomain)
 
   int particlesChecked = 0;
   for (auto iterator = vlContainer.begin(); iterator.isValid(); ++iterator) {
-    EXPECT_EQ(utils::inBox(iterator->getR(), regionOfInterstMin, regionOfInterstMax) ? 1 : 0,
-              iterator->getNumTouched());
+    EXPECT_EQ(utils::inBox(iterator->getR(), regionOfInterstMin, regionOfInterstMax) ? 1 : 0, iterator->getNumTouched())
+        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
+        << std::endl;
     ++particlesChecked;
   }
   EXPECT_EQ(particlesChecked, idShouldTouch + idShouldNotTouch - idOffset);

--- a/tests/testAutopas/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/RegionParticleIteratorTest.cpp
@@ -65,6 +65,11 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehavior
   for (auto iterator = lcContainer.getRegionIterator(testRegionMin, _regionMax, autopas::IteratorBehavior::haloOnly);
        iterator.isValid(); ++iterator) {
     iterator->touch();
+    EXPECT_TRUE(utils::inBox(iterator->getR(), testRegionMin, _regionMax)
+              ? (utils::inBox(iterator->getR(), _boxMin, _boxMax) ? 0 : 1)
+              : 0)
+              << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
+              << std::endl;
   }
 
   // check the touch using the normal iterator

--- a/tests/testAutopas/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/RegionParticleIteratorTest.cpp
@@ -3,6 +3,9 @@
  * @author seckler
  * @date 03.04.18
  */
+#ifdef AUTOPAS_OPENMP
+#include <omp.h>
+#endif
 
 #include "RegionParticleIteratorTest.h"
 
@@ -66,10 +69,13 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehavior
        iterator.isValid(); ++iterator) {
     iterator->touch();
     EXPECT_TRUE(utils::inBox(iterator->getR(), testRegionMin, _regionMax)
-              ? (utils::inBox(iterator->getR(), _boxMin, _boxMax) ? 0 : 1)
-              : 0)
-              << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
-              << std::endl;
+                    ? (utils::inBox(iterator->getR(), _boxMin, _boxMax) ? 0 : 1)
+                    : 0)
+        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
+#ifdef AUTOPAS_OPENMP
+        << " in thread: " << omp_get_thread_num()
+#endif
+        << std::endl;
   }
 
   // check the touch using the normal iterator

--- a/tests/testAutopas/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/RegionParticleIteratorTest.cpp
@@ -103,21 +103,20 @@ void RegionParticleIteratorTest::testLinkedCellsRegionParticleIteratorBehaviorHa
   for (auto iterator = lcContainer.getRegionIterator(testRegionMin, _regionMax, autopas::IteratorBehavior::haloOnly);
        iterator.isValid(); ++iterator) {
     iterator->touch();
-    EXPECT_TRUE(utils::inBox(iterator->getR(), testRegionMin, _regionMax)
-                    ? (utils::inBox(iterator->getR(), _boxMin, _boxMax) ? 0 : 1)
-                    : 0)
+    bool isInRegionOfInterest = utils::inBox(iterator->getR(), testRegionMin, _regionMax);
+    bool isInHalo = not utils::inBox(iterator->getR(), _boxMin, _boxMax);
+    EXPECT_TRUE(isInRegionOfInterest and isInHalo)
         << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
         << " in thread: " << autopas_get_thread_num() << std::endl;
   }
 
-  // check the touch using the normal iterator
+  // check the touch using the normal iterator (needed to check whether no particle was forgotten)
   for (auto iterator = lcContainer.begin(); iterator.isValid(); ++iterator) {
     // this is a test for halo only! so we first check whether it's within our region of interest and then whether it's
     // not in the halo
-    EXPECT_EQ(utils::inBox(iterator->getR(), testRegionMin, _regionMax)
-                  ? (utils::inBox(iterator->getR(), _boxMin, _boxMax) ? 0 : 1)
-                  : 0,
-              iterator->getNumTouched())
+    bool isInRegionOfInterest = utils::inBox(iterator->getR(), testRegionMin, _regionMax);
+    bool isInHalo = not utils::inBox(iterator->getR(), _boxMin, _boxMax);
+    EXPECT_EQ(isInRegionOfInterest and isInHalo ? 1 : 0, iterator->getNumTouched())
         << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
         << std::endl;
   }

--- a/tests/testAutopas/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/RegionParticleIteratorTest.cpp
@@ -44,8 +44,9 @@ void RegionParticleIteratorTest::testLinkedCellsRegionParticleIteratorBehaviorOw
        iterator.isValid(); ++iterator) {
     iterator->touch();
   }
-
-  checkTouches(lcContainer, testRegionMin, _regionMax);
+  // owned cells only start at [0, 0, 0]!
+  std::array<double, 3> realMin = {0, 0, 0};
+  checkTouches(lcContainer, realMin, _regionMax);
 }
 
 TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehaviorOwned1Thread) {

--- a/tests/testAutopas/RegionParticleIteratorTest.h
+++ b/tests/testAutopas/RegionParticleIteratorTest.h
@@ -45,7 +45,6 @@ class RegionParticleIteratorTest : public AutoPasTestBase {
   void checkTouches(LCTouch &lcContainer, std::array<double, 3> &regionMin, std::array<double, 3> &regionMax);
 
  protected:
-
   void testLinkedCellsRegionParticleIteratorBehaviorOwned();
 
   void testLinkedCellsRegionParticleIteratorBehaviorHalo();

--- a/tests/testAutopas/RegionParticleIteratorTest.h
+++ b/tests/testAutopas/RegionParticleIteratorTest.h
@@ -46,6 +46,8 @@ class RegionParticleIteratorTest : public AutoPasTestBase {
 
  protected:
 
+  void testLinkedCellsRegionParticleIteratorBehaviorOwned();
+
   void testLinkedCellsRegionParticleIteratorBehaviorHalo();
 
   // needs to be protected, because the test fixtures generate a derived class

--- a/tests/testAutopas/RegionParticleIteratorTest.h
+++ b/tests/testAutopas/RegionParticleIteratorTest.h
@@ -45,6 +45,9 @@ class RegionParticleIteratorTest : public AutoPasTestBase {
   void checkTouches(LCTouch &lcContainer, std::array<double, 3> &regionMin, std::array<double, 3> &regionMax);
 
  protected:
+
+  void testLinkedCellsRegionParticleIteratorBehaviorHalo();
+
   // needs to be protected, because the test fixtures generate a derived class
   // for each unit test.
 


### PR DESCRIPTION
# Description
Fixes RegionParticleIterators pointing to wrong cells, when iterating over halo or own cells using IteratorBehavior::haloOnly or IteratorBehavior::ownedOnly.

## Resolved Issues # (issue)
- [x] fixes #142 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Adds multiple additional tests for Linked Cells using different, but fixed numbers of threads (1, 16, 32, 50, 200)
