### PR TITLE
Make verlet lists a blackbox

### DIFF
--- a/docs/BlackBoxMode.md
+++ b/docs/BlackBoxMode.md
@@ -1,0 +1,11 @@
+## BlackBoxMode
+When the blackbox mode is enabled, the particle exchange is independent
+of the container type. It is required to be as follows:
+1. Leaving particles should be sent out and be received in every
+iteration.
+2. Halo particles need to be copied in each iteration.
+3. In each iteration the halo particles should be deleted after the
+force is calculated.
+
+The blackbox mode enables fluent interplay across different container
+types.

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1,12 +1,14 @@
 PROJECT_NAME           = "@CMAKE_PROJECT_NAME@"
 PROJECT_NUMBER         = @AUTOPAS_VERSION_MAJOR@.@AUTOPAS_VERSION_MINOR@.@AUTOPAS_VERSION_PATCH@
-STRIP_FROM_PATH        = @PROJECT_SOURCE_DIR@/src
+FULL_PATH_NAMES        = YES
+STRIP_FROM_PATH        = @PROJECT_SOURCE_DIR@/src @PROJECT_SOURCE_DIR@/docs
 OUTPUT_DIRECTORY       = @CMAKE_CURRENT_BINARY_DIR@/doc_doxygen/
 INPUT                  = @PROJECT_SOURCE_DIR@/@DOXY_MAIN_PAGE@ \
                          @PROJECT_SOURCE_DIR@/src/ \
-                         @CMAKE_SOURCE_DIR@/docs
+                         @PROJECT_SOURCE_DIR@/docs/
 FILE_PATTERNS          = *.h \
-                         *.cpp
+                         *.cpp \
+                         *.md
 RECURSIVE              = YES
 USE_MDFILE_AS_MAINPAGE = @PROJECT_SOURCE_DIR@/@DOXY_MAIN_PAGE@
 HTML_HEADER            = @CMAKE_SOURCE_DIR@/docs/AutoPasHeader.html

