### PR TITLE
Test and Fix Container Conversion

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,6 +92,7 @@ pipeline{
                                 sh "./tests/testAutopas/runTests"
                             }
                             dir('build-cuda/examples') {
+                                sh "cmake ."
                                 sh "ctest -C checkExamples -j8 --verbose"
                             }
                         }
@@ -111,6 +112,7 @@ pipeline{
                                 sh 'env GTEST_OUTPUT="xml:$(pwd)/test.xml" ./tests/testAutopas/runTests'
                             }
                             dir("build/examples") {
+                                sh "cmake ."
                                 sh 'ctest -C checkExamples -j8 --verbose'
                             }
                         }
@@ -125,6 +127,7 @@ pipeline{
                                 sh './tests/testAutopas/runTests'
                             }
                             dir("build-openmp/examples") {
+                                sh "cmake ."
                                 sh 'ctest -C checkExamples -j8 --verbose'
                             }
                         }
@@ -184,6 +187,7 @@ pipeline{
                                 sh './tests/testAutopas/runTests'
                             }
                             dir("build-clang-ninja-openmp/examples"){
+                                sh "cmake ."
                                 sh 'ctest -C checkExamples -j8 --verbose'
                             }
                         }
@@ -209,6 +213,7 @@ pipeline{
                                 sh './tests/testAutopas/runTests'
                             }
                             dir("build-clang-ninja-addresssanitizer-release/examples"){
+                                sh "cmake ."
                                 sh 'ctest -C checkExamples -j8 --verbose'
                             }
                         }
@@ -220,6 +225,7 @@ pipeline{
                             dir("build-archer"){
                                 sh "CXXFLAGS=-Wno-pass-failed CC=clang-archer CXX=clang-archer++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DUSE_VECTORIZATION=OFF .."
                                 sh "ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
+                                sh "cmake ."
                                 sh 'export TSAN_OPTIONS="ignore_noninstrumented_modules=1" && export ARCHER_OPTIONS="print_ompt_counters=1" && ctest --verbose'
                             }
                             dir("build-archer/examples"){
@@ -237,6 +243,7 @@ pipeline{
                                 sh "bash -i -c './tests/testAutopas/runTests'"
                             }
                             dir("build-intel/examples"){
+                                sh "cmake ."
                                 sh "bash -i -c 'ctest -C checkExamples -j8 --verbose'"
                             }
                         }
@@ -251,6 +258,7 @@ pipeline{
                                 sh "bash -i -c './tests/testAutopas/runTests'"
                             }
                             dir("build-intel-ninja-openmp/examples"){
+                                sh "cmake ."
                                 sh "bash -i -c 'ctest -C checkExamples -j8 --verbose'"
                             }
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,10 +89,10 @@ pipeline{
                                 sh "cmake -DENABLE_CUDA=ON .."
                                 sh "make -j 4 > buildlog-cuda.txt 2>&1 || (cat buildlog-cuda.txt && exit 1)"
                                 sh "cat buildlog-cuda.txt"
+                                sh "cmake ."
                                 sh "./tests/testAutopas/runTests"
                             }
                             dir('build-cuda/examples') {
-                                sh "cmake ."
                                 sh "ctest -C checkExamples -j8 --verbose"
                             }
                         }
@@ -109,10 +109,10 @@ pipeline{
                             dir("build"){
                                 sh "cmake .."
                                 sh "make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
+                                sh "cmake ."
                                 sh 'env GTEST_OUTPUT="xml:$(pwd)/test.xml" ./tests/testAutopas/runTests'
                             }
                             dir("build/examples") {
-                                sh "cmake ."
                                 sh 'ctest -C checkExamples -j8 --verbose'
                             }
                         }
@@ -124,10 +124,10 @@ pipeline{
                             dir("build-openmp"){
                                 sh "cmake -DOPENMP=ON .."
                                 sh "make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
+                                sh "cmake ."
                                 sh './tests/testAutopas/runTests'
                             }
                             dir("build-openmp/examples") {
-                                sh "cmake ."
                                 sh 'ctest -C checkExamples -j8 --verbose'
                             }
                         }
