### PR TITLE
Adapt owed particle bahavior [ad PR #215]

### DIFF
--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -416,7 +416,7 @@ bool CellBlock3D<ParticleCell>::checkInHalo(const std::array<double, 3> &positio
 template <class ParticleCell>
 void CellBlock3D<ParticleCell>::clearHaloCells() {
   std::vector<index_t> haloSlices(2 * _cellsPerInteractionLength);
-  std::vector<index_t>::iterator mid(haloSlices.begin() + _cellsPerInteractionLength);
+  auto mid = haloSlices.begin() + _cellsPerInteractionLength;
   std::iota(haloSlices.begin(), mid, 0);
 
   // x: min and max of x

--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -60,7 +60,7 @@ class CellBlock3D : public CellBorderAndFlagManager {
    */
   CellBlock3D &operator=(const CellBlock3D) = delete;
 
-  bool isHaloCell(index_t index1d) const override {
+  bool cellCanContainHaloParticles(index_t index1d) const override {
     auto index3d = index3D(index1d);
     bool isHaloCell = false;
     for (size_t i = 0; i < 3; i++) {
@@ -75,7 +75,7 @@ class CellBlock3D : public CellBorderAndFlagManager {
     return isHaloCell;
   }
 
-  bool isOwningCell(index_t index1d) const override {
+  bool cellCanContainOwnedParticles(index_t index1d) const override {
     auto index3d = index3D(index1d);
     bool isHaloCell = false;
     for (size_t i = 0; i < 3; i++) {

--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -64,8 +64,10 @@ class CellBlock3D : public CellBorderAndFlagManager {
     auto index3d = index3D(index1d);
     bool isHaloCell = false;
     for (size_t i = 0; i < 3; i++) {
-      if (index3d[i] < _cellsPerInteractionLength or
-          index3d[i] >= _cellsPerDimensionWithHalo[i] - _cellsPerInteractionLength) {
+      // we can have halo particles inside the domain, so we add a factor of 2 here, so we have cells marked as halo
+      // even if they are only close to the halo.
+      if (index3d[i] < 2 * _cellsPerInteractionLength or
+          index3d[i] >= _cellsPerDimensionWithHalo[i] - 2 * _cellsPerInteractionLength) {
         isHaloCell = true;
         break;
       }
@@ -73,7 +75,19 @@ class CellBlock3D : public CellBorderAndFlagManager {
     return isHaloCell;
   }
 
-  bool isOwningCell(index_t index1d) const override { return not isHaloCell(index1d); }
+  bool isOwningCell(index_t index1d) const override {
+    auto index3d = index3D(index1d);
+    bool isHaloCell = false;
+    for (size_t i = 0; i < 3; i++) {
+      // owned particles are always WITHIN the domain, so we don't need the factor 2 here!
+      if (index3d[i] < _cellsPerInteractionLength or
+          index3d[i] >= _cellsPerDimensionWithHalo[i] - _cellsPerInteractionLength) {
+        isHaloCell = true;
+        break;
+      }
+    }
+    return not isHaloCell;
+  }
 
   /**
    * get the ParticleCell of a specified 1d index

--- a/src/autopas/containers/CellBorderAndFlagManager.h
+++ b/src/autopas/containers/CellBorderAndFlagManager.h
@@ -25,18 +25,17 @@ class CellBorderAndFlagManager {
   virtual ~CellBorderAndFlagManager() = default;
 
   /**
-   * Checks if the cell with the one-dimensional index index1d is a halocell.
+   * Checks if the cell with the one-dimensional index index1d can contain halo particles.
    * @param index1d the one-dimensional index of the cell that should be checked
-   * @return true if the cell is a halo cell
+   * @return true if the cell can contain halo particles
    */
-  virtual bool isHaloCell(index_t index1d) const = 0;
+  virtual bool cellCanContainHaloParticles(index_t index1d) const = 0;
 
   /**
-   * Checks if the cell with the one-dimensional index index1d is owned by this
-   * process, i.e. it is NOT a halo cell.
+   * Checks if the cell with the one-dimensional index index1d can contain owned particles.
    * @param index1d the one-dimensional index of the cell that should be checked
-   * @return true if the cell is owned by the current process.
+   * @return true if the cell can contain owned particles
    */
-  virtual bool isOwningCell(index_t index1d) const = 0;
+  virtual bool cellCanContainOwnedParticles(index_t index1d) const = 0;
 };
 }  // namespace autopas

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -179,14 +179,14 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
     typedef std::size_t index_t;
 
    public:
-    /**
-     * This will always return true, as all cells can contain halo particles for DirectSum.
-     * @param index1d
-     * @return
-     */
-    bool isHaloCell(index_t index1d) const override { return true; }
+    bool cellCanContainHaloParticles(index_t index1d) const override {
+      // always return true, as there might be halo particles also within the domain, thus both cells can contain halo
+      // particles.
+      return true;
+    }
 
-    bool isOwningCell(index_t index1d) const override { return index1d == 0; }
+    bool cellCanContainOwnedParticles(index_t index1d) const override { return index1d == 0; }
+
   } _cellBorderFlagManager;
 
   ParticleCell *getCell() { return &(this->_cells.at(0)); };

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -186,7 +186,7 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
      */
     bool isHaloCell(index_t index1d) const override { return true; }
 
-    bool isOwningCell(index_t index1d) const override { return not isHaloCell(index1d); }
+    bool isOwningCell(index_t index1d) const override { return index1d == 0; }
   } _cellBorderFlagManager;
 
   ParticleCell *getCell() { return &(this->_cells.at(0)); };

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -156,12 +156,11 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
     std::vector<size_t> cellsOfInterest;
 
     switch (behavior) {
-      case IteratorBehavior::haloOnly:
-        cellsOfInterest.push_back(1);
-        break;
       case IteratorBehavior::ownedOnly:
         cellsOfInterest.push_back(0);
         break;
+      case IteratorBehavior::haloOnly:
+        // for haloOnly all cells can contain halo particles!
       case IteratorBehavior::haloAndOwned:
         cellsOfInterest.push_back(0);
         cellsOfInterest.push_back(1);
@@ -180,7 +179,12 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
     typedef std::size_t index_t;
 
    public:
-    bool isHaloCell(index_t index1d) const override { return index1d == 1; }
+    /**
+     * This will always return true, as all cells can contain halo particles for DirectSum.
+     * @param index1d
+     * @return
+     */
+    bool isHaloCell(index_t index1d) const override { return true; }
 
     bool isOwningCell(index_t index1d) const override { return not isHaloCell(index1d); }
   } _cellBorderFlagManager;

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -99,7 +99,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
 #ifdef AUTOPAS_OPENMP
 #pragma omp parallel
 #endif
-    for(auto iter = this->begin(IteratorBehavior::haloOnly); iter.isValid(); ++iter){
+    for (auto iter = this->begin(IteratorBehavior::haloOnly); iter.isValid(); ++iter) {
       iter.deleteCurrentParticle();
     }
   }

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -96,8 +96,12 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
   }
 
   void deleteHaloParticles() override {
-    delete also particles close to boundary if marked as non-owned
-    _cellBlock.clearHaloCells();
+#ifdef AUTOPAS_OPENMP
+#pragma omp parallel
+#endif
+    for(auto iter = this->begin(IteratorBehavior::haloOnly); iter.isValid(); ++iter){
+      iter.deleteCurrentParticle();
+    }
   }
 
   /**

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -78,25 +78,27 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
   }
 
   void addHaloParticle(Particle &haloParticle) override {
-    bool inHalo = _cellBlock.checkInHalo(haloParticle.getR());
-    if (inHalo) {
-      ParticleCell &cell = _cellBlock.getContainingCell(haloParticle.getR());
-      cell.addParticle(haloParticle);
+    // halo particles can also be inside of the domain (assuming non-precise interfaces)
+    bool inContainer =
+        autopas::utils::inBox(haloParticle.getR(), _cellBlock.getHaloBoxMin(), _cellBlock.getHaloBoxMax());
+    // here we could also check whether the particle is too far inside of the domain; we would need the verlet skin for
+    // that.
+    if (inContainer) {
+      Particle pCopy = haloParticle;
+      pCopy.setOwned(false);
+      ParticleCell &cell = _cellBlock.getContainingCell(pCopy.getR());
+      cell.addParticle(pCopy);
     } else {
-      auto inInnerBox = autopas::utils::inBox(haloParticle.getR(), this->getBoxMin(), this->getBoxMax());
-      if (inInnerBox) {
-        utils::ExceptionHandler::exception(
-            "LinkedCells: Trying to add a halo particle that is actually in the bounding box.\n" +
-            haloParticle.toString());
-      } else {
-        AutoPasLog(trace,
-                   "LinkedCells: Trying to add a halo particle that is outside the halo box. Particle not added!\n{}",
-                   haloParticle.toString());
-      }
+      AutoPasLog(trace,
+                 "LinkedCells: Trying to add a halo particle that is outside the halo box. Particle not added!\n{}",
+                 haloParticle.toString());
     }
   }
 
-  void deleteHaloParticles() override { _cellBlock.clearHaloCells(); }
+  void deleteHaloParticles() override {
+    delete also particles close to boundary if marked as non-owned
+    _cellBlock.clearHaloCells();
+  }
 
   /**
    * @copydoc DirectSum::iteratePairwise

--- a/src/autopas/iterators/ParticleIterator.h
+++ b/src/autopas/iterators/ParticleIterator.h
@@ -29,7 +29,7 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle> {
  protected:
   /**
    * Simple constructor without major calculation overhead for internal use.
-   * ATTENTION: This Iterator might be invalid after construction!
+   * @note ATTENTION: This Iterator might be invalid after construction!
    *
    * @param cont Linear data vector of ParticleCells.
    * @param flagManager The CellBorderAndFlagManager that shall be used to query the cell types.
@@ -73,6 +73,7 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle> {
     } else {
       _iteratorAcrossCells = cont->end();
       AutoPasLog(warn, "More threads than cells. No work left for thread {}!", myThreadId);
+      return;
     }
 
     if (behavior != haloAndOwned and flagManager == nullptr) {
@@ -83,11 +84,15 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle> {
           "Behavior is not haloAndOwned, but flagManager is "
           "nullptr!");
     }
-    if (_iteratorAcrossCells < cont->end()) {
-      _iteratorWithinOneCell = _iteratorAcrossCells->begin();
-      if (not isCellTypeBehaviorCorrect() or not _iteratorWithinOneCell.isValid()) {
-        ParticleIterator::next_non_empty_cell();
-      }
+
+    if (not _iteratorWithinOneCell.isValid()) {
+      ParticleIterator::next_non_empty_cell();
+    }
+    // The iterator might still be invalid (because the cell is empty or the owned-state of the particle is wrong), so
+    // we check it here!
+    if (not ParticleIterator<Particle, ParticleCell>::isValid() and this->_iteratorAcrossCells < cont->end()) {
+      // the iterator is invalid + we still have particles/cells, so we increment it!
+      operator++();
     }
   }
 
@@ -95,15 +100,17 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle> {
    * @copydoc ParticleIteratorInterface::operator++()
    */
   inline ParticleIterator<Particle, ParticleCell>& operator++() override {
-    if (_iteratorWithinOneCell.isValid()) {
-      ++_iteratorWithinOneCell;
-    }
+    // this iteration is done until a proper particle is found. i.e. one that satisfies the owning state.
+    do {
+      if (_iteratorWithinOneCell.isValid()) {
+        ++_iteratorWithinOneCell;
+      }
 
-    // don't merge into if-else, _cell_iterator may becoeme invalid after ++
-
-    if (not _iteratorWithinOneCell.isValid()) {
-      next_non_empty_cell();
-    }
+      // don't merge into if-else, _cell_iterator may become invalid after ++
+      if (not _iteratorWithinOneCell.isValid()) {
+        next_non_empty_cell();
+      }
+    } while (not isValid() && _iteratorAcrossCells < _vectorOfCells->end());
     return *this;
   }
 
@@ -129,7 +136,7 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle> {
    */
   bool isValid() const override {
     return _vectorOfCells != nullptr and _iteratorAcrossCells < _vectorOfCells->end() and
-           _iteratorWithinOneCell.isValid();
+           _iteratorWithinOneCell.isValid() and particleHasCorrectOwnedState();
   }
 
   ParticleIteratorInterfaceImpl<Particle>* clone() const override {
@@ -155,7 +162,7 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle> {
    * checks if a cell has the correct cell type according to the behavior
    * @return true iff the cell type is proper according to the behavior
    */
-  bool isCellTypeBehaviorCorrect() {
+  bool isCellTypeBehaviorCorrect() const {
     switch (_behavior) {
       case haloAndOwned:
         return true;
@@ -163,6 +170,24 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle> {
         return _flagManager->isHaloCell(_iteratorAcrossCells - _vectorOfCells->begin());
       case ownedOnly:
         return _flagManager->isOwningCell(_iteratorAcrossCells - _vectorOfCells->begin());
+      default:
+        utils::ExceptionHandler::exception("unknown iterator behavior");
+        return false;
+    }
+  }
+
+  /**
+   * Indicates whether the particle has the correct owned state.
+   * @return
+   */
+  bool particleHasCorrectOwnedState() const {
+    switch (_behavior) {
+      case haloAndOwned:
+        return true;
+      case haloOnly:
+        return not _iteratorWithinOneCell->isOwned();
+      case ownedOnly:
+        return _iteratorWithinOneCell->isOwned();
       default:
         utils::ExceptionHandler::exception("unknown iterator behavior");
         return false;

--- a/src/autopas/iterators/ParticleIterator.h
+++ b/src/autopas/iterators/ParticleIterator.h
@@ -167,9 +167,9 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle> {
       case haloAndOwned:
         return true;
       case haloOnly:
-        return _flagManager->isHaloCell(_iteratorAcrossCells - _vectorOfCells->begin());
+        return _flagManager->cellCanContainHaloParticles(_iteratorAcrossCells - _vectorOfCells->begin());
       case ownedOnly:
-        return _flagManager->isOwningCell(_iteratorAcrossCells - _vectorOfCells->begin());
+        return _flagManager->cellCanContainOwnedParticles(_iteratorAcrossCells - _vectorOfCells->begin());
       default:
         utils::ExceptionHandler::exception("unknown iterator behavior");
         return false;

--- a/src/autopas/iterators/ParticleIterator.h
+++ b/src/autopas/iterators/ParticleIterator.h
@@ -85,7 +85,7 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle> {
           "nullptr!");
     }
 
-    if (not _iteratorWithinOneCell.isValid()) {
+    if (not _iteratorWithinOneCell.isValid() or not isCellTypeBehaviorCorrect()) {
       ParticleIterator::next_non_empty_cell();
     }
     // The iterator might still be invalid (because the cell is empty or the owned-state of the particle is wrong), so

--- a/src/autopas/iterators/ParticleIterator.h
+++ b/src/autopas/iterators/ParticleIterator.h
@@ -90,9 +90,9 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle> {
     }
     // The iterator might still be invalid (because the cell is empty or the owned-state of the particle is wrong), so
     // we check it here!
-    if (not ParticleIterator<Particle, ParticleCell>::isValid() and this->_iteratorAcrossCells < cont->end()) {
+    if (not ParticleIterator::isValid() and this->_iteratorAcrossCells < cont->end()) {
       // the iterator is invalid + we still have particles/cells, so we increment it!
-      operator++();
+      ParticleIterator::operator++();
     }
   }
 

--- a/src/autopas/iterators/RegionParticleIterator.h
+++ b/src/autopas/iterators/RegionParticleIterator.h
@@ -50,24 +50,22 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell> {
       this->_iteratorWithinOneCell = this->_iteratorAcrossCells->begin();
     } else {
       this->_iteratorAcrossCells = cont->end();
+      return;
     }
-
-    this->_flagManager = flagManager;
-    this->_behavior = behavior;
 
     if (not this->isCellTypeBehaviorCorrect()) {
       this->next_non_empty_cell();
     }
 
-    // ParticleIterator's constructor will initialize the Iterator, such that it
-    // points to the first particle if one is found, otherwise the pointer is
-    // not valid
-    if (ParticleIterator<Particle, ParticleCell>::isValid()) {  // if there is NO particle, we can not dereference
-                                                                // it, so we need a check.
+    // The iterator might still be invalid (because the cell is empty or the owned-state of the particle is wrong), so
+    // we check it here!
+    if (ParticleIterator<Particle, ParticleCell>::isValid()) {
+      // The iterator is valid, so there is a particle, now we need to check whether it's actually in the box!
       if (utils::notInBox(this->operator*().getR(), _startRegion, _endRegion)) {
         operator++();
       }
     } else if (this->_iteratorAcrossCells != cont->end()) {
+      // the iterator is invalid + we still have particles, so we increment it!
       operator++();
     }
   }

--- a/src/autopas/particles/Particle.h
+++ b/src/autopas/particles/Particle.h
@@ -155,6 +155,14 @@ class ParticleBase {
   bool isOwned() { return _isOwned; }
 
   /**
+   * Set the owned state to the given value
+   * @param owned
+   */
+  void setOwned(bool owned){
+    _isOwned = owned;
+  }
+
+  /**
    * Enums used as ids for accessing and creating a dynamically sized SoA.
    */
   enum AttributeNames : int { id, posX, posY, posZ, forceX, forceY, forceZ };

--- a/src/autopas/particles/Particle.h
+++ b/src/autopas/particles/Particle.h
@@ -158,9 +158,7 @@ class ParticleBase {
    * Set the owned state to the given value
    * @param owned
    */
-  void setOwned(bool owned){
-    _isOwned = owned;
-  }
+  void setOwned(bool owned) { _isOwned = owned; }
 
   /**
    * Enums used as ids for accessing and creating a dynamically sized SoA.

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
@@ -47,7 +47,6 @@ void defaultInit(AutoPasT& autoPas1, AutoPasT& autoPas2, size_t direction) {
   }
 }
 
-
 /**
  * Convert the leaving particle to entering particles.
  * Hereby the periodic boundary position change is done.

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
@@ -10,7 +10,9 @@
 constexpr double cutoff = 1.;
 constexpr double skin = 0.2;
 constexpr std::array<double, 3> boxMin{0., 0., 0.};
+constexpr std::array<double, 3> haloBoxMin{0. - skin - cutoff, 0. - skin - cutoff, 0. - skin - cutoff};
 constexpr std::array<double, 3> boxMax{10., 10., 10.};
+constexpr std::array<double, 3> haloBoxMax{10. + skin + cutoff, 10. + skin + cutoff, 10. + skin + cutoff};
 constexpr double eps = 1.;
 constexpr double sigma = 1.;
 constexpr double shift = 0.1;
@@ -257,7 +259,7 @@ void testAdditionAndIteration(autopas::ContainerOption containerOption, bool alw
   // check number of halo particles for region iterator
   {
     size_t count = 0;
-    for (auto iter = autoPas.getRegionIterator(boxMin, boxMax, autopas::IteratorBehavior::haloOnly); iter.isValid();
+    for (auto iter = autoPas.getRegionIterator(haloBoxMin, haloBoxMax, autopas::IteratorBehavior::haloOnly); iter.isValid();
          ++iter) {
       ++count;
       EXPECT_FALSE(iter->isOwned());
@@ -272,7 +274,7 @@ void testAdditionAndIteration(autopas::ContainerOption containerOption, bool alw
   // check number of particles
   {
     size_t count = 0;
-    for (auto iter = autoPas.getRegionIterator(boxMin, boxMax, autopas::IteratorBehavior::haloAndOwned); iter.isValid();
+    for (auto iter = autoPas.getRegionIterator(haloBoxMin, haloBoxMax, autopas::IteratorBehavior::haloAndOwned); iter.isValid();
          ++iter) {
       ++count;
     }

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
@@ -226,13 +226,17 @@ void testAdditionAndIteration(autopas::ContainerOption containerOption, bool alw
     size_t count = 0;
     for (auto iter = autoPas.begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
       ++count;
+      EXPECT_TRUE(iter->isOwned());
     }
     EXPECT_EQ(count, 3 * 3 * 3);
   }
+
+  // check number of halo particles
   {
     size_t count = 0;
     for (auto iter = autoPas.begin(autopas::IteratorBehavior::haloOnly); iter.isValid(); ++iter) {
       ++count;
+      EXPECT_FALSE(iter->isOwned());
     }
     if (alwaysAddAsHalo) {
       EXPECT_EQ(count, 6 * 6 * 6);
@@ -240,6 +244,8 @@ void testAdditionAndIteration(autopas::ContainerOption containerOption, bool alw
       EXPECT_EQ(count, 6 * 6 * 6 - 3 * 3 * 3);
     }
   }
+
+  // check number of particles
   {
     size_t count = 0;
     for (auto iter = autoPas.begin(autopas::IteratorBehavior::haloAndOwned); iter.isValid(); ++iter) {
@@ -263,12 +269,13 @@ using ::testing::Combine;
 using ::testing::UnorderedElementsAreArray;
 using ::testing::ValuesIn;
 
+/// @todo: use this instead of below to enable testing of VerletClusterLists.
+// INSTANTIATE_TEST_SUITE_P(Generated, AutoPasInterfaceTest, ValuesIn(autopas::allContainerOptions),
+//                         AutoPasInterfaceTest::PrintToStringParamName());
+
 INSTANTIATE_TEST_SUITE_P(Generated, AutoPasInterfaceTest,
                          // proper indent
                          ValuesIn([]() -> std::vector<autopas::ContainerOption> {
-                           // return autopas::allContainerOptions;
-                           /// @todo: uncomment above lines and remove below lines to enable testing of
-                           /// verletClusterLists.
                            auto all = autopas::allContainerOptions;
                            all.erase(std::remove(all.begin(), all.end(), autopas::ContainerOption::verletClusterLists),
                                      all.end());

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
@@ -259,8 +259,8 @@ void testAdditionAndIteration(autopas::ContainerOption containerOption, bool alw
   // check number of halo particles for region iterator
   {
     size_t count = 0;
-    for (auto iter = autoPas.getRegionIterator(haloBoxMin, haloBoxMax, autopas::IteratorBehavior::haloOnly); iter.isValid();
-         ++iter) {
+    for (auto iter = autoPas.getRegionIterator(haloBoxMin, haloBoxMax, autopas::IteratorBehavior::haloOnly);
+         iter.isValid(); ++iter) {
       ++count;
       EXPECT_FALSE(iter->isOwned());
     }
@@ -274,8 +274,8 @@ void testAdditionAndIteration(autopas::ContainerOption containerOption, bool alw
   // check number of particles
   {
     size_t count = 0;
-    for (auto iter = autoPas.getRegionIterator(haloBoxMin, haloBoxMax, autopas::IteratorBehavior::haloAndOwned); iter.isValid();
-         ++iter) {
+    for (auto iter = autoPas.getRegionIterator(haloBoxMin, haloBoxMax, autopas::IteratorBehavior::haloAndOwned);
+         iter.isValid(); ++iter) {
       ++count;
     }
     EXPECT_EQ(count, 6 * 6 * 6);

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
@@ -135,7 +135,7 @@ void doAssertions(autopas::AutoPas<Molecule, FMCell>& autoPas, Functor* functor)
   EXPECT_DOUBLE_EQ(functor->getVirial(), 195072. /*todo: fix value*/) << "wrong virial calculated";
 }
 
-void testInterface(autopas::ContainerOption containerOption) {
+void testSimulationLoop(autopas::ContainerOption containerOption) {
   // create AutoPas object
   autopas::AutoPas<Molecule, FMCell> autoPas;
   autoPas.setAllowedContainers(std::vector<autopas::ContainerOption>{containerOption});
@@ -179,7 +179,38 @@ void testInterface(autopas::ContainerOption containerOption) {
   doAssertions(autoPas, &functor);
 }
 
-TEST_F(AutoPasInterfaceTest, InterfaceTest) {
+TEST_P(AutoPasInterfaceTest, SimulatonLoopTest) {
   // this test checks the correct behavior of the autopas interface.
-  testInterface(autopas::ContainerOption::linkedCells);
+  auto containerOption = GetParam();
+  testSimulationLoop(containerOption);
 }
+
+void testAdditionAndIteration(autopas::ContainerOption containerOption) {
+  // create AutoPas object
+  autopas::AutoPas<Molecule, FMCell> autoPas;
+  autoPas.setAllowedContainers(std::vector<autopas::ContainerOption>{containerOption});
+
+  defaultInit(autoPas);
+}
+
+TEST_P(AutoPasInterfaceTest, ParticleAdditionAndIterationTest) {
+  auto containerOption = GetParam();
+  testAdditionAndIteration(containerOption);
+}
+
+using ::testing::Combine;
+using ::testing::UnorderedElementsAreArray;
+using ::testing::ValuesIn;
+
+INSTANTIATE_TEST_SUITE_P(Generated, AutoPasInterfaceTest,
+                         // proper indent
+                         ValuesIn([]() -> std::vector<autopas::ContainerOption> {
+                           // return autopas::allContainerOptions;
+                           /// @todo: uncomment above lines and remove below lines to enable testing of
+                           /// verletClusterLists.
+                           auto all = autopas::allContainerOptions;
+                           all.erase(std::remove(all.begin(), all.end(), autopas::ContainerOption::verletClusterLists),
+                                     all.end());
+                           return all;
+                         }()),
+                         AutoPasInterfaceTest::PrintToStringParamName());

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
@@ -253,6 +253,31 @@ void testAdditionAndIteration(autopas::ContainerOption containerOption, bool alw
     }
     EXPECT_EQ(count, 6 * 6 * 6);
   }
+
+  // check number of halo particles for region iterator
+  {
+    size_t count = 0;
+    for (auto iter = autoPas.getRegionIterator(boxMin, boxMax, autopas::IteratorBehavior::haloOnly); iter.isValid();
+         ++iter) {
+      ++count;
+      EXPECT_FALSE(iter->isOwned());
+    }
+    if (alwaysAddAsHalo) {
+      EXPECT_EQ(count, 6 * 6 * 6);
+    } else {
+      EXPECT_EQ(count, 6 * 6 * 6 - 3 * 3 * 3);
+    }
+  }
+
+  // check number of particles
+  {
+    size_t count = 0;
+    for (auto iter = autoPas.getRegionIterator(boxMin, boxMax, autopas::IteratorBehavior::haloAndOwned); iter.isValid();
+         ++iter) {
+      ++count;
+    }
+    EXPECT_EQ(count, 6 * 6 * 6);
+  }
 }
 
 TEST_P(AutoPasInterfaceTest, ParticleAdditionAndIterationTestNormal) {

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
@@ -220,17 +220,17 @@ void testAdditionAndIteration(autopas::ContainerOption containerOption, bool alw
       }
     }
   }
-
-  if (alwaysAddAsHalo) {
-    ASSERT_FALSE(autoPas.begin(autopas::IteratorBehavior::ownedOnly).isValid())
-        << "for alwaysAddAsHalo=true, no owned particles should exist" << std::endl;
-  } else {
+  {
     size_t count = 0;
     for (auto iter = autoPas.begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
       ++count;
       EXPECT_TRUE(iter->isOwned());
     }
-    EXPECT_EQ(count, 3 * 3 * 3);
+    if (alwaysAddAsHalo) {
+      EXPECT_EQ(count, 0);
+    } else {
+      EXPECT_EQ(count, 3 * 3 * 3);
+    }
   }
 
   // check number of halo particles
@@ -271,7 +271,7 @@ void testAdditionAndIteration(autopas::ContainerOption containerOption, bool alw
     }
   }
 
-  // check number of particles
+  // check number of particles for region iterator
   {
     size_t count = 0;
     for (auto iter = autoPas.getRegionIterator(haloBoxMin, haloBoxMax, autopas::IteratorBehavior::haloAndOwned);
@@ -279,6 +279,20 @@ void testAdditionAndIteration(autopas::ContainerOption containerOption, bool alw
       ++count;
     }
     EXPECT_EQ(count, 6 * 6 * 6);
+  }
+
+  // check number of owned particles for region iterator
+  {
+    size_t count = 0;
+    for (auto iter = autoPas.getRegionIterator(haloBoxMin, haloBoxMax, autopas::IteratorBehavior::ownedOnly);
+         iter.isValid(); ++iter) {
+      ++count;
+    }
+    if (alwaysAddAsHalo) {
+      EXPECT_EQ(count, 0);
+    } else {
+      EXPECT_EQ(count, 3 * 3 * 3);
+    }
   }
 }
 

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.h
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.h
@@ -9,4 +9,15 @@
 #include <gtest/gtest.h>
 #include "autopas/AutoPas.h"
 
-class AutoPasInterfaceTest : public testing::Test {};
+class AutoPasInterfaceTest : public testing::Test,
+                             public ::testing::WithParamInterface<autopas::ContainerOption> {
+ public:
+  struct PrintToStringParamName {
+    template <class ParamType>
+    std::string operator()(const testing::TestParamInfo<ParamType> &info) const {
+      auto inputTuple = static_cast<ParamType>(info.param);
+      std::string containerSelector_str(autopas::utils::StringUtils::to_string(inputTuple));
+      return containerSelector_str;
+    }
+  };
+};

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.h
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.h
@@ -9,8 +9,7 @@
 #include <gtest/gtest.h>
 #include "autopas/AutoPas.h"
 
-class AutoPasInterfaceTest : public testing::Test,
-                             public ::testing::WithParamInterface<autopas::ContainerOption> {
+class AutoPasInterfaceTest : public testing::Test, public ::testing::WithParamInterface<autopas::ContainerOption> {
  public:
   struct PrintToStringParamName {
     template <class ParamType>

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.h
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.h
@@ -1,5 +1,5 @@
 /**
- * @file AutoPasVerletLikeInterfaceTest.h
+ * @file AutoPasInterfaceTest.h
  * @author seckler
  * @date 13.05.19
  */
@@ -17,6 +17,23 @@ class AutoPasInterfaceTest : public testing::Test, public ::testing::WithParamIn
       auto inputTuple = static_cast<ParamType>(info.param);
       std::string containerSelector_str(autopas::utils::StringUtils::to_string(inputTuple));
       return containerSelector_str;
+    }
+  };
+};
+
+class AutoPasInterface2ContainersTest
+    : public testing::Test,
+      public ::testing::WithParamInterface<std::tuple<autopas::ContainerOption, autopas::ContainerOption>> {
+ public:
+  struct PrintToStringParamName {
+    template <class ParamType>
+    std::string operator()(const testing::TestParamInfo<ParamType> &info) const {
+      auto inputTuple = static_cast<ParamType>(info.param);
+      std::string from_str(autopas::utils::StringUtils::to_string(std::get<0>(inputTuple)));
+      std::string to_str(autopas::utils::StringUtils::to_string(std::get<1>(inputTuple)));
+      // replace all '-' with '_', otherwise the test name is invalid
+      // std::replace(traversal.begin(), traversal.end(), '-', '_');
+      return from_str + "And" + to_str;
     }
   };
 };

--- a/tests/testAutopas/tests/containers/directSum/DirectSumContainerTest.cpp
+++ b/tests/testAutopas/tests/containers/directSum/DirectSumContainerTest.cpp
@@ -19,8 +19,8 @@ TEST_F(DirectSumContainerTest, testParticleAdding) {
           EXPECT_ANY_THROW(directSum.addParticle(p));     // outside, therefore not ok!
           EXPECT_NO_THROW(directSum.addHaloParticle(p));  // outside, therefore ok!
         } else {
-          EXPECT_NO_THROW(directSum.addParticle(p));       // inside, therefore ok!
-          EXPECT_ANY_THROW(directSum.addHaloParticle(p));  // inside, therefore not ok!
+          EXPECT_NO_THROW(directSum.addParticle(p));      // inside, therefore ok!
+          EXPECT_NO_THROW(directSum.addHaloParticle(p));  // inside, but ok, as we have inprecise boundaries!
         }
       }
     }

--- a/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
@@ -23,8 +23,9 @@ TEST_F(LinkedCellsTest, testParticleAdding) {
           EXPECT_ANY_THROW(linkedCells.addParticle(p));     // outside, therefore not ok!
           EXPECT_NO_THROW(linkedCells.addHaloParticle(p));  // outside, therefore ok!
         } else {
-          EXPECT_NO_THROW(linkedCells.addParticle(p));       // inside, therefore ok!
-          EXPECT_ANY_THROW(linkedCells.addHaloParticle(p));  // inside, therefore not ok!
+          EXPECT_NO_THROW(linkedCells.addParticle(p));  // inside, therefore ok!
+          EXPECT_NO_THROW(
+              linkedCells.addHaloParticle(p));  // inside, but still ok, as halo particle can be inside of the domain!
         }
       }
     }

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
@@ -112,18 +112,19 @@ TEST_P(ContainerSelectorTest, testContainerConversion) {
   }
 }
 
+/// @todo: use this instead of below to enable testing of VerletClusterLists.
+// INSTANTIATE_TEST_SUITE_P(Generated, ContainerSelectorTest,
+//                         Combine(ValuesIn(autopas::allContainerOptions), ValuesIn(autopas::allContainerOptions)),
+//                         ContainerSelectorTest::PrintToStringParamName());
+
 INSTANTIATE_TEST_SUITE_P(
     Generated, ContainerSelectorTest,
     Combine(ValuesIn([]() -> std::vector<autopas::ContainerOption> {
-              // return autopas::allContainerOptions;
-              /// @todo: uncomment above lines and remove below lines to enable testing of verletClusterLists.
               auto all = autopas::allContainerOptions;
               all.erase(std::remove(all.begin(), all.end(), autopas::ContainerOption::verletClusterLists), all.end());
               return all;
             }()),
             ValuesIn([]() -> std::vector<autopas::ContainerOption> {
-              // return autopas::allContainerOptions;
-              /// @todo: uncomment above lines and remove below lines to enable testing of verletClusterLists.
               auto all = autopas::allContainerOptions;
               all.erase(std::remove(all.begin(), all.end(), autopas::ContainerOption::verletClusterLists), all.end());
               return all;

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
@@ -63,14 +63,7 @@ TEST_P(ContainerSelectorTest, testContainerConversion) {
           if (autopas::utils::inBox(pos, bBoxMin, bBoxMax)) {
             container->addParticle(p);
           } else {
-            if (autopas::utils::inBox(pos, autopas::ArrayMath::sub(bBoxMin, std::array<double, 3>{cutoff}),
-                                      autopas::ArrayMath::add(bBoxMin, std::array<double, 3>{cutoff})) or
-                autopas::utils::StringUtils::to_string(container->getContainerType()).find("Verlet") !=
-                    std::string::npos) {
-              /// @todo: the above string comparison will most likely be unnecessary once the verlet interface is
-              /// properly introduced.
-              container->addHaloParticle(p);
-            }
+            container->addHaloParticle(p);
           }
           ++id;
         }


### PR DESCRIPTION
# Description

Implements parts of #215:
- [x] particle positions no longer completely define owned state.
- [x] particles inside of the domain can also not be owned.
- [x] particles outside of the domain can be owned. (verlet like only!)

- [x] iterators act accordingly


## Todo (later):
- [ ] verlet like containers can change state of particle ownage (addParticle and addHaloParticle have to do this)
- [ ] Adapt calculation of global values to new interface (in functor)

## Related Pull Requests

- #215

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] New test for ParticleAdditionAndIteration
