### PR TITLE
Adds initTraversal and endTraversal

### DIFF
--- a/src/autopas/pairwiseFunctors/Functor.h
+++ b/src/autopas/pairwiseFunctors/Functor.h
@@ -37,14 +37,14 @@ class Functor {
    * This function is called at the start of each traversal.
    * Use it for resetting global values or initializing them.
    */
-  virtual void initTraversal() {};
+  virtual void initTraversal(){};
 
   /**
    * This function is called at the end of each traversal.
    * You may accumulate values in this step.
    * @param newton3
    */
-  virtual void endTraversal(bool newton3) {};
+  virtual void endTraversal(bool newton3){};
 
   /**
    * @brief Functor for arrays of structures (AoS).

--- a/src/autopas/pairwiseFunctors/Functor.h
+++ b/src/autopas/pairwiseFunctors/Functor.h
@@ -34,6 +34,19 @@ class Functor {
   virtual ~Functor() = default;
 
   /**
+   * This function is called at the start of each traversal.
+   * Use it for resetting global values or initializing them.
+   */
+  virtual void initTraversal() {};
+
+  /**
+   * This function is called at the end of each traversal.
+   * You may accumulate values in this step.
+   * @param newton3
+   */
+  virtual void endTraversal(bool newton3) {};
+
+  /**
    * @brief Functor for arrays of structures (AoS).
    *
    * This functor should calculate the forces or any other pair-wise interaction

--- a/src/autopas/pairwiseFunctors/LJFunctor.h
+++ b/src/autopas/pairwiseFunctors/LJFunctor.h
@@ -463,7 +463,7 @@ class LJFunctor : public Functor<Particle, ParticleCell, typename Particle::SoAA
    * Reset the global values.
    * Will set the global values to zero to prepare for the next iteration.
    */
-  void resetGlobalValues() {
+  void initTraversal() override {
     _upotSum = 0.;
     _virialSum = {0., 0., 0.};
     _postProcessed = false;
@@ -473,14 +473,14 @@ class LJFunctor : public Functor<Particle, ParticleCell, typename Particle::SoAA
   }
 
   /**
-   * postprocesses global values, e.g. upot and virial
+   * Postprocesses global values, e.g. upot and virial
    * @param newton3
    */
-  void postProcessGlobalValues(bool newton3) {
+  void endTraversal(bool newton3) override {
     if (_postProcessed) {
       throw utils::ExceptionHandler::AutoPasException(
-          "Already postprocessed, please don't call postProcessGlobalValues(bool newton3) twice without calling "
-          "resetGlobalValues().");
+          "Already postprocessed, please don't call endTraversal(bool newton3) twice without calling "
+          "initTraversal().");
     }
     for (size_t i = 0; i < _aosThreadData.size(); ++i) {
       _upotSum += _aosThreadData[i].upotSum;
@@ -508,7 +508,7 @@ class LJFunctor : public Functor<Particle, ParticleCell, typename Particle::SoAA
     }
     if (not _postProcessed) {
       throw utils::ExceptionHandler::AutoPasException(
-          "Not yet postprocessed, please call postProcessGlobalValues first.");
+          "Not yet postprocessed, please call endTraversal first.");
     }
     return _upotSum;
   }
@@ -525,7 +525,7 @@ class LJFunctor : public Functor<Particle, ParticleCell, typename Particle::SoAA
     }
     if (not _postProcessed) {
       throw utils::ExceptionHandler::AutoPasException(
-          "Not yet postprocessed, please call postProcessGlobalValues first.");
+          "Not yet postprocessed, please call endTraversal first.");
     }
     return _virialSum[0] + _virialSum[1] + _virialSum[2];
   }

