### PR TITLE
Fixes CellBlock3D wrongly assigning cell to some particles

### DIFF
--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -294,6 +294,10 @@ inline std::array<typename CellBlock3D<ParticleCell>::index_t, 3> CellBlock3D<Pa
       cellIndex[dim] = _cellsPerDimensionWithHalo[dim] - 1;
     } else if (pos[dim] < _boxMin[dim]) {
       cellIndex[dim] = 0;
+    } else if (pos[dim] >= _boxMin[dim] && cellIndex[dim] == 0){
+      cellIndex[dim] = 1;
+    } else if (pos[dim] < _boxMax[dim] && cellIndex[dim] == _cellsPerDimensionWithHalo[dim] - 1){
+      cellIndex[dim] = _cellsPerDimensionWithHalo[dim] - 2;
     }
   }
 

--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -288,14 +288,11 @@ inline std::array<typename CellBlock3D<ParticleCell>::index_t, 3> CellBlock3D<Pa
     const index_t nonnegativeValue = static_cast<index_t>(std::max(value, 0l));
     const index_t nonLargerValue = std::min(nonnegativeValue, _cellsPerDimensionWithHalo[dim] - 1);
     cellIndex[dim] = nonLargerValue;
-    // @todo this is a sanity check to prevent doubling of particles, but
-    /// could be done better!
+    // todo this is a sanity check to prevent doubling of particles
     if (pos[dim] >= _boxMax[dim]) {
       cellIndex[dim] = _cellsPerDimensionWithHalo[dim] - 1;
     } else if (pos[dim] < _boxMin[dim]) {
       cellIndex[dim] = 0;
-    } else if (pos[dim] >= _boxMin[dim] && cellIndex[dim] == 0) {
-      cellIndex[dim] = 1;
     } else if (pos[dim] < _boxMax[dim] && cellIndex[dim] == _cellsPerDimensionWithHalo[dim] - 1) {
       cellIndex[dim] = _cellsPerDimensionWithHalo[dim] - 2;
     }

--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -294,9 +294,9 @@ inline std::array<typename CellBlock3D<ParticleCell>::index_t, 3> CellBlock3D<Pa
       cellIndex[dim] = _cellsPerDimensionWithHalo[dim] - 1;
     } else if (pos[dim] < _boxMin[dim]) {
       cellIndex[dim] = 0;
-    } else if (pos[dim] >= _boxMin[dim] && cellIndex[dim] == 0){
+    } else if (pos[dim] >= _boxMin[dim] && cellIndex[dim] == 0) {
       cellIndex[dim] = 1;
-    } else if (pos[dim] < _boxMax[dim] && cellIndex[dim] == _cellsPerDimensionWithHalo[dim] - 1){
+    } else if (pos[dim] < _boxMax[dim] && cellIndex[dim] == _cellsPerDimensionWithHalo[dim] - 1) {
       cellIndex[dim] = _cellsPerDimensionWithHalo[dim] - 2;
     }
   }

--- a/tests/testAutopas/tests/containers/CellBlock3DTest.cpp
+++ b/tests/testAutopas/tests/containers/CellBlock3DTest.cpp
@@ -82,6 +82,119 @@ TEST_F(CellBlock3DTest, testBoundaries) {
   }
 }
 
