### PR TITLE
add function needsContainerUpdate to autopas interface

### DIFF
--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -192,7 +192,7 @@ class AutoPas {
    * @return True if the lists are valid, false if a rebuild is needed.
    */
   bool needsContainerUpdate() {
-    if(_autoTuner->willRebuild()){
+    if (_autoTuner->willRebuild()) {
       return true;
     }
     if (auto container = dynamic_cast<VerletLists<Particle> *>(_autoTuner->getContainer().get())) {

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -185,17 +185,20 @@ class AutoPas {
   std::array<double, 3> getBoxMax() { return _autoTuner->getContainer()->getBoxMax(); }
 
   /**
-   * Checks if the neighbor lists are valid, or whether they need a rebuild.
+   * Checks if the container needs to be updated.
    * Will return false if no lists are used.
    * This function can indicate whether you should send only halo particles or whether you should send leaving particles
    * as well.
    * @return True if the lists are valid, false if a rebuild is needed.
    */
-  bool isNeighborListValid() {
+  bool needsContainerUpdate() {
+    if(_autoTuner->willRebuild()){
+      return true;
+    }
     if (auto container = dynamic_cast<VerletLists<Particle> *>(_autoTuner->getContainer().get())) {
-      return not container->needsRebuild();
+      return container->needsRebuild();
     } else {
-      return false;
+      return true;
     }
   }
 

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -94,6 +94,18 @@ class AutoTuner {
   template <class PairwiseFunctor>
   bool iteratePairwise(PairwiseFunctor *f, DataLayoutOption dataLayoutOption);
 
+  bool willRebuild() {
+    if (_iterationsSinceTuning >= _tuningInterval) {
+      if (_numSamples < _maxSamples) {
+        return false;
+      } else {
+        return true;
+      }
+    } else {
+      return false;
+    }
+  }
+
  private:
   template <class PairwiseFunctor, bool useSoA, bool useNewton3>
   bool iteratePairwiseTemplateHelper(PairwiseFunctor *f);

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -94,6 +94,10 @@ class AutoTuner {
   template <class PairwiseFunctor>
   bool iteratePairwise(PairwiseFunctor *f, DataLayoutOption dataLayoutOption);
 
+  /**
+   * Returns whether the container or the traversal will potentially be changed in the next iteration.
+   * @return True if the container will be rebuild on the next iteratePairwise() call. False otherwise.
+   */
   bool willRebuild() {
     if (_iterationsSinceTuning >= _tuningInterval) {
       if (_numSamples < _maxSamples) {

--- a/tests/testAutopas/tests/autopasInterface/AutoPasTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasTest.cpp
@@ -153,12 +153,12 @@ TEST_F(AutoPasTest, checkRebuildingCopyCreateNew) {
 
 TEST_F(AutoPasTest, checkIsNeighborListValid) {
   // for linked cells this should be false
-  EXPECT_FALSE(autoPas.isNeighborListValid());
+  EXPECT_TRUE(autoPas.needsContainerUpdate());
 
   // now build verlet lists
   autoPas.init({0., 0., 0.}, {5., 5., 5.}, 1., 0, 2, {autopas::ContainerOptions::verletLists}, {});
   // after build this should be false
-  EXPECT_FALSE(autoPas.isNeighborListValid());
+  EXPECT_TRUE(autoPas.needsContainerUpdate());
 
   // run once, builds verlet lists. (here for 0 particles)
   MockFunctor<Particle, FPCell> emptyFunctor;
@@ -169,5 +169,5 @@ TEST_F(AutoPasTest, checkIsNeighborListValid) {
   autoPas.iteratePairwise(&emptyFunctor, autopas::aos);
 
   // now verlet lists should be valid.
-  EXPECT_TRUE(autoPas.isNeighborListValid());
+  EXPECT_FALSE(autoPas.needsContainerUpdate());
 }

--- a/tests/testAutopas/tests/autopasInterface/AutoPasTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasTest.cpp
@@ -151,7 +151,7 @@ TEST_F(AutoPasTest, checkRebuildingCopyCreateNew) {
   AutoPasLog(info, "test logger working.");
 }
 
-TEST_F(AutoPasTest, checkIsNeighborListValid) {
+TEST_F(AutoPasTest, checkNeedsContainerUpdate) {
   // for linked cells this should be false
   EXPECT_TRUE(autoPas.needsContainerUpdate());
 


### PR DESCRIPTION
# Description

- [x] Adds function needsContainerUpdate to autopas interface.
- [x] Adds function `willRebuild()` to AutoTuner, that indicates whether the container or traversal will potentially be rebuilt on the next `iteratePairwise()` call

## Related Pull Requests

- #165 
- https://github.com/ls1mardyn/ls1-mardyn/pull/54