--- a/src/autopas/pairwiseFunctors/LJFunctor.h
+++ b/src/autopas/pairwiseFunctors/LJFunctor.h
@@ -479,8 +479,7 @@ class LJFunctor : public Functor<Particle, ParticleCell, typename Particle::SoAA
   void endTraversal(bool newton3) override {
     if (_postProcessed) {
       throw utils::ExceptionHandler::AutoPasException(
-          "Already postprocessed, please don't call endTraversal(bool newton3) twice without calling "
-          "initTraversal().");
+          "Already postprocessed, endTraversal(bool newton3) was called twice without calling initTraversal().");
     }
     for (size_t i = 0; i < _aosThreadData.size(); ++i) {
       _upotSum += _aosThreadData[i].upotSum;
@@ -507,8 +506,7 @@ class LJFunctor : public Functor<Particle, ParticleCell, typename Particle::SoAA
           "values, please specify calculateGlobals to be true.");
     }
     if (not _postProcessed) {
-      throw utils::ExceptionHandler::AutoPasException(
-          "Not yet postprocessed, please call endTraversal first.");
+      throw utils::ExceptionHandler::AutoPasException("Cannot get upot, because endTraversal was not called.");
     }
     return _upotSum;
   }
@@ -524,8 +522,7 @@ class LJFunctor : public Functor<Particle, ParticleCell, typename Particle::SoAA
           "values, please specify calculateGlobals to be true.");
     }
     if (not _postProcessed) {
-      throw utils::ExceptionHandler::AutoPasException(
-          "Not yet postprocessed, please call endTraversal first.");
+      throw utils::ExceptionHandler::AutoPasException("Cannot get virial, because endTraversal was not called.");
     }
     return _virialSum[0] + _virialSum[1] + _virialSum[2];
   }

--- a/src/autopas/pairwiseFunctors/LJFunctorAVX.h
+++ b/src/autopas/pairwiseFunctors/LJFunctorAVX.h
@@ -405,8 +405,8 @@ class LJFunctorAVX : public Functor<Particle, ParticleCell, typename Particle::S
   void postProcessGlobalValues(bool newton3) {
     if (_postProcessed) {
       throw utils::ExceptionHandler::AutoPasException(
-          "Already postprocessed, please don't call postProcessGlobalValues(bool newton3) twice without calling "
-          "resetGlobalValues().");
+          "Already postprocessed, please don't call endTraversal(bool newton3) twice without calling "
+          "initTraversal().");
     }
     for (size_t i = 0; i < _aosThreadData.size(); ++i) {
       _upotSum += _aosThreadData[i].upotSum;
@@ -434,7 +434,7 @@ class LJFunctorAVX : public Functor<Particle, ParticleCell, typename Particle::S
     }
     if (not _postProcessed) {
       throw utils::ExceptionHandler::AutoPasException(
-          "Not yet postprocessed, please call postProcessGlobalValues first.");
+          "Not yet postprocessed, please call endTraversal first.");
     }
     return _upotSum;
   }
@@ -451,7 +451,7 @@ class LJFunctorAVX : public Functor<Particle, ParticleCell, typename Particle::S
     }
     if (not _postProcessed) {
       throw utils::ExceptionHandler::AutoPasException(
-          "Not yet postprocessed, please call postProcessGlobalValues first.");
+          "Not yet postprocessed, please call endTraversal first.");
     }
     return _virialSum[0] + _virialSum[1] + _virialSum[2];
   }

--- a/src/autopas/pairwiseFunctors/LJFunctorAVX.h
+++ b/src/autopas/pairwiseFunctors/LJFunctorAVX.h
@@ -399,14 +399,13 @@ class LJFunctorAVX : public Functor<Particle, ParticleCell, typename Particle::S
   }
 
   /**
-   * postprocesses global values, e.g. upot and virial
+   * Accumulates global values, e.g. upot and virial.
    * @param newton3
    */
   void endTraversal(bool newton3) override {
     if (_postProcessed) {
       throw utils::ExceptionHandler::AutoPasException(
-          "Already postprocessed, please don't call endTraversal(bool newton3) twice without calling "
-          "initTraversal().");
+          "Already postprocessed, endTraversal(bool newton3) was called twice without calling initTraversal().");
     }
     for (size_t i = 0; i < _aosThreadData.size(); ++i) {
       _upotSum += _aosThreadData[i].upotSum;
@@ -433,8 +432,7 @@ class LJFunctorAVX : public Functor<Particle, ParticleCell, typename Particle::S
           "values, please specify calculateGlobals to be true.");
     }
     if (not _postProcessed) {
-      throw utils::ExceptionHandler::AutoPasException(
-          "Not yet postprocessed, please call endTraversal first.");
+      throw utils::ExceptionHandler::AutoPasException("Cannot get upot, because endTraversal was not called.");
     }
     return _upotSum;
   }
