### PR TITLE
Migrate jenkins pipeline to warnings-ng, resolves #147

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -183,7 +183,7 @@ pipeline{
             }
             post{
                 always{
-                    recordIssues(tools: [clang(pattern: 'build*/buildlog_clang.txt'), gcc3(pattern: 'build*/buildlog.txt'), gcc4(pattern: 'build*/buildlog.txt'), intel(pattern: 'build*/buildlog_intel.txt')])
+                    recordIssues tools: [clang(pattern: 'build*/buildlog_clang.txt'), gcc3(pattern: 'build*/buildlog.txt'), gcc4(pattern: 'build*/buildlog.txt'), intel(pattern: 'build*/buildlog_intel.txt')], unstableTotalAll: 1
                 }
                 success{
                     githubNotify context: 'build', description: currentBuild.durationString,  status: 'SUCCESS', targetUrl: currentBuild.absoluteUrl

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline{
                         stash includes: 'build-doxygen/doc_doxygen/html/**', name: 'doxydocs'
 
                         // get doxygen warnings
-                        warnings canComputeNew: false, canResolveRelativePaths: false, categoriesPattern: '', defaultEncoding: '', excludePattern: '.*README.*', healthy: '', includePattern: '', messagesPattern: '', parserConfigurations: [[parserName: 'Doxygen', pattern: 'build-doxygen/DoxygenWarningLog.txt']], unHealthy: '', failedTotalAll: '0'
+                        recordIssues filters: [excludeFile('.*README.*')], tools: [doxygen(pattern: 'build-doxygen/DoxygenWarningLog.txt')]
                     },
                     "clang format": {
                         dir("clang-format"){
@@ -183,7 +183,7 @@ pipeline{
             }
             post{
                 always{
-					warnings canComputeNew: false, categoriesPattern: '', defaultEncoding: '', excludePattern: '', healthy: '', includePattern: '', messagesPattern: '', parserConfigurations: [[parserName: 'Clang (LLVM based)', pattern: 'build*/buildlog_clang.txt'], [parserName: 'GNU Make + GNU C Compiler (gcc)', pattern: 'build*/buildlog.txt'], [parserName: 'Intel C Compiler', pattern: 'build*/buildlog_intel.txt']], unHealthy: '', unstableTotalAll: '0', unstableTotalHigh: '0', unstableTotalLow: '0', unstableTotalNormal: '0'
+                    recordIssues(tools: [clang(pattern: 'build*/buildlog_clang.txt'), gcc3(pattern: 'build*/buildlog.txt'), gcc4(pattern: 'build*/buildlog.txt'), intel(pattern: 'build*/buildlog_intel.txt')])
                 }
                 success{
                     githubNotify context: 'build', description: currentBuild.durationString,  status: 'SUCCESS', targetUrl: currentBuild.absoluteUrl

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline{
                         stash includes: 'build-doxygen/doc_doxygen/html/**', name: 'doxydocs'
 
                         // get doxygen warnings
-                        recordIssues filters: [excludeFile('.*README.*')], tools: [doxygen(pattern: 'build-doxygen/DoxygenWarningLog.txt')]
+                        recordIssues filters: [excludeFile('.*README.*')], tools: [doxygen(pattern: 'build-doxygen/DoxygenWarningLog.txt')], unstableTotalAll: 1
                     },
                     "clang format": {
                         dir("clang-format"){


### PR DESCRIPTION
# Description

Replaces the deprecated warnings jenkins plugin with warnings-ng.

## Resolved Issues # (issue)

- #147

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- Built on jenkins