+TEST_F(CellBlock3DTest, testCloseBoundaries) {
+  std::array<double, 3> position{0, 0, 0};
+  std::array<int, 3> shift = {};
+  for (shift[0] = -1; shift[0] < 2; ++shift[0]) {
+    for (shift[1] = -1; shift[1] < 2; ++shift[1]) {
+      for (shift[2] = -1; shift[2] < 2; ++shift[2]) {
+        for (int d = 0; d < 3; ++d) {
+          switch (shift[d]) {
+            case -1:
+              position[d] = std::nextafter(-0., -1.);  // for shift=-1 test close below 0. (outside)
+              // cell index should be 0
+              break;
+            case 0:
+              position[d] = 0.;
+              // cell index should be 1
+              break;
+            case 1:
+              position[d] = std::nextafter(10., -1.);  // for shift=1 test close below 10. (inside)
+              // cell index should be (size-2)
+              break;
+            default: { FAIL(); }
+          }
+        }
+
+        auto pos = _cells_1x1x1.get3DIndexOfPosition(position);
+
+        for (int d = 0; d < 3; ++d) {
+          EXPECT_EQ(pos[d], shift[d] == -1 ? 0 : 0 * shift[d] + 1)
+              << " for d = " << d << ", shift[d] = " << shift[d] << ", position[d] = " << position[d] << ".";
+        }
+
+        pos = _cells_2x2x2.get3DIndexOfPosition(position);
+
+        for (int d = 0; d < 3; ++d) {
+          EXPECT_EQ(pos[d], shift[d] == -1 ? 0 : 1 * shift[d] + 1)
+              << " for d = " << d << ", shift[d] = " << shift[d] << ", position[d] = " << position[d] << ".";
+        }
+
+        pos = _cells_3x3x3.get3DIndexOfPosition(position);
+
+        for (int d = 0; d < 3; ++d) {
+          EXPECT_EQ(pos[d], shift[d] == -1 ? 0 : 2 * shift[d] + 1)
+              << " for d = " << d << ", shift[d] = " << shift[d] << ", position[d] = " << position[d] << ".";
+        }
+
+        for (int d = 0; d < 3; ++d) {
+          double boxmin = d == 0 ? 2. / 3 : 0.;
+          double boxmax = d == 0 ? 1. : .125;
+          switch (shift[d]) {
+            case -1:
+              position[d] = std::nextafter(boxmin, -1.);  // for shift=-1 test close below 0. (outside)
+              // cell index should be 0
+              break;
+            case 0:
+              position[d] = boxmin;
+              // cell index should be 1
+              break;
+            case 1:
+              position[d] = std::nextafter(boxmax, -1.);  // for shift=1 test close below 10. (inside)
+              // cell index should be (size-2)
+              break;
+            default: { FAIL(); }
+          }
+        }
+
+        pos = _cells_11x4x4_nonZeroBoxMin.get3DIndexOfPosition(position);
+
+        EXPECT_EQ(pos[0], shift[0] == -1 ? 0 : 10 * shift[0] + 1)
+            << " for d = " << 0 << ", shift[d] = " << shift[0] << ", position[d] = " << position[0] << ".";
+        EXPECT_EQ(pos[1], shift[1] == -1 ? 0 : 3 * shift[1] + 1)
+            << " for d = " << 1 << ", shift[d] = " << shift[1] << ", position[d] = " << position[1] << ".";
+        EXPECT_EQ(pos[2], shift[2] == -1 ? 0 : 3 * shift[2] + 1)
+            << " for d = " << 2 << ", shift[d] = " << shift[2] << ", position[d] = " << position[2] << ".";
+      }
+    }
+  }
+}
+
+TEST_F(CellBlock3DTest, testCloseBoundaries19) {
+  std::array<double, 3> position{0, 0, 0};
+  std::array<int, 3> shift = {};
+  for (shift[0] = -1; shift[0] < 2; ++shift[0]) {
+    for (shift[1] = -1; shift[1] < 2; ++shift[1]) {
+      for (shift[2] = -1; shift[2] < 2; ++shift[2]) {
+        for (int d = 0; d < 3; ++d) {
+          switch (shift[d]) {
+            case -1:
+              position[d] = std::nextafter(-0., -1.);  // for shift=-1 test close below 0. (outside)
+              // cell index should be 0
+              break;
+            case 0:
+              position[d] = 0.;
+              // cell index should be 1
+              break;
+            case 1:
+              position[d] = std::nextafter(58.5, -1.);  // for shift=1 test close below 10. (inside)
+              // cell index should be (size-2)
+              break;
+            default: { FAIL(); }
+          }
+        }
+
+        auto pos = _cells_19x19x19.get3DIndexOfPosition(position);
+
+        for (int d = 0; d < 3; ++d) {
+          EXPECT_EQ(pos[d], shift[d] == -1 ? 0 : 18 * shift[d] + 1)
+                    << " for d = " << d << ", shift[d] = " << shift[d] << ", position[d] = " << position[d] << ".";
+        }
+      }
+    }
+  }
+}
+
 std::vector<std::array<double, 3>> CellBlock3DTest::getMesh(std::array<double, 3> start, std::array<double, 3> dr,
                                                             std::array<int, 3> numParts) const {
   std::vector<std::array<double, 3>> ret;

--- a/tests/testAutopas/tests/containers/CellBlock3DTest.cpp
+++ b/tests/testAutopas/tests/containers/CellBlock3DTest.cpp
@@ -188,7 +188,7 @@ TEST_F(CellBlock3DTest, testCloseBoundaries19) {
 
         for (int d = 0; d < 3; ++d) {
           EXPECT_EQ(pos[d], shift[d] == -1 ? 0 : 18 * shift[d] + 1)
-                    << " for d = " << d << ", shift[d] = " << shift[d] << ", position[d] = " << position[d] << ".";
+              << " for d = " << d << ", shift[d] = " << shift[d] << ", position[d] = " << position[d] << ".";
         }
       }
     }

