### PR TITLE
Refactored TraversalSelector to remove a lot of unnecessary dependencies

### DIFF
--- a/examples/sphDiagramGeneration/sph-diagram-generation.cpp
+++ b/examples/sphDiagramGeneration/sph-diagram-generation.cpp
@@ -10,6 +10,7 @@
 #include "autopas/autopasIncludes.h"
 #include "autopas/sph/autopassph.h"
 #include "autopas/utils/Timer.h"
+#include "autopas/containers/cellPairTraversals/DummyTraversal.h"
 
 template <class Container, class Functor>
 void measureContainer(Container *cont, Functor *func, int numParticles, int numIterations, bool useNewton3);

--- a/examples/sphDiagramGeneration/sph-diagram-generation.cpp
+++ b/examples/sphDiagramGeneration/sph-diagram-generation.cpp
@@ -8,9 +8,9 @@
 #include <iostream>
 #include "../../tests/testAutopas/testingHelpers/RandomGenerator.h"
 #include "autopas/autopasIncludes.h"
+#include "autopas/containers/cellPairTraversals/DummyTraversal.h"
 #include "autopas/sph/autopassph.h"
 #include "autopas/utils/Timer.h"
-#include "autopas/containers/cellPairTraversals/DummyTraversal.h"
 
 template <class Container, class Functor>
 void measureContainer(Container *cont, Functor *func, int numParticles, int numIterations, bool useNewton3);

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -157,8 +157,8 @@ class ParticleContainerInterface {
   virtual bool isContainerUpdateNeeded() = 0;
 
   /**
-   * Generates a traversal selector for this container type.
-   * @return Traversal selector for this container type.
+   * Generates a traversal selector info for this container.
+   * @return Traversal selector info for this container.
    */
   virtual TraversalSelectorInfo<ParticleCell> getTraversalSelectorInfo() = 0;
 

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -8,8 +8,11 @@
 #pragma once
 
 #include <array>
+#include <vector>
 #include "autopas/iterators/ParticleIteratorWrapper.h"
-#include "autopas/selectors/TraversalSelector.h"
+#include "autopas/options/ContainerOption.h"
+#include "autopas/options/TraversalOption.h"
+#include "autopas/selectors/TraversalSelectorInfo.h"
 
 namespace autopas {
 
@@ -157,7 +160,7 @@ class ParticleContainerInterface {
    * Generates a traversal selector for this container type.
    * @return Traversal selector for this container type.
    */
-  virtual TraversalSelector<ParticleCell> generateTraversalSelector() = 0;
+  virtual TraversalSelectorInfo<ParticleCell> generateTraversalSelectorInfo() = 0;
 
   /**
    * Generates a list of all traversals that are theoretically applicable to this container.

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -160,7 +160,7 @@ class ParticleContainerInterface {
    * Generates a traversal selector for this container type.
    * @return Traversal selector for this container type.
    */
-  virtual TraversalSelectorInfo<ParticleCell> generateTraversalSelectorInfo() = 0;
+  virtual TraversalSelectorInfo<ParticleCell> getTraversalSelectorInfo() = 0;
 
   /**
    * Generates a list of all traversals that are theoretically applicable to this container.

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -9,6 +9,7 @@
 
 #include "autopas/containers/CellBorderAndFlagManager.h"
 #include "autopas/containers/ParticleContainer.h"
+#include "autopas/containers/directSum/DirectSumTraversalInterface.h"
 #include "autopas/iterators/ParticleIterator.h"
 #include "autopas/iterators/RegionParticleIterator.h"
 #include "autopas/options/DataLayoutOption.h"
@@ -128,9 +129,9 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
     return outlierFound;
   }
 
-  TraversalSelector<ParticleCell> generateTraversalSelector() override {
+  TraversalSelectorInfo<ParticleCell> generateTraversalSelectorInfo() override {
     // direct sum technically consists of two cells (owned + halo)
-    return TraversalSelector<ParticleCell>({2, 0, 0});
+    return TraversalSelectorInfo<ParticleCell>({2, 0, 0});
   }
 
   ParticleIteratorWrapper<Particle> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -129,7 +129,7 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
     return outlierFound;
   }
 
-  TraversalSelectorInfo<ParticleCell> generateTraversalSelectorInfo() override {
+  TraversalSelectorInfo<ParticleCell> getTraversalSelectorInfo() override {
     // direct sum technically consists of two cells (owned + halo)
     return TraversalSelectorInfo<ParticleCell>({2, 0, 0});
   }

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -9,6 +9,7 @@
 
 #include "autopas/containers/CellBlock3D.h"
 #include "autopas/containers/ParticleContainer.h"
+#include "autopas/containers/linkedCells/traversals/LinkedCellTraversalInterface.h"
 #include "autopas/iterators/ParticleIterator.h"
 #include "autopas/iterators/RegionParticleIterator.h"
 #include "autopas/options/DataLayoutOption.h"
@@ -188,9 +189,9 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
     return outlierFound;
   }
 
-  TraversalSelector<ParticleCell> generateTraversalSelector() override {
-    return TraversalSelector<ParticleCell>(this->getCellBlock().getCellsPerDimensionWithHalo(), this->getCutoff(),
-                                           this->getCellBlock().getCellLength());
+  TraversalSelectorInfo<ParticleCell> generateTraversalSelectorInfo() override {
+    return TraversalSelectorInfo<ParticleCell>(this->getCellBlock().getCellsPerDimensionWithHalo(), this->getCutoff(),
+                                               this->getCellBlock().getCellLength());
   }
 
   ParticleIteratorWrapper<Particle> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -189,7 +189,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
     return outlierFound;
   }
 
-  TraversalSelectorInfo<ParticleCell> generateTraversalSelectorInfo() override {
+  TraversalSelectorInfo<ParticleCell> getTraversalSelectorInfo() override {
     return TraversalSelectorInfo<ParticleCell>(this->getCellBlock().getCellsPerDimensionWithHalo(), this->getCutoff(),
                                                this->getCellBlock().getCellLength());
   }

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -135,7 +135,7 @@ class VerletClusterLists : public ParticleContainer<Particle, FullParticleCell<P
     return false;
   }
 
-  TraversalSelectorInfo<FullParticleCell<Particle>> generateTraversalSelectorInfo() override {
+  TraversalSelectorInfo<FullParticleCell<Particle>> getTraversalSelectorInfo() override {
     return TraversalSelectorInfo<FullParticleCell<Particle>>(_cellsPerDim);
   }
 

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -135,8 +135,8 @@ class VerletClusterLists : public ParticleContainer<Particle, FullParticleCell<P
     return false;
   }
 
-  TraversalSelector<FullParticleCell<Particle>> generateTraversalSelector() override {
-    return TraversalSelector<FullParticleCell<Particle>>(_cellsPerDim);
+  TraversalSelectorInfo<FullParticleCell<Particle>> generateTraversalSelectorInfo() override {
+    return TraversalSelectorInfo<FullParticleCell<Particle>>(_cellsPerDim);
   }
 
   /**

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -205,7 +205,7 @@ class VerletListsLinkedBase : public ParticleContainer<Particle, FullParticleCel
    */
   bool needsRebuild() { return needsRebuild(_verletBuiltNewton3); }
 
-  TraversalSelectorInfo<ParticleCell> generateTraversalSelectorInfo() override {
+  TraversalSelectorInfo<ParticleCell> getTraversalSelectorInfo() override {
     return TraversalSelectorInfo<ParticleCell>(this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo());
   }
 

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -205,6 +205,10 @@ class VerletListsLinkedBase : public ParticleContainer<Particle, FullParticleCel
    */
   bool needsRebuild() { return needsRebuild(_verletBuiltNewton3); }
 
+  /**
+   * Generates a traversal selector info for this container.
+   * @return Traversal selector info for this container.
+   */
   TraversalSelectorInfo<ParticleCell> getTraversalSelectorInfo() override {
     return TraversalSelectorInfo<ParticleCell>(this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo());
   }

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -205,6 +205,10 @@ class VerletListsLinkedBase : public ParticleContainer<Particle, FullParticleCel
    */
   bool needsRebuild() { return needsRebuild(_verletBuiltNewton3); }
 
+  TraversalSelectorInfo<ParticleCell> generateTraversalSelectorInfo() override {
+    return TraversalSelectorInfo<ParticleCell>(this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo());
+  }
+
  protected:
   /**
    * Updates a found particle within cellI to the values of particleI.

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -9,7 +9,9 @@
 #include "VerletListHelpers.h"
 #include "autopas/containers/ParticleContainer.h"
 #include "autopas/containers/linkedCells/LinkedCells.h"
+#include "autopas/containers/linkedCells/traversals/C08Traversal.h"
 #include "autopas/containers/verletListsCellBased/VerletListsLinkedBase.h"
+#include "autopas/containers/verletListsCellBased/verletLists/traversals/TraversalVerlet.h"
 #include "autopas/options/DataLayoutOption.h"
 #include "autopas/utils/ArrayMath.h"
 #include "autopas/utils/StaticSelectorMacros.h"
@@ -143,11 +145,6 @@ class VerletLists
     this->_linkedCells.iteratePairwise(&validityCheckerFunctor, &traversal, useNewton3);
 
     return validityCheckerFunctor.neighborlistsAreValid();
-  }
-
-  TraversalSelector<ParticleCell> generateTraversalSelector() override {
-    // @FIXME dummyTraversal is a workaround because this container does not yet use traversals like it should
-    return TraversalSelector<ParticleCell>(this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo());
   }
 
  protected:

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
@@ -13,6 +13,7 @@
 #include "autopas/containers/linkedCells/traversals/C08Traversal.h"
 #include "autopas/containers/linkedCells/traversals/C18Traversal.h"
 #include "autopas/containers/verletListsCellBased/VerletListsLinkedBase.h"
+#include "autopas/containers/verletListsCellBased/verletListsCells/traversals/VerletListsCellsTraversal.h"
 #include "autopas/options/DataLayoutOption.h"
 #include "autopas/utils/ArrayMath.h"
 
@@ -69,10 +70,6 @@ class VerletListsCells
 
   ContainerOption getContainerType() override { return ContainerOption::verletListsCells; }
 
-  TraversalSelector<ParticleCell> generateTraversalSelector() override {
-    // Function needs to be overwritten
-    return TraversalSelector<ParticleCell>(this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo());
-  }
   /**
    * Function to iterate over all pairs of particles. (Only AoS)
    * This function only handles short-range interactions.

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -84,8 +84,8 @@ class AutoTuner {
     // generate all potential configs
     for (auto &containerOption : allowedContainerOptions) {
       _containerSelector.selectContainer(containerOption);
-      _traversalSelectors.emplace(containerOption,
-                                  _containerSelector.getCurrentContainer()->generateTraversalSelector());
+      _traversalSelectorInfos.emplace(containerOption,
+                                      _containerSelector.getCurrentContainer()->generateTraversalSelectorInfo());
 
       // get all traversals of the container and restrict them to the allowed ones
       auto allContainerTraversals = _containerSelector.getCurrentContainer()->getAllTraversals();
@@ -144,10 +144,10 @@ class AutoTuner {
     }
 
     for (auto &conf : allowedConfigurations) {
-      if (_traversalSelectors.find(conf._container) == _traversalSelectors.end()) {
+      if (_traversalSelectorInfos.find(conf._container) == _traversalSelectorInfos.end()) {
         _containerSelector.selectContainer(conf._container);
-        _traversalSelectors.emplace(conf._container,
-                                    _containerSelector.getCurrentContainer()->generateTraversalSelector());
+        _traversalSelectorInfos.emplace(conf._container,
+                                        _containerSelector.getCurrentContainer()->generateTraversalSelectorInfo());
       }
     }
 
@@ -248,7 +248,7 @@ class AutoTuner {
   /**
    * One selector / factory per possible container because every container might have a different number of cells.
    */
-  std::map<ContainerOption, TraversalSelector<ParticleCell>> _traversalSelectors;
+  std::map<ContainerOption, TraversalSelectorInfo<ParticleCell>> _traversalSelectorInfos;
 
   /**
    * How many times each configuration should be tested.
@@ -363,9 +363,8 @@ void AutoTuner<Particle, ParticleCell>::iteratePairwiseTemplateHelper(PairwiseFu
   auto container = getContainer();
   AutoPasLog(debug, "Iterating with configuration: {}", _currentConfig->toString());
 
-  auto traversal =
-      _traversalSelectors[_currentConfig->_container]
-          .template generateTraversal<PairwiseFunctor, DataLayout, useNewton3>(_currentConfig->_traversal, *f);
+  auto traversal = TraversalSelector<ParticleCell>::template generateTraversal<PairwiseFunctor, DataLayout, useNewton3>(
+      _currentConfig->_traversal, *f, _traversalSelectorInfos[_currentConfig->_container]);
 
   // if tuning execute with time measurements
   if (inTuningPhase) {
@@ -511,17 +510,18 @@ bool AutoTuner<Particle, ParticleCell>::configApplicable(const Configuration &co
     case DataLayoutOption::aos: {
       switch (conf._newton3) {
         case Newton3Option::enabled: {
-          traversalApplicable = _traversalSelectors[conf._container]
-                                    .template generateTraversal<PairwiseFunctor, DataLayoutOption::aos, true>(
-                                        conf._traversal, pairwiseFunctor)
-                                    ->isApplicable();
+          traversalApplicable =
+              TraversalSelector<ParticleCell>::template generateTraversal<PairwiseFunctor, DataLayoutOption::aos, true>(
+                  conf._traversal, pairwiseFunctor, _traversalSelectorInfos[conf._container])
+                  ->isApplicable();
           break;
         }
         case Newton3Option::disabled: {
-          traversalApplicable = _traversalSelectors[conf._container]
-                                    .template generateTraversal<PairwiseFunctor, DataLayoutOption::aos, false>(
-                                        conf._traversal, pairwiseFunctor)
-                                    ->isApplicable();
+          traversalApplicable =
+              TraversalSelector<ParticleCell>::template generateTraversal<PairwiseFunctor, DataLayoutOption::aos,
+                                                                          false>(
+                  conf._traversal, pairwiseFunctor, _traversalSelectorInfos[conf._container])
+                  ->isApplicable();
           break;
         }
       }
@@ -530,17 +530,18 @@ bool AutoTuner<Particle, ParticleCell>::configApplicable(const Configuration &co
     case DataLayoutOption::soa: {
       switch (conf._newton3) {
         case Newton3Option::enabled: {
-          traversalApplicable = _traversalSelectors[conf._container]
-                                    .template generateTraversal<PairwiseFunctor, DataLayoutOption::soa, true>(
-                                        conf._traversal, pairwiseFunctor)
-                                    ->isApplicable();
+          traversalApplicable =
+              TraversalSelector<ParticleCell>::template generateTraversal<PairwiseFunctor, DataLayoutOption::soa, true>(
+                  conf._traversal, pairwiseFunctor, _traversalSelectorInfos[conf._container])
+                  ->isApplicable();
           break;
         }
         case Newton3Option::disabled: {
-          traversalApplicable = _traversalSelectors[conf._container]
-                                    .template generateTraversal<PairwiseFunctor, DataLayoutOption::soa, false>(
-                                        conf._traversal, pairwiseFunctor)
-                                    ->isApplicable();
+          traversalApplicable =
+              TraversalSelector<ParticleCell>::template generateTraversal<PairwiseFunctor, DataLayoutOption::soa,
+                                                                          false>(
+                  conf._traversal, pairwiseFunctor, _traversalSelectorInfos[conf._container])
+                  ->isApplicable();
           break;
         }
       }
@@ -549,17 +550,19 @@ bool AutoTuner<Particle, ParticleCell>::configApplicable(const Configuration &co
     case DataLayoutOption::cuda: {
       switch (conf._newton3) {
         case Newton3Option::enabled: {
-          traversalApplicable = _traversalSelectors[conf._container]
-                                    .template generateTraversal<PairwiseFunctor, DataLayoutOption::cuda, true>(
-                                        conf._traversal, pairwiseFunctor)
-                                    ->isApplicable();
+          traversalApplicable =
+              TraversalSelector<ParticleCell>::template generateTraversal<PairwiseFunctor, DataLayoutOption::cuda,
+                                                                          true>(
+                  conf._traversal, pairwiseFunctor, _traversalSelectorInfos[conf._container])
+                  ->isApplicable();
           break;
         }
         case Newton3Option::disabled: {
-          traversalApplicable = _traversalSelectors[conf._container]
-                                    .template generateTraversal<PairwiseFunctor, DataLayoutOption::cuda, false>(
-                                        conf._traversal, pairwiseFunctor)
-                                    ->isApplicable();
+          traversalApplicable =
+              TraversalSelector<ParticleCell>::template generateTraversal<PairwiseFunctor, DataLayoutOption::cuda,
+                                                                          false>(
+                  conf._traversal, pairwiseFunctor, _traversalSelectorInfos[conf._container])
+                  ->isApplicable();
           break;
         }
       }

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -85,7 +85,7 @@ class AutoTuner {
     for (auto &containerOption : allowedContainerOptions) {
       _containerSelector.selectContainer(containerOption);
       _traversalSelectorInfos.emplace(containerOption,
-                                      _containerSelector.getCurrentContainer()->generateTraversalSelectorInfo());
+                                      _containerSelector.getCurrentContainer()->getTraversalSelectorInfo());
 
       // get all traversals of the container and restrict them to the allowed ones
       auto allContainerTraversals = _containerSelector.getCurrentContainer()->getAllTraversals();
@@ -147,7 +147,7 @@ class AutoTuner {
       if (_traversalSelectorInfos.find(conf._container) == _traversalSelectorInfos.end()) {
         _containerSelector.selectContainer(conf._container);
         _traversalSelectorInfos.emplace(conf._container,
-                                        _containerSelector.getCurrentContainer()->generateTraversalSelectorInfo());
+                                        _containerSelector.getCurrentContainer()->getTraversalSelectorInfo());
       }
     }
 

--- a/src/autopas/selectors/TraversalSelector.h
+++ b/src/autopas/selectors/TraversalSelector.h
@@ -39,8 +39,6 @@ namespace autopas {
  */
 template <class ParticleCell>
 class TraversalSelector {
-  friend TraversalSelectorInfo<ParticleCell>;
-
  public:
   /**
    * Generates a given Traversal for the given properties.
@@ -69,43 +67,43 @@ std::unique_ptr<CellPairTraversal<ParticleCell>> TraversalSelector<ParticleCell>
     // Linked cell
     case TraversalOption::c08: {
       return std::make_unique<C08Traversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>>(
-          info._dims, &pairwiseFunctor, info._cutoff, info._cellLength);
+          info.dims, &pairwiseFunctor, info.cutoff, info.cellLength);
     }
     case TraversalOption::sliced: {
       return std::make_unique<SlicedTraversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>>(
-          info._dims, &pairwiseFunctor, info._cutoff, info._cellLength);
+          info.dims, &pairwiseFunctor, info.cutoff, info.cellLength);
     }
     case TraversalOption::c18: {
       return std::make_unique<C18Traversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>>(
-          info._dims, &pairwiseFunctor, info._cutoff, info._cellLength);
+          info.dims, &pairwiseFunctor, info.cutoff, info.cellLength);
     }
     case TraversalOption::c01: {
       return std::make_unique<C01Traversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>>(
-          info._dims, &pairwiseFunctor, info._cutoff, info._cellLength);
+          info.dims, &pairwiseFunctor, info.cutoff, info.cellLength);
     }
     // Verlet
     case TraversalOption::slicedVerlet: {
       return std::make_unique<SlicedTraversalVerlet<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>>(
-          info._dims, &pairwiseFunctor);
+          info.dims, &pairwiseFunctor);
     }
     case TraversalOption::c18Verlet: {
       return std::make_unique<C18TraversalVerlet<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>>(
-          info._dims, &pairwiseFunctor);
+          info.dims, &pairwiseFunctor);
     }
     case TraversalOption::c01Verlet: {
       return std::make_unique<C01TraversalVerlet<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>>(
-          info._dims, &pairwiseFunctor);
+          info.dims, &pairwiseFunctor);
     }
     case TraversalOption::c01Cuda: {
       return std::make_unique<C01CudaTraversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>>(
-          info._dims, &pairwiseFunctor);
+          info.dims, &pairwiseFunctor);
     }
     case TraversalOption::verletTraversal: {
-      return std::make_unique<TraversalVerlet<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>>(info._dims,
+      return std::make_unique<TraversalVerlet<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>>(info.dims,
                                                                                                       &pairwiseFunctor);
     }
     case TraversalOption::dummyTraversal: {
-      return std::make_unique<DummyTraversal<ParticleCell>>(info._dims);
+      return std::make_unique<DummyTraversal<ParticleCell>>(info.dims);
     }
   }
   autopas::utils::ExceptionHandler::exception("Traversal type {} is not a known type!",

--- a/src/autopas/selectors/TraversalSelector.h
+++ b/src/autopas/selectors/TraversalSelector.h
@@ -47,6 +47,7 @@ class TraversalSelector {
    * @tparam useNewton3
    * @param traversalType
    * @param pairwiseFunctor
+   * @param info
    * @return Smartpointer to the traversal.
    */
   template <class PairwiseFunctor, DataLayoutOption DataLayout, bool useNewton3>

--- a/src/autopas/selectors/TraversalSelector.h
+++ b/src/autopas/selectors/TraversalSelector.h
@@ -10,6 +10,7 @@
 #include <numeric>
 #include <unordered_map>
 #include <vector>
+#include "TraversalSelectorInfo.h"
 #include "autopas/containers/cellPairTraversals/CellPairTraversal.h"
 #include "autopas/containers/cellPairTraversals/DummyTraversal.h"
 #include "autopas/containers/cellPairTraversals/TraversalInterface.h"
@@ -38,21 +39,9 @@ namespace autopas {
  */
 template <class ParticleCell>
 class TraversalSelector {
- public:
-  /**
-   * Dummy constructor such that this class can be used in maps
-   */
-  TraversalSelector() : _dims({0, 0, 0}), _cutoff(1.0), _cellLength({0.0, 0.0, 0.0}) {}
-  /**
-   * Constructor of the TraversalSelector class.
-   * @param dims Array with the dimension lengths of the domain
-   * @param cutoff Cutoff radius
-   * @param cellLength cell length.
-   */
-  TraversalSelector(const std::array<unsigned long, 3> &dims, const double cutoff = 1.0,
-                    const std::array<double, 3> &cellLength = {1.0, 1.0, 1.0})
-      : _dims(dims), _cutoff(cutoff), _cellLength(cellLength) {}
+  friend TraversalSelectorInfo<ParticleCell>;
 
+ public:
   /**
    * Generates a given Traversal for the given properties.
    * @tparam PairwiseFunctor
@@ -63,24 +52,14 @@ class TraversalSelector {
    * @return Smartpointer to the traversal.
    */
   template <class PairwiseFunctor, DataLayoutOption DataLayout, bool useNewton3>
-  std::unique_ptr<CellPairTraversal<ParticleCell>> generateTraversal(TraversalOption traversalType,
-                                                                     PairwiseFunctor &pairwiseFunctor);
-
- private:
-  /**
-   * indicating whether or not the optimalTraversalOption is already initialized
-   */
-  const std::array<unsigned long, 3> _dims;
-
-  const double _cutoff;
-
-  const std::array<double, 3> _cellLength;
+  static std::unique_ptr<CellPairTraversal<ParticleCell>> generateTraversal(
+      TraversalOption traversalType, PairwiseFunctor& pairwiseFunctor, const TraversalSelectorInfo<ParticleCell>& info);
 };
 
 template <class ParticleCell>
 template <class PairwiseFunctor, DataLayoutOption DataLayout, bool useNewton3>
 std::unique_ptr<CellPairTraversal<ParticleCell>> TraversalSelector<ParticleCell>::generateTraversal(
-    TraversalOption traversalType, PairwiseFunctor &pairwiseFunctor) {
+    TraversalOption traversalType, PairwiseFunctor& pairwiseFunctor, const TraversalSelectorInfo<ParticleCell>& info) {
   switch (traversalType) {
     // Direct sum
     case TraversalOption::directSumTraversal: {
@@ -90,48 +69,47 @@ std::unique_ptr<CellPairTraversal<ParticleCell>> TraversalSelector<ParticleCell>
     // Linked cell
     case TraversalOption::c08: {
       return std::make_unique<C08Traversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>>(
-          _dims, &pairwiseFunctor, _cutoff, _cellLength);
+          info._dims, &pairwiseFunctor, info._cutoff, info._cellLength);
     }
     case TraversalOption::sliced: {
       return std::make_unique<SlicedTraversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>>(
-          _dims, &pairwiseFunctor, _cutoff, _cellLength);
+          info._dims, &pairwiseFunctor, info._cutoff, info._cellLength);
     }
     case TraversalOption::c18: {
       return std::make_unique<C18Traversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>>(
-          _dims, &pairwiseFunctor, _cutoff, _cellLength);
+          info._dims, &pairwiseFunctor, info._cutoff, info._cellLength);
     }
     case TraversalOption::c01: {
       return std::make_unique<C01Traversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>>(
-          _dims, &pairwiseFunctor, _cutoff, _cellLength);
+          info._dims, &pairwiseFunctor, info._cutoff, info._cellLength);
     }
     // Verlet
     case TraversalOption::slicedVerlet: {
       return std::make_unique<SlicedTraversalVerlet<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>>(
-          _dims, &pairwiseFunctor);
+          info._dims, &pairwiseFunctor);
     }
     case TraversalOption::c18Verlet: {
       return std::make_unique<C18TraversalVerlet<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>>(
-          _dims, &pairwiseFunctor);
+          info._dims, &pairwiseFunctor);
     }
     case TraversalOption::c01Verlet: {
       return std::make_unique<C01TraversalVerlet<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>>(
-          _dims, &pairwiseFunctor);
+          info._dims, &pairwiseFunctor);
     }
     case TraversalOption::c01Cuda: {
       return std::make_unique<C01CudaTraversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>>(
-          _dims, &pairwiseFunctor);
+          info._dims, &pairwiseFunctor);
     }
     case TraversalOption::verletTraversal: {
-      return std::make_unique<TraversalVerlet<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>>(_dims,
+      return std::make_unique<TraversalVerlet<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>>(info._dims,
                                                                                                       &pairwiseFunctor);
     }
     case TraversalOption::dummyTraversal: {
-      return std::make_unique<DummyTraversal<ParticleCell>>(_dims);
+      return std::make_unique<DummyTraversal<ParticleCell>>(info._dims);
     }
   }
   autopas::utils::ExceptionHandler::exception("Traversal type {} is not a known type!",
                                               utils::StringUtils::to_string(traversalType));
   return std::unique_ptr<CellPairTraversal<ParticleCell>>(nullptr);
 }
