### PR TITLE
Bug fixes Newton3OnOffTest

### DIFF
--- a/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
@@ -104,8 +104,8 @@ void Newton3OnOffTest::countFunctorCalls(autopas::ContainerOption containerOptio
   }
 
   // with newton 3:
-  int callsNewton3SC = 0;    // same cell
-  int callsNewton3Pair = 0;  // pair of cells
+  std::atomic<unsigned int> callsNewton3SC (0ul);    // same cell
+  std::atomic<unsigned int> callsNewton3Pair (0ul);  // pair of cells
   EXPECT_CALL(mockFunctor, allowsNewton3()).WillRepeatedly(Return(true));
   EXPECT_CALL(mockFunctor, allowsNonNewton3()).WillRepeatedly(Return(false));
 
@@ -158,8 +158,8 @@ void Newton3OnOffTest::countFunctorCalls(autopas::ContainerOption containerOptio
   }
 
   // without newton 3:
-  int callsNonNewton3SC = 0;
-  int callsNonNewton3Pair = 0;
+  std::atomic<unsigned int> callsNonNewton3SC (0ul);
+  std::atomic<unsigned int> callsNonNewton3Pair (0ul);
   EXPECT_CALL(mockFunctor, allowsNewton3()).WillRepeatedly(Return(false));
   EXPECT_CALL(mockFunctor, allowsNonNewton3()).WillRepeatedly(Return(true));
 

--- a/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
@@ -104,8 +104,8 @@ void Newton3OnOffTest::countFunctorCalls(autopas::ContainerOption containerOptio
   }
 
   // with newton 3:
-  std::atomic<unsigned int> callsNewton3SC (0ul);    // same cell
-  std::atomic<unsigned int> callsNewton3Pair (0ul);  // pair of cells
+  std::atomic<unsigned int> callsNewton3SC(0ul);    // same cell
+  std::atomic<unsigned int> callsNewton3Pair(0ul);  // pair of cells
   EXPECT_CALL(mockFunctor, allowsNewton3()).WillRepeatedly(Return(true));
   EXPECT_CALL(mockFunctor, allowsNonNewton3()).WillRepeatedly(Return(false));
 
@@ -158,8 +158,8 @@ void Newton3OnOffTest::countFunctorCalls(autopas::ContainerOption containerOptio
   }
 
   // without newton 3:
-  std::atomic<unsigned int> callsNonNewton3SC (0ul);
-  std::atomic<unsigned int> callsNonNewton3Pair (0ul);
+  std::atomic<unsigned int> callsNonNewton3SC(0ul);
+  std::atomic<unsigned int> callsNonNewton3Pair(0ul);
   EXPECT_CALL(mockFunctor, allowsNewton3()).WillRepeatedly(Return(false));
   EXPECT_CALL(mockFunctor, allowsNonNewton3()).WillRepeatedly(Return(true));
 

--- a/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
@@ -9,7 +9,7 @@
 
 using ::testing::_;  // anything is ok
 using ::testing::Combine;
-using ::testing::Return;  // anything is ok
+using ::testing::Return;
 using ::testing::ValuesIn;
 
 // Parse combination strings and call actual test function