@@ -450,8 +448,7 @@ class LJFunctorAVX : public Functor<Particle, ParticleCell, typename Particle::S
           "values, please specify calculateGlobals to be true.");
     }
     if (not _postProcessed) {
-      throw utils::ExceptionHandler::AutoPasException(
-          "Not yet postprocessed, please call endTraversal first.");
+      throw utils::ExceptionHandler::AutoPasException("Cannot get virial, because endTraversal was not called.");
     }
     return _virialSum[0] + _virialSum[1] + _virialSum[2];
   }

--- a/src/autopas/pairwiseFunctors/LJFunctorAVX.h
+++ b/src/autopas/pairwiseFunctors/LJFunctorAVX.h
@@ -389,7 +389,7 @@ class LJFunctorAVX : public Functor<Particle, ParticleCell, typename Particle::S
    * Reset the global values.
    * Will set the global values to zero to prepare for the next iteration.
    */
-  void resetGlobalValues() {
+  void initTraversal() override {
     _upotSum = 0.;
     _virialSum = {0., 0., 0.};
     _postProcessed = false;
@@ -402,7 +402,7 @@ class LJFunctorAVX : public Functor<Particle, ParticleCell, typename Particle::S
    * postprocesses global values, e.g. upot and virial
    * @param newton3
    */
-  void postProcessGlobalValues(bool newton3) {
+  void endTraversal(bool newton3) override {
     if (_postProcessed) {
       throw utils::ExceptionHandler::AutoPasException(
           "Already postprocessed, please don't call endTraversal(bool newton3) twice without calling "

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -338,11 +338,17 @@ void AutoTuner<Particle, ParticleCell>::iteratePairwiseTemplateHelper(PairwiseFu
     auto start = std::chrono::high_resolution_clock::now();
     // @todo remove useNewton3 in iteratePairwise by introducing traversals for DS and VL
     if (useSoA) {
-      withStaticContainerType(container,
-                              [&](auto container) { container->iteratePairwiseSoA(f, traversal.get(), useNewton3); });
+      withStaticContainerType(container, [&](auto container) {
+        f->initTraversal();
+        container->iteratePairwiseSoA(f, traversal.get(), useNewton3);
+        f->endTraversal(useNewton3);
+      });
     } else {
-      withStaticContainerType(container,
-                              [&](auto container) { container->iteratePairwiseAoS(f, traversal.get(), useNewton3); });
+      withStaticContainerType(container, [&](auto container) {
+        f->initTraversal();
+        container->iteratePairwiseAoS(f, traversal.get(), useNewton3);
+        f->endTraversal(useNewton3);
+      });
     }
     auto stop = std::chrono::high_resolution_clock::now();
     auto runtime = std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start).count();
@@ -352,11 +358,17 @@ void AutoTuner<Particle, ParticleCell>::iteratePairwiseTemplateHelper(PairwiseFu
     addTimeMeasurement(*f, runtime);
   } else {
     if (useSoA) {
-      withStaticContainerType(container,
-                              [&](auto container) { container->iteratePairwiseSoA(f, traversal.get(), useNewton3); });
+      withStaticContainerType(container, [&](auto container) {
+        f->initTraversal();
+        container->iteratePairwiseSoA(f, traversal.get(), useNewton3);
+        f->endTraversal(useNewton3);
+      });
     } else {
-      withStaticContainerType(container,
-                              [&](auto container) { container->iteratePairwiseAoS(f, traversal.get(), useNewton3); });
+      withStaticContainerType(container, [&](auto container) {
+        f->initTraversal();
+        container->iteratePairwiseAoS(f, traversal.get(), useNewton3);
+        f->endTraversal(useNewton3);
+      });
     }
   }
 }

--- a/tests/testAutopas/tests/pairwiseFunctors/LJFunctorTest.cpp
+++ b/tests/testAutopas/tests/pairwiseFunctors/LJFunctorTest.cpp
@@ -195,16 +195,16 @@ TEST_F(LJFunctorTest, testFunctorGlobalsThrowBad) {
   EXPECT_THROW(functor.getUpot(), exception_type);
   EXPECT_THROW(functor.getVirial(), exception_type);
 
-  EXPECT_NO_THROW(functor.resetGlobalValues());
+  EXPECT_NO_THROW(functor.initTraversal());
 
-  EXPECT_NO_THROW(functor.postProcessGlobalValues(true));
-  EXPECT_NO_THROW(functor.resetGlobalValues());
-  EXPECT_NO_THROW(functor.postProcessGlobalValues(true));
+  EXPECT_NO_THROW(functor.endTraversal(true));
+  EXPECT_NO_THROW(functor.initTraversal());
+  EXPECT_NO_THROW(functor.endTraversal(true));
   // repeated postprocessing is not allowed
-  EXPECT_THROW(functor.postProcessGlobalValues(true), exception_type);
+  EXPECT_THROW(functor.endTraversal(true), exception_type);
 
-  EXPECT_NO_THROW(functor.resetGlobalValues());
-  EXPECT_NO_THROW(functor.postProcessGlobalValues(true));
+  EXPECT_NO_THROW(functor.initTraversal());
+  EXPECT_NO_THROW(functor.endTraversal(true));
 }
 
 void LJFunctorTest::testAoSGlobals(LJFunctorTest::where_type where, bool newton3, bool duplicatedCalculation) {
@@ -241,13 +241,13 @@ void LJFunctorTest::testAoSGlobals(LJFunctorTest::where_type where, bool newton3
   Molecule p1({0. + xOffset, 0., 0.}, {0., 0., 0.}, 0);
   Molecule p2({0.1 + xOffset, 0.2, 0.3}, {0., 0., 0.}, 1);
 
-  functor.resetGlobalValues();
+  functor.initTraversal();
 
   functor.AoSFunctor(p1, p2, newton3);
   if (not newton3) {
     functor.AoSFunctor(p2, p1, newton3);
   }
-  functor.postProcessGlobalValues(newton3);
+  functor.endTraversal(newton3);
 
   double upot = functor.getUpot();
   double virial = functor.getVirial();
@@ -328,7 +328,7 @@ void LJFunctorTest::testSoAGlobals(LJFunctorTest::where_type where, bool newton3
     }
   }
 
-  functor.resetGlobalValues();
+  functor.initTraversal();
 
   functor.SoALoader(cell1, cell1._particleSoABuffer);
   functor.SoALoader(cell2, cell2._particleSoABuffer);
@@ -362,7 +362,7 @@ void LJFunctorTest::testSoAGlobals(LJFunctorTest::where_type where, bool newton3
   functor.SoAExtractor(cell1, cell1._particleSoABuffer);
   functor.SoAExtractor(cell2, cell2._particleSoABuffer);
 
-  functor.postProcessGlobalValues(newton3);
+  functor.endTraversal(newton3);
 
   double upot = functor.getUpot();
   double virial = functor.getVirial();
@@ -432,7 +432,7 @@ TEST_F(LJFunctorTest, testAoSFunctorGlobalsOpenMPParallel) {
   autopas::LJFunctor<Molecule, FMCell, autopas::FunctorN3Modes::Both, true> functor(
       cutoff, epsilon, sigma, shift, lowCorner, highCorner, duplicatedCalculation);
 
-  functor.resetGlobalValues();
+  functor.initTraversal();
   // This is a basic check for the global calculations, by checking the handling of two particle interactions in
   // parallel. If interactions are dangerous, archer will complain.
 #if defined(AUTOPAS_OPENMP)
@@ -453,7 +453,7 @@ TEST_F(LJFunctorTest, testAoSFunctorGlobalsOpenMPParallel) {
       functor.AoSFunctor(p3, p4, newton3);
     }
   }
-  functor.postProcessGlobalValues(newton3);
+  functor.endTraversal(newton3);
 
   double upot = functor.getUpot();
   double virial = functor.getVirial();


### PR DESCRIPTION
# Description

Adds initTraversal and endTraversal to functors.
These will be called by AutoPas at the start, resp. the end of a simulation to implement things like global value accumulation.
They were needed, as the newton3 type of a simulation cannot be known anymore from the outside

## Related Pull Requests

- needed since #170 that newton3 switching by autopas

## Resolved Issues # (issue)

- [x] closes #119 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Tests that were already there in autopas
- [x] using ls1 mardyn