-
 }  // namespace autopas

--- a/src/autopas/selectors/TraversalSelectorInfo.h
+++ b/src/autopas/selectors/TraversalSelectorInfo.h
@@ -29,12 +29,19 @@ class TraversalSelectorInfo {
       : dims(dims), cutoff(cutoff), cellLength(cellLength) {}
 
   /**
+   * Array with the dimension lengths of the domain
    * indicating whether or not the optimalTraversalOption is already initialized
    */
   const std::array<unsigned long, 3> dims;
 
+  /**
+   * Cutoff radius
+   */
   const double cutoff;
 
+  /**
+   * cell length
+   */
   const std::array<double, 3> cellLength;
 };
 }  // namespace autopas

--- a/src/autopas/selectors/TraversalSelectorInfo.h
+++ b/src/autopas/selectors/TraversalSelectorInfo.h
@@ -1,0 +1,47 @@
+/**
+ * @file TraversalSelectorInfo.h
+ * @author humig
+ * @date 28.05.19
+ */
+
+#pragma once
+
+namespace autopas {
+
+template <class ParticleCell>
+class TraversalSelector;
+
+/**
+ * Info for traversals of a specific container.
+ * @tparam ParticleCell
+ */
+template <class ParticleCell>
+class TraversalSelectorInfo {
+  friend TraversalSelector<ParticleCell>;
+
+ public:
+  /**
+   * Dummy constructor such that this class can be used in maps
+   */
+  TraversalSelectorInfo() : _dims({0, 0, 0}), _cutoff(1.0), _cellLength({0.0, 0.0, 0.0}) {}
+  /**
+   * Constructor of the TraversalSelector class.
+   * @param dims Array with the dimension lengths of the domain
+   * @param cutoff Cutoff radius
+   * @param cellLength cell length.
+   */
+  explicit TraversalSelectorInfo(const std::array<unsigned long, 3> &dims, const double cutoff = 1.0,
+                                 const std::array<double, 3> &cellLength = {1.0, 1.0, 1.0})
+      : _dims(dims), _cutoff(cutoff), _cellLength(cellLength) {}
+
+ private:
+  /**
+   * indicating whether or not the optimalTraversalOption is already initialized
+   */
+  const std::array<unsigned long, 3> _dims;
+
+  const double _cutoff;
+
+  const std::array<double, 3> _cellLength;
+};
+}  // namespace autopas