--- a/examples/sph-verlet/sph-main-verlet.cpp
+++ b/examples/sph-verlet/sph-main-verlet.cpp
@@ -248,7 +248,7 @@ void densityPressureHydroForce(Container& sphSystem) {
 
   // 1.first calculate density
   // 1.1 to calculate the density we need the halo particles
-  updateHaloParticles(sphSystem, sphSystem.needsRebuildInner());
+  updateHaloParticles(sphSystem, sphSystem.needsRebuild());
 
   // 1.2 then calculate density
   for (auto part = sphSystem.begin(); part.isValid(); ++part) {
@@ -344,7 +344,7 @@ int main() {
     leapfrogFullDrift(sphSystem, dt);
 
     // for verlet-lists this only needs to be done, if particles moved too far.
-    if (sphSystem.needsRebuildInner() or sphSystem.isContainerUpdateNeeded()) {
+    if (sphSystem.needsRebuild() or sphSystem.isContainerUpdateNeeded()) {
       // ensure that there are no halo particles if we need to update the
       // container
       deleteHaloParticles(sphSystem);

--- a/examples/sph-verlet/sph-main-verlet.cpp
+++ b/examples/sph-verlet/sph-main-verlet.cpp
@@ -248,7 +248,7 @@ void densityPressureHydroForce(Container& sphSystem) {
 
   // 1.first calculate density
   // 1.1 to calculate the density we need the halo particles
-  updateHaloParticles(sphSystem, sphSystem.needsRebuild());
+  updateHaloParticles(sphSystem, sphSystem.needsRebuildInner());
 
   // 1.2 then calculate density
   for (auto part = sphSystem.begin(); part.isValid(); ++part) {
@@ -344,7 +344,7 @@ int main() {
     leapfrogFullDrift(sphSystem, dt);
 
     // for verlet-lists this only needs to be done, if particles moved too far.
-    if (sphSystem.needsRebuild() or sphSystem.isContainerUpdateNeeded()) {
+    if (sphSystem.needsRebuildInner() or sphSystem.isContainerUpdateNeeded()) {
       // ensure that there are no halo particles if we need to update the
       // container
       deleteHaloParticles(sphSystem);

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -196,7 +196,7 @@ class AutoPas {
       return true;
     }
     if (auto container = dynamic_cast<VerletLists<Particle> *>(_autoTuner->getContainer().get())) {
-      return container->needsRebuild();
+      return container->needsRebuildInner();
     } else {
       return true;
     }

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -196,7 +196,7 @@ class AutoPas {
       return true;
     }
     if (auto container = dynamic_cast<VerletLists<Particle> *>(_autoTuner->getContainer().get())) {
-      return container->needsRebuildInner();
+      return container->needsRebuild();
     } else {
       return true;
     }

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -76,6 +76,7 @@ class AutoPas {
    * @param traversalSelectorStrategy Strategy for the traversal selector.
    * @param tuningInterval Number of timesteps after which the auto-tuner shall reevaluate all selections.
    * @param numSamples Number of samples the tuner should collect for each combination.
+   * @param blackBoxMode Indicates whether the [blackbox mode](@ref md_BlackBoxMode) shall be used.
    */
   void init(std::array<double, 3> boxMin, std::array<double, 3> boxMax, double cutoff, double verletSkin,
             unsigned int verletRebuildFrequency,
@@ -83,10 +84,10 @@ class AutoPas {
             const std::vector<autopas::TraversalOptions> &allowedTraversals = autopas::allTraversalOptions,
             SelectorStrategy containerSelectorStrategy = SelectorStrategy::fastestAbs,
             SelectorStrategy traversalSelectorStrategy = SelectorStrategy::fastestAbs,
-            unsigned int tuningInterval = 100, unsigned int numSamples = 3) {
+            unsigned int tuningInterval = 100, unsigned int numSamples = 3, bool blackBoxMode = false) {
     _autoTuner = std::make_unique<autopas::AutoTuner<Particle, ParticleCell>>(
         boxMin, boxMax, cutoff, verletSkin, verletRebuildFrequency, allowedContainers, allowedTraversals,
-        containerSelectorStrategy, traversalSelectorStrategy, tuningInterval, numSamples);
+        containerSelectorStrategy, traversalSelectorStrategy, tuningInterval, numSamples, blackBoxMode);
   }
 
   /**

--- a/src/autopas/containers/cellPairTraversals/C01BasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/C01BasedTraversal.h
@@ -19,20 +19,17 @@ namespace autopas {
  * only if particles of the first cell are modified. This means that newton3 optimizations are NOT allowed.
  *
  * @tparam ParticleCell the type of cells
- * @tparam PairwiseFunctor The functor that defines the interaction of two particles.
  * @tparam useSoA
  */
-template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3>
+template <class ParticleCell, bool useSoA, bool useNewton3>
 class C01BasedTraversal : public CellPairTraversal<ParticleCell> {
  public:
   /**
    * Constructor of the c01 traversal.
    * @param dims The dimensions of the cellblock, i.e. the number of cells in x,
    * y and z direction.
-   * @param pairwiseFunctor The functor that defines the interaction of two particles.
    */
-  explicit C01BasedTraversal(const std::array<unsigned long, 3>& dims, PairwiseFunctor* pairwiseFunctor)
-      : CellPairTraversal<ParticleCell>(dims) {}
+  explicit C01BasedTraversal(const std::array<unsigned long, 3>& dims) : CellPairTraversal<ParticleCell>(dims) {}
 
   /**
    * C01 traversals are only usable if useNewton3 is disabled.
@@ -52,9 +49,9 @@ class C01BasedTraversal : public CellPairTraversal<ParticleCell> {
   inline void c01Traversal(LoopBody&& loopBody);
 };
 
-template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3>
+template <class ParticleCell, bool useSoA, bool useNewton3>
 template <typename LoopBody>
-inline void C01BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>::c01Traversal(LoopBody&& loopBody) {
+inline void C01BasedTraversal<ParticleCell, useSoA, useNewton3>::c01Traversal(LoopBody&& loopBody) {
   const unsigned long end_x = this->_cellsPerDimension[0] - 1;
   const unsigned long end_y = this->_cellsPerDimension[1] - 1;
   const unsigned long end_z = this->_cellsPerDimension[2] - 1;

--- a/src/autopas/containers/cellPairTraversals/C08BasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/C08BasedTraversal.h
@@ -123,7 +123,7 @@ inline void C08BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3,
   const array<unsigned long, 3> stride = {2, 2, 2};
   array<unsigned long, 3> end = {};
   for (int d = 0; d < 3; ++d) {
-    end[d] = this->_cellsPerDimension[d] - 1;
+    end[d] = this->_cellsPerDimension[d];
   }
 
 #if defined(AUTOPAS_OPENMP)
@@ -233,12 +233,12 @@ inline void C08BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3,
       {
         // upper y: always only one value for y:
         unsigned long x;
-        if (start_y % 2 == 1) {
+        if (start_x % 2 == 1) {
           // round to first uneven number smaller than end_z
-          x = (end_y & ~1ul) - 1ul;
+          x = (end_x & ~1ul) - 1ul;
         } else {  // start_z == 0
           // round to first even number smaller than end_z
-          x = (end_y - 1ul) & ~1ul;
+          x = (end_x - 1ul) & ~1ul;
         }
 #if defined(AUTOPAS_OPENMP)
 #pragma omp for schedule(dynamic, 1) collapse(2)

--- a/src/autopas/containers/cellPairTraversals/C08BasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/C08BasedTraversal.h
@@ -19,23 +19,19 @@ namespace autopas {
  * cell and all adjacent cells with greater ID in each direction are safe, even when using newton3 optimizations.
  *
  * @tparam ParticleCell the type of cells
- * @tparam PairwiseFunctor The functor that defines the interaction of two particles.
  * @tparam useSoA
  * @tparam useNewton3
  * @tparam blackBoxTraversalOption The blackbox traversal option to be used.
  */
-template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3,
-          BlackBoxTraversalOption blackBoxTraversalOption = normal>
+template <class ParticleCell, bool useSoA, bool useNewton3, BlackBoxTraversalOption blackBoxTraversalOption = normal>
 class C08BasedTraversal : public CellPairTraversal<ParticleCell> {
  public:
   /**
    * Constructor of the c08 traversal.
    * @param dims The dimensions of the cellblock, i.e. the number of cells in x,
    * y and z direction.
-   * @param pairwiseFunctor The functor that defines the interaction of two particles.
    */
-  explicit C08BasedTraversal(const std::array<unsigned long, 3>& dims, PairwiseFunctor* pairwiseFunctor)
-      : CellPairTraversal<ParticleCell>(dims) {}
+  explicit C08BasedTraversal(const std::array<unsigned long, 3>& dims) : CellPairTraversal<ParticleCell>(dims) {}
 
   /**
    * C08 traversals are always usable.
@@ -59,10 +55,9 @@ class C08BasedTraversal : public CellPairTraversal<ParticleCell> {
   inline void c08TraversalOuter(LoopBody&& loopBody);
 };
 
-template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3,
-          BlackBoxTraversalOption blackBoxTraversalOption>
+template <class ParticleCell, bool useSoA, bool useNewton3, BlackBoxTraversalOption blackBoxTraversalOption>
 template <typename LoopBody>
-inline void C08BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3, blackBoxTraversalOption>::c08Traversal(
+inline void C08BasedTraversal<ParticleCell, useSoA, useNewton3, blackBoxTraversalOption>::c08Traversal(
     LoopBody&& loopBody) {
   if (blackBoxTraversalOption == outer) {
     // tooSmall indicates whether there is any inner region.
@@ -116,11 +111,10 @@ inline void C08BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3,
   }
 }
 
-template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3,
-          BlackBoxTraversalOption blackBoxTraversalOption>
+template <class ParticleCell, bool useSoA, bool useNewton3, BlackBoxTraversalOption blackBoxTraversalOption>
 template <typename LoopBody>
-inline void C08BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3,
-                              blackBoxTraversalOption>::c08TraversalOuter(LoopBody&& loopBody) {
+inline void C08BasedTraversal<ParticleCell, useSoA, useNewton3, blackBoxTraversalOption>::c08TraversalOuter(
+    LoopBody&& loopBody) {
   using std::array;
   const array<unsigned long, 3> stride = {2, 2, 2};
   array<unsigned long, 3> end = {};
@@ -198,10 +192,10 @@ inline void C08BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3,
         // upper y: always only one value for y:
         unsigned long y;
         if (start_y % 2 == 1) {
-          // round to first uneven number smaller than end_z
+          // round to first uneven number smaller than end_y
           y = (end_y & ~1ul) - 1ul;
         } else {  // start_z == 0
-          // round to first even number smaller than end_z
+          // round to first even number smaller than end_y
           y = (end_y - 1ul) & ~1ul;
         }
         end_y_inner = y;
@@ -236,10 +230,10 @@ inline void C08BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3,
         // upper y: always only one value for y:
         unsigned long x;
         if (start_x % 2 == 1) {
-          // round to first uneven number smaller than end_z
+          // round to first uneven number smaller than end_x
           x = (end_x & ~1ul) - 1ul;
         } else {  // start_z == 0
-          // round to first even number smaller than end_z
+          // round to first even number smaller than end_x
           x = (end_x - 1ul) & ~1ul;
         }
 #if defined(AUTOPAS_OPENMP)

--- a/src/autopas/containers/cellPairTraversals/C08BasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/C08BasedTraversal.h
@@ -64,7 +64,7 @@ inline void C08BasedTraversal<ParticleCell, useSoA, useNewton3, blackBoxTraversa
     // If there is no inner region, just do a normal traversal, as the traversals are supposedly the same.
     bool tooSmall = false;
     for (unsigned short d = 0; d < 3; ++d) {
-      tooSmall |= this->_cellsPerDimension[d] <= 6;
+      tooSmall |= this->_cellsPerDimension[d] < 6;
     }
     if (not tooSmall) {
       return c08TraversalOuter(loopBody);

--- a/src/autopas/containers/cellPairTraversals/C08BasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/C08BasedTraversal.h
@@ -191,7 +191,7 @@ inline void C08BasedTraversal<ParticleCell, useSoA, useNewton3, blackBoxTraversa
       {
         // upper y: always only one value for y:
         unsigned long y;
-        if (start_y % 2 == 1) {
+        if (start_y == 1) {
           // round to first uneven number smaller than end_y
           y = (end_y & ~1ul) - 1ul;
         } else {  // start_z == 0
@@ -216,7 +216,7 @@ inline void C08BasedTraversal<ParticleCell, useSoA, useNewton3, blackBoxTraversa
 #if defined(AUTOPAS_OPENMP)
 #pragma omp for schedule(dynamic, 1) collapse(3) nowait
 #endif
-        // lower y
+        // lower x
         for (unsigned long z = start_z_inner; z < end_z_inner; z += stride_z) {
           for (unsigned long y = start_y_inner; y < end_y_inner; y += stride_y) {
             for (unsigned long x = start_x; x < 3; x += stride_x) {
@@ -227,9 +227,9 @@ inline void C08BasedTraversal<ParticleCell, useSoA, useNewton3, blackBoxTraversa
       }
 
       {
-        // upper y: always only one value for y:
+        // upper x: always only one value for x:
         unsigned long x;
-        if (start_x % 2 == 1) {
+        if (start_x == 1) {
           // round to first uneven number smaller than end_x
           x = (end_x & ~1ul) - 1ul;
         } else {  // start_z == 0
@@ -237,7 +237,7 @@ inline void C08BasedTraversal<ParticleCell, useSoA, useNewton3, blackBoxTraversa
           x = (end_x - 1ul) & ~1ul;
         }
 #if defined(AUTOPAS_OPENMP)
-        // no nowait here!
+        // no nowait here, as we want a barrier at the end of the entire loop over the color.
 #pragma omp for schedule(dynamic, 1) collapse(2)
 #endif
         for (unsigned long z = start_z_inner; z < end_z_inner; z += stride_z) {

--- a/src/autopas/containers/cellPairTraversals/C08BasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/C08BasedTraversal.h
@@ -7,8 +7,9 @@
 #pragma once
 
 #include "autopas/containers/cellPairTraversals/CellPairTraversal.h"
+#include "autopas/options/BlackBoxOptions.h"
+#include "autopas/utils/ArrayMath.h"
 #include "autopas/utils/ThreeDimensionalMapping.h"
-
 namespace autopas {
 
 /**
@@ -21,8 +22,10 @@ namespace autopas {
  * @tparam PairwiseFunctor The functor that defines the interaction of two particles.
  * @tparam useSoA
  * @tparam useNewton3
+ * @tparam blackBoxTraversalOption The blackbox traversal option to be used.
  */
-template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3>
+template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3,
+          BlackBoxTraversalOption blackBoxTraversalOption = normal>
 class C08BasedTraversal : public CellPairTraversal<ParticleCell> {
  public:
   /**
@@ -47,13 +50,34 @@ class C08BasedTraversal : public CellPairTraversal<ParticleCell> {
    */
   template <typename LoopBody>
   inline void c08Traversal(LoopBody&& loopBody);
+
+  /**
+   * The main traversal of the C08Traversal for the outer blackbox case.
+   * @copydetails C01BasedTraversal::c01Traversal()
+   */
+  template <typename LoopBody>
+  inline void c08TraversalOuter(LoopBody&& loopBody);
 };
 
-template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3>
+template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3,
+          BlackBoxTraversalOption blackBoxTraversalOption>
 template <typename LoopBody>
-inline void C08BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>::c08Traversal(LoopBody&& loopBody) {
+inline void C08BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3, blackBoxTraversalOption>::c08Traversal(
+    LoopBody&& loopBody) {
+  if (blackBoxTraversalOption == outer) {
+    // tooSmall indicates whether there is any inner region.
+    // If there is no inner region, just do a normal traversal, as the traversals are supposedly the same.
+    bool tooSmall = false;
+    for (unsigned short d = 0; d < 3; ++d) {
+      tooSmall |= this->_cellsPerDimension[d] <= 6;
+    }
+    if (not tooSmall) {
+      return c08TraversalOuter(loopBody);
+    }  // else: do normal traversal!
+  }
   using std::array;
   const array<unsigned long, 3> stride = {2, 2, 2};
+  const array<unsigned long, 3> blackBoxOffset = {2, 2, 2};
   array<unsigned long, 3> end = {};
   for (int d = 0; d < 3; ++d) {
     end[d] = this->_cellsPerDimension[d] - 1;
@@ -65,6 +89,11 @@ inline void C08BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>
   {
     for (unsigned long col = 0; col < 8; ++col) {
       std::array<unsigned long, 3> start = utils::ThreeDimensionalMapping::oneToThreeD(col, stride);
+
+      if (blackBoxTraversalOption == inner) {
+        start = ArrayMath::add(start, blackBoxOffset);
+        end = ArrayMath::sub(end, blackBoxOffset);
+      }
 
       // intel compiler demands following:
       const unsigned long start_x = start[0], start_y = start[1], start_z = start[2];
@@ -84,4 +113,144 @@ inline void C08BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>
     }
   }
 }
+
+template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3,
+          BlackBoxTraversalOption blackBoxTraversalOption>
+template <typename LoopBody>
+inline void C08BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3,
+                              blackBoxTraversalOption>::c08TraversalOuter(LoopBody&& loopBody) {
+  using std::array;
+  const array<unsigned long, 3> stride = {2, 2, 2};
+  array<unsigned long, 3> end = {};
+  for (int d = 0; d < 3; ++d) {
+    end[d] = this->_cellsPerDimension[d] - 1;
+  }
+
+#if defined(AUTOPAS_OPENMP)
+#pragma omp parallel
+#endif
+  {
+    for (unsigned long col = 0; col < 8; ++col) {
+      std::array<unsigned long, 3> start = utils::ThreeDimensionalMapping::oneToThreeD(col, stride);
+
+      // intel compiler demands following:
+      const unsigned long start_x = start[0], start_y = start[1], start_z = start[2];
+      const unsigned long end_x = end[0], end_y = end[1], end_z = end[2];
+      const unsigned long stride_x = stride[0], stride_y = stride[1], stride_z = stride[2];
+
+      // z:
+      {
+#if defined(AUTOPAS_OPENMP)
+#pragma omp for schedule(dynamic, 1) collapse(3) nowait
+#endif
+        // lower z
+        for (unsigned long z = start_z; z < 3; z += stride_z) {
+          for (unsigned long y = start_y; y < end_y; y += stride_y) {
+            for (unsigned long x = start_x; x < end_x; x += stride_x) {
+              loopBody(x, y, z);
+            }
+          }
+        }
+      }
+
+      unsigned long end_z_inner;
+      {
+        // upper z: always only one value for z:
+        unsigned long z;
+        if (start_z == 1) {
+          // round to first uneven number smaller than end_z
+          z = (end_z & ~1ul) - 1ul;
+        } else {  // start_z == 0
+          // round to first even number smaller than end_z
+          z = (end_z - 1ul) & ~1ul;
+        }
+        end_z_inner = z;
+#if defined(AUTOPAS_OPENMP)
+#pragma omp for schedule(dynamic, 1) collapse(2) nowait
+#endif
+        for (unsigned long y = start_y; y < end_y; y += stride_y) {
+          for (unsigned long x = start_x; x < end_x; x += stride_x) {
+            loopBody(x, y, z);
+          }
+        }
+      }
+
+      const unsigned long start_z_inner = 4 - start_z;  // (start_z == 0 ? 4 : 3);
+      // y:
+      {
+#if defined(AUTOPAS_OPENMP)
+#pragma omp for schedule(dynamic, 1) collapse(3) nowait
+#endif
+        // lower y
+        for (unsigned long z = start_z_inner; z < end_z_inner; z += stride_z) {
+          for (unsigned long y = start_y; y < 3; y += stride_y) {
+            for (unsigned long x = start_x; x < end_x; x += stride_x) {
+              loopBody(x, y, z);
+            }
+          }
+        }
+      }
+
+      unsigned long end_y_inner;
+      {
+        // upper y: always only one value for y:
+        unsigned long y;
+        if (start_y % 2 == 1) {
+          // round to first uneven number smaller than end_z
+          y = (end_y & ~1ul) - 1ul;
+        } else {  // start_z == 0
+          // round to first even number smaller than end_z
+          y = (end_y - 1ul) & ~1ul;
+        }
+        end_y_inner = y;
+#if defined(AUTOPAS_OPENMP)
+#pragma omp for schedule(dynamic, 1) collapse(2) nowait
+#endif
+        for (unsigned long z = start_z_inner; z < end_z_inner; z += stride_z) {
+          for (unsigned long x = start_x; x < end_x; x += stride_x) {
+            loopBody(x, y, z);
+          }
+        }
+      }
+
+      const unsigned long start_y_inner = 4 - start_y;  // (start_z == 0 ? 4 : 3);
+
+      // x:
+      {
+#if defined(AUTOPAS_OPENMP)
+#pragma omp for schedule(dynamic, 1) collapse(3) nowait
+#endif
+        // lower y
+        for (unsigned long z = start_z_inner; z < end_z_inner; z += stride_z) {
+          for (unsigned long y = start_y_inner; y < end_y_inner; y += stride_y) {
+            for (unsigned long x = start_x; x < 3; x += stride_x) {
+              loopBody(x, y, z);
+            }
+          }
+        }
+      }
+
+      {
+        // upper y: always only one value for y:
+        unsigned long x;
+        if (start_y % 2 == 1) {
+          // round to first uneven number smaller than end_z
+          x = (end_y & ~1ul) - 1ul;
+        } else {  // start_z == 0
+          // round to first even number smaller than end_z
+          x = (end_y - 1ul) & ~1ul;
+        }
+#if defined(AUTOPAS_OPENMP)
+#pragma omp for schedule(dynamic, 1) collapse(2)
+#endif
+        for (unsigned long z = start_z_inner; z < end_z_inner; z += stride_z) {
+          for (unsigned long y = start_y_inner; y < end_y_inner; y += stride_y) {
+            loopBody(x, y, z);
+          }
+        }
+      }
+    }
+  }
+}
+
 }  // namespace autopas

--- a/src/autopas/containers/cellPairTraversals/C18BasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/C18BasedTraversal.h
@@ -17,21 +17,18 @@ namespace autopas {
  * cell and all adjacent cells with greater ID are safe, even when using newton3 optimizations.
  *
  * @tparam ParticleCell the type of cells
- * @tparam PairwiseFunctor The functor that defines the interaction of two particles.
  * @tparam useSoA
  * @tparam useNewton3
  */
-template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3>
+template <class ParticleCell, bool useSoA, bool useNewton3>
 class C18BasedTraversal : public CellPairTraversal<ParticleCell> {
  public:
   /**
    * Constructor of the c18 traversal.
    * @param dims The dimensions of the cellblock, i.e. the number of cells in x,
    * y and z direction.
-   * @param pairwiseFunctor The functor that defines the interaction of two particles.
    */
-  explicit C18BasedTraversal(const std::array<unsigned long, 3>& dims, PairwiseFunctor* pairwiseFunctor)
-      : CellPairTraversal<ParticleCell>(dims) {}
+  explicit C18BasedTraversal(const std::array<unsigned long, 3>& dims) : CellPairTraversal<ParticleCell>(dims) {}
 
   /**
    * C18 traversals are always usable.
@@ -48,9 +45,9 @@ class C18BasedTraversal : public CellPairTraversal<ParticleCell> {
   inline void c18Traversal(LoopBody&& loopBody);
 };
 
-template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3>
+template <class ParticleCell, bool useSoA, bool useNewton3>
 template <typename LoopBody>
-inline void C18BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>::c18Traversal(LoopBody&& loopBody) {
+inline void C18BasedTraversal<ParticleCell, useSoA, useNewton3>::c18Traversal(LoopBody&& loopBody) {
   using std::array;
   const array<unsigned long, 3> stride = {3, 3, 2};
   array<unsigned long, 3> end = {};

--- a/src/autopas/containers/cellPairTraversals/SlicedBasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/SlicedBasedTraversal.h
@@ -24,20 +24,18 @@ namespace autopas {
  * as soon the boundary wall is fully processed.
  *
  * @tparam ParticleCell The type of cells.
- * @tparam PairwiseFunctor The functor that defines the interaction of two particles.
  * @tparam useSoA
  * @tparam useNewton3
  */
-template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3>
+template <class ParticleCell, bool useSoA, bool useNewton3>
 class SlicedBasedTraversal : public CellPairTraversal<ParticleCell> {
  public:
   /**
    * Constructor of the sliced traversal.
    * @param dims The dimensions of the cellblock, i.e. the number of cells in x,
    * y and z direction.
-   * @param pairwiseFunctor The functor that defines the interaction of two particles.
    */
-  explicit SlicedBasedTraversal(const std::array<unsigned long, 3> &dims, PairwiseFunctor *pairwiseFunctor)
+  explicit SlicedBasedTraversal(const std::array<unsigned long, 3> &dims)
       : CellPairTraversal<ParticleCell>(dims), _dimsPerLength{}, _sliceThickness{}, locks() {
     rebuild(dims);
   }
@@ -67,9 +65,8 @@ class SlicedBasedTraversal : public CellPairTraversal<ParticleCell> {
   std::vector<AutoPasLock> locks;
 };
 
-template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3>
-inline void SlicedBasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>::rebuild(
-    const std::array<unsigned long, 3> &dims) {
+template <class ParticleCell, bool useSoA, bool useNewton3>
+inline void SlicedBasedTraversal<ParticleCell, useSoA, useNewton3>::rebuild(const std::array<unsigned long, 3> &dims) {
   CellPairTraversal<ParticleCell>::rebuild(dims);
 
   // find longest dimension
@@ -101,9 +98,9 @@ inline void SlicedBasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewto
 
   locks.resize(numSlices);
 }
-template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3>
+template <class ParticleCell, bool useSoA, bool useNewton3>
 template <typename LoopBody>
-void SlicedBasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>::slicedTraversal(LoopBody &&loopBody) {
+void SlicedBasedTraversal<ParticleCell, useSoA, useNewton3>::slicedTraversal(LoopBody &&loopBody) {
   using std::array;
 
   auto numSlices = _sliceThickness.size();

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -92,8 +92,8 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
    */
   template <class ParticleFunctor, class Traversal>
   void iteratePairwiseSoA(ParticleFunctor *f, Traversal *traversal, bool useNewton3 = true) {
-    AutoPasLog(debug, "Using traversal {} with SoA ", utils::StringUtils::to_string(traversal->getTraversalType()))
-        f->SoALoader(*getCell(), (*getCell())._particleSoABuffer);
+    AutoPasLog(debug, "Using traversal {} with SoA ", utils::StringUtils::to_string(traversal->getTraversalType()));
+    f->SoALoader(*getCell(), (*getCell())._particleSoABuffer);
     f->SoALoader(*getHaloCell(), (*getHaloCell())._particleSoABuffer);
 
     if (auto *traversalInterface = dynamic_cast<DirectSumTraversalInterface<ParticleCell> *>(traversal)) {

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -90,14 +90,10 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
    */
   template <class ParticleFunctor, class Traversal>
   void iteratePairwiseAoS(ParticleFunctor *f, Traversal *traversal, bool useNewton3 = true) {
-    AutoPasLog(debug, "Using traversal {} with AoS",
-               utils::StringUtils::to_string(
-                   traversal->getTraversalType())) if (auto *traversalInterface =
-                                                           dynamic_cast<LinkedCellTraversalInterface<ParticleCell> *>(
-                                                               traversal)) {
+    AutoPasLog(debug, "Using traversal {} with AoS", utils::StringUtils::to_string(traversal->getTraversalType()));
+    if (auto *traversalInterface = dynamic_cast<LinkedCellTraversalInterface<ParticleCell> *>(traversal)) {
       traversalInterface->traverseCellPairs(this->_cells);
-    }
-    else {
+    } else {
       autopas::utils::ExceptionHandler::exception(
           "Trying to use a traversal of wrong type in LinkedCells::iteratePairwiseAoS. TraversalID: {}",
           traversal->getTraversalType());
@@ -115,8 +111,8 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
    */
   template <class ParticleFunctor, class Traversal>
   void iteratePairwiseSoA(ParticleFunctor *f, Traversal *traversal, bool useNewton3 = true) {
-    AutoPasLog(debug, "Using traversal {} with SoA ", utils::StringUtils::to_string(traversal->getTraversalType()))
-        loadSoAs(f);
+    AutoPasLog(debug, "Using traversal {} with SoA ", utils::StringUtils::to_string(traversal->getTraversalType()));
+    loadSoAs(f);
     if (auto *traversalInterface = dynamic_cast<LinkedCellTraversalInterface<ParticleCell> *>(traversal)) {
       traversalInterface->traverseCellPairs(this->_cells);
     } else {

--- a/src/autopas/containers/linkedCells/traversals/C01Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/C01Traversal.h
@@ -24,7 +24,7 @@ namespace autopas {
  * @tparam useNewton3
  */
 template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3>
-class C01Traversal : public C01BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>,
+class C01Traversal : public C01BasedTraversal<ParticleCell, useSoA, useNewton3>,
                      public LinkedCellTraversalInterface<ParticleCell> {
  public:
   /**
@@ -34,7 +34,7 @@ class C01Traversal : public C01BasedTraversal<ParticleCell, PairwiseFunctor, use
    * @param pairwiseFunctor The functor that defines the interaction of two particles.
    */
   explicit C01Traversal(const std::array<unsigned long, 3> &dims, PairwiseFunctor *pairwiseFunctor)
-      : C01BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>(dims, pairwiseFunctor),
+      : C01BasedTraversal<ParticleCell, useSoA, useNewton3>(dims),
         _cellFunctor(
             CellFunctor<typename ParticleCell::ParticleType, ParticleCell, PairwiseFunctor, useSoA, false, false>(
                 pairwiseFunctor)) {

--- a/src/autopas/containers/linkedCells/traversals/C08Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/C08Traversal.h
@@ -27,9 +27,8 @@ namespace autopas {
  */
 template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3,
           BlackBoxTraversalOption blackBoxTraversalOption = normal>
-class C08Traversal
-    : public C08BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3, blackBoxTraversalOption>,
-      public LinkedCellTraversalInterface<ParticleCell> {
+class C08Traversal : public C08BasedTraversal<ParticleCell, useSoA, useNewton3, blackBoxTraversalOption>,
+                     public LinkedCellTraversalInterface<ParticleCell> {
  public:
   /**
    * Constructor of the c08 traversal.
@@ -38,8 +37,7 @@ class C08Traversal
    * @param pairwiseFunctor The functor that defines the interaction of two particles.
    */
   explicit C08Traversal(const std::array<unsigned long, 3> &dims, PairwiseFunctor *pairwiseFunctor)
-      : C08BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3, blackBoxTraversalOption>(dims,
-                                                                                                      pairwiseFunctor),
+      : C08BasedTraversal<ParticleCell, useSoA, useNewton3, blackBoxTraversalOption>(dims),
         _cellHandler(pairwiseFunctor, this->_cellsPerDimension) {}
 
   /**

--- a/src/autopas/containers/linkedCells/traversals/C08Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/C08Traversal.h
@@ -25,9 +25,11 @@ namespace autopas {
  * @tparam useSoA
  * @tparam useNewton3
  */
-template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3>
-class C08Traversal : public C08BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>,
-                     public LinkedCellTraversalInterface<ParticleCell> {
+template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3,
+          BlackBoxTraversalOption blackBoxTraversalOption = normal>
+class C08Traversal
+    : public C08BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3, blackBoxTraversalOption>,
+      public LinkedCellTraversalInterface<ParticleCell> {
  public:
   /**
    * Constructor of the c08 traversal.
@@ -36,7 +38,8 @@ class C08Traversal : public C08BasedTraversal<ParticleCell, PairwiseFunctor, use
    * @param pairwiseFunctor The functor that defines the interaction of two particles.
    */
   explicit C08Traversal(const std::array<unsigned long, 3> &dims, PairwiseFunctor *pairwiseFunctor)
-      : C08BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>(dims, pairwiseFunctor),
+      : C08BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3, blackBoxTraversalOption>(dims,
+                                                                                                      pairwiseFunctor),
         _cellHandler(pairwiseFunctor, this->_cellsPerDimension) {}
 
   /**
@@ -49,8 +52,9 @@ class C08Traversal : public C08BasedTraversal<ParticleCell, PairwiseFunctor, use
   C08CellHandler<ParticleCell, PairwiseFunctor, useSoA, useNewton3> _cellHandler;
 };
 
-template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3>
-inline void C08Traversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>::traverseCellPairs(
+template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3,
+          BlackBoxTraversalOption blackBoxTraversalOption>
+inline void C08Traversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3, blackBoxTraversalOption>::traverseCellPairs(
     std::vector<ParticleCell> &cells) {
   this->c08Traversal([&](unsigned long x, unsigned long y, unsigned long z) {
     unsigned long baseIndex = utils::ThreeDimensionalMapping::threeToOneD(x, y, z, this->_cellsPerDimension);

--- a/src/autopas/containers/linkedCells/traversals/C18Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/C18Traversal.h
@@ -25,7 +25,7 @@ namespace autopas {
  * @tparam useNewton3
  */
 template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3>
-class C18Traversal : public C18BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>,
+class C18Traversal : public C18BasedTraversal<ParticleCell, useSoA, useNewton3>,
                      public LinkedCellTraversalInterface<ParticleCell> {
  public:
   /**
@@ -35,7 +35,7 @@ class C18Traversal : public C18BasedTraversal<ParticleCell, PairwiseFunctor, use
    * @param pairwiseFunctor The functor that defines the interaction of two particles.
    */
   explicit C18Traversal(const std::array<unsigned long, 3> &dims, PairwiseFunctor *pairwiseFunctor)
-      : C18BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>(dims, pairwiseFunctor),
+      : C18BasedTraversal<ParticleCell, useSoA, useNewton3>(dims),
         _cellFunctor(
             CellFunctor<typename ParticleCell::ParticleType, ParticleCell, PairwiseFunctor, useSoA, useNewton3>(
                 pairwiseFunctor)) {

--- a/src/autopas/containers/linkedCells/traversals/SlicedTraversal.h
+++ b/src/autopas/containers/linkedCells/traversals/SlicedTraversal.h
@@ -32,7 +32,7 @@ namespace autopas {
  * @tparam useNewton3
  */
 template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3>
-class SlicedTraversal : public SlicedBasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>,
+class SlicedTraversal : public SlicedBasedTraversal<ParticleCell, useSoA, useNewton3>,
                         public LinkedCellTraversalInterface<ParticleCell> {
  public:
   /**
@@ -42,7 +42,7 @@ class SlicedTraversal : public SlicedBasedTraversal<ParticleCell, PairwiseFuncto
    * @param pairwiseFunctor The functor that defines the interaction of two particles.
    */
   explicit SlicedTraversal(const std::array<unsigned long, 3> &dims, PairwiseFunctor *pairwiseFunctor)
-      : SlicedBasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>(dims, pairwiseFunctor),
+      : SlicedBasedTraversal<ParticleCell, useSoA, useNewton3>(dims),
         _cellHandler(pairwiseFunctor, this->_cellsPerDimension) {}
 
   /**

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -60,10 +60,11 @@ class VerletListsLinkedBase : public ParticleContainer<Particle, FullParticleCel
       _neighborListIsValid = false;
     } else {
       // If the blackBoxMode is used the lists become invalid if the particles are added to far into the domain.
+      double cutoff = this->getCutoff();
       if (autopas::utils::inBox(p.getR(),
                                 // cutoff includes skin already!
-                                ArrayMath::add(this->getBoxMin(), {this->_cutoff, this->_cutoff, this->_cutoff}),
-                                ArrayMath::sub(this->getBoxMax(), {this->_cutoff, this->_cutoff, this->_cutoff}))) {
+                                ArrayMath::add(this->getBoxMin(), {cutoff, cutoff, cutoff}),
+                                ArrayMath::sub(this->getBoxMax(), {cutoff, cutoff, cutoff}))) {
         _neighborListIsValid = false;
       }
     }

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -202,6 +202,25 @@ class VerletListsLinkedBase : public ParticleContainer<Particle, FullParticleCel
     return _linkedCells.getCellBlock().getCellsPerDimensionWithHalo();
   }
 
+  /**
+   * Specifies whether the neighbor lists need to be rebuild.
+   * @param useNewton3 if newton3 is gonna be used to traverse
+   * @return True if the neighbor lists need to be rebuild, false otherwise.
+   */
+  bool needsRebuild(bool useNewton3) {
+    AutoPasLog(debug, "VerletLists: neighborlist is valid: {}", _neighborListIsValid);
+    // if the neighbor list is NOT valid, we have not rebuild for _rebuildFrequency steps or useNewton3 changed
+    return (not _neighborListIsValid) or (_traversalsSinceLastRebuild >= _rebuildFrequency) or
+           (useNewton3 != _verletBuiltNewton3);
+  }
+
+  /**
+   * Specifies whether the neighbor lists need to be rebuild.
+   * @note Assumes that the newton3 type has NOT changed!
+   * @return True if the neighbor lists need to be rebuild, false otherwise.
+   */
+  bool needsRebuild() { return needsRebuild(_verletBuiltNewton3); }
+
  protected:
   /**
    * Updates a found particle within cellI to the values of particleI.
@@ -239,6 +258,9 @@ class VerletListsLinkedBase : public ParticleContainer<Particle, FullParticleCel
 
   /// specifies whether this verlet list container runs in blackbox mode
   bool _blackBoxMode;
+
+  /// specifies if the current verlet list was built for newton3
+  bool _verletBuiltNewton3;
 };
 
 }  // namespace autopas

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -106,8 +106,8 @@ class VerletListsLinkedBase : public ParticleContainer<Particle, FullParticleCel
   bool isContainerUpdateNeeded() override {
     std::atomic<bool> outlierFound(false);
 #ifdef AUTOPAS_OPENMP
-    // TODO: find a sensible value for "threshold"
-#pragma omp parallel for shared(outlierFound)  // if (this->_cells.size() / omp_get_max_threads() > threshold)
+    // TODO: find a sensible value for ???
+#pragma omp parallel for shared(outlierFound)  // if (this->_cells.size() / omp_get_max_threads() > ???)
 #endif
     for (size_t cellIndex1d = 0; cellIndex1d < _linkedCells.getCells().size(); ++cellIndex1d) {
       std::array<double, 3> boxmin{0., 0., 0.};

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -106,8 +106,8 @@ class VerletListsLinkedBase : public ParticleContainer<Particle, FullParticleCel
   bool isContainerUpdateNeeded() override {
     std::atomic<bool> outlierFound(false);
 #ifdef AUTOPAS_OPENMP
-    // TODO: find a sensible value for ???
-#pragma omp parallel for shared(outlierFound)  // if (this->_cells.size() / omp_get_max_threads() > ???)
+    // TODO: find a sensible value for "threshold"
+#pragma omp parallel for shared(outlierFound)  // if (this->_cells.size() / omp_get_max_threads() > threshold)
 #endif
     for (size_t cellIndex1d = 0; cellIndex1d < _linkedCells.getCells().size(); ++cellIndex1d) {
       std::array<double, 3> boxmin{0., 0., 0.};

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
@@ -24,11 +24,11 @@ class VerletListHelpers {
   typedef std::unordered_map<Particle *, std::vector<Particle *>> AoS_verletlist_storage_type;
 
   /// typedef for soa's of verlet list's linked cells (only id and position needs to be stored)
-  //typedef utils::SoAType<size_t, double, double, double>::Type SoAArraysType;
+  // typedef utils::SoAType<size_t, double, double, double>::Type SoAArraysType;
   using SoAArraysType = typename Particle::SoAArraysType;
 
   /// attributes for soa's of verlet list's linked cells (only id and position needs to be stored)
-  //enum AttributeNames : int { id, posX, posY, posZ };
+  // enum AttributeNames : int { id, posX, posY, posZ };
   using AttributeNames = typename Particle::AttributeNames;
 
   /// typedef for verlet-list particle cell type

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
@@ -24,10 +24,12 @@ class VerletListHelpers {
   typedef std::unordered_map<Particle *, std::vector<Particle *>> AoS_verletlist_storage_type;
 
   /// typedef for soa's of verlet list's linked cells (only id and position needs to be stored)
-  typedef utils::SoAType<size_t, double, double, double>::Type SoAArraysType;
+  //typedef utils::SoAType<size_t, double, double, double>::Type SoAArraysType;
+  using SoAArraysType = typename Particle::SoAArraysType;
 
   /// attributes for soa's of verlet list's linked cells (only id and position needs to be stored)
-  enum AttributeNames : int { id, posX, posY, posZ };
+  //enum AttributeNames : int { id, posX, posY, posZ };
+  using AttributeNames = typename Particle::AttributeNames;
 
   /// typedef for verlet-list particle cell type
   typedef FullParticleCell<Particle, SoAArraysType> VerletListParticleCellType;
@@ -71,10 +73,10 @@ class VerletListHelpers {
     void SoAFunctor(SoA<SoAArraysType> &soa, bool newton3) override {
       if (soa.getNumParticles() == 0) return;
 
-      auto **const __restrict__ idptr = reinterpret_cast<Particle **const>(soa.begin<AttributeNames::id>());
-      double *const __restrict__ xptr = soa.begin<AttributeNames::posX>();
-      double *const __restrict__ yptr = soa.begin<AttributeNames::posY>();
-      double *const __restrict__ zptr = soa.begin<AttributeNames::posZ>();
+      auto **const __restrict__ idptr = reinterpret_cast<Particle **const>(soa.template begin<AttributeNames::id>());
+      double *const __restrict__ xptr = soa.template begin<AttributeNames::posX>();
+      double *const __restrict__ yptr = soa.template begin<AttributeNames::posY>();
+      double *const __restrict__ zptr = soa.template begin<AttributeNames::posZ>();
 
       size_t numPart = soa.getNumParticles();
       for (unsigned int i = 0; i < numPart; ++i) {
@@ -109,15 +111,15 @@ class VerletListHelpers {
     void SoAFunctor(SoA<SoAArraysType> &soa1, SoA<SoAArraysType> &soa2, bool /*newton3*/) override {
       if (soa1.getNumParticles() == 0 || soa2.getNumParticles() == 0) return;
 
-      auto **const __restrict__ id1ptr = reinterpret_cast<Particle **const>(soa1.begin<AttributeNames::id>());
-      double *const __restrict__ x1ptr = soa1.begin<AttributeNames::posX>();
-      double *const __restrict__ y1ptr = soa1.begin<AttributeNames::posY>();
-      double *const __restrict__ z1ptr = soa1.begin<AttributeNames::posZ>();
+      auto **const __restrict__ id1ptr = reinterpret_cast<Particle **const>(soa1.template begin<AttributeNames::id>());
+      double *const __restrict__ x1ptr = soa1.template begin<AttributeNames::posX>();
+      double *const __restrict__ y1ptr = soa1.template begin<AttributeNames::posY>();
+      double *const __restrict__ z1ptr = soa1.template begin<AttributeNames::posZ>();
 
-      auto **const __restrict__ id2ptr = reinterpret_cast<Particle **const>(soa2.begin<AttributeNames::id>());
-      double *const __restrict__ x2ptr = soa2.begin<AttributeNames::posX>();
-      double *const __restrict__ y2ptr = soa2.begin<AttributeNames::posY>();
-      double *const __restrict__ z2ptr = soa2.begin<AttributeNames::posZ>();
+      auto **const __restrict__ id2ptr = reinterpret_cast<Particle **const>(soa2.template begin<AttributeNames::id>());
+      double *const __restrict__ x2ptr = soa2.template begin<AttributeNames::posX>();
+      double *const __restrict__ y2ptr = soa2.template begin<AttributeNames::posY>();
+      double *const __restrict__ z2ptr = soa2.template begin<AttributeNames::posZ>();
 
       size_t numPart1 = soa1.getNumParticles();
       for (unsigned int i = 0; i < numPart1; ++i) {
@@ -152,14 +154,14 @@ class VerletListHelpers {
      */
     void SoALoader(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override {
       assert(offset == 0);
-      soa.resizeArrays(cell.numParticles());
+      soa.template resizeArrays<4>(cell.numParticles());
 
       if (cell.numParticles() == 0) return;
 
-      unsigned long *const __restrict__ idptr = soa.begin<AttributeNames::id>();
-      double *const __restrict__ xptr = soa.begin<AttributeNames::posX>();
-      double *const __restrict__ yptr = soa.begin<AttributeNames::posY>();
-      double *const __restrict__ zptr = soa.begin<AttributeNames::posZ>();
+      unsigned long *const __restrict__ idptr = soa.template begin<AttributeNames::id>();
+      double *const __restrict__ xptr = soa.template begin<AttributeNames::posX>();
+      double *const __restrict__ yptr = soa.template begin<AttributeNames::posY>();
+      double *const __restrict__ zptr = soa.template begin<AttributeNames::posZ>();
 
       auto cellIter = cell.begin();
       // load particles in SoAs

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
@@ -55,7 +55,7 @@ class VerletListHelpers {
     void AoSFunctor(Particle &i, Particle &j, bool newton3) override {
       auto dist = ArrayMath::sub(i.getR(), j.getR());
       double distsquare = ArrayMath::dot(dist, dist);
-      if (distsquare < _cutoffskinsquared)
+      if (distsquare < _cutoffskinsquared) {
         // this is thread safe, only if particle i is accessed by only one
         // thread at a time. which is ensured, as particle i resides in a
         // specific cell and each cell is only accessed by one thread at a time
@@ -63,6 +63,10 @@ class VerletListHelpers {
         // also the list is not allowed to be resized!
 
         _verletListsAoS.at(&i).push_back(&j);
+        if (not newton3) {
+          _verletListsAoS.at(&j).push_back(&i);
+        }
+      }
     }
 
     /**

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -291,7 +291,19 @@ class VerletLists
    * @param useNewton3
    */
   template <class ParticleFunctor>
-  void iterateBoundaryPartsSoA(ParticleFunctor* f, const bool useNewton3) {}
+  void iterateBoundaryPartsSoA(ParticleFunctor* f, const bool useNewton3) {
+    if (useNewton3) {
+      C08Traversal<ParticleCell, ParticleFunctor, /*useSoA*/ true, /*useNewton3*/ true,
+                   BlackBoxTraversalOption::outer>
+          traversal(this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), f);
+      traversal.traverseCellPairs(this->_linkedCells.getCells());
+    } else {
+      C08Traversal<ParticleCell, ParticleFunctor, /*useSoA*/ true, /*useNewton3*/ false,
+                   BlackBoxTraversalOption::outer>
+          traversal(this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), f);
+      traversal.traverseCellPairs(this->_linkedCells.getCells());
+    }
+  }
 
   /**
    * Iterate over the boundary dependent parts of the domain using the SoA traversal.
@@ -300,7 +312,19 @@ class VerletLists
    * @param useNewton3
    */
   template <class ParticleFunctor>
-  void iterateBoundaryPartsAoS(ParticleFunctor* f, const bool useNewton3) {}
+  void iterateBoundaryPartsAoS(ParticleFunctor* f, const bool useNewton3) {
+    if (useNewton3) {
+      C08Traversal<ParticleCell, ParticleFunctor, /*useSoA*/ false, /*useNewton3*/ true,
+                   BlackBoxTraversalOption::outer>
+          traversal(this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), f);
+      traversal.traverseCellPairs(this->_linkedCells.getCells());
+    } else {
+      C08Traversal<ParticleCell, ParticleFunctor, /*useSoA*/ false, /*useNewton3*/ false,
+                   BlackBoxTraversalOption::outer>
+          traversal(this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), f);
+      traversal.traverseCellPairs(this->_linkedCells.getCells());
+    }
+  }
 
   /**
    * Iterate over the verlet lists using the SoA traversal

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -293,13 +293,11 @@ class VerletLists
   template <class ParticleFunctor>
   void iterateBoundaryPartsSoA(ParticleFunctor* f, const bool useNewton3) {
     if (useNewton3) {
-      C08Traversal<ParticleCell, ParticleFunctor, /*useSoA*/ true, /*useNewton3*/ true,
-                   BlackBoxTraversalOption::outer>
+      C08Traversal<ParticleCell, ParticleFunctor, /*useSoA*/ true, /*useNewton3*/ true, BlackBoxTraversalOption::outer>
           traversal(this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), f);
       traversal.traverseCellPairs(this->_linkedCells.getCells());
     } else {
-      C08Traversal<ParticleCell, ParticleFunctor, /*useSoA*/ true, /*useNewton3*/ false,
-                   BlackBoxTraversalOption::outer>
+      C08Traversal<ParticleCell, ParticleFunctor, /*useSoA*/ true, /*useNewton3*/ false, BlackBoxTraversalOption::outer>
           traversal(this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), f);
       traversal.traverseCellPairs(this->_linkedCells.getCells());
     }
@@ -314,8 +312,7 @@ class VerletLists
   template <class ParticleFunctor>
   void iterateBoundaryPartsAoS(ParticleFunctor* f, const bool useNewton3) {
     if (useNewton3) {
-      C08Traversal<ParticleCell, ParticleFunctor, /*useSoA*/ false, /*useNewton3*/ true,
-                   BlackBoxTraversalOption::outer>
+      C08Traversal<ParticleCell, ParticleFunctor, /*useSoA*/ false, /*useNewton3*/ true, BlackBoxTraversalOption::outer>
           traversal(this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), f);
       traversal.traverseCellPairs(this->_linkedCells.getCells());
     } else {

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -11,6 +11,7 @@
 #include "autopas/containers/linkedCells/LinkedCells.h"
 #include "autopas/containers/verletListsCellBased/VerletListsLinkedBase.h"
 #include "autopas/utils/ArrayMath.h"
+#include "autopas/utils/StaticSelectorMacros.h"
 
 namespace autopas {
 
@@ -200,8 +201,7 @@ class VerletLists
 
   /**
    * update the verlet lists for AoS usage
-   * @param useNewton3 CURRENTLY NOT USED!
-   * @todo Build verlet lists according to newton 3.
+   * @param useNewton3 Specifies whether newton 3 should be used or not.
    */
   virtual void updateVerletListsAoS(bool useNewton3) {
     updateIdMapAoS();
@@ -211,29 +211,37 @@ class VerletLists
     switch (_buildVerletListType) {
       case BuildVerletListType::VerletAoS: {
         if (this->_blackBoxMode) {
-          auto traversal =
-              C08Traversal<LinkedParticleCell, typename verlet_internal::VerletListGeneratorFunctor, false, true,
-                           inner>(this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), &f);
-          this->_linkedCells.iteratePairwiseAoS(&f, &traversal);
+          AUTOPAS_WITH_STATIC_BOOL(useNewton3, {
+            auto traversal =
+                C08Traversal<LinkedParticleCell, typename verlet_internal::VerletListGeneratorFunctor, false,
+                             c_useNewton3, inner>(this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), &f);
+            this->_linkedCells.iteratePairwiseAoS(&f, &traversal);
+          })
         } else {
-          auto traversal =
-              C08Traversal<LinkedParticleCell, typename verlet_internal::VerletListGeneratorFunctor, false, true>(
-                  this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), &f);
-          this->_linkedCells.iteratePairwiseAoS(&f, &traversal);
+          AUTOPAS_WITH_STATIC_BOOL(useNewton3, {
+            auto traversal =
+                C08Traversal<LinkedParticleCell, typename verlet_internal::VerletListGeneratorFunctor, false,
+                             c_useNewton3>(this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), &f);
+            this->_linkedCells.iteratePairwiseAoS(&f, &traversal);
+          })
         }
         break;
       }
       case BuildVerletListType::VerletSoA: {
         if (this->_blackBoxMode) {
-          auto traversal =
-              C08Traversal<LinkedParticleCell, typename verlet_internal::VerletListGeneratorFunctor, true, true, inner>(
-                  this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), &f);
-          this->_linkedCells.iteratePairwiseSoA(&f, &traversal);
+          AUTOPAS_WITH_STATIC_BOOL(useNewton3, {
+            auto traversal =
+                C08Traversal<LinkedParticleCell, typename verlet_internal::VerletListGeneratorFunctor, true,
+                             c_useNewton3, inner>(this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), &f);
+            this->_linkedCells.iteratePairwiseSoA(&f, &traversal);
+          })
         } else {
-          auto traversal =
-              C08Traversal<LinkedParticleCell, typename verlet_internal::VerletListGeneratorFunctor, true, true>(
-                  this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), &f);
-          this->_linkedCells.iteratePairwiseSoA(&f, &traversal);
+          AUTOPAS_WITH_STATIC_BOOL(useNewton3, {
+            auto traversal =
+                C08Traversal<LinkedParticleCell, typename verlet_internal::VerletListGeneratorFunctor, true,
+                             c_useNewton3>(this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), &f);
+            this->_linkedCells.iteratePairwiseSoA(&f, &traversal);
+          })
         }
         break;
       }

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -38,7 +38,7 @@ class VerletLists
 
  private:
   static const std::vector<TraversalOptions>& VLApplicableTraversals() {
-    // @todo: implement some traversals for this
+    /// @todo: implement some traversals for this
     static const std::vector<TraversalOptions> v{};
     return v;
   }
@@ -72,11 +72,10 @@ class VerletLists
               const BuildVerletListType buildVerletListType = BuildVerletListType::VerletSoA,
               const bool blackBoxMode = false)
       : VerletListsLinkedBase<Particle, LinkedParticleCell, SoAArraysType>(
-            boxMin, boxMax, cutoff, skin, rebuildFrequency, allVLApplicableTraversals()),
+            boxMin, boxMax, cutoff, skin, rebuildFrequency, allVLApplicableTraversals(), blackBoxMode),
         _soaListIsValid(false),
         _soa(),
-        _buildVerletListType(buildVerletListType),
-        _blackBoxMode(blackBoxMode) {}
+        _buildVerletListType(buildVerletListType) {}
 
   /**
    * Lists all traversal options applicable for the Verlet Lists container.
@@ -102,7 +101,7 @@ class VerletLists
     // we iterated, so increase traversal counter
     this->_traversalsSinceLastRebuild++;
 
-    if (_blackBoxMode) {
+    if (this->_blackBoxMode) {
       iterateBoundaryPartsAoS(f, useNewton3);
     }
   }
@@ -121,7 +120,7 @@ class VerletLists
     iterateVerletListsSoA(f, useNewton3);
     this->_traversalsSinceLastRebuild++;
 
-    if (_blackBoxMode) {
+    if (this->_blackBoxMode) {
       iterateBoundaryPartsSoA(f, useNewton3);
     }
   }
@@ -211,7 +210,7 @@ class VerletLists
     /// @todo autotune traversal
     switch (_buildVerletListType) {
       case BuildVerletListType::VerletAoS: {
-        if (_blackBoxMode) {
+        if (this->_blackBoxMode) {
           auto traversal =
               C08Traversal<LinkedParticleCell, typename verlet_internal::VerletListGeneratorFunctor, false, true,
                            inner>(this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), &f);
@@ -225,7 +224,7 @@ class VerletLists
         break;
       }
       case BuildVerletListType::VerletSoA: {
-        if (_blackBoxMode) {
+        if (this->_blackBoxMode) {
           auto traversal =
               C08Traversal<LinkedParticleCell, typename verlet_internal::VerletListGeneratorFunctor, true, true, inner>(
                   this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), &f);
@@ -582,9 +581,6 @@ class VerletLists
 
   /// specifies how the verlet lists are build
   BuildVerletListType _buildVerletListType;
-
-  /// specifies whether this verlet list container runs in blackbox mode
-  bool _blackBoxMode;
 };
 
 }  // namespace autopas

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -525,7 +525,6 @@ class VerletLists
       // set the map
       _aos2soaMap[&(*iter)] = i;
     }
-    i = 0;
     size_t accumulatedListSize = 0;
     for (auto& aosList : _aosNeighborLists) {
       accumulatedListSize += aosList.second.size();
@@ -537,7 +536,6 @@ class VerletLists
         _soaNeighborLists[i_id][j] = _aos2soaMap.at(neighbor);
         j++;
       }
-      i++;
     }
     AutoPasLog(debug,
                "VerletLists::generateSoAListFromAoSVerletLists: average verlet list "

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -481,8 +481,13 @@ class VerletLists
     auto& cells = this->_linkedCells.getCells();
     auto& dims = this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo();
     if (dims[0] < 6 or dims[1] < 6 or dims[2] < 6) {
-      std::for_each(cells.begin(), cells.end(),
-                    [&](auto& cell) { functor->SoALoader(cell, cell._particleSoABuffer, 0); });
+#ifdef AUTOPAS_OPENMP
+#pragma omp parallel for
+#endif
+      for (size_t i = 0; i < cells.size(); ++i) {
+        auto& cell = cells[i];
+        functor->SoALoader(cell, cell._particleSoABuffer, 0);
+      }
     } else {
       boundaryRelevantTraversal(dims, [&](size_t x, size_t y, size_t z) {
         auto& cell = cells[utils::ThreeDimensionalMapping::threeToOneD(x, y, z, dims)];

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -390,6 +390,7 @@ class VerletLists
   /**
    * Loops over relevant parts of the boundary.
    * @tparam LoopBody
+   * @param dims
    * @param loopBody
    */
   template <class LoopBody>

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -480,10 +480,15 @@ class VerletLists
   void loadBoundarySoA(ParticleFunctor* functor) {
     auto& cells = this->_linkedCells.getCells();
     auto& dims = this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo();
-    boundaryRelevantTraversal(dims, [&](size_t x, size_t y, size_t z) {
-      auto& cell = cells[utils::ThreeDimensionalMapping::threeToOneD(x, y, z, dims)];
-      functor->SoALoader(cell, cell._particleSoABuffer, 0);
-    });
+    if (dims[0] < 6 or dims[1] < 6 or dims[2] < 6) {
+      std::for_each(cells.begin(), cells.end(),
+                    [&](auto& cell) { functor->SoALoader(cell, cell._particleSoABuffer, 0); });
+    } else {
+      boundaryRelevantTraversal(dims, [&](size_t x, size_t y, size_t z) {
+        auto& cell = cells[utils::ThreeDimensionalMapping::threeToOneD(x, y, z, dims)];
+        functor->SoALoader(cell, cell._particleSoABuffer, 0);
+      });
+    }
   }
 
   /**

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -398,13 +398,14 @@ class VerletLists
 #pragma omp parallel
 #endif
     {
+      const size_t dim_x = dims[0], dim_y = dims[1], dim_z = dims[2];
       // lower z
 #if defined(AUTOPAS_OPENMP)
 #pragma omp for collapse(3) nowait
 #endif
       for (size_t z = 0; z < 3; ++z) {
-        for (size_t y = 0; y < dims[1]; ++y) {
-          for (size_t x = 0; x < dims[0]; ++x) {
+        for (size_t y = 0; y < dim_y; ++y) {
+          for (size_t x = 0; x < dim_x; ++x) {
             loopBody(x, y, z);
           }
         }
@@ -413,9 +414,9 @@ class VerletLists
 #if defined(AUTOPAS_OPENMP)
 #pragma omp for collapse(3) nowait
 #endif
-      for (size_t z = dims[2] - 3; z < dims[2]; ++z) {
-        for (size_t y = 0; y < dims[1]; ++y) {
-          for (size_t x = 0; x < dims[0]; ++x) {
+      for (size_t z = dim_z - 3; z < dim_z; ++z) {
+        for (size_t y = 0; y < dim_y; ++y) {
+          for (size_t x = 0; x < dim_x; ++x) {
             loopBody(x, y, z);
           }
         }
@@ -425,9 +426,9 @@ class VerletLists
 #if defined(AUTOPAS_OPENMP)
 #pragma omp for collapse(3) nowait
 #endif
-      for (size_t z = 3; z < dims[2] - 3; ++z) {
+      for (size_t z = 3; z < dim_z - 3; ++z) {
         for (size_t y = 0; y < 3; ++y) {
-          for (size_t x = 0; x < dims[0]; ++x) {
+          for (size_t x = 0; x < dim_x; ++x) {
             loopBody(x, y, z);
           }
         }
@@ -436,9 +437,9 @@ class VerletLists
 #if defined(AUTOPAS_OPENMP)
 #pragma omp for collapse(3) nowait
 #endif
-      for (size_t z = 3; z < dims[2] - 3; ++z) {
-        for (size_t y = dims[1] - 3; y < dims[1]; ++y) {
-          for (size_t x = 0; x < dims[0]; ++x) {
+      for (size_t z = 3; z < dim_z - 3; ++z) {
+        for (size_t y = dim_y - 3; y < dim_y; ++y) {
+          for (size_t x = 0; x < dim_x; ++x) {
             loopBody(x, y, z);
           }
         }
@@ -448,8 +449,8 @@ class VerletLists
 #if defined(AUTOPAS_OPENMP)
 #pragma omp for collapse(3) nowait
 #endif
-      for (size_t z = 3; z < dims[2] - 3; ++z) {
-        for (size_t y = 3; y < dims[1] - 3; ++y) {
+      for (size_t z = 3; z < dim_z - 3; ++z) {
+        for (size_t y = 3; y < dim_y - 3; ++y) {
           for (size_t x = 0; x < 3; ++x) {
             loopBody(x, y, z);
           }
@@ -459,9 +460,9 @@ class VerletLists
 #if defined(AUTOPAS_OPENMP)
 #pragma omp for collapse(3) nowait
 #endif
-      for (size_t z = 3; z < dims[2] - 3; ++z) {
-        for (size_t y = 3; y < dims[1] - 3; ++y) {
-          for (size_t x = dims[0] - 3; x < dims[0]; ++x) {
+      for (size_t z = 3; z < dim_z - 3; ++z) {
+        for (size_t y = 3; y < dim_y - 3; ++y) {
+          for (size_t x = dim_x - 3; x < dim_x; ++x) {
             loopBody(x, y, z);
           }
         }

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -95,7 +95,7 @@ class VerletLists
    */
   template <class ParticleFunctor, class Traversal>
   void iteratePairwiseAoS(ParticleFunctor* f, Traversal* traversal, bool useNewton3 = true) {
-    if (needsRebuild()) {  // if we need to rebuild the list, we should rebuild it!
+    if (this->needsRebuild(useNewton3)) {  // if we need to rebuild the list, we should rebuild it!
       rebuildVerletLists(useNewton3);
     }
     this->iterateVerletListsAoS(f, useNewton3);
@@ -112,7 +112,7 @@ class VerletLists
    */
   template <class ParticleFunctor, class Traversal>
   void iteratePairwiseSoA(ParticleFunctor* f, Traversal* traversal, bool useNewton3 = true) {
-    if (needsRebuild()) {
+    if (this->needsRebuild(useNewton3)) {
       rebuildVerletLists(useNewton3);
       generateSoAListFromAoSVerletLists();
     } else if (not _soaListIsValid) {
@@ -176,16 +176,6 @@ class VerletLists
     return TraversalSelector<ParticleCell>({0, 0, 0}, {dummyTraversal});
   }
 
-  /**
-   * specifies whether the neighbor lists need to be rebuild
-   * @return true if the neighbor lists need to be rebuild, false otherwise
-   */
-  bool needsRebuild() {
-    AutoPasLog(debug, "Neighborlist is valid: {}", this->_neighborListIsValid);
-    // if the neighbor list is NOT valid or we have not rebuilt since this->_rebuildFrequency steps
-    return (not this->_neighborListIsValid) or (this->_traversalsSinceLastRebuild >= this->_rebuildFrequency);
-  }
-
  protected:
   /**
    * Rebuilds the verlet lists, marks them valid and resets the internal counter.
@@ -193,6 +183,7 @@ class VerletLists
    * @param useNewton3
    */
   void rebuildVerletLists(bool useNewton3 = true) {
+    this->_verletBuiltNewton3 = useNewton3;
     this->updateVerletListsAoS(useNewton3);
     // the neighbor list is now valid
     this->_neighborListIsValid = true;

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -366,22 +366,18 @@ class VerletLists
   }
 
   /**
-   * update the AoS id maps.
+   * Update the AoS id maps.
    * The Id Map is used to map the id of a particle to the actual particle
-   * @return
    */
-  size_t updateIdMapAoS() {
+  void updateIdMapAoS() {
     /// @todo: potentially adapt to _blackBox -- only consider inner parts -- not necessary, but might be useful
-    size_t i = 0;
     _aosNeighborLists.clear();
     // DON'T simply parallelize this loop!!! this needs modifications if you
     // want to parallelize it!
-    for (auto iter = this->begin(); iter.isValid(); ++iter, ++i) {
+    for (auto iter = this->begin(); iter.isValid(); ++iter) {
       // create the verlet list entries for all particles
       _aosNeighborLists[&(*iter)];
     }
-
-    return i;
   }
 
   /**
@@ -514,6 +510,8 @@ class VerletLists
    */
   void generateSoAListFromAoSVerletLists() {
     /// @todo adapt to _blackBoxMode
+    /// @todo openmp parallelization?
+
     // resize the list to the size of the aos neighborlist
     _soaNeighborLists.resize(_aosNeighborLists.size());
     // clear the aos 2 soa map

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -156,12 +156,20 @@ class VerletLists
     typename verlet_internal::template VerletListValidityCheckerFunctor<LinkedParticleCell> validityCheckerFunctor(
         _aosNeighborLists, ((this->getCutoff() - this->_skin) * (this->getCutoff() - this->_skin)));
 
-    auto traversal =
-        C08Traversal<LinkedParticleCell,
-                     typename verlet_internal::template VerletListValidityCheckerFunctor<LinkedParticleCell>, false,
-                     true>(this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), &validityCheckerFunctor);
-    this->_linkedCells.iteratePairwiseAoS(&validityCheckerFunctor, &traversal, useNewton3);
-
+    if (this->_blackBoxMode) {
+      auto traversal =
+          C08Traversal<LinkedParticleCell,
+                       typename verlet_internal::template VerletListValidityCheckerFunctor<LinkedParticleCell>, false,
+                       true, BlackBoxTraversalOption::inner>(
+              this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), &validityCheckerFunctor);
+      this->_linkedCells.iteratePairwiseAoS(&validityCheckerFunctor, &traversal, useNewton3);
+    } else {
+      auto traversal =
+          C08Traversal<LinkedParticleCell,
+                       typename verlet_internal::template VerletListValidityCheckerFunctor<LinkedParticleCell>, false,
+                       true>(this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), &validityCheckerFunctor);
+      this->_linkedCells.iteratePairwiseAoS(&validityCheckerFunctor, &traversal, useNewton3);
+    }
     return validityCheckerFunctor.neighborlistsAreValid();
   }
 

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -381,61 +381,82 @@ class VerletLists
   }
 
   /**
-   * Loops over relevant parts of the boundary!
+   * Loops over relevant parts of the boundary.
    * @tparam LoopBody
    * @param loopBody
    */
   template <class LoopBody>
   void boundaryRelevantTraversal(const std::array<size_t, 3>& dims, LoopBody loopBody) {
-    /// @todo optimize OpenMP
+#if defined(AUTOPAS_OPENMP)
+#pragma omp parallel
+#endif
+    {
+      // lower z
+#if defined(AUTOPAS_OPENMP)
+#pragma omp for collapse(3) nowait
+#endif
+      for (size_t z = 0; z < 3; ++z) {
+        for (size_t y = 0; y < dims[1]; ++y) {
+          for (size_t x = 0; x < dims[0]; ++x) {
+            loopBody(x, y, z);
+          }
+        }
+      }
+      // upper z
+#if defined(AUTOPAS_OPENMP)
+#pragma omp for collapse(3) nowait
+#endif
+      for (size_t z = dims[2] - 3; z < dims[2]; ++z) {
+        for (size_t y = 0; y < dims[1]; ++y) {
+          for (size_t x = 0; x < dims[0]; ++x) {
+            loopBody(x, y, z);
+          }
+        }
+      }
 
-    // lower z
-    for (size_t z = 0; z < 3; ++z) {
-      for (size_t y = 0; y < dims[1]; ++y) {
-        for (size_t x = 0; x < dims[0]; ++x) {
-          loopBody(x, y, z);
+      // lower y
+#if defined(AUTOPAS_OPENMP)
+#pragma omp for collapse(3) nowait
+#endif
+      for (size_t z = 3; z < dims[2] - 3; ++z) {
+        for (size_t y = 0; y < 3; ++y) {
+          for (size_t x = 0; x < dims[0]; ++x) {
+            loopBody(x, y, z);
+          }
         }
       }
-    }
-    // upper z
-    for (size_t z = dims[2] - 3; z < dims[2]; ++z) {
-      for (size_t y = 0; y < dims[1]; ++y) {
-        for (size_t x = 0; x < dims[0]; ++x) {
-          loopBody(x, y, z);
+      // upper y
+#if defined(AUTOPAS_OPENMP)
+#pragma omp for collapse(3) nowait
+#endif
+      for (size_t z = 3; z < dims[2] - 3; ++z) {
+        for (size_t y = dims[1] - 3; y < dims[1]; ++y) {
+          for (size_t x = 0; x < dims[0]; ++x) {
+            loopBody(x, y, z);
+          }
         }
       }
-    }
 
-    // lower y
-    for (size_t z = 3; z < dims[2] - 3; ++z) {
-      for (size_t y = 0; y < 3; ++y) {
-        for (size_t x = 0; x < dims[0]; ++x) {
-          loopBody(x, y, z);
+      // lower x
+#if defined(AUTOPAS_OPENMP)
+#pragma omp for collapse(3) nowait
+#endif
+      for (size_t z = 3; z < dims[2] - 3; ++z) {
+        for (size_t y = 3; y < dims[1] - 3; ++y) {
+          for (size_t x = 0; x < 3; ++x) {
+            loopBody(x, y, z);
+          }
         }
       }
-    }
-    // upper y
-    for (size_t z = 3; z < dims[2] - 3; ++z) {
-      for (size_t y = dims[1] - 3; y < dims[1]; ++y) {
-        for (size_t x = 0; x < dims[0]; ++x) {
-          loopBody(x, y, z);
-        }
-      }
-    }
-
-    // lower x
-    for (size_t z = 3; z < dims[2] - 3; ++z) {
-      for (size_t y = 3; y < dims[1] - 3; ++y) {
-        for (size_t x = 0; x < 3; ++x) {
-          loopBody(x, y, z);
-        }
-      }
-    }
-    // upper x
-    for (size_t z = 3; z < dims[2] - 3; ++z) {
-      for (size_t y = 3; y < dims[1] - 3; ++y) {
-        for (size_t x = dims[0] - 3; x < dims[0]; ++x) {
-          loopBody(x, y, z);
+      // upper x
+#if defined(AUTOPAS_OPENMP)
+#pragma omp for collapse(3) nowait
+#endif
+      for (size_t z = 3; z < dims[2] - 3; ++z) {
+        for (size_t y = 3; y < dims[1] - 3; ++y) {
+          for (size_t x = dims[0] - 3; x < dims[0]; ++x) {
+            loopBody(x, y, z);
+          }
         }
       }
     }

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -91,7 +91,7 @@ class VerletLists
    * @note This function will be called in iteratePairwiseAoS() and iteratePairwiseSoA() appropriately!
    * @param useNewton3
    */
-  void rebuildInnerVerletLists(bool useNewton3 = true) {
+  void rebuild(bool useNewton3 = true) {
     this->updateVerletListsAoS(useNewton3);
     // the neighbor list is now valid
     this->_neighborListIsValid = true;
@@ -103,8 +103,8 @@ class VerletLists
    */
   template <class ParticleFunctor, class Traversal>
   void iteratePairwiseAoS(ParticleFunctor* f, Traversal* traversal, bool useNewton3 = true) {
-    if (needsRebuildInner()) {  // if we need to rebuild the list, we should rebuild it!
-      rebuildInnerVerletLists(useNewton3);
+    if (needsRebuild()) {  // if we need to rebuild the list, we should rebuild it!
+      rebuild(useNewton3);
     }
     this->iterateVerletListsAoS(f, useNewton3);
     // we iterated, so increase traversal counter
@@ -116,8 +116,8 @@ class VerletLists
    */
   template <class ParticleFunctor, class Traversal>
   void iteratePairwiseSoA(ParticleFunctor* f, Traversal* traversal, bool useNewton3 = true) {
-    if (needsRebuildInner()) {
-      rebuildInnerVerletLists(useNewton3);
+    if (needsRebuild()) {
+      rebuild(useNewton3);
       generateSoAListFromAoSVerletLists();
     } else if (not _soaListIsValid) {
       generateSoAListFromAoSVerletLists();
@@ -130,7 +130,7 @@ class VerletLists
    * get the actual neighbour list
    * @return the neighbour list
    */
-  typename verlet_internal::AoS_verletlist_storage_type& getVerletListsAoS() { return _aosNeighborListsInner; }
+  typename verlet_internal::AoS_verletlist_storage_type& getVerletListsAoS() { return _aosNeighborLists; }
 
   /**
    * Checks whether the neighbor lists are valid.
@@ -154,7 +154,7 @@ class VerletLists
 
     // particles can also simply be very close already:
     typename verlet_internal::template VerletListValidityCheckerFunctor<LinkedParticleCell> validityCheckerFunctor(
-        _aosNeighborListsInner, ((this->getCutoff() - this->_skin) * (this->getCutoff() - this->_skin)));
+        _aosNeighborLists, ((this->getCutoff() - this->_skin) * (this->getCutoff() - this->_skin)));
 
     auto traversal =
         C08Traversal<LinkedParticleCell,
@@ -180,7 +180,7 @@ class VerletLists
    * specifies whether the neighbor lists need to be rebuild
    * @return true if the neighbor lists need to be rebuild, false otherwise
    */
-  bool needsRebuildInner() {
+  bool needsRebuild() {
     AutoPasLog(debug, "Neighborlist is valid: {}", this->_neighborListIsValid);
     // if the neighbor list is NOT valid or we have not rebuilt since this->_rebuildFrequency steps
     return (not this->_neighborListIsValid) or (this->_traversalsSinceLastRebuild >= this->_rebuildFrequency);
@@ -194,7 +194,7 @@ class VerletLists
    */
   virtual void updateVerletListsAoS(bool useNewton3) {
     updateIdMapAoS();
-    typename verlet_internal::VerletListGeneratorFunctor f(_aosNeighborListsInner, this->getCutoff());
+    typename verlet_internal::VerletListGeneratorFunctor f(_aosNeighborLists, this->getCutoff());
 
     /// @todo autotune traversal
     switch (_buildVerletListType) {
@@ -233,12 +233,12 @@ class VerletLists
 
 #if defined(AUTOPAS_OPENMP)
     if (not useNewton3) {
-      size_t buckets = _aosNeighborListsInner.bucket_count();
+      size_t buckets = _aosNeighborLists.bucket_count();
       // @todo find a sensible chunk size
 #pragma omp parallel for schedule(dynamic)
       for (size_t b = 0; b < buckets; b++) {
-        auto endIter = _aosNeighborListsInner.end(b);
-        for (auto it = _aosNeighborListsInner.begin(b); it != endIter; ++it) {
+        auto endIter = _aosNeighborLists.end(b);
+        for (auto it = _aosNeighborLists.begin(b); it != endIter; ++it) {
           Particle& i = *(it->first);
           for (auto j_ptr : it->second) {
             Particle& j = *j_ptr;
@@ -249,7 +249,7 @@ class VerletLists
     } else
 #endif
     {
-      for (auto& list : _aosNeighborListsInner) {
+      for (auto& list : _aosNeighborLists) {
         Particle& i = *list.first;
         for (auto j_ptr : list.second) {
           Particle& j = *j_ptr;
@@ -297,18 +297,18 @@ class VerletLists
   }
 
   /**
-   * Update the AoS id maps.
+   * update the AoS id maps.
    * The Id Map is used to map the id of a particle to the actual particle
    * @return
    */
   size_t updateIdMapAoS() {
     size_t i = 0;
-    _aosNeighborListsInner.clear();
+    _aosNeighborLists.clear();
     // DON'T simply parallelize this loop!!! this needs modifications if you
     // want to parallelize it!
     for (auto iter = this->begin(); iter.isValid(); ++iter, ++i) {
       // create the verlet list entries for all particles
-      _aosNeighborListsInner[&(*iter)];
+      _aosNeighborLists[&(*iter)];
     }
 
     return i;
@@ -351,11 +351,11 @@ class VerletLists
    */
   void generateSoAListFromAoSVerletLists() {
     // resize the list to the size of the aos neighborlist
-    _soaNeighborLists.resize(_aosNeighborListsInner.size());
+    _soaNeighborLists.resize(_aosNeighborLists.size());
     // clear the aos 2 soa map
     _aos2soaMap.clear();
 
-    _aos2soaMap.reserve(_aosNeighborListsInner.size());
+    _aos2soaMap.reserve(_aosNeighborLists.size());
     size_t i = 0;
     for (auto iter = this->begin(); iter.isValid(); ++iter, ++i) {
       // set the map
@@ -363,7 +363,7 @@ class VerletLists
     }
     i = 0;
     size_t accumulatedListSize = 0;
-    for (auto& aosList : _aosNeighborListsInner) {
+    for (auto& aosList : _aosNeighborLists) {
       accumulatedListSize += aosList.second.size();
       size_t i_id = _aos2soaMap[aosList.first];
       // each soa neighbor list should be of the same size as for aos
@@ -378,16 +378,13 @@ class VerletLists
     AutoPasLog(debug,
                "VerletLists::generateSoAListFromAoSVerletLists: average verlet list "
                "size is {}",
-               static_cast<double>(accumulatedListSize) / _aosNeighborListsInner.size());
+               static_cast<double>(accumulatedListSize) / _aosNeighborLists.size());
     _soaListIsValid = true;
   }
 
  private:
-  /// Verlet lists for all inner cells
-  typename verlet_internal::AoS_verletlist_storage_type _aosNeighborListsInner;
-
-  // Verlet lists for outer cells
-  typename verlet_internal::AoS_verletlist_storage_type _aosNeighborListsBoundary;
+  /// verlet lists.
+  typename verlet_internal::AoS_verletlist_storage_type _aosNeighborLists;
 
   /// map converting from the aos type index (Particle *) to the soa type index
   /// (continuous, size_t)

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
@@ -61,8 +61,7 @@ class VerletListsCells
       : VerletListsLinkedBase<Particle, LinkedParticleCell>(boxMin, boxMax, cutoff, skin, rebuildFrequency,
                                                             VLCApplicableTraversals(),
                                                             /*blackbox not yet supported*/ false),
-        _buildTraversal(buildTraversal),
-        _verletBuiltNewton3(false) {}
+        _buildTraversal(buildTraversal) {}
 
   ContainerOptions getContainerType() override { return ContainerOptions::verletListsCells; }
 
@@ -77,7 +76,7 @@ class VerletListsCells
    */
   template <class ParticleFunctor, class Traversal>
   void iteratePairwiseAoS(ParticleFunctor* f, Traversal* traversal, bool useNewton3 = true) {
-    if (needsRebuild(useNewton3)) {
+    if (this->needsRebuild(useNewton3)) {
       updateVerletLists(useNewton3);
     }
 
@@ -125,25 +124,13 @@ class VerletListsCells
   }
 
   /**
-   * Specifies whether the neighbor lists need to be rebuild.
-   * @param useNewton3 if newton3 is gonna be used to traverse
-   * @return true if the neighbor lists need to be rebuild, false otherwise
-   */
-  bool needsRebuild(bool useNewton3) {
-    AutoPasLog(debug, "VerletLists: neighborlist is valid: {}", this->_neighborListIsValid);
-    // if the neighbor list is NOT valid, we have not rebuild for _rebuildFrequency steps or useNewton3 changed
-    return (not this->_neighborListIsValid) or (this->_traversalsSinceLastRebuild >= this->_rebuildFrequency) or
-           (useNewton3 != this->_verletBuiltNewton3);
-  }
-
-  /**
    * Get the neighbors list of a particle.
    * @param particle
    * @param useNewton3
    * @return the neighbor list of the particle
    */
   std::vector<Particle*>& getVerletList(Particle* particle, bool useNewton3 = true) {
-    if (needsRebuild(useNewton3)) {
+    if (this->needsRebuild(useNewton3)) {
       updateVerletLists(useNewton3);
     }
     auto indices = _cellMap[particle];
@@ -156,7 +143,7 @@ class VerletListsCells
    * @param useNewton3 use newton3?
    */
   void updateVerletLists(bool useNewton3) {
-    _verletBuiltNewton3 = useNewton3;
+    this->_verletBuiltNewton3 = useNewton3;
 
     // create a Verlet Lists for each cell
     _neighborLists.clear();
@@ -235,9 +222,6 @@ class VerletListsCells
 
   // the traversal used to build the verletlists
   TraversalOptions _buildTraversal;
-
-  // specifies if the current verlet list was built for newton3
-  bool _verletBuiltNewton3;
 };
 
 }  // namespace autopas

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
@@ -59,7 +59,8 @@ class VerletListsCells
                    const TraversalOptions buildTraversal, const double skin = 0,
                    const unsigned int rebuildFrequency = 1)
       : VerletListsLinkedBase<Particle, LinkedParticleCell>(boxMin, boxMax, cutoff, skin, rebuildFrequency,
-                                                            VLCApplicableTraversals()),
+                                                            VLCApplicableTraversals(),
+                                                            /*blackbox not yet supported*/ false),
         _buildTraversal(buildTraversal),
         _verletBuiltNewton3(false) {}
 

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/C01TraversalVerlet.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/C01TraversalVerlet.h
@@ -25,7 +25,7 @@ namespace autopas {
  */
 template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3>
 class C01TraversalVerlet
-    : public C01BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>,
+    : public C01BasedTraversal<ParticleCell, useSoA, useNewton3>,
       public VerletListsCellsTraversal<typename ParticleCell::ParticleType, PairwiseFunctor, useNewton3> {
  public:
   /**
@@ -35,7 +35,7 @@ class C01TraversalVerlet
    * @param pairwiseFunctor The functor that defines the interaction of two particles.
    */
   explicit C01TraversalVerlet(const std::array<unsigned long, 3> &dims, PairwiseFunctor *pairwiseFunctor)
-      : C01BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>(dims, pairwiseFunctor),
+      : C01BasedTraversal<ParticleCell, useSoA, useNewton3>(dims),
         VerletListsCellsTraversal<typename ParticleCell::ParticleType, PairwiseFunctor, useNewton3>(pairwiseFunctor) {}
 
   /**

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/C18TraversalVerlet.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/C18TraversalVerlet.h
@@ -25,7 +25,7 @@ namespace autopas {
  */
 template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3>
 class C18TraversalVerlet
-    : public C18BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>,
+    : public C18BasedTraversal<ParticleCell, useSoA, useNewton3>,
       public VerletListsCellsTraversal<typename ParticleCell::ParticleType, PairwiseFunctor, useNewton3> {
  public:
   /**
@@ -35,7 +35,7 @@ class C18TraversalVerlet
    * @param pairwiseFunctor The functor that defines the interaction of two particles.
    */
   explicit C18TraversalVerlet(const std::array<unsigned long, 3> &dims, PairwiseFunctor *pairwiseFunctor)
-      : C18BasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>(dims, pairwiseFunctor),
+      : C18BasedTraversal<ParticleCell, useSoA, useNewton3>(dims),
         VerletListsCellsTraversal<typename ParticleCell::ParticleType, PairwiseFunctor, useNewton3>(pairwiseFunctor) {}
 
   /**

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/SlicedTraversalVerlet.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/SlicedTraversalVerlet.h
@@ -31,7 +31,7 @@ namespace autopas {
  */
 template <class ParticleCell, class PairwiseFunctor, bool useSoA, bool useNewton3>
 class SlicedTraversalVerlet
-    : public SlicedBasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>,
+    : public SlicedBasedTraversal<ParticleCell, useSoA, useNewton3>,
       public VerletListsCellsTraversal<typename ParticleCell::ParticleType, PairwiseFunctor, useNewton3> {
  public:
   /**
@@ -41,7 +41,7 @@ class SlicedTraversalVerlet
    * @param pairwiseFunctor The functor that defines the interaction of two particles.
    */
   explicit SlicedTraversalVerlet(const std::array<unsigned long, 3> &dims, PairwiseFunctor *pairwiseFunctor)
-      : SlicedBasedTraversal<ParticleCell, PairwiseFunctor, useSoA, useNewton3>(dims, pairwiseFunctor),
+      : SlicedBasedTraversal<ParticleCell, useSoA, useNewton3>(dims),
         VerletListsCellsTraversal<typename ParticleCell::ParticleType, PairwiseFunctor, useNewton3>(pairwiseFunctor) {}
 
   /**

--- a/src/autopas/options/BlackBoxOptions.h
+++ b/src/autopas/options/BlackBoxOptions.h
@@ -1,0 +1,20 @@
+/**
+ * @file BlackBoxOptions.h
+ * @author seckler
+ * @date 04.02.19
+ */
+
+#pragma once
+
+namespace autopas {
+
+/**
+ * Possible choices for the cell pair traversal.
+ */
+enum BlackBoxTraversalOption {
+  normal,  ///< iterate over everything, this is the default option if blackbox is deactivated
+  inner,   ///< iterate only over the inner parts of the domain
+  outer    ///< iterate over the outer parts of the domain
+};
+
+}  // namespace autopas

--- a/src/autopas/pairwiseFunctors/FlopCounterFunctor.h
+++ b/src/autopas/pairwiseFunctors/FlopCounterFunctor.h
@@ -144,7 +144,7 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell> {
     double *const __restrict__ yptr = soa.template begin<Particle::AttributeNames::posY>();
     double *const __restrict__ zptr = soa.template begin<Particle::AttributeNames::posZ>();
 
-    for (unsigned int i = iFrom; i < iTo; ++i) {
+    for (unsigned long i = iFrom; i < iTo; ++i) {
       const size_t listSizeI = neighborList[i].size();
       const size_t *const __restrict__ currentList = neighborList[i].data();
 
@@ -167,7 +167,7 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell> {
       // if the size of the verlet list is larger than the given size vecsize,
       // we will use a vectorized version.
       if (listSizeI >= vecsize) {
-        alignas(64) std::array<double, vecsize> xtmp, ytmp, ztmp, xArr, yArr, zArr;
+        alignas(64) std::array<double, vecsize> xtmp{}, ytmp{}, ztmp{}, xArr{}, yArr{}, zArr{};
         // broadcast of the position of particle i
         for (size_t tmpj = 0; tmpj < vecsize; tmpj++) {
           xtmp[tmpj] = xptr[i];
@@ -268,8 +268,8 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell> {
                             })
 
   /**
-   * empty SoAExtractor.
-   * nothing to be done yet.
+   * Empty SoAExtractor.
+   * Nothing to be done yet.
    */
   AUTOPAS_FUNCTOR_SOAEXTRACTOR(, , , )
 

--- a/src/autopas/pairwiseFunctors/FlopCounterFunctor.h
+++ b/src/autopas/pairwiseFunctors/FlopCounterFunctor.h
@@ -204,7 +204,7 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell> {
 
             const double dr2 = drx2 + dry2 + drz2;
 
-            const double mask = (dr2 <= _cutoffSquare) ? 1. : 0.;
+            const unsigned long mask = (dr2 <= _cutoffSquare) ? 1 : 0;
 
             kernelCallsAcc += mask;
           }

--- a/src/autopas/pairwiseFunctors/Functor.h
+++ b/src/autopas/pairwiseFunctors/Functor.h
@@ -163,15 +163,8 @@ class Functor {
  * @note generates two loaders, one for verlet lists, one for the normal case.
  * @note the need for this could be removed if the soa's are removed from the particlecells (highly unlikely)
  */
-#define AUTOPAS_FUNCTOR_SOALOADER(cell, soa, offset, ...)                                                            \
-  void SoALoader(ParticleCell &cell, ::autopas::SoA<SoAArraysType> &soa, size_t offset = 0) override { __VA_ARGS__ } \
-  /** @copydoc SoALoader(ParticleCell &cell, ::autopas::SoA<SoAArraysType> &soa, size_t offset) */                   \
-  template <typename = std::enable_if_t<not std::is_same<                                                            \
-                typename ::autopas::VerletListHelpers<Particle>::VerletListParticleCellType, ParticleCell>::value>>  \
-  void SoALoader(typename ::autopas::VerletListHelpers<Particle>::VerletListParticleCellType &cell,                  \
-                 ::autopas::SoA<SoAArraysType> &soa, size_t offset = 0) {                                            \
-    __VA_ARGS__                                                                                                      \
-  }
+#define AUTOPAS_FUNCTOR_SOALOADER(cell, soa, offset, ...) \
+  void SoALoader(ParticleCell &cell, ::autopas::SoA<SoAArraysType> &soa, size_t offset = 0) override { __VA_ARGS__ }
 
 /**
  * Macro to define the SoAExtractors. The body to be executed is the variadic argument.
@@ -184,17 +177,8 @@ class Functor {
  * @note generates two extractors, one for verlet lists, one for the normal case.
  * @note the need for this could be removed if the soa's are removed from the particlecells (highly unlikely)
  */
-#define AUTOPAS_FUNCTOR_SOAEXTRACTOR(cell, soa, offset, ...)                                                        \
-  void SoAExtractor(ParticleCell &cell, ::autopas::SoA<SoAArraysType> &soa, size_t offset = 0) override {           \
-    __VA_ARGS__                                                                                                     \
-  }                                                                                                                 \
-  /** @copydoc SoAExtractor(ParticleCell &, ::autopas::SoA<SoAArraysType> &, size_t) */                             \
-  template <typename = std::enable_if_t<not std::is_same<                                                           \
-                typename ::autopas::VerletListHelpers<Particle>::VerletListParticleCellType, ParticleCell>::value>> \
-  void SoAExtractor(typename ::autopas::VerletListHelpers<Particle>::VerletListParticleCellType &cell,              \
-                    ::autopas::SoA<SoAArraysType> &soa, size_t offset = 0) {                                        \
-    __VA_ARGS__                                                                                                     \
-  }
+#define AUTOPAS_FUNCTOR_SOAEXTRACTOR(cell, soa, offset, ...) \
+  void SoAExtractor(ParticleCell &cell, ::autopas::SoA<SoAArraysType> &soa, size_t offset = 0) override { __VA_ARGS__ }
 
 }  // namespace autopas
 

--- a/src/autopas/pairwiseFunctors/LJFunctor.h
+++ b/src/autopas/pairwiseFunctors/LJFunctor.h
@@ -381,33 +381,34 @@ class LJFunctor : public Functor<Particle, ParticleCell, typename Particle::SoAA
    * @param soa
    * @param offset
    */
-  AUTOPAS_FUNCTOR_SOALOADER(
-      cell, soa, offset,
-      // @todo it is probably better to resize the soa only once, before calling
-      // SoALoader (verlet-list only)
-      soa.resizeArrays(offset + cell.numParticles());
+  void SoALoader(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override {
+    // @todo it is probably better to resize the soa only once, before calling
+    // SoALoader (verlet-list only)
+    soa.resizeArrays(offset + cell.numParticles());
 
-      if (cell.numParticles() == 0) return;
+    if (cell.numParticles() == 0) return;
 
-      unsigned long *const __restrict__ idptr = soa.template begin<Particle::AttributeNames::id>();
-      double *const __restrict__ xptr = soa.template begin<Particle::AttributeNames::posX>();
-      double *const __restrict__ yptr = soa.template begin<Particle::AttributeNames::posY>();
-      double *const __restrict__ zptr = soa.template begin<Particle::AttributeNames::posZ>();
-      double *const __restrict__ fxptr = soa.template begin<Particle::AttributeNames::forceX>();
-      double *const __restrict__ fyptr = soa.template begin<Particle::AttributeNames::forceY>();
-      double *const __restrict__ fzptr = soa.template begin<Particle::AttributeNames::forceZ>();
+    unsigned long *const __restrict__ idptr = soa.template begin<Particle::AttributeNames::id>();
+    double *const __restrict__ xptr = soa.template begin<Particle::AttributeNames::posX>();
+    double *const __restrict__ yptr = soa.template begin<Particle::AttributeNames::posY>();
+    double *const __restrict__ zptr = soa.template begin<Particle::AttributeNames::posZ>();
+    double *const __restrict__ fxptr = soa.template begin<Particle::AttributeNames::forceX>();
+    double *const __restrict__ fyptr = soa.template begin<Particle::AttributeNames::forceY>();
+    double *const __restrict__ fzptr = soa.template begin<Particle::AttributeNames::forceZ>();
 
-      auto cellIter = cell.begin();
-      // load particles in SoAs
-      for (size_t i = offset; cellIter.isValid(); ++cellIter, ++i) {
-        idptr[i] = cellIter->getID();
-        xptr[i] = cellIter->getR()[0];
-        yptr[i] = cellIter->getR()[1];
-        zptr[i] = cellIter->getR()[2];
-        fxptr[i] = cellIter->getF()[0];
-        fyptr[i] = cellIter->getF()[1];
-        fzptr[i] = cellIter->getF()[2];
-      })
+    auto cellIter = cell.begin();
+    // load particles in SoAs
+    for (size_t i = offset; cellIter.isValid(); ++cellIter, ++i) {
+      idptr[i] = cellIter->getID();
+      xptr[i] = cellIter->getR()[0];
+      yptr[i] = cellIter->getR()[1];
+      zptr[i] = cellIter->getR()[2];
+      fxptr[i] = cellIter->getF()[0];
+      fyptr[i] = cellIter->getF()[1];
+      fzptr[i] = cellIter->getF()[2];
+    }
+  }
+
   /**
    * soaextractor
    * @param cell

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -53,15 +53,17 @@ class AutoTuner {
    * @param traversalSelectorStrategy Strategy for the traversal selector.
    * @param tuningInterval Number of timesteps after which the auto-tuner shall reevaluate all selections.
    * @param maxSamples Number of samples that shall be collected for each combination.
+   * @param blackBoxMode Indicates whether the [blackbox mode](@ref md_BlackBoxMode) shall be used.
    */
   AutoTuner(std::array<double, 3> boxMin, std::array<double, 3> boxMax, double cutoff, double verletSkin,
             unsigned int verletRebuildFrequency, std::vector<ContainerOptions> allowedContainerOptions,
             std::vector<TraversalOptions> allowedTraversalOptions, SelectorStrategy containerSelectorStrategy,
-            SelectorStrategy traversalSelectorStrategy, unsigned int tuningInterval, unsigned int maxSamples)
+            SelectorStrategy traversalSelectorStrategy, unsigned int tuningInterval, unsigned int maxSamples,
+            bool blackBoxMode)
       : _tuningInterval(tuningInterval),
         _iterationsSinceTuning(tuningInterval),  // init to max so that tuning happens in first iteration
         _containerSelector(boxMin, boxMax, cutoff, verletSkin, verletRebuildFrequency, allowedContainerOptions,
-                           allowedTraversalOptions),
+                           allowedTraversalOptions, blackBoxMode),
         _allowedTraversalOptions(allowedTraversalOptions),
         _maxSamples(maxSamples),
         _numSamples(maxSamples),

--- a/src/autopas/selectors/ContainerSelector.h
+++ b/src/autopas/selectors/ContainerSelector.h
@@ -40,10 +40,11 @@ class ContainerSelector {
    * @param verletRebuildFrequency Specifies after how many pair-wise traversals the neighbor lists are to be rebuild.
    * @param allowedContainerOptions Vector of container types the selector can choose from.
    * @param allowedTraversalOptions Vector of traversals the selector can choose from.
+   * @param blackBoxMode Indicates whether the [blackbox mode](@ref md_BlackBoxMode) shall be used.
    */
   ContainerSelector(std::array<double, 3> &boxMin, std::array<double, 3> &boxMax, double cutoff, double verletSkin,
                     unsigned int verletRebuildFrequency, std::vector<ContainerOptions> allowedContainerOptions,
-                    std::vector<TraversalOptions> allowedTraversalOptions)
+                    std::vector<TraversalOptions> allowedTraversalOptions, bool blackBoxMode)
       : _boxMin(boxMin),
         _boxMax(boxMax),
         _cutoff(cutoff),
@@ -51,7 +52,8 @@ class ContainerSelector {
         _verletRebuildFrequency(verletRebuildFrequency),
         _allowedContainerOptions(std::move(allowedContainerOptions)),
         _allowedTraversalOptions(std::move(allowedTraversalOptions)),
-        _optimalContainer(nullptr) {
+        _optimalContainer(nullptr),
+        _blackBoxMode(blackBoxMode) {
     // @FIXME This is a workaround because this container does not yet use traversals like it should
     _allowedTraversalOptions.push_back(TraversalOptions::dummyTraversal);
   }
@@ -100,6 +102,7 @@ class ContainerSelector {
   std::vector<TraversalOptions> _allowedTraversalOptions;
   std::shared_ptr<autopas::ParticleContainer<Particle, ParticleCell>> _optimalContainer;
   std::vector<std::pair<ContainerOptions, long>> _containerTimes;
+  bool _blackBoxMode;
 };
 
 template <class Particle, class ParticleCell>
@@ -119,7 +122,8 @@ ContainerSelector<Particle, ParticleCell>::generateContainer(ContainerOptions co
     case verletLists: {
       // @todo determine verletSkin and verletRebuildFrequency via tuning
       container =
-          std::make_unique<VerletLists<Particle>>(_boxMin, _boxMax, _cutoff, _verletSkin, _verletRebuildFrequency);
+          std::make_unique<VerletLists<Particle>>(_boxMin, _boxMax, _cutoff, _verletSkin, _verletRebuildFrequency,
+                                                  VerletLists<Particle>::BuildVerletListType::VerletSoA, _blackBoxMode);
       break;
     }
     case verletListsCells: {

--- a/src/autopas/sph/SPHParticle.h
+++ b/src/autopas/sph/SPHParticle.h
@@ -401,8 +401,8 @@ class SPHParticle : public autopas::Particle {
   /**
    * SoA arrays type, cf. AttributeNames
    */
-  typedef autopas::utils::SoAType<size_t, double, double, double, double, double, double, double, double, double, double,
-                                  double, double, double, double, double, double>::Type SoAArraysType;
+  typedef autopas::utils::SoAType<size_t, double, double, double, double, double, double, double, double, double,
+                                  double, double, double, double, double, double, double>::Type SoAArraysType;
 
  private:
   double _density;   // density

--- a/src/autopas/sph/SPHParticle.h
+++ b/src/autopas/sph/SPHParticle.h
@@ -379,10 +379,11 @@ class SPHParticle : public autopas::Particle {
    * Attribute names for the soa arrays
    */
   enum AttributeNames : int {
-    mass,
+    id,
     posX,
     posY,
     posZ,
+    mass,
     smth,
     density,
     velX,
@@ -400,7 +401,7 @@ class SPHParticle : public autopas::Particle {
   /**
    * SoA arrays type, cf. AttributeNames
    */
-  typedef autopas::utils::SoAType<double, double, double, double, double, double, double, double, double, double,
+  typedef autopas::utils::SoAType<size_t, double, double, double, double, double, double, double, double, double, double,
                                   double, double, double, double, double, double>::Type SoAArraysType;
 
  private:

--- a/src/autopas/utils/Logger.h
+++ b/src/autopas/utils/Logger.h
@@ -45,7 +45,7 @@
  * @param ... Formatting arguments
  */
 #define AutoPasLog(lvl, fmt, ...) \
-  { spdlog::get("AutoPasLog")->lvl(fmt, ##__VA_ARGS__); }
+  spdlog::get("AutoPasLog")->lvl(fmt, ##__VA_ARGS__)
 
 #endif
 

--- a/src/autopas/utils/Logger.h
+++ b/src/autopas/utils/Logger.h
@@ -44,8 +44,7 @@
  * @param fmt Message with formatting tokens
  * @param ... Formatting arguments
  */
-#define AutoPasLog(lvl, fmt, ...) \
-  spdlog::get("AutoPasLog")->lvl(fmt, ##__VA_ARGS__)
+#define AutoPasLog(lvl, fmt, ...) spdlog::get("AutoPasLog")->lvl(fmt, ##__VA_ARGS__)
 
 #endif
 

--- a/src/autopas/utils/SoA.h
+++ b/src/autopas/utils/SoA.h
@@ -46,6 +46,17 @@ class SoA {
   }
 
   /**
+   * @brief Resizes all Vectors to the given length.
+   * @details Resizes only the first numElements arrays to the new value.
+   * @param length New length the arrays should be resized to.
+   * @tparam numElements Indicates how many of the arrays should be resized.
+   */
+  template <unsigned int numElements>
+  void resizeArrays(size_t length) {
+    soaStorage.template apply<numElements>([=](auto &list) { list.resize(length); });
+  }
+
+  /**
    * @brief Pushes a given value to the desired attribute array.
    * @tparam attribute Index of array to push to.
    * @param value Value to push.

--- a/src/autopas/utils/StaticSelectorMacros.h
+++ b/src/autopas/utils/StaticSelectorMacros.h
@@ -12,12 +12,12 @@
  * @note The second Argument is variadic such that commas pose no problem.
  */
 #define AUTOPAS_WITH_STATIC_BOOL(theBool, ...) \
-  {                                           \
-    if (theBool) {                            \
-      constexpr bool c_##theBool = true;      \
-      __VA_ARGS__                             \
-    } else {                                  \
-      constexpr bool c_##theBool = false;     \
-      __VA_ARGS__                             \
-    }                                         \
+  {                                            \
+    if (theBool) {                             \
+      constexpr bool c_##theBool = true;       \
+      __VA_ARGS__                              \
+    } else {                                   \
+      constexpr bool c_##theBool = false;      \
+      __VA_ARGS__                              \
+    }                                          \
   }

--- a/src/autopas/utils/StaticSelectorMacros.h
+++ b/src/autopas/utils/StaticSelectorMacros.h
@@ -1,0 +1,23 @@
+/**
+ * @file StaticSelectorMacros.h
+ * @author seckler
+ * @date 07.02.19
+ */
+
+#pragma once
+
+/**
+ * Will execute the passed body (=variadic argument) with the static value of the bool.
+ * @param theBool The bool to be used.
+ * @note The second Argument is variadic such that commas pose no problem.
+ */
+#define AUTOPAS_WITH_STATIC_BOOL(theBool, ...) \
+  {                                           \
+    if (theBool) {                            \
+      constexpr bool c_##theBool = true;      \
+      __VA_ARGS__                             \
+    } else {                                  \
+      constexpr bool c_##theBool = false;     \
+      __VA_ARGS__                             \
+    }                                         \
+  }

--- a/tests/testAutopas/mocks/MockFunctor.h
+++ b/tests/testAutopas/mocks/MockFunctor.h
@@ -42,33 +42,13 @@ class MockFunctor : public autopas::Functor<Particle, ParticleCell> {
   MOCK_METHOD3_T(SoALoader,
                  void(ParticleCell &cell, autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset));
 
-  MOCK_METHOD3_T(SoALoaderVerlet, void(typename autopas::VerletListHelpers<Particle>::VerletListParticleCellType &cell,
-                                       autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset));
-
-  template <typename /*dummy*/ = void,
-            typename = std::enable_if_t<not std::is_same<
-                typename autopas::VerletListHelpers<Particle>::VerletListParticleCellType, ParticleCell>::value>>
-  void SoALoader(typename autopas::VerletListHelpers<Particle>::VerletListParticleCellType &cell,
-                 autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset = 0) {
-    SoALoaderVerlet(cell, soa, offset);
-  }
-
   // virtual void SoAExtractor(ParticleCell &cell, autopas::SoA &soa, size_t
   // offset=0) {}
   MOCK_METHOD2_T(SoAExtractor, void(ParticleCell &cell, autopas::SoA<typename Particle::SoAArraysType> &soa));
   MOCK_METHOD3_T(SoAExtractor,
                  void(ParticleCell &cell, autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset));
 
-  MOCK_METHOD3_T(SoAExtractorVerlet,
-                 void(typename autopas::VerletListHelpers<Particle>::VerletListParticleCellType &cell,
-                      autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset));
 
-  template <typename = std::enable_if_t<not std::is_same<
-                typename autopas::VerletListHelpers<Particle>::VerletListParticleCellType, ParticleCell>::value>>
-  void SoAExtractor(typename autopas::VerletListHelpers<Particle>::VerletListParticleCellType &cell,
-                    autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset = 0) {
-    SoAExtractorVerlet(cell, soa, offset);
-  }
 
   // virtual bool allowsNewton3() { return true; }
   MOCK_METHOD0(allowsNewton3, bool());

--- a/tests/testAutopas/mocks/MockFunctor.h
+++ b/tests/testAutopas/mocks/MockFunctor.h
@@ -48,8 +48,6 @@ class MockFunctor : public autopas::Functor<Particle, ParticleCell> {
   MOCK_METHOD3_T(SoAExtractor,
                  void(ParticleCell &cell, autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset));
 
-
-
   // virtual bool allowsNewton3() { return true; }
   MOCK_METHOD0(allowsNewton3, bool());
 

--- a/tests/testAutopas/tests/containers/LinkedCellsVersusVerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/LinkedCellsVersusVerletListsTest.cpp
@@ -70,7 +70,6 @@ void LinkedCellsVersusVerletListsTest::test(unsigned long numMolecules, double r
   // blackbox mode: the following line is only true, if the verlet lists do NOT use less cells than the linked cells
   // (for small scenarios), as the verlet lists fall back to linked cells.
   EXPECT_GE(flopsLinked.getDistanceCalculations(), flopsVerlet.getDistanceCalculations());
-
 }
 
 TEST_F(LinkedCellsVersusVerletListsTest, test100) {

--- a/tests/testAutopas/tests/containers/LinkedCellsVersusVerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/LinkedCellsVersusVerletListsTest.cpp
@@ -82,22 +82,18 @@ void LinkedCellsVersusVerletListsTest::test(unsigned long numMolecules, double r
     _verletLists->iteratePairwiseAoS(&flopsVerlet, &dummy, useNewton3);
   }
 
-  if(not useNewton3 and useSoA and (boxMax[0]==10. or not blackBoxMode)) {
+  if (not useNewton3 and useSoA and (boxMax[0] == 10. or not blackBoxMode)) {
     // special case if newton3 is disabled and soa are used: here linked cells will anyways partially use newton3 (for
     // the intra cell interactions), so linked cell kernel calls will be less than for verlet.
     EXPECT_LE(flopsLinked.getKernelCalls(), flopsVerlet.getKernelCalls())
-              << "N3: " << (useNewton3 ? "true" : "false") << ", blackBox: " << (blackBoxMode ? "true" : "false")
-              << ", "
-              << (useSoA ? "soa" : "aos") << ", boxMax = [" << boxMax[0] << ", " << boxMax[1] << ", " << boxMax[2]
-              << "]";
+        << "N3: " << (useNewton3 ? "true" : "false") << ", blackBox: " << (blackBoxMode ? "true" : "false") << ", "
+        << (useSoA ? "soa" : "aos") << ", boxMax = [" << boxMax[0] << ", " << boxMax[1] << ", " << boxMax[2] << "]";
 
   } else {
     // normally the number of kernel calls should be exactly the same
     EXPECT_EQ(flopsLinked.getKernelCalls(), flopsVerlet.getKernelCalls())
-              << "N3: " << (useNewton3 ? "true" : "false") << ", blackBox: " << (blackBoxMode ? "true" : "false")
-              << ", "
-              << (useSoA ? "soa" : "aos") << ", boxMax = [" << boxMax[0] << ", " << boxMax[1] << ", " << boxMax[2]
-              << "]";
+        << "N3: " << (useNewton3 ? "true" : "false") << ", blackBox: " << (blackBoxMode ? "true" : "false") << ", "
+        << (useSoA ? "soa" : "aos") << ", boxMax = [" << boxMax[0] << ", " << boxMax[1] << ", " << boxMax[2] << "]";
   }
   // blackbox mode: the following line is only true, if the verlet lists do NOT use less cells than the linked cells
   // (for small scenarios), as the verlet lists fall back to linked cells.

--- a/tests/testAutopas/tests/containers/LinkedCellsVersusVerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/LinkedCellsVersusVerletListsTest.cpp
@@ -99,7 +99,7 @@ void LinkedCellsVersusVerletListsTest::test(unsigned long numMolecules, double r
 
   // now test what happens if we remove halo and boundary molecules.
   std::vector<Molecule> haloMolecules, boundaryMolecules;
-  for(auto iter = _verletLists->begin(autopas::IteratorBehavior::haloOnly); iter.isValid(); ++iter){
+  for (auto iter = _verletLists->begin(autopas::IteratorBehavior::haloOnly); iter.isValid(); ++iter) {
     haloMolecules.push_back(*iter);
   }
   _verletLists->deleteHaloParticles();
@@ -133,7 +133,7 @@ void LinkedCellsVersusVerletListsTest::test(unsigned long numMolecules, double r
   EXPECT_EQ(_verletLists->checkNeighborListsAreValid(), blackBoxMode);
 
   // add boundary molecules again.
-  for(auto& m : boundaryMolecules){
+  for (auto &m : boundaryMolecules) {
     _verletLists->addParticle(m);
   }
 
@@ -141,7 +141,7 @@ void LinkedCellsVersusVerletListsTest::test(unsigned long numMolecules, double r
   EXPECT_EQ(_verletLists->checkNeighborListsAreValid(), blackBoxMode);
 
   // add halo molecules again.
-  for(auto& m : haloMolecules){
+  for (auto &m : haloMolecules) {
     _verletLists->addHaloParticle(m);
   }
 

--- a/tests/testAutopas/tests/containers/LinkedCellsVersusVerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/LinkedCellsVersusVerletListsTest.cpp
@@ -44,6 +44,7 @@ void LinkedCellsVersusVerletListsTest::test(unsigned long numMolecules, double r
     _linkedCells->iteratePairwiseAoS(&func, &traversalLJ);
     _verletLists->iteratePairwiseAoS(&func, &dummy, useNewton3);
   }
+  EXPECT_TRUE(_verletLists->checkNeighborListsAreValid(useNewton3));
 
   auto itDirect = _verletLists->begin();
   auto itLinked = _linkedCells->begin();

--- a/tests/testAutopas/tests/containers/LinkedCellsVersusVerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/LinkedCellsVersusVerletListsTest.cpp
@@ -65,10 +65,12 @@ void LinkedCellsVersusVerletListsTest::test(unsigned long numMolecules, double r
   _verletLists->iteratePairwiseAoS(&flopsVerlet, &traversalFLOPS);
   _linkedCells->iteratePairwiseAoS(&flopsLinked, &traversalFLOPS);
 
-  ASSERT_EQ(flopsLinked.getKernelCalls(), flopsVerlet.getKernelCalls());
-  if (not blackBoxMode) {
-    ASSERT_GE(flopsLinked.getDistanceCalculations(), flopsVerlet.getDistanceCalculations());
-  }
+  EXPECT_EQ(flopsLinked.getKernelCalls(), flopsVerlet.getKernelCalls());
+
+  // blackbox mode: the following line is only true, if the verlet lists do NOT use less cells than the linked cells
+  // (for small scenarios), as the verlet lists fall back to linked cells.
+  EXPECT_GE(flopsLinked.getDistanceCalculations(), flopsVerlet.getDistanceCalculations());
+
 }
 
 TEST_F(LinkedCellsVersusVerletListsTest, test100) {

--- a/tests/testAutopas/tests/containers/LinkedCellsVersusVerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/LinkedCellsVersusVerletListsTest.cpp
@@ -149,14 +149,8 @@ void LinkedCellsVersusVerletListsTest::test(unsigned long numMolecules, double r
   EXPECT_EQ(_verletLists->checkNeighborListsAreValid(), blackBoxMode);
 
   if (useSoA) {
-    autopas::C08Traversal<FMCell, autopas::LJFunctor<Molecule, FMCell>, true, useNewton3> traversalLJ(
-        _linkedCells->getCellBlock().getCellsPerDimensionWithHalo(), &func);
-    _linkedCells->iteratePairwiseSoA(&func, &traversalLJ);
     _verletLists->iteratePairwiseSoA(&func, &dummy, useNewton3);
   } else {
-    autopas::C08Traversal<FMCell, autopas::LJFunctor<Molecule, FMCell>, false, useNewton3> traversalLJ(
-        _linkedCells->getCellBlock().getCellsPerDimensionWithHalo(), &func);
-    _linkedCells->iteratePairwiseAoS(&func, &traversalLJ);
     _verletLists->iteratePairwiseAoS(&func, &dummy, useNewton3);
   }
   EXPECT_TRUE(_verletLists->checkNeighborListsAreValid(useNewton3));

--- a/tests/testAutopas/tests/containers/LinkedCellsVersusVerletListsTest.h
+++ b/tests/testAutopas/tests/containers/LinkedCellsVersusVerletListsTest.h
@@ -8,6 +8,7 @@
 
 #include <gtest/gtest.h>
 #include <cstdlib>
+#include <memory>
 #include "AutoPasTestBase.h"
 #include "autopas/autopasIncludes.h"
 #include "testingHelpers/RandomGenerator.h"
@@ -21,13 +22,14 @@ class LinkedCellsVersusVerletListsTest : public AutoPasTestBase {
 
   std::array<double, 3> getBoxMin() const { return {0.0, 0.0, 0.0}; }
 
-  std::array<double, 3> getBoxMax() const { return {3.0, 3.0, 3.0}; }
-
   double getCutoff() const { return 1.0; }
 
  protected:
-  void test(unsigned long numMolecules, double rel_err_tolerance);
+  void test(unsigned long numMolecules, double rel_err_tolerance, std::array<double, 3> boxMax,
+            bool blackBoxMode = false);
 
-  autopas::VerletLists<autopas::MoleculeLJ> _verletLists;
-  autopas::LinkedCells<autopas::MoleculeLJ, autopas::FullParticleCell<autopas::MoleculeLJ>> _linkedCells;
+  using vltype = autopas::VerletLists<autopas::MoleculeLJ>;
+  using lctype = autopas::LinkedCells<autopas::MoleculeLJ, autopas::FullParticleCell<autopas::MoleculeLJ>>;
+  std::unique_ptr<vltype> _verletLists;
+  std::unique_ptr<lctype> _linkedCells;
 };

--- a/tests/testAutopas/tests/containers/LinkedCellsVersusVerletListsTest.h
+++ b/tests/testAutopas/tests/containers/LinkedCellsVersusVerletListsTest.h
@@ -25,6 +25,7 @@ class LinkedCellsVersusVerletListsTest : public AutoPasTestBase {
   double getCutoff() const { return .9; }
 
  protected:
+  template <bool useNewton3>
   void test(unsigned long numMolecules, double rel_err_tolerance, std::array<double, 3> boxMax, bool useSoA,
             bool blackBoxMode);
 

--- a/tests/testAutopas/tests/containers/LinkedCellsVersusVerletListsTest.h
+++ b/tests/testAutopas/tests/containers/LinkedCellsVersusVerletListsTest.h
@@ -25,8 +25,8 @@ class LinkedCellsVersusVerletListsTest : public AutoPasTestBase {
   double getCutoff() const { return .9; }
 
  protected:
-  void test(unsigned long numMolecules, double rel_err_tolerance, std::array<double, 3> boxMax,
-            bool blackBoxMode = false);
+  void test(unsigned long numMolecules, double rel_err_tolerance, std::array<double, 3> boxMax, bool useSoA,
+            bool blackBoxMode);
 
   using vltype = autopas::VerletLists<autopas::MoleculeLJ>;
   using lctype = autopas::LinkedCells<autopas::MoleculeLJ, autopas::FullParticleCell<autopas::MoleculeLJ>>;

--- a/tests/testAutopas/tests/containers/LinkedCellsVersusVerletListsTest.h
+++ b/tests/testAutopas/tests/containers/LinkedCellsVersusVerletListsTest.h
@@ -22,7 +22,7 @@ class LinkedCellsVersusVerletListsTest : public AutoPasTestBase {
 
   std::array<double, 3> getBoxMin() const { return {0.0, 0.0, 0.0}; }
 
-  double getCutoff() const { return 1.0; }
+  double getCutoff() const { return .9; }
 
  protected:
   void test(unsigned long numMolecules, double rel_err_tolerance, std::array<double, 3> boxMax,

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/C08TraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/C08TraversalTest.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "C08TraversalTest.h"
+#include "testingHelpers/commonTypedefs.h"
 
 using ::testing::_;
 using ::testing::AtLeast;
@@ -56,4 +57,43 @@ TEST_F(C08TraversalTest, testTraversal2x3x4) {
 TEST_F(C08TraversalTest, testTraversal7x8x9) {
   std::array<size_t, 3> edgeLength = {7, 8, 9};
   testC08Traversal(edgeLength);
+}
+
+template <autopas::BlackBoxTraversalOption blackBoxTraversalOption>
+class C08BasedTraversalDummy
+    : public autopas::C08BasedTraversal<FPCell, MFunctor, false, true, blackBoxTraversalOption> {
+ public:
+  explicit C08BasedTraversalDummy(const std::array<unsigned long, 3>& dims, MFunctor* pairwiseFunctor)
+      : autopas::C08BasedTraversal<FPCell, MFunctor, false /*useSoA*/, true /*newton3*/, blackBoxTraversalOption>(
+            dims, pairwiseFunctor) {}
+
+  autopas::TraversalOptions getTraversalType() override {
+    autopas::utils::ExceptionHandler::exception("not yet implemented.");
+    return autopas::TraversalOptions::dummyTraversal;
+  }
+  FRIEND_TEST(C08TraversalTest, testOuterTraversal);
+};
+
+TEST_F(C08TraversalTest, testOuterTraversal) {
+  constexpr std::array<size_t, 3> edgeLength = {7, 8, 9};
+  MFunctor functor;
+  C08BasedTraversalDummy<autopas::outer> traversal(edgeLength, &functor);
+  std::array<std::array<std::array<int, edgeLength[2]>, edgeLength[1]>, edgeLength[0]> touchableArray = {};
+  traversal.c08TraversalOuter([&](unsigned long x, unsigned long y, unsigned long z) {
+    touchableArray[x][y][z]++;
+  });
+  for (unsigned int x = 0; x < edgeLength[0]; ++x) {
+    for (unsigned int y = 0; y < edgeLength[1]; ++y) {
+      for (unsigned int z = 0; z < edgeLength[2]; ++z) {
+        bool shouldBeTrue = false;
+        if(x < 3 or x >= edgeLength[0] - 2)
+          shouldBeTrue = true;
+        if(y < 3 or y >= edgeLength[1] - 2)
+          shouldBeTrue = true;
+        if(z < 3 or z >= edgeLength[2] - 2)
+          shouldBeTrue = true;
+        EXPECT_EQ(touchableArray[x][y][z], shouldBeTrue ? 1 : 0) << "x: " << x << ", y: "<< y << ", z: " << z;
+      }
+    }
+  }
 }

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/C08TraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/C08TraversalTest.cpp
@@ -87,9 +87,9 @@ TEST_F(C08TraversalTest, testOuterTraversal) {
     for (unsigned int y = 0; y < edgeLength[1] - 1; ++y) {
       for (unsigned int z = 0; z < edgeLength[2] - 1; ++z) {
         bool outside = false;
-        if (x < 3 or x >= edgeLength[0] - 3) outside = true;
-        if (y < 3 or y >= edgeLength[1] - 3) outside = true;
-        if (z < 3 or z >= edgeLength[2] - 3) outside = true;
+        if (x < 2 or x >= edgeLength[0] - 3) outside = true;
+        if (y < 2 or y >= edgeLength[1] - 3) outside = true;
+        if (z < 2 or z >= edgeLength[2] - 3) outside = true;
         EXPECT_EQ(touchableArray[x][y][z], outside ? 1 : 0) << "x: " << x << ", y: " << y << ", z: " << z;
       }
     }
@@ -123,9 +123,9 @@ TEST_F(C08TraversalTest, testOuterTraversalColors) {
       for (unsigned int z = 0; z < edgeLength[2] - 1; ++z) {
         unsigned long currentColor = touchableArray[x][y][z];
         bool outside = false;
-        if (x < 3 or x >= edgeLength[0] - 3) outside = true;
-        if (y < 3 or y >= edgeLength[1] - 3) outside = true;
-        if (z < 3 or z >= edgeLength[2] - 3) outside = true;
+        if (x < 2 or x >= edgeLength[0] - 3) outside = true;
+        if (y < 2 or y >= edgeLength[1] - 3) outside = true;
+        if (z < 2 or z >= edgeLength[2] - 3) outside = true;
         if (not outside) continue;
 
         for (unsigned int dx = 0; dx < 2; ++dx) {
@@ -155,9 +155,9 @@ TEST_F(C08TraversalTest, testInnerTraversal) {
     for (unsigned int y = 0; y < edgeLength[1]; ++y) {
       for (unsigned int z = 0; z < edgeLength[2]; ++z) {
         bool outside = false;
-        if (x < 3 or x >= edgeLength[0] - 3) outside = true;
-        if (y < 3 or y >= edgeLength[1] - 3) outside = true;
-        if (z < 3 or z >= edgeLength[2] - 3) outside = true;
+        if (x < 2 or x >= edgeLength[0] - 3) outside = true;
+        if (y < 2 or y >= edgeLength[1] - 3) outside = true;
+        if (z < 2 or z >= edgeLength[2] - 3) outside = true;
         EXPECT_EQ(touchableArray[x][y][z], outside ? 0 : 1) << "x: " << x << ", y: " << y << ", z: " << z;
       }
     }

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/C08TraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/C08TraversalTest.cpp
@@ -71,7 +71,7 @@ class C08BasedTraversalDummy
     autopas::utils::ExceptionHandler::exception("not yet implemented.");
     return autopas::TraversalOptions::dummyTraversal;
   }
-  FRIEND_TEST(C08TraversalTest, testOuterTraversal);
+  friend class C08TraversalTest_testOuterTraversal_Test;
 };
 
 TEST_F(C08TraversalTest, testOuterTraversal) {

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/C08TraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/C08TraversalTest.cpp
@@ -79,20 +79,15 @@ TEST_F(C08TraversalTest, testOuterTraversal) {
   MFunctor functor;
   C08BasedTraversalDummy<autopas::outer> traversal(edgeLength, &functor);
   std::array<std::array<std::array<int, edgeLength[2]>, edgeLength[1]>, edgeLength[0]> touchableArray = {};
-  traversal.c08TraversalOuter([&](unsigned long x, unsigned long y, unsigned long z) {
-    touchableArray[x][y][z]++;
-  });
+  traversal.c08TraversalOuter([&](unsigned long x, unsigned long y, unsigned long z) { touchableArray[x][y][z]++; });
   for (unsigned int x = 0; x < edgeLength[0]; ++x) {
     for (unsigned int y = 0; y < edgeLength[1]; ++y) {
       for (unsigned int z = 0; z < edgeLength[2]; ++z) {
         bool shouldBeTrue = false;
-        if(x < 3 or x >= edgeLength[0] - 2)
-          shouldBeTrue = true;
-        if(y < 3 or y >= edgeLength[1] - 2)
-          shouldBeTrue = true;
-        if(z < 3 or z >= edgeLength[2] - 2)
-          shouldBeTrue = true;
-        EXPECT_EQ(touchableArray[x][y][z], shouldBeTrue ? 1 : 0) << "x: " << x << ", y: "<< y << ", z: " << z;
+        if (x < 3 or x >= edgeLength[0] - 2) shouldBeTrue = true;
+        if (y < 3 or y >= edgeLength[1] - 2) shouldBeTrue = true;
+        if (z < 3 or z >= edgeLength[2] - 2) shouldBeTrue = true;
+        EXPECT_EQ(touchableArray[x][y][z], shouldBeTrue ? 1 : 0) << "x: " << x << ", y: " << y << ", z: " << z;
       }
     }
   }

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/C08TraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/C08TraversalTest.cpp
@@ -97,7 +97,7 @@ TEST_F(C08TraversalTest, testOuterTraversal) {
 }
 
 TEST_F(C08TraversalTest, testOuterTraversalColors) {
-  // the idea of this test is to check whether the colors used correctly, such that no race conditions can occur.
+  // the idea of this test is to check whether the colors are used correctly, such that no race conditions can occur.
 
 #if defined(AUTOPAS_OPENMP)
   int previousThreadCount = autopas::autopas_get_max_threads();

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/C08TraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/C08TraversalTest.cpp
@@ -60,12 +60,10 @@ TEST_F(C08TraversalTest, testTraversal7x8x9) {
 }
 
 template <autopas::BlackBoxTraversalOption blackBoxTraversalOption>
-class C08BasedTraversalDummy
-    : public autopas::C08BasedTraversal<FPCell, MFunctor, false, true, blackBoxTraversalOption> {
+class C08BasedTraversalDummy : public autopas::C08BasedTraversal<FPCell, false, true, blackBoxTraversalOption> {
  public:
-  explicit C08BasedTraversalDummy(const std::array<unsigned long, 3>& dims, MFunctor* pairwiseFunctor)
-      : autopas::C08BasedTraversal<FPCell, MFunctor, false /*useSoA*/, true /*newton3*/, blackBoxTraversalOption>(
-            dims, pairwiseFunctor) {}
+  explicit C08BasedTraversalDummy(const std::array<unsigned long, 3>& dims)
+      : autopas::C08BasedTraversal<FPCell, false /*useSoA*/, true /*newton3*/, blackBoxTraversalOption>(dims) {}
 
   autopas::TraversalOptions getTraversalType() override {
     autopas::utils::ExceptionHandler::exception("not yet implemented.");
@@ -80,11 +78,11 @@ class C08BasedTraversalDummy
 
 TEST_F(C08TraversalTest, testOuterTraversal) {
   constexpr std::array<size_t, 3> edgeLength = {7, 8, 9};
-  MFunctor functor;
-  C08BasedTraversalDummy<autopas::outer> traversal(edgeLength, &functor);
+  C08BasedTraversalDummy<autopas::outer> traversal(edgeLength);
   std::array<std::array<std::array<int, edgeLength[2]>, edgeLength[1]>, edgeLength[0]> touchableArray = {};
-  traversal.c08Traversal_public(
-      [&](unsigned long x, unsigned long y, unsigned long z) { touchableArray[x][y][z]++; });
+  traversal.c08Traversal_public([&](unsigned long x, unsigned long y, unsigned long z) { touchableArray[x][y][z]++; });
+
+  // the upper halo is NOT traversed => "x < edgeLength[0] - 1"
   for (unsigned int x = 0; x < edgeLength[0] - 1; ++x) {
     for (unsigned int y = 0; y < edgeLength[1] - 1; ++y) {
       for (unsigned int z = 0; z < edgeLength[2] - 1; ++z) {
@@ -100,8 +98,7 @@ TEST_F(C08TraversalTest, testOuterTraversal) {
 
 TEST_F(C08TraversalTest, testInnerTraversal) {
   constexpr std::array<size_t, 3> edgeLength = {7, 8, 9};
-  MFunctor functor;
-  C08BasedTraversalDummy<autopas::inner> traversal(edgeLength, &functor);
+  C08BasedTraversalDummy<autopas::inner> traversal(edgeLength);
   std::array<std::array<std::array<int, edgeLength[2]>, edgeLength[1]>, edgeLength[0]> touchableArray = {};
   traversal.c08Traversal_public([&](unsigned long x, unsigned long y, unsigned long z) { touchableArray[x][y][z]++; });
   for (unsigned int x = 0; x < edgeLength[0]; ++x) {

--- a/tests/testAutopas/tests/containers/verletLists/VerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletLists/VerletListsTest.cpp
@@ -563,8 +563,8 @@ TEST_F(VerletListsTest, LoadExtractSoA) {
   MockFunctor<Particle, FPCell> mockFunctor;
   autopas::C08Traversal<FPCell, MFunctor, false, true> dummyTraversal({0, 0, 0}, &mockFunctor);
 
-  EXPECT_CALL(mockFunctor, SoALoaderVerlet(_, _, _)).Times(216);  // 6*6*6=216 cells
-  EXPECT_CALL(mockFunctor, SoAExtractorVerlet(_, _, _)).Times(216);
+  EXPECT_CALL(mockFunctor, SoALoader(_, _, _)).Times(216);  // 6*6*6=216 cells
+  EXPECT_CALL(mockFunctor, SoAExtractor(_, _, _)).Times(216);
   EXPECT_CALL(mockFunctor, SoAFunctor(_, _, _, _, _)).Times(1);
   verletLists.iteratePairwiseSoA(&mockFunctor, &dummyTraversal, true);
 }

--- a/tests/testAutopas/tests/containers/verletLists/VerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletLists/VerletListsTest.cpp
@@ -82,7 +82,7 @@ TEST_F(VerletListsTest, testVerletListBuild) {
 
   EXPECT_EQ(list.size(), 2);
   int partners = 0;
-  for (auto i : list) {
+  for (const auto& i : list) {
     partners += i.second.size();
   }
   EXPECT_EQ(partners, 1);
@@ -113,7 +113,7 @@ TEST_F(VerletListsTest, testVerletList) {
 
   EXPECT_EQ(list.size(), 2);
   int partners = 0;
-  for (auto i : list) {
+  for (const auto& i : list) {
     partners += i.second.size();
   }
   EXPECT_EQ(partners, 1);
@@ -144,7 +144,7 @@ TEST_F(VerletListsTest, testVerletListInSkin) {
 
   EXPECT_EQ(list.size(), 2);
   int partners = 0;
-  for (auto i : list) {
+  for (const auto& i : list) {
     partners += i.second.size();
   }
   EXPECT_EQ(partners, 1);
@@ -176,7 +176,7 @@ TEST_F(VerletListsTest, testVerletListBuildTwice) {
 
   EXPECT_EQ(list.size(), 2);
   int partners = 0;
-  for (auto i : list) {
+  for (const auto& i : list) {
     partners += i.second.size();
   }
   EXPECT_EQ(partners, 1);
@@ -210,7 +210,7 @@ TEST_F(VerletListsTest, testVerletListBuildFarAway) {
 
   ASSERT_EQ(list.size(), 3);
   int partners = 0;
-  for (auto i : list) {
+  for (const auto& i : list) {
     partners += i.second.size();
   }
   ASSERT_EQ(partners, 1);
@@ -242,7 +242,7 @@ TEST_F(VerletListsTest, testVerletListBuildHalo) {
   ASSERT_EQ(list.size(), 2);
   EXPECT_EQ(list.size(), 2);
   int partners = 0;
-  for (auto i : list) {
+  for (const auto& i : list) {
     partners += i.second.size();
   }
   ASSERT_EQ(partners, 1);

--- a/tests/testAutopas/tests/selectors/AutoTunerTest.cpp
+++ b/tests/testAutopas/tests/selectors/AutoTunerTest.cpp
@@ -24,7 +24,7 @@ void AutoTunerTest::testTune(autopas::DataLayoutOption dataLayoutOption) {
   const unsigned int numSamples = 2;
   autopas::AutoTuner<Particle, FPCell> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkin, verletRebuildFrequency,
                                                  containers, traversals, autopas::SelectorStrategy::fastestAbs,
-                                                 autopas::SelectorStrategy::fastestAbs, 100, numSamples);
+                                                 autopas::SelectorStrategy::fastestAbs, 100, numSamples, false);
 
   std::shared_ptr<autopas::ParticleContainer<Particle, FPCell>> fastestContainer;
   autopas::Logger::get()->set_level(autopas::Logger::LogLevel::debug);

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
@@ -19,11 +19,11 @@ TEST_F(ContainerSelectorTest, testGetOptimalContainerOneOption) {
   const double verletSkin = 0;
   const unsigned int verletRebuildFrequency = 1;
   autopas::ContainerSelector<Particle, FPCell> containerSelectorDir(
-      bBoxMin, bBoxMax, cutoff, verletSkin, verletRebuildFrequency, optionVectorDir, traversals);
-  autopas::ContainerSelector<Particle, FPCell> containerSelectorLC(bBoxMin, bBoxMax, cutoff, verletSkin,
-                                                                   verletRebuildFrequency, optionVectorLC, traversals);
+      bBoxMin, bBoxMax, cutoff, verletSkin, verletRebuildFrequency, optionVectorDir, traversals, false);
+  autopas::ContainerSelector<Particle, FPCell> containerSelectorLC(
+      bBoxMin, bBoxMax, cutoff, verletSkin, verletRebuildFrequency, optionVectorLC, traversals, false);
   autopas::ContainerSelector<Particle, FPCell> containerSelectorVerlet(
-      bBoxMin, bBoxMax, cutoff, verletSkin, verletRebuildFrequency, optionVectorVerlet, traversals);
+      bBoxMin, bBoxMax, cutoff, verletSkin, verletRebuildFrequency, optionVectorVerlet, traversals, false);
 
   auto containerDir = containerSelectorDir.getOptimalContainer();
   auto containerLC = containerSelectorLC.getOptimalContainer();
@@ -45,7 +45,7 @@ TEST_F(ContainerSelectorTest, testNextContainer) {
                                                              autopas::ContainerOptions::linkedCells};
   std::vector<autopas::TraversalOptions> traversalOptions = {autopas::TraversalOptions::c08};
   autopas::ContainerSelector<Particle, FPCell> containerSelector(
-      bBoxMin, bBoxMax, cutoff, verletSkin, verletRebuildFrequency, containerOptions, traversalOptions);
+      bBoxMin, bBoxMax, cutoff, verletSkin, verletRebuildFrequency, containerOptions, traversalOptions, false);
 
   auto container = containerSelector.selectNextContainer();
   EXPECT_EQ(autopas::ContainerOptions::verletLists, container->getContainerType());
@@ -74,7 +74,7 @@ TEST_F(ContainerSelectorTest, testSelectOptimalContainer) {
                                                              autopas::ContainerOptions::linkedCells};
   std::vector<autopas::TraversalOptions> traversalOptions = {autopas::TraversalOptions::c08};
   autopas::ContainerSelector<Particle, FPCell> containerSelector(
-      bBoxMin, bBoxMax, cutoff, verletSkin, verletRebuildFrequency, containerOptions, traversalOptions);
+      bBoxMin, bBoxMax, cutoff, verletSkin, verletRebuildFrequency, containerOptions, traversalOptions, false);
 
   EXPECT_THROW(containerSelector.selectOptimalContainer(), std::exception);
 


### PR DESCRIPTION
# Description

Makes it possible to use VerletLists as a black box. 

- [x] Implement BlackBoxMode.
- [x] Make black box mode usable from outside. Integration in AutoPas interface
- [x] Check convenience functions (checkNeighborListsAreValid, isContainerUpdateNeeded, needsRebuild)
- [x] save type of verlet lists (newton3 or not) in VerletLists

## Resolved Issues

- [x] fixes #171: implements option 2.
- [x] fixes wrong verlet list results if newton3 is disabled.

# How Has This Been Tested?

- [x] Test for AoS - N3 and noN3
- [x] Test for SoA - N3 and noN3
- [x] Test with halo deletion
- [x] Tested within ls1

# Performance data:
for single thread's verlet lists remain faster than linked cells, even in blackbox mode:
(tested in ls1 mardyn)

| type              | verlet | verletBB | linkedCells |
|-------------------|--------|----------|-------------|
| single thread aos | 0.26   | 0.39     | 0.44        |
| single thread soa | 0.1    | 0.31     | 0.40        |