@@ -112,16 +112,14 @@ void Newton3OnOffTest::countFunctorCalls(autopas::ContainerOption containerOptio
   switch (dataLayout) {
     case autopas::DataLayoutOption::soa: {
       // single cell
-      EXPECT_CALL(mockFunctor, SoAFunctor(_, true)).WillRepeatedly(testing::InvokeWithoutArgs([&]() {
-        callsNewton3SC++;
-      }));
-      EXPECT_CALL(mockFunctor, SoAFunctor(_, true)).Times(testing::AtLeast(1));
+      EXPECT_CALL(mockFunctor, SoAFunctor(_, true))
+          .Times(testing::AtLeast(1))
+          .WillRepeatedly(testing::InvokeWithoutArgs([&]() { callsNewton3SC++; }));
 
       // pair of cells
-      EXPECT_CALL(mockFunctor, SoAFunctor(_, _, true)).WillRepeatedly(testing::InvokeWithoutArgs([&]() {
-        callsNewton3Pair++;
-      }));
-      EXPECT_CALL(mockFunctor, SoAFunctor(_, _, true)).Times(testing::AtLeast(1));
+      EXPECT_CALL(mockFunctor, SoAFunctor(_, _, true))
+          .Times(testing::AtLeast(1))
+          .WillRepeatedly(testing::InvokeWithoutArgs([&]() { callsNewton3Pair++; }));
 
       // non newton3 variant should not happen
       EXPECT_CALL(mockFunctor, SoAFunctor(_, _, false)).Times(0);
@@ -133,10 +131,9 @@ void Newton3OnOffTest::countFunctorCalls(autopas::ContainerOption containerOptio
       break;
     }
     case autopas::DataLayoutOption::aos: {
-      EXPECT_CALL(mockFunctor, AoSFunctor(_, _, true)).WillRepeatedly(testing::InvokeWithoutArgs([&]() {
-        callsNewton3Pair++;
-      }));
-      EXPECT_CALL(mockFunctor, AoSFunctor(_, _, true)).Times(testing::AtLeast(1));
+      EXPECT_CALL(mockFunctor, AoSFunctor(_, _, true))
+          .Times(testing::AtLeast(1))
+          .WillRepeatedly(testing::InvokeWithoutArgs([&]() { callsNewton3Pair++; }));
       // non newton3 variant should not happen
       EXPECT_CALL(mockFunctor, AoSFunctor(_, _, false)).Times(0);
       iterate(container,
@@ -169,16 +166,14 @@ void Newton3OnOffTest::countFunctorCalls(autopas::ContainerOption containerOptio
   switch (dataLayout) {
     case autopas::DataLayoutOption::soa: {
       // single cell
-      EXPECT_CALL(mockFunctor, SoAFunctor(_, false)).WillRepeatedly(testing::InvokeWithoutArgs([&]() {
-        callsNonNewton3SC++;
-      }));
-      EXPECT_CALL(mockFunctor, SoAFunctor(_, false)).Times(testing::AtLeast(1));
+      EXPECT_CALL(mockFunctor, SoAFunctor(_, false))
+          .Times(testing::AtLeast(1))
+          .WillRepeatedly(testing::InvokeWithoutArgs([&]() { callsNonNewton3SC++; }));
 
       // pair of cells
-      EXPECT_CALL(mockFunctor, SoAFunctor(_, _, false)).WillRepeatedly(testing::InvokeWithoutArgs([&]() {
-        callsNonNewton3Pair++;
-      }));
-      EXPECT_CALL(mockFunctor, SoAFunctor(_, _, false)).Times(testing::AtLeast(1));
+      EXPECT_CALL(mockFunctor, SoAFunctor(_, _, false))
+          .Times(testing::AtLeast(1))
+          .WillRepeatedly(testing::InvokeWithoutArgs([&]() { callsNonNewton3Pair++; }));
 
       // newton3 variant should not happen
       EXPECT_CALL(mockFunctor, SoAFunctor(_, _, true)).Times(0);
@@ -190,10 +185,10 @@ void Newton3OnOffTest::countFunctorCalls(autopas::ContainerOption containerOptio
       break;
     }
     case autopas::DataLayoutOption::aos: {
-      EXPECT_CALL(mockFunctor, AoSFunctor(_, _, false)).WillRepeatedly(testing::InvokeWithoutArgs([&]() {
-        callsNewton3Pair++;
-      }));
-      EXPECT_CALL(mockFunctor, AoSFunctor(_, _, false)).Times(testing::AtLeast(1));
+      EXPECT_CALL(mockFunctor, AoSFunctor(_, _, false))
+          .Times(testing::AtLeast(1))
+          .WillRepeatedly(testing::InvokeWithoutArgs([&]() { callsNonNewton3Pair++; }));
+
       // newton3 variant should not happen
       EXPECT_CALL(mockFunctor, AoSFunctor(_, _, true)).Times(0);
       iterate(container,


### PR DESCRIPTION
# Description

1. There were multiple `EXPECT_CALL` statements with the same signature. GMock only uses the last one of these [(documented here)](https://github.com/google/googletest/blob/master/googlemock/docs/ForDummies.md#using-multiple-expectations), leading to unrecognized expectations.
2. The wrong counter for "without newton3" was used (`callsNewton3Pair` instead of `callsNonNewton3Pair`) (old line 194, new line 190)
3. Call counters were not atomic and caused data races. Changed type to std::atomic.

# How Has This Been Tested?

- [x] Jenkins
