### PR TITLE
Enable and test rebuilding of AutoPas

### DIFF
--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -51,6 +51,7 @@ class AutoPas {
   /**
    * Move assignment operator
    * @param other
+   * @return
    */
   AutoPas &operator=(AutoPas &&other) noexcept {
     _autoTuner = std::move(other._autoTuner);

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -13,7 +13,9 @@
 
 namespace autopas {
 
-/// instance counter to help track the number of autopas instances. Needed for correct management of the logger.
+/**
+ * instance counter to help track the number of autopas instances. Needed for correct management of the logger.
+ */
 static unsigned int _instanceCounter = 0;
 
 /**

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
@@ -64,14 +64,14 @@ class VerletListHelpers {
     }
 
     /**
-     * SoAFunctor for verlet list generation. (two cell version)
+     * SoAFunctor for verlet list generation. (single cell version)
      * @param soa the soa
      * @param newton3 whether to use newton 3
      */
     void SoAFunctor(SoA<SoAArraysType> &soa, bool newton3) override {
       if (soa.getNumParticles() == 0) return;
 
-      Particle **const __restrict__ idptr = reinterpret_cast<Particle **const>(soa.begin<AttributeNames::id>());
+      auto **const __restrict__ idptr = reinterpret_cast<Particle **const>(soa.begin<AttributeNames::id>());
       double *const __restrict__ xptr = soa.begin<AttributeNames::posX>();
       double *const __restrict__ yptr = soa.begin<AttributeNames::posY>();
       double *const __restrict__ zptr = soa.begin<AttributeNames::posZ>();
@@ -102,19 +102,19 @@ class VerletListHelpers {
     }
 
     /**
-     * SoAfunctor for the verlet list generation. (two cell version)
+     * SoAFunctor for the verlet list generation. (two cell version)
      * @param soa1 soa of first cell
      * @param soa2 soa of second cell
      */
     void SoAFunctor(SoA<SoAArraysType> &soa1, SoA<SoAArraysType> &soa2, bool /*newton3*/) override {
       if (soa1.getNumParticles() == 0 || soa2.getNumParticles() == 0) return;
 
-      Particle **const __restrict__ id1ptr = reinterpret_cast<Particle **const>(soa1.begin<AttributeNames::id>());
+      auto **const __restrict__ id1ptr = reinterpret_cast<Particle **const>(soa1.begin<AttributeNames::id>());
       double *const __restrict__ x1ptr = soa1.begin<AttributeNames::posX>();
       double *const __restrict__ y1ptr = soa1.begin<AttributeNames::posY>();
       double *const __restrict__ z1ptr = soa1.begin<AttributeNames::posZ>();
 
-      Particle **const __restrict__ id2ptr = reinterpret_cast<Particle **const>(soa2.begin<AttributeNames::id>());
+      auto **const __restrict__ id2ptr = reinterpret_cast<Particle **const>(soa2.begin<AttributeNames::id>());
       double *const __restrict__ x2ptr = soa2.begin<AttributeNames::posX>();
       double *const __restrict__ y2ptr = soa2.begin<AttributeNames::posY>();
       double *const __restrict__ z2ptr = soa2.begin<AttributeNames::posZ>();

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -196,7 +196,7 @@ class VerletLists
     updateIdMapAoS();
     typename verlet_internal::VerletListGeneratorFunctor f(_aosNeighborLists, this->getCutoff());
 
-    // @todo autotune traversal
+    /// @todo autotune traversal
     switch (_buildVerletListType) {
       case BuildVerletListType::VerletAoS: {
         auto traversal =

--- a/tests/testAutopas/tests/autopasInterface/AutoPasTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasTest.cpp
@@ -17,3 +17,29 @@ TEST_F(AutoPasTest, getRegionParticleIterator) {
     iter->setR(iter->getR());
   }
 }
+
+/**
+ * Check whether an AutoPas object can be rebuild using
+ */
+TEST_F(AutoPasTest, checkRebuilding) {
+
+  autoPas.addParticle();
+  // ensure some particles
+
+
+  {
+    decltype(autoPas) autoPasTmp;
+    autoPasTmp.init({0., 0., 0.}, {10., 10., 10.}, 1., 0, 1, {autopas::ContainerOptions::linkedCells},
+                    {autopas::TraversalOptions::c08});
+    // ensure no particles
+
+
+    // copy particles
+
+
+    // move objects
+    autoPas = std::move(autoPasTmp);
+  }
+
+  // ensure same particles as before
+}


### PR DESCRIPTION
# Description
Allows for AutoPas to somehow cope with changing MPI domains.

## Resolved Issues # (issue)

- [x] fixes #156 

# How Has This Been Tested?

Two strategies are supported and tested:

1.  
```
0. create normal AutoPas container + initialize and fill with particles
1. create additional AutoPas container + initialize
2. fill additional AutoPas container with particles
3. std::move the new container over the old one.
```
```C++
    // 0. normal container
    autopas::AutoPas<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> autoPas;
    autoPas.init({0., 0., 0.}, {10., 10., 10.}, 1., 0, 1, {autopas::ContainerOptions::linkedCells},
                 {autopas::TraversalOptions::c08});

    // 1. create new AutoPas container + initialize
    decltype(autoPas) autoPasTmp;
    autoPasTmp.init({0., 0., 0.}, {5., 5., 5.}, 1., 0, 1, {autopas::ContainerOptions::linkedCells},
                    {autopas::TraversalOptions::c08});

    // 2. copy particles
    for (auto iter = autoPas.begin(); iter.isValid(); ++iter) {
      autoPasTmp.addParticle(*iter);
    }

    // 3. move new container over old one. will loose information of the old one.
    autoPas = std::move(autoPasTmp);
```

2.
```
0. create normal AutoPas container + initialize and fill with particles
1. copy particles out of first container
2. recreate container by calling constructor + initialize again
3. fill container with copied particles
```
```C++
    // 0. normal container
    autopas::AutoPas<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> autoPas;
    autoPas.init({0., 0., 0.}, {10., 10., 10.}, 1., 0, 1, {autopas::ContainerOptions::linkedCells},
                 {autopas::TraversalOptions::c08});

    // 1. copy particles out of first container
    std::vector<Particle> particleVector;
    particleVector.reserve(autoPas.getNumberOfParticles());
    for (auto iter = autoPas.begin(); iter.isValid(); ++iter) {
      particleVector.push_back(*iter);
    }

    // 2. recreate container by calling constructor + init
    autoPas = decltype(autoPas)();
    autoPas.init({0., 0., 0.}, {5., 5., 5.}, 1., 0, 1, {autopas::ContainerOptions::linkedCells},
                 {autopas::TraversalOptions::c08});

    // 3. copy particles from particleVector into container
    for (auto particle : particleVector) {
      autoPas.addParticle(particle);
    }
```

