### PR TITLE
Make autopas use a proper lock class

### DIFF
--- a/src/autopas/cells/FullParticleCell.h
+++ b/src/autopas/cells/FullParticleCell.h
@@ -21,46 +21,10 @@ namespace autopas {
 template <class Particle, class SoAArraysType = typename Particle::SoAArraysType>
 class FullParticleCell : public ParticleCell<Particle> {
  public:
-  FullParticleCell() { autopas_init_lock(&particlesLock); }
-
-  ~FullParticleCell() { autopas_destroy_lock(&particlesLock); }
-
-  /**
-   * Move Constructor
-   * @param other
-   */
-  FullParticleCell(FullParticleCell&& other) {
-    _particles = std::move(other._particles);
-    _particleSoABuffer = std::move(other._particleSoABuffer);
-    autopas_init_lock(&particlesLock);
-  }
-
-  /**
-   * Copy constructor
-   * @param other
-   */
-  FullParticleCell(const FullParticleCell& other) {
-    _particles = other._particles;
-    _particleSoABuffer = other._particleSoABuffer;
-    autopas_init_lock(&particlesLock);
-  }
-
-  /**
-   * Assignment operator
-   * @param other
-   * @return reference to this object after copy
-   */
-  FullParticleCell& operator=(FullParticleCell& other) {
-    _particles = other._particles;
-    _particleSoABuffer = other._particleSoABuffer;
-    autopas_init_lock(&particlesLock);
-    return *this;
-  }
-
   void addParticle(Particle& m) override {
-    autopas_set_lock(&particlesLock);
+    particlesLock.lock();
     _particles.push_back(m);
-    autopas_unset_lock(&particlesLock);
+    particlesLock.unlock();
   }
 
   virtual SingleCellIteratorWrapper<Particle> begin() override {
@@ -81,14 +45,14 @@ class FullParticleCell : public ParticleCell<Particle> {
   void clear() override { _particles.clear(); }
 
   void deleteByIndex(size_t index) override {
-    autopas_set_lock(&particlesLock);
+    particlesLock.lock();
     assert(index < numParticles());
 
     if (index < numParticles() - 1) {
       std::swap(_particles[index], _particles[numParticles() - 1]);
     }
     _particles.pop_back();
-    autopas_unset_lock(&particlesLock);
+    particlesLock.unlock();
   }
 
   /**
@@ -128,6 +92,6 @@ class FullParticleCell : public ParticleCell<Particle> {
   typedef internal::SingleCellIterator<Particle, FullParticleCell<Particle, SoAArraysType>> iterator_t;
 
  private:
-  autopas_lock_t particlesLock;
+  AutoPasLock particlesLock;
 };
 }  // namespace autopas

--- a/src/autopas/utils/WrapOpenMP.h
+++ b/src/autopas/utils/WrapOpenMP.h
@@ -116,24 +116,24 @@ inline int autopas_get_num_threads() { return 1; }
 inline int autopas_get_max_threads() { return 1; }
 
 /**
- * AutoPasLock for the sequential case, that uses an enum for checking the base functionality.
+ * AutoPasLock for the sequential case.
  */
 class AutoPasLock {
  public:
   /**
    * Default constructor
    */
-  AutoPasLock() { _lock = unlocked; }
+  AutoPasLock() { _locked = false; }
 
   /**
    * Move Constructor
    */
-  AutoPasLock(AutoPasLock&&) noexcept { _lock = unlocked; }
+  AutoPasLock(AutoPasLock&&) noexcept { _locked = false; }
 
   /**
    * Copy constructor
    */
-  AutoPasLock(AutoPasLock&) { _lock = unlocked; }
+  AutoPasLock(AutoPasLock&) { _locked = false; }
 
   /**
    * Assignment operator
@@ -144,27 +144,27 @@ class AutoPasLock {
   /**
    * Destructor
    */
-  ~AutoPasLock() { assert(_lock == unlocked); }
+  ~AutoPasLock() { assert(not _locked); }
 
   /**
    * Acquire the lock.
    */
   void lock() {
-    assert(_lock == unlocked);
-    _lock = locked;
+    assert(not _locked);
+    _locked = true;
   }
 
   /**
    * Release the lock.
    */
   void unlock() {
-    assert(_lock == locked);
-    _lock = unlocked;
+    assert(_locked);
+    _locked = false;
   }
 
  private:
-  // lock: 0 means unlocked, 1 locked.
-  enum { unlocked, locked } _lock;
+  // true if locked, false if unlocked
+  bool _locked;
 };
 
 #endif

--- a/src/autopas/utils/WrapOpenMP.h
+++ b/src/autopas/utils/WrapOpenMP.h
@@ -19,6 +19,8 @@
 #include <cassert>
 #if defined(AUTOPAS_OPENMP)
 #include <omp.h>
+#else
+#include "ExceptionHandler.h"
 #endif
 
 namespace autopas {
@@ -144,13 +146,19 @@ class AutoPasLock {
   /**
    * Destructor
    */
-  ~AutoPasLock() { assert(not _locked); }
+  ~AutoPasLock() {
+    if (_locked) {
+      utils::ExceptionHandler::exception("AutoPasLocked destroyed in locked state.");
+    }
+  }
 
   /**
    * Acquire the lock.
    */
   void lock() {
-    assert(not _locked);
+    if (_locked) {
+      utils::ExceptionHandler::exception("Tried to acquire a locked lock.");
+    }
     _locked = true;
   }
 
@@ -158,7 +166,9 @@ class AutoPasLock {
    * Release the lock.
    */
   void unlock() {
-    assert(_locked);
+    if (not _locked) {
+      utils::ExceptionHandler::exception("Tried to release an unlocked lock.");
+    }
     _locked = false;
   }
 

--- a/src/autopas/utils/WrapOpenMP.h
+++ b/src/autopas/utils/WrapOpenMP.h
@@ -56,16 +56,12 @@ class AutoPasLock {
   /**
    * Move Constructor
    */
-  AutoPasLock(AutoPasLock&&) noexcept {
-    omp_init_lock(&_lock);
-  }
+  AutoPasLock(AutoPasLock&&) noexcept { omp_init_lock(&_lock); }
 
   /**
    * Copy constructor
    */
-  AutoPasLock(const AutoPasLock&) {
-    omp_init_lock(&_lock);
-  }
+  AutoPasLock(const AutoPasLock&) { omp_init_lock(&_lock); }
 
   /**
    * Assignment operator
@@ -132,16 +128,12 @@ class AutoPasLock {
   /**
    * Move Constructor
    */
-  AutoPasLock(AutoPasLock&&) noexcept {
-    _lock = unlocked;
-  }
+  AutoPasLock(AutoPasLock&&) noexcept { _lock = unlocked; }
 
   /**
    * Copy constructor
    */
-  AutoPasLock(AutoPasLock&) {
-    _lock = unlocked;
-  }
+  AutoPasLock(AutoPasLock&) { _lock = unlocked; }
 
   /**
    * Assignment operator
@@ -152,9 +144,7 @@ class AutoPasLock {
   /**
    * Destructor
    */
-  ~AutoPasLock() {
-    assert(_lock == unlocked);
-  }
+  ~AutoPasLock() { assert(_lock == unlocked); }
 
   /**
    * Acquire the lock.
@@ -174,7 +164,7 @@ class AutoPasLock {
 
  private:
   // lock: 0 means unlocked, 1 locked.
-  enum {unlocked, locked} _lock;
+  enum { unlocked, locked } _lock;
 };
 
 #endif


### PR DESCRIPTION
# Description

Replaces autopas_lock_t (wrapper for omp_lock_t if AutoPas is compiled with OpenMP // to some dummy lock if AutoPas is compiled without OpenMP) with a proper lock class.
This makes copying of objects that have a lock straightforward and is no longer a possible problem.

## Resolved Issues # (issue)

- [x] fixes #132