### PR TITLE
Error message if wrong functor type is given in AutoPas::iteratePairwise

### DIFF
--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -8,6 +8,7 @@
 
 #include <iostream>
 #include <memory>
+#include <type_traits>
 #include "autopas/autopasIncludes.h"
 #include "autopas/selectors/AutoTuner.h"
 
@@ -137,6 +138,10 @@ class AutoPas {
    */
   template <class Functor>
   void iteratePairwise(Functor *f) {
+    static_assert(not std::is_same<Functor, autopas::Functor<Particle, ParticleCell>>::value,
+                  "The static type of Functor in iteratePairwise is not allowed to be autopas::Functor. Please use the "
+                  "derived type instead, e.g. using a dynamic_cast.");
+
     _autoTuner->iteratePairwise(f);
   }
 

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -140,7 +140,7 @@ class AutoPas {
   void iteratePairwise(Functor *f) {
     static_assert(not std::is_same<Functor, autopas::Functor<Particle, ParticleCell>>::value,
                   "The static type of Functor in iteratePairwise is not allowed to be autopas::Functor. Please use the "
-                  "derived type instead, e.g. using a dynamic_cast.");
+                  "derived type instead, e.g. by using a dynamic_cast.");
 
     _autoTuner->iteratePairwise(f);
   }


### PR DESCRIPTION
print an error if static type of given functor in AutoPas::iteratePairwise() is autopas::Functor.

# How Has This Been Tested?

- [x] using a dynamic_cast to autopas::Functor<Particle,ParticleCell> in md-flex