--- a/src/autopas/selectors/TraversalSelectorInfo.h
+++ b/src/autopas/selectors/TraversalSelectorInfo.h
@@ -7,23 +7,17 @@
 #pragma once
 
 namespace autopas {
-
-template <class ParticleCell>
-class TraversalSelector;
-
 /**
  * Info for traversals of a specific container.
  * @tparam ParticleCell
  */
 template <class ParticleCell>
 class TraversalSelectorInfo {
-  friend TraversalSelector<ParticleCell>;
-
  public:
   /**
    * Dummy constructor such that this class can be used in maps
    */
-  TraversalSelectorInfo() : _dims({0, 0, 0}), _cutoff(1.0), _cellLength({0.0, 0.0, 0.0}) {}
+  TraversalSelectorInfo() : dims({0, 0, 0}), cutoff(1.0), cellLength({0.0, 0.0, 0.0}) {}
   /**
    * Constructor of the TraversalSelector class.
    * @param dims Array with the dimension lengths of the domain
@@ -32,16 +26,15 @@ class TraversalSelectorInfo {
    */
   explicit TraversalSelectorInfo(const std::array<unsigned long, 3> &dims, const double cutoff = 1.0,
                                  const std::array<double, 3> &cellLength = {1.0, 1.0, 1.0})
-      : _dims(dims), _cutoff(cutoff), _cellLength(cellLength) {}
+      : dims(dims), cutoff(cutoff), cellLength(cellLength) {}
 
- private:
   /**
    * indicating whether or not the optimalTraversalOption is already initialized
    */
-  const std::array<unsigned long, 3> _dims;
+  const std::array<unsigned long, 3> dims;
 
-  const double _cutoff;
+  const double cutoff;
 
-  const std::array<double, 3> _cellLength;
+  const std::array<double, 3> cellLength;
 };
 }  // namespace autopas

