### PR TITLE
Lock resource to avoid weird kubernetes errors

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,7 @@
 pipeline{
+    options {
+        lock(quantity: 1, resource: 'openshift_cluster')
+    }
     agent {
         node {
             //cloud 'kubernetes'


### PR DESCRIPTION
# Description

This limits the number of parallel builds jenkins performs by acquiring a lock on the `openshift_cluster` resource, of which there's currently two. This is to avoid weird circular wait conditions when many builds are triggered at the same time. It happened a lot when master was updated, because all PRs would then be triggered at the same time and request a lot of default containers where they would build and then sit idly for hours waiting for the GPU container of which we can only have one at a time, resulting in timeouts and weird behavior.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Jenkins build