### PR TITLE
fix md-flexible's measureperf.sh

### DIFF
--- a/examples/md-flexible/MDFlexParser.cpp
+++ b/examples/md-flexible/MDFlexParser.cpp
@@ -322,8 +322,7 @@ void MDFlexParser::printConfig() {
        << ":  " << iterableToString(containerOptions) << endl;
 
   // if verlet lists are in the container options print verlet config data
-  if (find(containerOptions.begin(), containerOptions.end(), autopas::ContainerOption::verletLists) !=
-      containerOptions.end()) {
+  if (iterableToString(containerOptions).find("erlet") != std::string::npos) {
     cout << setw(valueOffset) << left << "Verlet rebuild frequency"
          << ":  " << verletRebuildFrequency << endl;
 

--- a/examples/md-flexible/measurePerf.sh
+++ b/examples/md-flexible/measurePerf.sh
@@ -89,7 +89,7 @@ do
             # workaround because there is no traversal for Verlet clusters with newton 3 yet.
             if [[ ${container} =~ 'VerletCluster' ]];
             then
-                noNewton3="--no-newton3"
+                noNewton3="--newton3 off"
             else
                 noNewton3=""
             fi

--- a/examples/md-flexible/measurePerf.sh
+++ b/examples/md-flexible/measurePerf.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+#should abort on errors!
+set -e
 export LC_NUMERIC=en_US.UTF-8
 
 if [[ "$#" -lt 1 ]]

--- a/examples/md-flexible/measurePerf.sh
+++ b/examples/md-flexible/measurePerf.sh
@@ -73,78 +73,83 @@ do
     do
         separate "${dataLayout}"
 
-        for iVL in `seq 0 $(( ${#VLRebuild[@]} - 1 ))` ;
+        for newton3Opt in on off ;
         do
-            configPrinted=false
 
-            # since this loop only has one iteration for non verlet container only print for verlet
-            if [[ ${container} =~ 'Verlet' ]];
-            then
-                separate "VLRebuild: ${VLRebuild[$iVL]} VLSkin: ${VLSkin[$iVL]}"
-                filename="runtimes_${container}_${dataLayout}_${VLRebuild[$iVL]}_${VLSkin[$iVL]}.csv"
-            else
-                filename="runtimes_${container}_${dataLayout}.csv"
-            fi
+            separate "Newton 3 ${newton3Opt}"
 
-            # workaround because there is no traversal for Verlet clusters with newton 3 yet.
-            if [[ ${container} =~ 'VerletCluster' ]];
-            then
-                noNewton3="--newton3 off"
-            else
-                noNewton3=""
-            fi
-
-            # iterate over molecules with the correct repetition
-            for i in `seq 0 $(( ${#Mols[@]} - 1 ))` ;
+            # loop for different verlet rebuild frequencies and skins
+            for iVL in `seq 0 $(( ${#VLRebuild[@]} - 1 ))` ;
             do
-                thisReps=${Reps[$i]}
-                # Direct sum is slow for huge number of particles -> limit number of iterations
-                if [[ ${container} = 'DirectSum' && ${Mols[$i]} -ge 2048 ]];
+                configPrinted=false
+
+                # since this loop only has one iteration for non verlet container only print for verlet
+                if [[ ${container} =~ 'Verlet' ]];
                 then
-                    thisReps=3
+                    separate "VLRebuild: ${VLRebuild[$iVL]} VLSkin: ${VLSkin[$iVL]}"
+                    filename="runtimes_${container}_${dataLayout}_N3${newton3Opt}_${VLRebuild[$iVL]}_${VLSkin[$iVL]}.csv"
+                else
+                    filename="runtimes_${container}_${dataLayout}_N3${newton3Opt}.csv"
                 fi
 
-                separate "Particles: ${Mols[$i]} Iterations: ${thisReps}"
+                # workaround because there is no traversal for Verlet clusters with newton 3 yet.
+                if [[ ${container} =~ 'VerletCluster' && ${newton3Opt} =~ 'on' ]];
+                then
+                    continue
+                fi
 
-                # workaround because bash3 does not support declare -A
-                t=traversals__${container}
-
-                output=$(${EXECUTABLE} \
-                    --container ${container} \
-                    --traversal ${!t} \
-                    --data-layout ${dataLayout} \
-                    --cutoff 1 \
-                    --box-length 10 \
-                    --particles-generator uniform \
-                    --particles-total ${Mols[$i]} \
-                    --iterations ${thisReps} \
-                    --tuning-interval $(( ${thisReps} + 1 )) \
-                    --verlet-rebuild-frequency ${VLRebuild[$iVL]} \
-                    --verlet-skin-radius ${VLSkin[$iVL]} \
-                    --no-flops \
-                    ${noNewton3}
-                )
-
-                printf "${output}\n"
-
-                if [[ "${SILENT}" = false ]] ; then
-                    if [[ "${configPrinted}" = false ]] ; then
-                        configPrinted=true
-                        # print all output lines until, excluding, "Using" (this is the whole config part)
-                        allMols=${Mols[@]}
-                        allIterations=${Reps[@]}
-                        sed '/Using/Q' <<< "${output}" | sed -e "s|\( *total[ :]*\)[0-9]*|\1${allMols}|" -e "s|\(Iterations[ :]*\)[0-9]*|\1${allIterations}|" >> ${filename}
-                        echo >> ${filename}
-                        printf "%12s%15s%15s%15s%24s\n" "NumParticles" "GFLOPs/s" "MFUPs/s" "Time[micros]" "SingleIteration[micros]" >> ${filename}
+                # iterate over molecules with the correct repetition
+                for i in `seq 0 $(( ${#Mols[@]} - 1 ))` ;
+                do
+                    thisReps=${Reps[$i]}
+                    # Direct sum is slow for huge number of particles -> limit number of iterations
+                    if [[ ${container} = 'DirectSum' && ${Mols[$i]} -ge 2048 ]];
+                    then
+                        thisReps=3
                     fi
 
-                    gflops=$(echo "$output" | sed --quiet -e 's|GFLOPs/sec.*: \(.*\)|\1|gp')
-                    mfups=$(echo "$output" | sed --quiet -e 's|MFUPs/sec.*: \(.*\)|\1|gp')
-                    timeTotal=$(echo "$output" | sed --quiet -e 's|Time total.*: \(.*\) .*s (.*|\1|gp')
-                    timeOne=$(echo "$output" | sed --quiet -e 's|One iteration.*: \(.*\) .*s (.*|\1|gp')
+                    separate "Particles: ${Mols[$i]} Iterations: ${thisReps}"
 
-                    printf "%12d%15.2f%15.2f%15.2f%24.2f\n" "${Mols[$i]}" "$gflops" "$mfups" "$timeTotal" "$timeOne"  >> ${filename}
-                fi
+                    # workaround because bash3 does not support declare -A
+                    t=traversals__${container}
+
+                    output=$(${EXECUTABLE} \
+                        --container ${container} \
+                        --traversal ${!t} \
+                        --data-layout ${dataLayout} \
+                        --cutoff 1 \
+                        --box-length 10 \
+                        --particles-generator uniform \
+                        --particles-total ${Mols[$i]} \
+                        --iterations ${thisReps} \
+                        --tuning-interval $(( ${thisReps} + 1 )) \
+                        --verlet-rebuild-frequency ${VLRebuild[$iVL]} \
+                        --verlet-skin-radius ${VLSkin[$iVL]} \
+                        --no-flops \
+                        --newton3 ${newton3Opt}
+                    )
+
+                    printf "${output}\n"
+
+                    if [[ "${SILENT}" = false ]] ; then
+                        if [[ "${configPrinted}" = false ]] ; then
+                            configPrinted=true
+                            # print all output lines until, excluding, "Using" (this is the whole config part)
+                            allMols=${Mols[@]}
+                            allIterations=${Reps[@]}
+                            sed '/Using/Q' <<< "${output}" | sed -e "s|\( *total[ :]*\)[0-9]*|\1${allMols}|" -e "s|\(Iterations[ :]*\)[0-9]*|\1${allIterations}|" >> ${filename}
+                            echo >> ${filename}
+                            printf "%12s%15s%15s%15s%24s\n" "NumParticles" "GFLOPs/s" "MFUPs/s" "Time[micros]" "SingleIteration[micros]" >> ${filename}
+                        fi
+
+                        gflops=$(echo "$output" | sed --quiet -e 's|GFLOPs/sec.*: \(.*\)|\1|gp')
+                        mfups=$(echo "$output" | sed --quiet -e 's|MFUPs/sec.*: \(.*\)|\1|gp')
+                        timeTotal=$(echo "$output" | sed --quiet -e 's|Time total.*: \(.*\) .*s (.*|\1|gp')
+                        timeOne=$(echo "$output" | sed --quiet -e 's|One iteration.*: \(.*\) .*s (.*|\1|gp')
+
+                        printf "%12d%15.2f%15.2f%15.2f%24.2f\n" "${Mols[$i]}" "$gflops" "$mfups" "$timeTotal" "$timeOne"  >> ${filename}
+                    fi
+                done
             done
         done
     done


### PR DESCRIPTION
# Description

Fixes bugs in measureperf.sh of md-flexible

## Resolved Issues

- [x] fixed bug in measurePerf.sh: --no-newton3 is no longer supported
- [x] fixed bug in measurePerf.sh: errors were not propagated to the outside and thus not shown in jenkins.

# How Has This Been Tested?

- [x] tested locally: using the first commit only, the script properly exits.