--- a/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
@@ -89,7 +89,7 @@ void Newton3OnOffTest::countFunctorCalls(autopas::ContainerOption containerOptio
   containerSelector.selectContainer(containerOption);
 
   auto container = containerSelector.getCurrentContainer();
-  auto traversalSelector = container->generateTraversalSelector();
+  auto traversalSelectorInfo = container->generateTraversalSelectorInfo();
 
   autopas::MoleculeLJ defaultParticle;
   RandomGenerator::fillWithParticles(*container, defaultParticle, 100);
@@ -126,8 +126,9 @@ void Newton3OnOffTest::countFunctorCalls(autopas::ContainerOption containerOptio
       // non newton3 variant should not happen
       EXPECT_CALL(mockFunctor, SoAFunctor(_, _, false)).Times(0);
       iterate(container,
-              traversalSelector.generateTraversal<MockFunctor<Particle, FPCell>, autopas::DataLayoutOption::soa, true>(
-                  traversalOption, mockFunctor),
+              autopas::TraversalSelector<FPCell>::template generateTraversal<MockFunctor<Particle, FPCell>,
+                                                                             autopas::DataLayoutOption::soa, true>(
+                  traversalOption, mockFunctor, traversalSelectorInfo),
               dataLayout, autopas::Newton3Option::enabled, &mockFunctor);
       break;
     }
@@ -139,18 +140,19 @@ void Newton3OnOffTest::countFunctorCalls(autopas::ContainerOption containerOptio
       // non newton3 variant should not happen
       EXPECT_CALL(mockFunctor, AoSFunctor(_, _, false)).Times(0);
       iterate(container,
-              traversalSelector.generateTraversal<MockFunctor<Particle, FPCell>, autopas::DataLayoutOption::aos, true>(
-                  traversalOption, mockFunctor),
+              autopas::TraversalSelector<FPCell>::template generateTraversal<MockFunctor<Particle, FPCell>,
+                                                                             autopas::DataLayoutOption::aos, true>(
+                  traversalOption, mockFunctor, traversalSelectorInfo),
               dataLayout, autopas::Newton3Option::enabled, &mockFunctor);
       break;
       case autopas::DataLayoutOption::cuda: {
         // supresses Warning
         // TODO implement suitable test
-        iterate(
-            container,
-            traversalSelector.generateTraversal<MockFunctor<Particle, FPCell>, autopas::DataLayoutOption::aos, true>(
-                traversalOption, mockFunctor),
-            dataLayout, autopas::Newton3Option::enabled, &mockFunctor);
+        iterate(container,
+                autopas::TraversalSelector<FPCell>::template generateTraversal<MockFunctor<Particle, FPCell>,
+                                                                               autopas::DataLayoutOption::aos, true>(
+                    traversalOption, mockFunctor, traversalSelectorInfo),
+                dataLayout, autopas::Newton3Option::enabled, &mockFunctor);
         break;
       }
     }
@@ -181,8 +183,9 @@ void Newton3OnOffTest::countFunctorCalls(autopas::ContainerOption containerOptio
       // newton3 variant should not happen
       EXPECT_CALL(mockFunctor, SoAFunctor(_, _, true)).Times(0);
       iterate(container,
-              traversalSelector.generateTraversal<MockFunctor<Particle, FPCell>, autopas::DataLayoutOption::soa, false>(
-                  traversalOption, mockFunctor),
+              autopas::TraversalSelector<FPCell>::template generateTraversal<MockFunctor<Particle, FPCell>,
+                                                                             autopas::DataLayoutOption::soa, false>(
+                  traversalOption, mockFunctor, traversalSelectorInfo),
               dataLayout, autopas::Newton3Option::disabled, &mockFunctor);
       break;
     }
@@ -194,8 +197,9 @@ void Newton3OnOffTest::countFunctorCalls(autopas::ContainerOption containerOptio
       // newton3 variant should not happen
       EXPECT_CALL(mockFunctor, AoSFunctor(_, _, true)).Times(0);
       iterate(container,
-              traversalSelector.generateTraversal<MockFunctor<Particle, FPCell>, autopas::DataLayoutOption::aos, false>(
-                  traversalOption, mockFunctor),
+              autopas::TraversalSelector<FPCell>::template generateTraversal<MockFunctor<Particle, FPCell>,
+                                                                             autopas::DataLayoutOption::aos, false>(
+                  traversalOption, mockFunctor, traversalSelectorInfo),
               dataLayout, autopas::Newton3Option::disabled, &mockFunctor);
       break;
     }
@@ -203,8 +207,9 @@ void Newton3OnOffTest::countFunctorCalls(autopas::ContainerOption containerOptio
       // supresses Warning
       // TODO implement suitable test
       iterate(container,
-              traversalSelector.generateTraversal<MockFunctor<Particle, FPCell>, autopas::DataLayoutOption::aos, true>(
-                  traversalOption, mockFunctor),
+              autopas::TraversalSelector<FPCell>::template generateTraversal<MockFunctor<Particle, FPCell>,
+                                                                             autopas::DataLayoutOption::aos, true>(
+                  traversalOption, mockFunctor, traversalSelectorInfo),
               dataLayout, autopas::Newton3Option::enabled, &mockFunctor);
       break;
     }

--- a/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
@@ -89,7 +89,7 @@ void Newton3OnOffTest::countFunctorCalls(autopas::ContainerOption containerOptio
   containerSelector.selectContainer(containerOption);
 
   auto container = containerSelector.getCurrentContainer();
-  auto traversalSelectorInfo = container->generateTraversalSelectorInfo();
+  auto traversalSelectorInfo = container->getTraversalSelectorInfo();
 
   autopas::MoleculeLJ defaultParticle;
   RandomGenerator::fillWithParticles(*container, defaultParticle, 100);

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.cpp
@@ -23,14 +23,16 @@ void testTraversal(autopas::TraversalOption traversalOption, bool useN3, const s
 
   NumThreadGuard(4);
 
-  autopas::TraversalSelector<FPCell> ts(edgeLength, cutoff);
+  autopas::TraversalSelectorInfo<FPCell> tsi(edgeLength, cutoff);
   std::unique_ptr<autopas::CellPairTraversal<FPCell>> Traversal;
   if (useN3 and traversalOption != autopas::TraversalOption::c01) {
-    Traversal = ts.generateTraversal<TraversalTest::CountFunctor, autopas::DataLayoutOption::aos, true>(traversalOption,
-                                                                                                        functor);
+    Traversal = autopas::TraversalSelector<FPCell>::template generateTraversal<TraversalTest::CountFunctor,
+                                                                               autopas::DataLayoutOption::aos, true>(
+        traversalOption, functor, tsi);
   } else {
-    Traversal = ts.generateTraversal<TraversalTest::CountFunctor, autopas::DataLayoutOption::aos, false>(
-        traversalOption, functor);
+    Traversal = autopas::TraversalSelector<FPCell>::template generateTraversal<TraversalTest::CountFunctor,
+                                                                               autopas::DataLayoutOption::aos, false>(
+        traversalOption, functor, tsi);
   }
 
   unsigned long cellId = 0;

--- a/tests/testAutopas/tests/selectors/TraversalSelectorTest.cpp
+++ b/tests/testAutopas/tests/selectors/TraversalSelectorTest.cpp
@@ -16,16 +16,18 @@ TEST_F(TraversalSelectorTest, testSelectAndGetCurrentTraversal) {
 
   // this should be high enough so that sliced is still valid for the current processors thread count.
   constexpr size_t domainSize = 900;
-  autopas::TraversalSelector<FPCell> traversalSelector({domainSize, domainSize, domainSize});
+  autopas::TraversalSelectorInfo<FPCell> traversalSelectorInfo({domainSize, domainSize, domainSize});
 
   // expect an exception if nothing is selected yet
-  EXPECT_THROW((traversalSelector.generateTraversal<MFunctor, autopas::DataLayoutOption::aos, false>(
-                   autopas::TraversalOption(-1), functor)),
-               autopas::utils::ExceptionHandler::AutoPasException);
+  EXPECT_THROW(
+      (autopas::TraversalSelector<FPCell>::template generateTraversal<MFunctor, autopas::DataLayoutOption::aos, false>(
+          autopas::TraversalOption(-1), functor, traversalSelectorInfo)),
+      autopas::utils::ExceptionHandler::AutoPasException);
 
   for (auto &traversalOption : autopas::allTraversalOptions) {
     auto traversal =
-        traversalSelector.generateTraversal<MFunctor, autopas::DataLayoutOption::aos, false>(traversalOption, functor);
+        autopas::TraversalSelector<FPCell>::template generateTraversal<MFunctor, autopas::DataLayoutOption::aos, false>(
+            traversalOption, functor, traversalSelectorInfo);
 
     // check that traversals are of the expected type
     EXPECT_EQ(traversalOption, traversal->getTraversalType())


### PR DESCRIPTION

# Description
Refactored TraversalSelector: Extracted TraversalSelectorInfo, which represents the container specific data, and made generateTraversal() method static.

Before, all containers included TraversalSelector which itself included all of the traversals. Now, these dependencies are reduced to the necessary ones.

This refactoring was probably the simplest one as other ideas would have been problematic because of the template parameters of generateTraversal().

# How Has This Been Tested?

With all the tests from before.