--- a/tests/testAutopas/tests/containers/CellBlock3DTest.cpp
+++ b/tests/testAutopas/tests/containers/CellBlock3DTest.cpp
@@ -45,154 +45,66 @@ TEST_F(CellBlock3DTest, test3x3x3) {
   }
 }
 
+void testBoundary(autopas::CellBlock3D<autopas::FullParticleCell<autopas::MoleculeLJ>> &cellBlock,
+                  std::array<double, 3> boxMin, std::array<double, 3> boxMax) {
+  std::array<std::array<double, 4>, 3> possibleShifts = {};
+  for (unsigned short dim = 0; dim < 3; ++dim) {
+    possibleShifts[dim] = {std::nextafter(boxMin[dim], -1.),  // slightly below boxmin (outside)
+                           boxMin[dim],                       // at boxmin (inside)
+                           std::nextafter(boxMax[dim], -1.),  // slightly below boxmax (inside)
+                           boxMax[dim]};                      // boxmax (outside)
+  }
+  std::array<size_t, 3> cellsPerDimWithHalo = cellBlock.getCellsPerDimensionWithHalo();
+  std::array<size_t, 3> ind = {};
+  for (ind[0] = 0; ind[0] < 4; ++ind[0]) {
+    for (ind[1] = 0; ind[1] < 4; ++ind[1]) {
+      for (ind[2] = 0; ind[2] < 4; ++ind[2]) {
+        std::array<double, 3> position = {possibleShifts[0][ind[0]], possibleShifts[1][ind[1]],
+                                          possibleShifts[2][ind[2]]};
+        auto pos = cellBlock.get3DIndexOfPosition(position);
+
+        for (int d = 0; d < 3; ++d) {
+          switch (ind[d]) {
+            case 0:
+              // slightly below boxmin (outside)
+              EXPECT_EQ(pos[d], 0) << " for d = " << d << ", ind[d] = " << ind[d] << ", position[d] = " << position[d]
+                                   << ", cellsPerDimWithHalo[d]: " << cellsPerDimWithHalo[d];
+              break;
+            case 1:
+              // at boxmin (inside)
+              EXPECT_EQ(pos[d], 1) << " for d = " << d << ", ind[d] = " << ind[d] << ", position[d] = " << position[d]
+                                   << ", cellsPerDimWithHalo[d]: " << cellsPerDimWithHalo[d];
+              break;
+            case 2:
+              // slightly below boxmax (inside)
+              EXPECT_EQ(pos[d], cellsPerDimWithHalo[d] - 2)
+                  << " for d = " << d << ", ind[d] = " << ind[d] << ", position[d] = " << position[d]
+                  << ", cellsPerDimWithHalo[d]: " << cellsPerDimWithHalo[d];
+              break;
+            case 3:
+              // boxmax (outside)
+              EXPECT_EQ(pos[d], cellsPerDimWithHalo[d] - 1)
+                  << " for d = " << d << ", ind[d] = " << ind[d] << ", position[d] = " << position[d]
+                  << ", cellsPerDimWithHalo[d]: " << cellsPerDimWithHalo[d];
+              break;
+            default: { FAIL(); }
+          }
+        }
+      }
+    }
+  }
+}
+
 TEST_F(CellBlock3DTest, testBoundaries) {
-  std::array<double, 3> position{0, 0, 0};
-  for (int x_ind : {0, 1}) {
-    for (int y_ind : {0, 1}) {
-      for (int z_ind : {0, 1}) {
-        position = {x_ind * 10., y_ind * 10., z_ind * 10.};
+  testBoundary(_cells_1x1x1, {0., 0., 0.}, {10., 10., 10.});
 
-        auto pos = _cells_1x1x1.get3DIndexOfPosition(position);
+  testBoundary(_cells_2x2x2, {0., 0., 0.}, {10., 10., 10.});
 
-        ASSERT_EQ(pos[0], 1 * x_ind + 1);
-        ASSERT_EQ(pos[1], 1 * y_ind + 1);
-        ASSERT_EQ(pos[2], 1 * z_ind + 1);
+  testBoundary(_cells_3x3x3, {0., 0., 0.}, {10., 10., 10.});
 
-        pos = _cells_2x2x2.get3DIndexOfPosition(position);
+  testBoundary(_cells_11x4x4_nonZeroBoxMin, {2. / 3., 0., 0.}, {1., .125, .125});
 
-        ASSERT_EQ(pos[0], 2 * x_ind + 1);
-        ASSERT_EQ(pos[1], 2 * y_ind + 1);
-        ASSERT_EQ(pos[2], 2 * z_ind + 1);
-
-        pos = _cells_3x3x3.get3DIndexOfPosition(position);
-
-        ASSERT_EQ(pos[0], 3 * x_ind + 1);
-        ASSERT_EQ(pos[1], 3 * y_ind + 1);
-        ASSERT_EQ(pos[2], 3 * z_ind + 1);
-
-        position = {x_ind ? 1. : 2. / 3, y_ind * .125, z_ind * .125};
-
-        pos = _cells_11x4x4_nonZeroBoxMin.get3DIndexOfPosition(position);
-
-        ASSERT_EQ(pos[0], 11 * x_ind + 1);
-        ASSERT_EQ(pos[1], 4 * y_ind + 1);
-        ASSERT_EQ(pos[2], 4 * z_ind + 1);
-      }
-    }
-  }
-}
-
-TEST_F(CellBlock3DTest, testCloseBoundaries) {
-  std::array<double, 3> position{0, 0, 0};
-  std::array<int, 3> shift = {};
-  for (shift[0] = -1; shift[0] < 2; ++shift[0]) {
-    for (shift[1] = -1; shift[1] < 2; ++shift[1]) {
-      for (shift[2] = -1; shift[2] < 2; ++shift[2]) {
-        for (int d = 0; d < 3; ++d) {
-          switch (shift[d]) {
-            case -1:
-              position[d] = std::nextafter(-0., -1.);  // for shift=-1 test close below 0. (outside)
-              // cell index should be 0
-              break;
-            case 0:
-              position[d] = 0.;
-              // cell index should be 1
-              break;
-            case 1:
-              position[d] = std::nextafter(10., -1.);  // for shift=1 test close below 10. (inside)
-              // cell index should be (size-2)
-              break;
-            default: { FAIL(); }
-          }
-        }
-
-        auto pos = _cells_1x1x1.get3DIndexOfPosition(position);
-
-        for (int d = 0; d < 3; ++d) {
-          EXPECT_EQ(pos[d], shift[d] == -1 ? 0 : 0 * shift[d] + 1)
-              << " for d = " << d << ", shift[d] = " << shift[d] << ", position[d] = " << position[d] << ".";
-        }
-
-        pos = _cells_2x2x2.get3DIndexOfPosition(position);
-
-        for (int d = 0; d < 3; ++d) {
-          EXPECT_EQ(pos[d], shift[d] == -1 ? 0 : 1 * shift[d] + 1)
-              << " for d = " << d << ", shift[d] = " << shift[d] << ", position[d] = " << position[d] << ".";
-        }
-
-        pos = _cells_3x3x3.get3DIndexOfPosition(position);
-
-        for (int d = 0; d < 3; ++d) {
-          EXPECT_EQ(pos[d], shift[d] == -1 ? 0 : 2 * shift[d] + 1)
-              << " for d = " << d << ", shift[d] = " << shift[d] << ", position[d] = " << position[d] << ".";
-        }
-
-        for (int d = 0; d < 3; ++d) {
-          double boxmin = d == 0 ? 2. / 3 : 0.;
-          double boxmax = d == 0 ? 1. : .125;
-          switch (shift[d]) {
-            case -1:
-              position[d] = std::nextafter(boxmin, -1.);  // for shift=-1 test close below 0. (outside)
-              // cell index should be 0
-              break;
-            case 0:
-              position[d] = boxmin;
-              // cell index should be 1
-              break;
-            case 1:
-              position[d] = std::nextafter(boxmax, -1.);  // for shift=1 test close below 10. (inside)
-              // cell index should be (size-2)
-              break;
-            default: { FAIL(); }
-          }
-        }
-
-        pos = _cells_11x4x4_nonZeroBoxMin.get3DIndexOfPosition(position);
-
-        EXPECT_EQ(pos[0], shift[0] == -1 ? 0 : 10 * shift[0] + 1)
-            << " for d = " << 0 << ", shift[d] = " << shift[0] << ", position[d] = " << position[0] << ".";
-        EXPECT_EQ(pos[1], shift[1] == -1 ? 0 : 3 * shift[1] + 1)
-            << " for d = " << 1 << ", shift[d] = " << shift[1] << ", position[d] = " << position[1] << ".";
-        EXPECT_EQ(pos[2], shift[2] == -1 ? 0 : 3 * shift[2] + 1)
-            << " for d = " << 2 << ", shift[d] = " << shift[2] << ", position[d] = " << position[2] << ".";
-      }
-    }
-  }
-}
-
-TEST_F(CellBlock3DTest, testCloseBoundaries19) {
-  std::array<double, 3> position{0, 0, 0};
-  std::array<int, 3> shift = {};
-  for (shift[0] = -1; shift[0] < 2; ++shift[0]) {
-    for (shift[1] = -1; shift[1] < 2; ++shift[1]) {
-      for (shift[2] = -1; shift[2] < 2; ++shift[2]) {
-        for (int d = 0; d < 3; ++d) {
-          switch (shift[d]) {
-            case -1:
-              position[d] = std::nextafter(-0., -1.);  // for shift=-1 test close below 0. (outside)
-              // cell index should be 0
-              break;
-            case 0:
-              position[d] = 0.;
-              // cell index should be 1
-              break;
-            case 1:
-              position[d] = std::nextafter(58.5, -1.);  // for shift=1 test close below 10. (inside)
-              // cell index should be (size-2)
-              break;
-            default: { FAIL(); }
-          }
-        }
-
-        auto pos = _cells_19x19x19.get3DIndexOfPosition(position);
-
-        for (int d = 0; d < 3; ++d) {
-          EXPECT_EQ(pos[d], shift[d] == -1 ? 0 : 18 * shift[d] + 1)
-              << " for d = " << d << ", shift[d] = " << shift[d] << ", position[d] = " << position[d] << ".";
-        }
-      }
-    }
-  }
+  testBoundary(_cells_19x19x19, {0., 0., 0.}, {58.5, 58.5, 58.5});
 }
 
 std::vector<std::array<double, 3>> CellBlock3DTest::getMesh(std::array<double, 3> start, std::array<double, 3> dr,

--- a/tests/testAutopas/tests/containers/CellBlock3DTest.h
+++ b/tests/testAutopas/tests/containers/CellBlock3DTest.h
@@ -17,14 +17,16 @@ class CellBlock3DTest : public AutoPasTestBase {
         _cells_2x2x2(_vec2, std::array<double, 3>({0.0, 0.0, 0.0}), std::array<double, 3>({10.0, 10.0, 10.0}), 5.0),
         _cells_3x3x3(_vec3, std::array<double, 3>({0.0, 0.0, 0.0}), std::array<double, 3>({10.0, 10.0, 10.0}), 3.0),
         _cells_11x4x4_nonZeroBoxMin(_vec4, std::array<double, 3>({2. / 3., 0.0, 0.0}),
-                                    std::array<double, 3>({1., .125, .125}), 3. / 100.) {}
+                                    std::array<double, 3>({1., .125, .125}), 3. / 100.),
+        _cells_19x19x19(_vec19, std::array<double, 3>({0.0, 0.0, 0.0}), std::array<double, 3>({58.5, 58.5, 58.5}),
+                        3.0) {}
   ~CellBlock3DTest() override = default;
 
  protected:
   std::vector<std::array<double, 3>> getMesh(std::array<double, 3> start, std::array<double, 3> dx,
                                              std::array<int, 3> numParts) const;
 
-  std::vector<autopas::FullParticleCell<autopas::MoleculeLJ>> _vec1, _vec2, _vec3, _vec4;
+  std::vector<autopas::FullParticleCell<autopas::MoleculeLJ>> _vec1, _vec2, _vec3, _vec4, _vec19;
   autopas::CellBlock3D<autopas::FullParticleCell<autopas::MoleculeLJ>> _cells_1x1x1, _cells_2x2x2, _cells_3x3x3,
-      _cells_11x4x4_nonZeroBoxMin;
+      _cells_11x4x4_nonZeroBoxMin, _cells_19x19x19;
 };


### PR DESCRIPTION
# Description

Particles that were added within the domain, but very close to the boundary were sometimes added to HaloCells. This has been fixed.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Adds test, that failed without the fix. And works with the fix.
