### PR TITLE
verlet list AutoPas interface usability changes

### DIFF
--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -189,7 +189,7 @@ class AutoPas {
    * @return True if the lists are valid, false if a rebuild is needed.
    */
   bool isNeighborListValid() {
-    if(auto container = dynamic_cast<VerletLists<Particle>*>(_autoTuner->getContainer().get())){
+    if (auto container = dynamic_cast<VerletLists<Particle> *>(_autoTuner->getContainer().get())) {
       return not container->needsRebuild();
     }
   }

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -189,7 +189,7 @@ class AutoPas {
    * @return True if the lists are valid, false if a rebuild is needed.
    */
   bool isNeighborListValid() {
-    if(auto container = dynamic_cast<VerletLists<Particle>>(_autoTuner->getContainer().get())){
+    if(auto container = dynamic_cast<VerletLists<Particle>*>(_autoTuner->getContainer().get())){
       return not container.needsRebuild();
     }
   }

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -184,6 +184,16 @@ class AutoPas {
    */
   std::array<double, 3> getBoxMax() { return _autoTuner->getContainer()->getBoxMax(); }
 
+  /**
+   * Checks if the neighbor lists are valid, or whether they need a rebuild.
+   * @return True if the lists are valid, false if a rebuild is needed.
+   */
+  bool isNeighborListValid() {
+    if(auto container = dynamic_cast<VerletLists<Particle>>(_autoTuner->getContainer().ptr())){
+      return not container.needsRebuild();
+    }
+  }
+
  private:
   std::unique_ptr<autopas::AutoTuner<Particle, ParticleCell>> _autoTuner;
 };

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -189,7 +189,7 @@ class AutoPas {
    * @return True if the lists are valid, false if a rebuild is needed.
    */
   bool isNeighborListValid() {
-    if(auto container = dynamic_cast<VerletLists<Particle>>(_autoTuner->getContainer().ptr())){
+    if(auto container = dynamic_cast<VerletLists<Particle>>(_autoTuner->getContainer().get())){
       return not container.needsRebuild();
     }
   }

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -186,11 +186,16 @@ class AutoPas {
 
   /**
    * Checks if the neighbor lists are valid, or whether they need a rebuild.
+   * Will return false if no lists are used.
+   * This function can indicate whether you should send only halo particles or whether you should send leaving particles
+   * as well.
    * @return True if the lists are valid, false if a rebuild is needed.
    */
   bool isNeighborListValid() {
     if (auto container = dynamic_cast<VerletLists<Particle> *>(_autoTuner->getContainer().get())) {
       return not container->needsRebuild();
+    } else {
+      return false;
     }
   }
 

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -190,7 +190,7 @@ class AutoPas {
    */
   bool isNeighborListValid() {
     if(auto container = dynamic_cast<VerletLists<Particle>*>(_autoTuner->getContainer().get())){
-      return not container.needsRebuild();
+      return not container->needsRebuild();
     }
   }
 

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -182,7 +182,7 @@ class VerletLists
    */
   bool needsRebuild() {
     AutoPasLog(debug, "Neighborlist is valid: {}", this->_neighborListIsValid);
-    // if the neighbor list is NOT validor we have not rebuild for this->_rebuildFrequency steps
+    // if the neighbor list is NOT valid or we have not rebuilt since this->_rebuildFrequency steps
     return (not this->_neighborListIsValid) or (this->_traversalsSinceLastRebuild >= this->_rebuildFrequency);
   }
 

--- a/tests/testAutopas/tests/autopasInterface/AutoPasTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasTest.cpp
@@ -151,12 +151,12 @@ TEST_F(AutoPasTest, checkRebuildingCopyCreateNew) {
   AutoPasLog(info, "test logger working.");
 }
 
-TEST_F(AutoPasTest, checkIsNeighborListValid){
+TEST_F(AutoPasTest, checkIsNeighborListValid) {
   // for linked cells this should be false
   EXPECT_FALSE(autoPas.isNeighborListValid());
 
   // now build verlet lists
-  autoPas.init({0., 0., 0.}, {5., 5., 5.}, 1., 0, 2, {autopas::ContainerOptions::verletLists},{});
+  autoPas.init({0., 0., 0.}, {5., 5., 5.}, 1., 0, 2, {autopas::ContainerOptions::verletLists}, {});
   // after build this should be false
   EXPECT_FALSE(autoPas.isNeighborListValid());
 

--- a/tests/testAutopas/tests/autopasInterface/AutoPasTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasTest.cpp
@@ -7,6 +7,10 @@
 #include "AutoPasTest.h"
 #include "testingHelpers/commonTypedefs.h"
 
+using ::testing::_;
+using ::testing::AtLeast;
+using ::testing::Return;
+
 /**
  * test whether the RegionIterator can be generated and something is returned.
  * This mainly makes certain, that the specific parts of the code can be compiled.
@@ -145,4 +149,25 @@ TEST_F(AutoPasTest, checkRebuildingCopyCreateNew) {
 
   // ensure logger still working
   AutoPasLog(info, "test logger working.");
+}
+
+TEST_F(AutoPasTest, checkIsNeighborListValid){
+  // for linked cells this should be false
+  EXPECT_FALSE(autoPas.isNeighborListValid());
+
+  // now build verlet lists
+  autoPas.init({0., 0., 0.}, {5., 5., 5.}, 1., 0, 2, {autopas::ContainerOptions::verletLists},{});
+  // after build this should be false
+  EXPECT_FALSE(autoPas.isNeighborListValid());
+
+  // run once, builds verlet lists. (here for 0 particles)
+  MockFunctor<Particle, FPCell> emptyFunctor;
+  EXPECT_CALL(emptyFunctor, allowsNewton3()).Times(AtLeast(1)).WillOnce(Return(true));
+  EXPECT_CALL(emptyFunctor, allowsNonNewton3()).Times(AtLeast(1)).WillOnce(Return(false));
+  EXPECT_CALL(emptyFunctor, isRelevantForTuning()).Times(AtLeast(1)).WillOnce(Return(true));
+  autopas::C08Traversal<FPCell, MFunctor, false, true> dummyTraversal({0, 0, 0}, &emptyFunctor);
+  autoPas.iteratePairwise(&emptyFunctor, autopas::aos);
+
+  // now verlet lists should be valid.
+  EXPECT_TRUE(autoPas.isNeighborListValid());
 }


### PR DESCRIPTION
# Description

Adds interfaces to make verlet lists usable in the external AutoPas interface

Implements the following functions:

- [x] `bool isNeighborListValid()` that defines whether the neighbor lists are still valid

Tested:
- [x] using unit test checkIsNeighborListValid

## Related Pull Requests

- dependency for: https://github.com/ls1mardyn/ls1-mardyn/pull/54