@@ -184,10 +184,10 @@ pipeline{
                             dir("build-clang-ninja-openmp"){
                                 sh "CC=clang CXX=clang++ cmake -G Ninja -DOPENMP=ON .."
                                 sh "ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
+                                sh "cmake ."
                                 sh './tests/testAutopas/runTests'
                             }
                             dir("build-clang-ninja-openmp/examples"){
-                                sh "cmake ."
                                 sh 'ctest -C checkExamples -j8 --verbose'
                             }
                         }
@@ -210,10 +210,10 @@ pipeline{
                             dir("build-clang-ninja-addresssanitizer-release"){
                                 sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_ADDRESS_SANITIZER=ON .."
                                 sh "ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
+                                sh "cmake ."
                                 sh './tests/testAutopas/runTests'
                             }
                             dir("build-clang-ninja-addresssanitizer-release/examples"){
-                                sh "cmake ."
                                 sh 'ctest -C checkExamples -j8 --verbose'
                             }
                         }
@@ -240,10 +240,10 @@ pipeline{
                             dir("build-intel"){
                                 sh "bash -i -c 'which icc && CC=`which icc` CXX=`which icpc` cmake -DOPENMP=OFF ..'"
                                 sh "bash -i -c 'make -j 8 > buildlog_intel.txt 2>&1 || (cat buildlog_intel.txt && exit 1)'"
+                                sh "cmake ."
                                 sh "bash -i -c './tests/testAutopas/runTests'"
                             }
                             dir("build-intel/examples"){
-                                sh "cmake ."
                                 sh "bash -i -c 'ctest -C checkExamples -j8 --verbose'"
                             }
                         }
