### PR TITLE
Refactoring: Move initTraversal/endTraversal to superclass CBasedTraversal

### DIFF
--- a/src/autopas/containers/cellPairTraversals/C08BasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/C08BasedTraversal.h
@@ -8,7 +8,6 @@
 
 #include "autopas/containers/cellPairTraversals/CBasedTraversal.h"
 #include "autopas/utils/ArrayMath.h"
-#include "autopas/utils/DataLayoutConverter.h"
 
 namespace autopas {
 
@@ -24,7 +23,7 @@ namespace autopas {
  * @tparam useNewton3
  */
 template <class ParticleCell, class PairwiseFunctor, DataLayoutOption DataLayout, bool useNewton3>
-class C08BasedTraversal : public CBasedTraversal<ParticleCell> {
+class C08BasedTraversal : public CBasedTraversal<ParticleCell, PairwiseFunctor, DataLayout> {
  public:
   /**
    * Constructor of the c08 traversal.
@@ -36,27 +35,7 @@ class C08BasedTraversal : public CBasedTraversal<ParticleCell> {
    */
   explicit C08BasedTraversal(const std::array<unsigned long, 3>& dims, PairwiseFunctor* pairwiseFunctor,
                              const double cutoff = 1.0, const std::array<double, 3>& cellLength = {1.0, 1.0, 1.0})
-      : CBasedTraversal<ParticleCell>(dims, cutoff, cellLength), _dataLayoutConverter(pairwiseFunctor) {}
-
-  void initTraversal(std::vector<ParticleCell>& cells) override {
-#ifdef AUTOPAS_OPENMP
-    // @todo find a condition on when to use omp or when it is just overhead
-#pragma omp parallel for
-#endif
-    for (size_t i = 0; i < cells.size(); ++i) {
-      _dataLayoutConverter.loadDataLayout(cells[i]);
-    }
-  }
-
-  void endTraversal(std::vector<ParticleCell>& cells) override {
-#ifdef AUTOPAS_OPENMP
-    // @todo find a condition on when to use omp or when it is just overhead
-#pragma omp parallel for
-#endif
-    for (size_t i = 0; i < cells.size(); ++i) {
-      _dataLayoutConverter.storeDataLayout(cells[i]);
-    }
-  }
+      : CBasedTraversal<ParticleCell, PairwiseFunctor, DataLayout>(dims, pairwiseFunctor, cutoff, cellLength) {}
 
  protected:
   /**
@@ -65,12 +44,6 @@ class C08BasedTraversal : public CBasedTraversal<ParticleCell> {
    */
   template <typename LoopBody>
   inline void c08Traversal(LoopBody&& loopBody);
-
- private:
-  /**
-   * Data Layout Converter to be used with this traversal
-   */
-  utils::DataLayoutConverter<PairwiseFunctor, DataLayout> _dataLayoutConverter;
 };
 
 template <class ParticleCell, class PairwiseFunctor, DataLayoutOption DataLayout, bool useNewton3>

--- a/src/autopas/containers/cellPairTraversals/C18BasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/C18BasedTraversal.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "autopas/containers/cellPairTraversals/CBasedTraversal.h"
-#include "autopas/utils/DataLayoutConverter.h"
 #include "autopas/utils/ThreeDimensionalMapping.h"
 
 namespace autopas {
@@ -23,7 +22,7 @@ namespace autopas {
  * @tparam useNewton3
  */
 template <class ParticleCell, class PairwiseFunctor, DataLayoutOption DataLayout, bool useNewton3>
-class C18BasedTraversal : public CBasedTraversal<ParticleCell> {
+class C18BasedTraversal : public CBasedTraversal<ParticleCell, PairwiseFunctor, DataLayout> {
  public:
   /**
    * Constructor of the c18 traversal.
@@ -35,27 +34,7 @@ class C18BasedTraversal : public CBasedTraversal<ParticleCell> {
    */
   explicit C18BasedTraversal(const std::array<unsigned long, 3>& dims, PairwiseFunctor* pairwiseFunctor,
                              const double cutoff = 1.0, const std::array<double, 3>& cellLength = {1.0, 1.0, 1.0})
-      : CBasedTraversal<ParticleCell>(dims, cutoff, cellLength), _dataLayoutConverter(pairwiseFunctor) {}
-
-  void initTraversal(std::vector<ParticleCell>& cells) override {
-#ifdef AUTOPAS_OPENMP
-    // @todo find a condition on when to use omp or when it is just overhead
-#pragma omp parallel for
-#endif
-    for (size_t i = 0; i < cells.size(); ++i) {
-      _dataLayoutConverter.loadDataLayout(cells[i]);
-    }
-  }
-
-  void endTraversal(std::vector<ParticleCell>& cells) override {
-#ifdef AUTOPAS_OPENMP
-    // @todo find a condition on when to use omp or when it is just overhead
-#pragma omp parallel for
-#endif
-    for (size_t i = 0; i < cells.size(); ++i) {
-      _dataLayoutConverter.storeDataLayout(cells[i]);
-    }
-  }
+      : CBasedTraversal<ParticleCell, PairwiseFunctor, DataLayout>(dims, pairwiseFunctor, cutoff, cellLength) {}
 
  protected:
   /**
@@ -64,12 +43,6 @@ class C18BasedTraversal : public CBasedTraversal<ParticleCell> {
    */
   template <typename LoopBody>
   inline void c18Traversal(LoopBody&& loopBody);
-
- private:
-  /**
-   * Data Layout Converter to be used with this traversal
-   */
-  utils::DataLayoutConverter<PairwiseFunctor, DataLayout> _dataLayoutConverter;
 };
 
 template <class ParticleCell, class PairwiseFunctor, DataLayoutOption DataLayout, bool useNewton3>

--- a/src/autopas/containers/cellPairTraversals/CBasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/CBasedTraversal.h
@@ -8,6 +8,7 @@
 
 #include "autopas/containers/cellPairTraversals/CellPairTraversal.h"
 #include "autopas/utils/ArrayMath.h"
+#include "autopas/utils/DataLayoutConverter.h"
 #include "autopas/utils/ThreeDimensionalMapping.h"
 
 namespace autopas {
@@ -16,20 +17,26 @@ namespace autopas {
  * This class provides the base for traversals using base steps based on cell coloring.
  *
  * @tparam ParticleCell the type of cells
+ * @tparam PairwiseFunctor The functor that defines the interaction of two particles.
+ * @tparam DataLayout
  */
-template <class ParticleCell>
+template <class ParticleCell, class PairwiseFunctor, DataLayoutOption DataLayout>
 class CBasedTraversal : public CellPairTraversal<ParticleCell> {
  protected:
   /**
    * Constructor of the CBasedTraversal.
    * @param dims The dimensions of the cellblock, i.e. the number of cells in x,
    * y and z direction.
+   * @param pairwiseFunctor The functor that defines the interaction of two particles.
    * @param cutoff Cutoff radius.
    * @param cellLength cell length.
    */
-  explicit CBasedTraversal(const std::array<unsigned long, 3>& dims, const double cutoff,
-                           const std::array<double, 3>& cellLength)
-      : CellPairTraversal<ParticleCell>(dims), _cutoff(cutoff), _cellLength(cellLength) {
+  explicit CBasedTraversal(const std::array<unsigned long, 3>& dims, PairwiseFunctor* pairwiseFunctor,
+                           const double cutoff, const std::array<double, 3>& cellLength)
+      : CellPairTraversal<ParticleCell>(dims),
+        _cutoff(cutoff),
+        _cellLength(cellLength),
+        _dataLayoutConverter(pairwiseFunctor) {
     for (unsigned int d = 0; d < 3; d++) {
       _overlap[d] = std::ceil(_cutoff / _cellLength[d]);
     }
@@ -40,6 +47,28 @@ class CBasedTraversal : public CellPairTraversal<ParticleCell> {
    */
   ~CBasedTraversal() override = default;
 
+ public:
+  void initTraversal(std::vector<ParticleCell>& cells) override {
+#ifdef AUTOPAS_OPENMP
+    // @todo find a condition on when to use omp or when it is just overhead
+#pragma omp parallel for
+#endif
+    for (size_t i = 0; i < cells.size(); ++i) {
+      _dataLayoutConverter.loadDataLayout(cells[i]);
+    }
+  }
+
+  void endTraversal(std::vector<ParticleCell>& cells) override {
+#ifdef AUTOPAS_OPENMP
+    // @todo find a condition on when to use omp or when it is just overhead
+#pragma omp parallel for
+#endif
+    for (size_t i = 0; i < cells.size(); ++i) {
+      _dataLayoutConverter.storeDataLayout(cells[i]);
+    }
+  }
+
+ protected:
   /**
    * The main traversal of the CTraversal.
    * @tparam LoopBody type of the loop body
@@ -68,13 +97,19 @@ class CBasedTraversal : public CellPairTraversal<ParticleCell> {
    * overlap of interacting cells. Array allows asymmetric cell sizes.
    */
   std::array<unsigned long, 3> _overlap;
+
+ private:
+  /**
+   * Data Layout Converter to be used with this traversal
+   */
+  utils::DataLayoutConverter<PairwiseFunctor, DataLayout> _dataLayoutConverter;
 };
 
-template <class ParticleCell>
+template <class ParticleCell, class PairwiseFunctor, DataLayoutOption DataLayout>
 template <typename LoopBody>
-inline void CBasedTraversal<ParticleCell>::cTraversal(LoopBody&& loopBody, const std::array<unsigned long, 3>& end,
-                                                      const std::array<unsigned long, 3>& stride,
-                                                      const std::array<unsigned long, 3>& offset) {
+inline void CBasedTraversal<ParticleCell, PairwiseFunctor, DataLayout>::cTraversal(
+    LoopBody&& loopBody, const std::array<unsigned long, 3>& end, const std::array<unsigned long, 3>& stride,
+    const std::array<unsigned long, 3>& offset) {
 #if defined(AUTOPAS_OPENMP)
 #pragma omp parallel
 #endif


### PR DESCRIPTION
# Description

Move initTraversal/endTraversal to superclass CBasedTraversal, thus remove a lot of code duplicates. 

# How Has This Been Tested?

- [x] Jenkins
