### PR TITLE
Correct wrong formatted CMake comments

### DIFF
--- a/cmake/modules/CodeCoverage.cmake
+++ b/cmake/modules/CodeCoverage.cmake
@@ -1,23 +1,33 @@
 # taken from: https://github.com/pyarmak/cmake-gtest-coverage-example/
 #
-# 2012-01-31, Lars Bilke * Enable Code Coverage
-
-# 2013-09-17, Joakim Söderberg * Added support for Clang. * Some additional usage instructions.
+# 2012-01-31, Lars Bilke
+#
+# * Enable Code Coverage
+#
+# 2013-09-17, Joakim Söderberg
+#
+# * Added support for Clang.
+# * Some additional usage instructions.
 #
 # USAGE:
-
+# ~~~
 # 1. (Mac only) If you use Xcode 5.1 make sure to patch geninfo as described here:
 #    http://stackoverflow.com/a/22404544/80480
 # 2. Copy this file into your cmake modules path.
 # 3. Add the following line to your CMakeLists.txt: INCLUDE(CodeCoverage)
-# 4. Set compiler flags to turn off optimization and enable coverage: SET(CMAKE_CXX_FLAGS "-g -O0
-#    -fprofile-arcs -ftest-coverage") SET(CMAKE_C_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
+# 4. Set compiler flags to turn off optimization and enable coverage:
+#    SET(CMAKE_CXX_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
+#    SET(CMAKE_C_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
 # 5. Use the function SETUP_TARGET_FOR_COVERAGE to create a custom make target which runs your test
-#    executable and produces a lcov code coverage report: Example: SETUP_TARGET_FOR_COVERAGE(
-#    my_coverage_target  # Name for custom target. test_driver         # Name of the test driver
-#    executable that runs the tests. # NOTE! This should always have a ZERO as exit code # otherwise
-#    the coverage generation will not complete. coverage            # Name of output directory. )
+#    executable and produces a lcov code coverage report: Example:
+#    SETUP_TARGET_FOR_COVERAGE (
+#        my_coverage_target  # Name for custom target.
+#        test_driver         # Name of the test driver executable that runs the tests.
+#        # NOTE! This should always have a ZERO as exit code otherwise the coverage generation will not complete.
+#        coverage            # Name of output directory.
+#    )
 # 6. Build a Debug build: cmake -DCMAKE_BUILD_TYPE=Debug .. make make my_coverage_target
+# ~~~
 
 # Check prereqs
 find_package(PythonInterp 2.7 REQUIRED)
@@ -73,11 +83,12 @@ if (NOT (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "Coverag
     message(WARNING "Code coverage results with an optimized (non-Debug) build may be misleading")
 endif () # NOT CMAKE_BUILD_TYPE STREQUAL "Debug"
 
-# Param _targetname     The name of new the custom make target Param _testrunner     The name of the
-# target which runs the tests. MUST return ZERO always, even on errors. If not, no coverage report
-# will be created! Param _outputname     lcov output is generated as _outputname.info HTML report is
-# generated in _outputname/index.html Optional fourth parameter is passed as arguments to
-# _testrunner Pass them in list form, e.g.: "-j;2" for -j 2
+# 1. Param _targetname     The name of new the custom make target
+# 2. Param _testrunner     The name of the target which runs the tests. MUST return ZERO always, even
+#    on errors. If not, no coverage report will be created!
+# 3. Param _outputname     lcov output is generated as _outputname.info HTML report is generated in
+#    _outputname/index.html Optional fourth parameter is passed as arguments to _testrunner Pass them
+#    in list form, e.g.: "-j;2" for -j 2
 function (
     SETUP_TARGET_FOR_COVERAGE
     _targetname
@@ -146,11 +157,13 @@ function (
 
 endfunction () # SETUP_TARGET_FOR_COVERAGE
 
-# Param _targetname     The name of new the custom make target Param _testrunner     The name of the
-# target which runs the tests Param _outputname     cobertura output is generated as _outputname.xml
-# Param _testcommandparam parameters for the test runner Param _customexcludepattern exclude pattern
-# (empty string to not exclude anything) Optional fourth parameter is passed as arguments to
-# _testrunner Pass them in list form, e.g.: "-j;2" for -j 2
+# 1. Param _targetname     The name of new the custom make target
+# 2. Param _testrunner     The name of the target which runs the tests
+# 3. Param _outputname     cobertura output is generated as _outputname.xml
+# 4. Param _testcommandparam parameters for the test runner
+# 5. Param _customexcludepattern exclude pattern (empty string to not exclude anything) Optional
+#    fourth parameter is passed as arguments to _testrunner Pass them in list form, e.g.: "-j;2" for
+#    -j 2
 function (
     SETUP_TARGET_FOR_COVERAGE_COBERTURA
     _targetname


### PR DESCRIPTION
# Description

Correct wrong formatted CMake comments.
I didn't turn comment formatting off, since it is beneficial most of the time. If comments include some sort of code or ascii art which shouldn't be formatted, code formatting for comments can be turned off using the following syntax
```
# ~~~
# <unformatted comment>
# ~~~
```

## Resolved Issues

- [x] closes #251 

# How Has This Been Tested?
- [ ] Jenkins