@@ -255,10 +255,10 @@ pipeline{
                             dir("build-intel-ninja-openmp"){
                                 sh "bash -i -c 'which icc && CC=`which icc` CXX=`which icpc` cmake -G Ninja -DOPENMP=ON ..'"
                                 sh "bash -i -c 'ninja -j 8 > buildlog_intel.txt 2>&1 || (cat buildlog_intel.txt && exit 1)'"
+                                sh "cmake ."
                                 sh "bash -i -c './tests/testAutopas/runTests'"
                             }
                             dir("build-intel-ninja-openmp/examples"){
-                                sh "cmake ."
                                 sh "bash -i -c 'ctest -C checkExamples -j8 --verbose'"
                             }
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,7 +89,6 @@ pipeline{
                                 sh "cmake -DENABLE_CUDA=ON .."
                                 sh "make -j 4 > buildlog-cuda.txt 2>&1 || (cat buildlog-cuda.txt && exit 1)"
                                 sh "cat buildlog-cuda.txt"
-                                sh "cmake ."
                                 sh "./tests/testAutopas/runTests"
                             }
                             dir('build-cuda/examples') {
@@ -109,7 +108,6 @@ pipeline{
                             dir("build"){
                                 sh "cmake .."
                                 sh "make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
-                                sh "cmake ."
                                 sh 'env GTEST_OUTPUT="xml:$(pwd)/test.xml" ./tests/testAutopas/runTests'
                             }
                             dir("build/examples") {
@@ -124,7 +122,6 @@ pipeline{
                             dir("build-openmp"){
                                 sh "cmake -DOPENMP=ON .."
                                 sh "make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
-                                sh "cmake ."
                                 sh './tests/testAutopas/runTests'
                             }
                             dir("build-openmp/examples") {
@@ -184,7 +181,6 @@ pipeline{
                             dir("build-clang-ninja-openmp"){
                                 sh "CC=clang CXX=clang++ cmake -G Ninja -DOPENMP=ON .."
                                 sh "ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
-                                sh "cmake ."
                                 sh './tests/testAutopas/runTests'
                             }
                             dir("build-clang-ninja-openmp/examples"){
@@ -210,7 +206,6 @@ pipeline{
                             dir("build-clang-ninja-addresssanitizer-release"){
                                 sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_ADDRESS_SANITIZER=ON .."
                                 sh "ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
-                                sh "cmake ."
                                 sh './tests/testAutopas/runTests'
                             }
                             dir("build-clang-ninja-addresssanitizer-release/examples"){
@@ -225,7 +220,6 @@ pipeline{
                             dir("build-archer"){
                                 sh "CXXFLAGS=-Wno-pass-failed CC=clang-archer CXX=clang-archer++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DUSE_VECTORIZATION=OFF .."
                                 sh "ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
-                                sh "cmake ."
                                 sh 'export TSAN_OPTIONS="ignore_noninstrumented_modules=1" && export ARCHER_OPTIONS="print_ompt_counters=1" && ctest --verbose'
                             }
                             dir("build-archer/examples"){
@@ -240,7 +234,6 @@ pipeline{
                             dir("build-intel"){
                                 sh "bash -i -c 'which icc && CC=`which icc` CXX=`which icpc` cmake -DOPENMP=OFF ..'"
                                 sh "bash -i -c 'make -j 8 > buildlog_intel.txt 2>&1 || (cat buildlog_intel.txt && exit 1)'"
-                                sh "cmake ."
                                 sh "bash -i -c './tests/testAutopas/runTests'"
                             }
                             dir("build-intel/examples"){
@@ -255,7 +248,6 @@ pipeline{
                             dir("build-intel-ninja-openmp"){
                                 sh "bash -i -c 'which icc && CC=`which icc` CXX=`which icpc` cmake -G Ninja -DOPENMP=ON ..'"
                                 sh "bash -i -c 'ninja -j 8 > buildlog_intel.txt 2>&1 || (cat buildlog_intel.txt && exit 1)'"
-                                sh "cmake ."
                                 sh "bash -i -c './tests/testAutopas/runTests'"
                             }
                             dir("build-intel-ninja-openmp/examples"){

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -71,8 +71,8 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
       ParticleCell &cell = _cellBlock.getContainingCell(p.getR());
       cell.addParticle(p);
     } else {
-      utils::ExceptionHandler::exception("LinkedCells: trying to add particle that is not inside the bounding box.\n" +
-                                         p.toString());
+      utils::ExceptionHandler::exception(
+          "LinkedCells: Trying to add a particle that is not inside the bounding box.\n" + p.toString());
     }
   }
 
@@ -82,8 +82,16 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
       ParticleCell &cell = _cellBlock.getContainingCell(haloParticle.getR());
       cell.addParticle(haloParticle);
     } else {
-      utils::ExceptionHandler::exception("LinkedCells: trying to add halo particle that is not in the halo box.\n" +
-                                         haloParticle.toString());
+      auto inInnerBox = autopas::utils::inBox(haloParticle.getR(), this->getBoxMin(), this->getBoxMax());
+      if (inInnerBox) {
+        utils::ExceptionHandler::exception(
+            "LinkedCells: Trying to add a halo particle that is actually in the bounding box.\n" +
+            haloParticle.toString());
+      } else {
+        AutoPasLog(trace,
+                   "LinkedCells: Trying to add a halo particle that is outside the halo box. Particle not added!\n{}",
+                   haloParticle.toString());
+      }
     }
   }
 

--- a/src/autopas/particles/Particle.h
+++ b/src/autopas/particles/Particle.h
@@ -55,7 +55,7 @@ class ParticleBase {
    * @param rhs
    * @return
    */
-  bool operator!=(const ParticleBase &rhs) const { return !(rhs == *this); }
+  bool operator!=(const ParticleBase &rhs) const { return not(rhs == *this); }
 
   /**
    * get the force acting on the particle

--- a/src/autopas/particles/Particle.h
+++ b/src/autopas/particles/Particle.h
@@ -36,7 +36,26 @@ class ParticleBase {
   ParticleBase(std::array<floatType, 3> r, std::array<floatType, 3> v, unsigned long id)
       : _r(r), _v(v), _f({0.0, 0.0, 0.0}), _id(id) {}
 
+  /**
+   * Destructor of ParticleBase class
+   */
   virtual ~ParticleBase() = default;
+
+  /**
+   * Equality operator for ParticleBase class.
+   * @param rhs
+   * @return
+   */
+  bool operator==(const ParticleBase &rhs) const {
+    return std::tie(_r, _v, _f, _id) == std::tie(rhs._r, rhs._v, rhs._f, rhs._id);
+  }
+
+  /**
+   * Not-Equals operator for ParticleBase class.
+   * @param rhs
+   * @return
+   */
+  bool operator!=(const ParticleBase &rhs) const { return !(rhs == *this); }
 
   /**
    * get the force acting on the particle

--- a/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
@@ -16,7 +16,7 @@ TEST_F(LinkedCellsTest, testParticleAdding) {
       for (double z : {-1.5, -.5, 0., 5., 9.999, 10., 10.5, 11.5}) {
         autopas::Particle p({x, y, z}, {0., 0., 0.}, id++);
         if (x == -1.5 or y == -1.5 or z == -1.5 or x == 11.5 or y == 11.5 or z == 11.5) {
-          EXPECT_ANY_THROW(linkedCells.addParticle(p));      // outside, therefore not ok!
+          EXPECT_ANY_THROW(linkedCells.addParticle(p));     // outside, therefore not ok!
           EXPECT_NO_THROW(linkedCells.addHaloParticle(p));  // much outside, still ok!
         } else if (x == 10. or y == 10. or z == 10. or x == -.5 or y == -.5 or z == -.5 or x == 10.5 or y == 10.5 or
                    z == 10.5) {

--- a/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
@@ -17,7 +17,7 @@ TEST_F(LinkedCellsTest, testParticleAdding) {
         autopas::Particle p({x, y, z}, {0., 0., 0.}, id++);
         if (x == -1.5 or y == -1.5 or z == -1.5 or x == 11.5 or y == 11.5 or z == 11.5) {
           EXPECT_ANY_THROW(linkedCells.addParticle(p));     // outside, therefore not ok!
-          EXPECT_NO_THROW(linkedCells.addHaloParticle(p));  // much outside, still ok!
+          EXPECT_NO_THROW(linkedCells.addHaloParticle(p));  // much outside, still ok because it is ignored!
         } else if (x == 10. or y == 10. or z == 10. or x == -.5 or y == -.5 or z == -.5 or x == 10.5 or y == 10.5 or
                    z == 10.5) {
           EXPECT_ANY_THROW(linkedCells.addParticle(p));     // outside, therefore not ok!

--- a/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
@@ -17,7 +17,7 @@ TEST_F(LinkedCellsTest, testParticleAdding) {
         autopas::Particle p({x, y, z}, {0., 0., 0.}, id++);
         if (x == -1.5 or y == -1.5 or z == -1.5 or x == 11.5 or y == 11.5 or z == 11.5) {
           EXPECT_ANY_THROW(linkedCells.addParticle(p));      // outside, therefore not ok!
-          EXPECT_ANY_THROW(linkedCells.addHaloParticle(p));  // much outside, therefore not ok!
+          EXPECT_NO_THROW(linkedCells.addHaloParticle(p));  // much outside, still ok!
         } else if (x == 10. or y == 10. or z == 10. or x == -.5 or y == -.5 or z == -.5 or x == 10.5 or y == 10.5 or
                    z == 10.5) {
           EXPECT_ANY_THROW(linkedCells.addParticle(p));     // outside, therefore not ok!

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
@@ -7,6 +7,7 @@
 #include "ContainerSelectorTest.h"
 
 using ::testing::Combine;
+using ::testing::UnorderedElementsAreArray;
 using ::testing::ValuesIn;
 
 // must be TEST_F because the logger which is called in the LC constructor is part of the fixture
@@ -74,8 +75,21 @@ TEST_P(ContainerSelectorTest, testContainerConversion) {
       }
     }
   }
-  // select container from which we want to convert to
+  std::vector<Particle> beforeList;
+  for (auto iter = containerSelector.getCurrentContainer()->begin(); iter.isValid(); ++iter) {
+    beforeList.push_back(*iter);
+  }
+
+  // select container to which we want to convert to
   containerSelector.selectContainer(to);
+
+  std::vector<Particle> afterList;
+  for (auto iter = containerSelector.getCurrentContainer()->begin(); iter.isValid(); ++iter) {
+    afterList.push_back(*iter);
+  }
+
+  ASSERT_EQ(afterList.size(), beforeList.size());
+  EXPECT_THAT(afterList, UnorderedElementsAreArray(beforeList));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
@@ -6,6 +6,9 @@
 
 #include "ContainerSelectorTest.h"
 
+using ::testing::Combine;
+using ::testing::ValuesIn;
+
 // must be TEST_F because the logger which is called in the LC constructor is part of the fixture
 TEST_F(ContainerSelectorTest, testSelectAndGetCurrentContainer) {
   std::array<double, 3> bBoxMin = {0, 0, 0}, bBoxMax = {10, 10, 10};
@@ -28,9 +31,9 @@ TEST_F(ContainerSelectorTest, testSelectAndGetCurrentContainer) {
   }
 }
 
-TEST_F(ContainerSelectorTest, testContainerConversion) {
-  auto from = autopas::ContainerOption::directSum;
-  auto to = autopas::ContainerOption::linkedCells;
+TEST_P(ContainerSelectorTest, testContainerConversion) {
+  auto from = std::get<0>(GetParam());
+  auto to = std::get<1>(GetParam());
 
   std::array<double, 3> bBoxMin = {0, 0, 0}, bBoxMax = {10, 10, 10};
   const double cutoff = 1;
@@ -74,3 +77,9 @@ TEST_F(ContainerSelectorTest, testContainerConversion) {
   // select container from which we want to convert to
   containerSelector.selectContainer(to);
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    Generated, ContainerSelectorTest,
+    Combine(ValuesIn([]() -> std::vector<autopas::ContainerOption> { return autopas::allContainerOptions; }()),
+            ValuesIn([]() -> std::vector<autopas::ContainerOption> { return autopas::allContainerOptions; }())),
+    ContainerSelectorTest::PrintToStringParamName());

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
@@ -51,7 +51,7 @@ TEST_P(ContainerSelectorTest, testContainerConversion) {
   {
     auto container = containerSelector.getCurrentContainer();
     auto getPossible1D = [&](double min, double max) -> auto {
-      return std::initializer_list<double>{min - cutoff - verletSkin,       min - cutoff, min, max, max + cutoff - 1e-3,
+      return std::array<double,6>{min - cutoff - verletSkin,       min - cutoff, min, max, max + cutoff - 1e-3,
                                            min - cutoff - verletSkin - 1e-3};
     };
     size_t id = 0;

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
@@ -120,11 +120,13 @@ TEST_P(ContainerSelectorTest, testContainerConversion) {
 INSTANTIATE_TEST_SUITE_P(
     Generated, ContainerSelectorTest,
     Combine(ValuesIn([]() -> std::vector<autopas::ContainerOption> {
+              // return autopas::allContainerOptions;
               auto all = autopas::allContainerOptions;
               all.erase(std::remove(all.begin(), all.end(), autopas::ContainerOption::verletClusterLists), all.end());
               return all;
             }()),
             ValuesIn([]() -> std::vector<autopas::ContainerOption> {
+              // return autopas::allContainerOptions;
               auto all = autopas::allContainerOptions;
               all.erase(std::remove(all.begin(), all.end(), autopas::ContainerOption::verletClusterLists), all.end());
               return all;

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
@@ -27,3 +27,50 @@ TEST_F(ContainerSelectorTest, testSelectAndGetCurrentContainer) {
     EXPECT_EQ(containerOp, containerSelector.getCurrentContainer()->getContainerType());
   }
 }
+
+TEST_F(ContainerSelectorTest, testContainerConversion) {
+  auto from = autopas::ContainerOption::directSum;
+  auto to = autopas::ContainerOption::linkedCells;
+
+  std::array<double, 3> bBoxMin = {0, 0, 0}, bBoxMax = {10, 10, 10};
+  const double cutoff = 1;
+  const double cellSizeFactor = 1;
+  const double verletSkin = 0.1;
+  const unsigned int verletRebuildFrequency = 1;
+
+  autopas::ContainerSelector<Particle, FPCell> containerSelector(bBoxMin, bBoxMax, cutoff, cellSizeFactor, verletSkin,
+                                                                 verletRebuildFrequency);
+  // select container from which we want to convert from
+  containerSelector.selectContainer(from);
+
+  // fill witch problematic particles
+  {
+    auto container = containerSelector.getCurrentContainer();
+    auto getPossible1D = [&](double min, double max) -> auto {
+      return std::initializer_list<double>{min - cutoff - verletSkin,       min - cutoff, min, max, max + cutoff - 1e-3,
+                                           min - cutoff - verletSkin - 1e-3};
+    };
+    size_t id = 0;
+    for (auto x : getPossible1D(bBoxMin[0], bBoxMax[0])) {
+      for (auto y : getPossible1D(bBoxMin[1], bBoxMax[1])) {
+        for (auto z : getPossible1D(bBoxMin[2], bBoxMax[2])) {
+          std::array<double, 3> pos{x, y, z};
+          Particle p(pos, {0., 0., 0.}, id);
+          if (autopas::utils::inBox(pos, bBoxMin, bBoxMax)) {
+            container->addParticle(p);
+          } else {
+            if (autopas::utils::inBox(pos, autopas::ArrayMath::sub(bBoxMin, std::array<double, 3>{cutoff}),
+                                      autopas::ArrayMath::add(bBoxMin, std::array<double, 3>{cutoff})) or
+                autopas::utils::StringUtils::to_string(container->getContainerType()).find("Verlet") !=
+                    std::string::npos) {
+              container->addHaloParticle(p);
+            }
+          }
+          ++id;
+        }
+      }
+    }
+  }
+  // select container from which we want to convert to
+  containerSelector.selectContainer(to);
+}

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
@@ -51,8 +51,8 @@ TEST_P(ContainerSelectorTest, testContainerConversion) {
   {
     auto container = containerSelector.getCurrentContainer();
     auto getPossible1D = [&](double min, double max) -> auto {
-      return std::array<double,6>{min - cutoff - verletSkin,       min - cutoff, min, max, max + cutoff - 1e-3,
-                                           min - cutoff - verletSkin - 1e-3};
+      return std::array<double, 6>{min - cutoff - verletSkin,       min - cutoff, min, max, max + cutoff - 1e-3,
+                                   min - cutoff - verletSkin - 1e-3};
     };
     size_t id = 0;
     for (auto x : getPossible1D(bBoxMin[0], bBoxMax[0])) {

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
@@ -50,14 +50,14 @@ TEST_P(ContainerSelectorTest, testContainerConversion) {
   // fill witch problematic particles
   {
     auto container = containerSelector.getCurrentContainer();
-    auto getPossible1D = [&](double min, double max) -> auto {
+    auto getPossible1DPositions = [&](double min, double max) -> auto {
       return std::array<double, 6>{min - cutoff - verletSkin,       min - cutoff, min, max, max + cutoff - 1e-3,
                                    min - cutoff - verletSkin - 1e-3};
     };
     size_t id = 0;
-    for (auto x : getPossible1D(bBoxMin[0], bBoxMax[0])) {
-      for (auto y : getPossible1D(bBoxMin[1], bBoxMax[1])) {
-        for (auto z : getPossible1D(bBoxMin[2], bBoxMax[2])) {
+    for (auto x : getPossible1DPositions(bBoxMin[0], bBoxMax[0])) {
+      for (auto y : getPossible1DPositions(bBoxMin[1], bBoxMax[1])) {
+        for (auto z : getPossible1DPositions(bBoxMin[2], bBoxMax[2])) {
           std::array<double, 3> pos{x, y, z};
           Particle p(pos, {0., 0., 0.}, id);
           if (autopas::utils::inBox(pos, bBoxMin, bBoxMax)) {
@@ -67,6 +67,8 @@ TEST_P(ContainerSelectorTest, testContainerConversion) {
                                       autopas::ArrayMath::add(bBoxMin, std::array<double, 3>{cutoff})) or
                 autopas::utils::StringUtils::to_string(container->getContainerType()).find("Verlet") !=
                     std::string::npos) {
+              /// @todo: the above string comparison will most likely be unnecessary once the verlet interface is
+              /// properly introduced.
               container->addHaloParticle(p);
             }
           }
@@ -84,7 +86,7 @@ TEST_P(ContainerSelectorTest, testContainerConversion) {
   for (auto iter = containerSelector.getCurrentContainer()->begin(autopas::IteratorBehavior::haloOnly); iter.isValid();
        ++iter) {
     if (autopas::utils::inBox(iter->getR(), autopas::ArrayMath::sub(bBoxMin, std::array<double, 3>{cutoff}),
-                              autopas::ArrayMath::add(bBoxMin, std::array<double, 3>{cutoff}))) {
+                              autopas::ArrayMath::add(bBoxMax, std::array<double, 3>{cutoff}))) {
       beforeListHalo.push_back(*iter);
     } else {
       beforeListHaloVerletOnly.push_back(*iter);
@@ -102,7 +104,7 @@ TEST_P(ContainerSelectorTest, testContainerConversion) {
   for (auto iter = containerSelector.getCurrentContainer()->begin(autopas::IteratorBehavior::haloOnly); iter.isValid();
        ++iter) {
     if (autopas::utils::inBox(iter->getR(), autopas::ArrayMath::sub(bBoxMin, std::array<double, 3>{cutoff}),
-                              autopas::ArrayMath::add(bBoxMin, std::array<double, 3>{cutoff}))) {
+                              autopas::ArrayMath::add(bBoxMax, std::array<double, 3>{cutoff}))) {
       afterListHalo.push_back(*iter);
     } else {
       afterListHaloVerletOnly.push_back(*iter);
@@ -121,12 +123,14 @@ INSTANTIATE_TEST_SUITE_P(
     Generated, ContainerSelectorTest,
     Combine(ValuesIn([]() -> std::vector<autopas::ContainerOption> {
               // return autopas::allContainerOptions;
+              /// @todo: uncomment above lines and remove below lines to enable testing of verletClusterLists.
               auto all = autopas::allContainerOptions;
               all.erase(std::remove(all.begin(), all.end(), autopas::ContainerOption::verletClusterLists), all.end());
               return all;
             }()),
             ValuesIn([]() -> std::vector<autopas::ContainerOption> {
               // return autopas::allContainerOptions;
+              /// @todo: uncomment above lines and remove below lines to enable testing of verletClusterLists.
               auto all = autopas::allContainerOptions;
               all.erase(std::remove(all.begin(), all.end(), autopas::ContainerOption::verletClusterLists), all.end());
               return all;

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTest.h
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTest.h
@@ -25,7 +25,7 @@ class ContainerSelectorTest
       std::string from_str(autopas::utils::StringUtils::to_string(std::get<0>(inputTuple)));
       std::string to_str(autopas::utils::StringUtils::to_string(std::get<1>(inputTuple)));
       // replace all '-' with '_', otherwise the test name is invalid
-      //std::replace(traversal.begin(), traversal.end(), '-', '_');
+      // std::replace(traversal.begin(), traversal.end(), '-', '_');
       return "from" + from_str + "To" + to_str;
     }
   };

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTest.h
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTest.h
@@ -11,8 +11,22 @@
 #include "autopas/selectors/ContainerSelector.h"
 #include "testingHelpers/commonTypedefs.h"
 
-class ContainerSelectorTest : public AutoPasTestBase {
+class ContainerSelectorTest
+    : public AutoPasTestBase,
+      public ::testing::WithParamInterface<std::tuple<autopas::ContainerOption, autopas::ContainerOption>> {
  public:
   ContainerSelectorTest() = default;
-  ~ContainerSelectorTest() = default;
+  ~ContainerSelectorTest() override = default;
+
+  struct PrintToStringParamName {
+    template <class ParamType>
+    std::string operator()(const testing::TestParamInfo<ParamType> &info) const {
+      auto inputTuple = static_cast<ParamType>(info.param);
+      std::string from_str(autopas::utils::StringUtils::to_string(std::get<0>(inputTuple)));
+      std::string to_str(autopas::utils::StringUtils::to_string(std::get<1>(inputTuple)));
+      // replace all '-' with '_', otherwise the test name is invalid
+      //std::replace(traversal.begin(), traversal.end(), '-', '_');
+      return "from" + from_str + "To" + to_str;
+    }
+  };
 };


### PR DESCRIPTION
# Description

This PR introduces tests and fixes for the conversion between containers

- [x] Test for the conversion between all containers
- [x] Fixes container conversion
- [x] Linked Cells will now simply ignore particles that should be added in the halo if they are outside of the halo (fixes conversion of verlet type container to LC type container.

## Resolved Issues # (issue)

- [x] #208 (might still be broken for VerletClusterLists)

## TODO:
- [ ] #155 (will come later)

## Additional context

- ref #155 

# How Has This Been Tested?

- [x] New test for container conversion
