### PR TITLE
Removed newton3 parameter from all iteratePairwise methods in the containers

### DIFF
--- a/examples/cluster-test/cluster-test.cpp
+++ b/examples/cluster-test/cluster-test.cpp
@@ -105,7 +105,7 @@ int main(int argc, char *argv[]) {
       dummyTraversal({0, 0, 0}, &func);
 
   // iterate to rebuild
-  cont.iteratePairwise(&func, &dummyTraversal, useNewton3);
+  cont.iteratePairwise(&func, &dummyTraversal);
 
   int newNumParticles = 0;
   for (auto iter = cont.begin(); iter.isValid(); ++iter) {

--- a/examples/cluster-test/cluster-test.cpp
+++ b/examples/cluster-test/cluster-test.cpp
@@ -77,7 +77,6 @@ int main(int argc, char *argv[]) {
   double cutoff = .03;
 
   int numParticles = 16;
-  bool useNewton3 = false;
   double skin = 0.;
   int rebuildFrequency = 1;
   if (argc == 4) {

--- a/examples/sph-mpi/sph-main-mpi.cpp
+++ b/examples/sph-mpi/sph-main-mpi.cpp
@@ -387,7 +387,7 @@ void densityPressureHydroForce(Container &sphSystem, MPI_Comm &comm, const std::
     part->setDensity(part->getDensity() / 2);
   }
   DensityTraversal densityTraversal(sphSystem.getCellBlock().getCellsPerDimensionWithHalo(), &densityFunctor);
-  sphSystem.iteratePairwise(&densityFunctor, &densityTraversal, false);
+  sphSystem.iteratePairwise(&densityFunctor, &densityTraversal);
   // 1.3 delete halo particles, as their values are no longer valid
   deleteHaloParticles(sphSystem);
 
@@ -408,7 +408,7 @@ void densityPressureHydroForce(Container &sphSystem, MPI_Comm &comm, const std::
     part->setEngDot(0.);
   }
   HydroTraversal hydroTraversal(sphSystem.getCellBlock().getCellsPerDimensionWithHalo(), &hydroForceFunctor);
-  sphSystem.iteratePairwise(&hydroForceFunctor, &hydroTraversal, false);
+  sphSystem.iteratePairwise(&hydroForceFunctor, &hydroTraversal);
   // 0.3.3 delete halo particles, as their values are no longer valid
   deleteHaloParticles(sphSystem);
 }

--- a/examples/sph-traversals/sph-traversals.cpp
+++ b/examples/sph-traversals/sph-traversals.cpp
@@ -253,7 +253,7 @@ void measureContainer(Container *cont, autopas::sph::SPHCalcDensityFunctor *func
 
   t.start();
   for (int i = 0; i < numIterations; ++i) {
-    cont->iteratePairwise(func, traversal, useNewton3);
+    cont->iteratePairwise(func, traversal);
   }
   double elapsedTime = t.stop();
   double MFUPS = numParticles * numIterations / elapsedTime * 1e-6;

--- a/examples/sph-verlet/sph-main-verlet.cpp
+++ b/examples/sph-verlet/sph-main-verlet.cpp
@@ -257,7 +257,7 @@ void densityPressureHydroForce(Container &sphSystem) {
   autopas::TraversalVerlet<autopas::FullParticleCell<autopas::sph::SPHParticle>, autopas::sph::SPHCalcDensityFunctor,
                            autopas::DataLayoutOption::aos, false>
       densityTraversal({0, 0, 0}, &densityFunctor);
-  sphSystem.iteratePairwise(&densityFunctor, &densityTraversal, false);
+  sphSystem.iteratePairwise(&densityFunctor, &densityTraversal);
   std::cout << "calculation of density... completed" << std::endl;
   // 1.3 delete halo particles, as their values are no longer valid
   // deleteHaloParticles(sphSystem);
@@ -284,7 +284,7 @@ void densityPressureHydroForce(Container &sphSystem) {
   autopas::TraversalVerlet<autopas::FullParticleCell<autopas::sph::SPHParticle>, autopas::sph::SPHCalcHydroForceFunctor,
                            autopas::DataLayoutOption::aos, false>
       hydroTraversal({0, 0, 0}, &hydroForceFunctor);
-  sphSystem.iteratePairwise(&hydroForceFunctor, &hydroTraversal, false);
+  sphSystem.iteratePairwise(&hydroForceFunctor, &hydroTraversal);
   std::cout << "calculation of hydroforces... completed" << std::endl;
   // 0.3.3 delete halo particles, as their values are no longer valid
   // deleteHaloParticles(sphSystem);

--- a/examples/sph/sph-main.cpp
+++ b/examples/sph/sph-main.cpp
@@ -266,7 +266,7 @@ void densityPressureHydroForce(Container &sphSystem) {
   }
   DensityTraversal densityTraversal(sphSystem.getCellBlock().getCellsPerDimensionWithHalo(), &densityFunctor);
   std::cout << "calculation of density... started" << std::endl;
-  sphSystem.iteratePairwise(&densityFunctor, &densityTraversal, false);
+  sphSystem.iteratePairwise(&densityFunctor, &densityTraversal);
   std::cout << "calculation of density... completed" << std::endl;
   // 1.3 delete halo particles, as their values are no longer valid
   deleteHaloParticles(sphSystem);
@@ -303,7 +303,7 @@ void densityPressureHydroForce(Container &sphSystem) {
   }
   HydroTraversal hydroTraversal(sphSystem.getCellBlock().getCellsPerDimensionWithHalo(), &hydroForceFunctor);
   std::cout << "calculation of hydroforces... started" << std::endl;
-  sphSystem.iteratePairwise(&hydroForceFunctor, &hydroTraversal, false);
+  sphSystem.iteratePairwise(&hydroForceFunctor, &hydroTraversal);
   std::cout << "calculation of hydroforces... completed" << std::endl;
   // 0.3.3 delete halo particles, as their values are no longer valid
   deleteHaloParticles(sphSystem);

--- a/examples/sphDiagramGeneration/sph-diagram-generation.cpp
+++ b/examples/sphDiagramGeneration/sph-diagram-generation.cpp
@@ -18,7 +18,7 @@ void measureContainer(Container *cont, Functor *func, int numParticles, int numI
 
 template <class Container, class Functor, class Traversal>
 void measureContainerTraversal(Container *cont, Functor *func, Traversal *traversal, int numParticles,
-                               int numIterations, bool useNewton3);
+                               int numIterations);
 
 void addParticles(
     autopas::LinkedCells<autopas::sph::SPHParticle, autopas::FullParticleCell<autopas::sph::SPHParticle>> &sph_system,
@@ -218,7 +218,8 @@ void measureContainer(Container *cont, Functor *func, int numParticles, int numI
       }
       break;
     }
-    default: {}
+    default: {
+    }
   }
   auto traversal = autopas::TraversalSelector<CellType>::template generateTraversal<Functor>(
       traversalType, *func, traversalInfo, autopas::DataLayoutOption::aos,
@@ -227,18 +228,18 @@ void measureContainer(Container *cont, Functor *func, int numParticles, int numI
     measureContainerTraversal(
         cont, func,
         dynamic_cast<autopas::CellPairTraversal<CellType, autopas::DataLayoutOption::aos, true> *>(traversal.get()),
-        numParticles, numIterations, useNewton3);
+        numParticles, numIterations);
   } else {
     measureContainerTraversal(
         cont, func,
         dynamic_cast<autopas::CellPairTraversal<CellType, autopas::DataLayoutOption::aos, false> *>(traversal.get()),
-        numParticles, numIterations, useNewton3);
+        numParticles, numIterations);
   }
 }
 
 template <class Container, class Functor, class Traversal>
 void measureContainerTraversal(Container *cont, Functor *func, Traversal *traversal, int numParticles,
-                               int numIterations, bool useNewton3) {
+                               int numIterations) {
   // autopas::FlopCounterFunctor<autopas::sph::SPHParticle, autopas::FullParticleCell<autopas::sph::SPHParticle>>
   //    flopFunctor(cont->getCutoff());
 
@@ -248,7 +249,7 @@ void measureContainerTraversal(Container *cont, Functor *func, Traversal *traver
   // double flopsPerIteration = flopFunctor.getFlops(func.getNumFlopsPerKernelCall());
 
   t.start();
-  for (int i = 0; i < numIterations; ++i) cont->iteratePairwise(func, traversal, useNewton3);
+  for (int i = 0; i < numIterations; ++i) cont->iteratePairwise(func, traversal);
 
   double elapsedTime = t.stop();
 
@@ -257,7 +258,7 @@ void measureContainerTraversal(Container *cont, Functor *func, Traversal *traver
   double MFUPS_aos = numParticles * numIterations / elapsedTime * 1e-6;
 
   t.start();
-  for (int i = 0; i < numIterations; ++i) cont->iteratePairwise(func, traversal, useNewton3);
+  for (int i = 0; i < numIterations; ++i) cont->iteratePairwise(func, traversal);
 
   elapsedTime = t.stop();
 

--- a/examples/sphDiagramGeneration/sph-diagram-generation.cpp
+++ b/examples/sphDiagramGeneration/sph-diagram-generation.cpp
@@ -218,8 +218,7 @@ void measureContainer(Container *cont, Functor *func, int numParticles, int numI
       }
       break;
     }
-    default: {
-    }
+    default: {}
   }
   auto traversal = autopas::TraversalSelector<CellType>::template generateTraversal<Functor>(
       traversalType, *func, traversalInfo, autopas::DataLayoutOption::aos,

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -78,7 +78,7 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
    * @param useNewton3 whether newton 3 optimization should be used
    */
   template <class ParticleFunctor, class Traversal>
-  void iteratePairwise(ParticleFunctor *f, Traversal *traversal, bool useNewton3 = false) {
+  void iteratePairwise(ParticleFunctor *f, Traversal *traversal) {
     AutoPasLog(debug, "Using traversal {}.", utils::StringUtils::to_string(traversal->getTraversalType()));
 
     traversal->initTraversal(this->_cells);

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -75,7 +75,6 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
    * @tparam Traversal
    * @param f functor that describes the pair-potential
    * @param traversal the traversal that will be used
-   * @param useNewton3 whether newton 3 optimization should be used
    */
   template <class ParticleFunctor, class Traversal>
   void iteratePairwise(ParticleFunctor *f, Traversal *traversal) {

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -88,7 +88,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
    * @copydoc DirectSum::iteratePairwise
    */
   template <class ParticleFunctor, class Traversal>
-  void iteratePairwise(ParticleFunctor *f, Traversal *traversal, bool useNewton3 = false) {
+  void iteratePairwise(ParticleFunctor *f, Traversal *traversal) {
     AutoPasLog(debug, "Using traversal {}.", utils::StringUtils::to_string(traversal->getTraversalType()));
 
     traversal->initTraversal(this->_cells);

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -73,7 +73,8 @@ class VerletClusterLists : public ParticleContainer<Particle, FullParticleCell<P
    * @param useNewton3 whether newton 3 optimization should be used
    */
   template <class ParticleFunctor, class Traversal>
-  void iteratePairwise(ParticleFunctor *f, Traversal *traversal, bool useNewton3 = true) {
+  void iteratePairwise(ParticleFunctor *f, Traversal *traversal) {
+    bool useNewton3 = traversal->getUseNewton3();
     if (useNewton3) {
       /// @todo implement newton3 for VerletClusterLists
       AutoPasLog(error, "Newton3 not implemented yet.");

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -70,7 +70,6 @@ class VerletClusterLists : public ParticleContainer<Particle, FullParticleCell<P
    * @tparam Traversal
    * @param f functor that describes the pair-potential
    * @param traversal not used
-   * @param useNewton3 whether newton 3 optimization should be used
    */
   template <class ParticleFunctor, class Traversal>
   void iteratePairwise(ParticleFunctor *f, Traversal *traversal) {

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -80,8 +80,9 @@ class VerletLists
    * @copydoc LinkedCells::iteratePairwise
    */
   template <class ParticleFunctor, class Traversal>
-  void iteratePairwise(ParticleFunctor *f, Traversal *traversal, bool useNewton3 = true) {
-    if (this->needsRebuild()) {
+  void iteratePairwise(ParticleFunctor *f, Traversal *traversal) {
+    bool useNewton3 = traversal->getUseNewton3();
+    if (this->needsRebuild(useNewton3)) {
       rebuildVerletLists(useNewton3);
     }
 
@@ -136,7 +137,7 @@ class VerletLists
                      typename verlet_internal::template VerletListValidityCheckerFunctor<LinkedParticleCell>,
                      DataLayoutOption::aos, true>(this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(),
                                                   &validityCheckerFunctor);
-    this->_linkedCells.iteratePairwise(&validityCheckerFunctor, &traversal, useNewton3);
+    this->_linkedCells.iteratePairwise(&validityCheckerFunctor, &traversal);
 
     return validityCheckerFunctor.neighborlistsAreValid();
   }

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
@@ -72,7 +72,8 @@ class VerletListsCells
    * @param useNewton3 whether newton 3 optimization should be used
    */
   template <class ParticleFunctor, class Traversal>
-  void iteratePairwise(ParticleFunctor *f, Traversal *traversal, bool useNewton3 = true) {
+  void iteratePairwise(ParticleFunctor *f, Traversal *traversal) {
+    bool useNewton3 = traversal->getUseNewton3();
     if (this->needsRebuild(useNewton3)) {
       updateVerletLists(useNewton3);
     }

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
@@ -69,7 +69,6 @@ class VerletListsCells
    * @tparam Traversal
    * @param f functor that describes the pair-potential
    * @param traversal the traversal that will be used
-   * @param useNewton3 whether newton 3 optimization should be used
    */
   template <class ParticleFunctor, class Traversal>
   void iteratePairwise(ParticleFunctor *f, Traversal *traversal) {

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -323,8 +323,7 @@ void AutoTuner<Particle, ParticleCell>::iteratePairwiseTemplateHelper(PairwiseFu
     // @todo remove useNewton3 in iteratePairwise by introducing traversals for DS and VL
 
     f->initTraversal();
-    withStaticContainerType(container,
-                            [&](auto container) { container->iteratePairwise(f, traversal.get(), useNewton3); });
+    withStaticContainerType(container, [&](auto container) { container->iteratePairwise(f, traversal.get()); });
     f->endTraversal(useNewton3);
 
     auto stop = std::chrono::high_resolution_clock::now();
@@ -333,8 +332,7 @@ void AutoTuner<Particle, ParticleCell>::iteratePairwiseTemplateHelper(PairwiseFu
     addTimeMeasurement(*f, runtime);
   } else {
     f->initTraversal();
-    withStaticContainerType(container,
-                            [&](auto container) { container->iteratePairwise(f, traversal.get(), useNewton3); });
+    withStaticContainerType(container, [&](auto container) { container->iteratePairwise(f, traversal.get()); });
     f->endTraversal(useNewton3);
   }
 }

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -320,7 +320,6 @@ void AutoTuner<Particle, ParticleCell>::iteratePairwiseTemplateHelper(PairwiseFu
   // if tuning execute with time measurements
   if (inTuningPhase) {
     auto start = std::chrono::high_resolution_clock::now();
-    // @todo remove useNewton3 in iteratePairwise by introducing traversals for DS and VL
 
     f->initTraversal();
     withStaticContainerType(container, [&](auto container) { container->iteratePairwise(f, traversal.get()); });

--- a/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
@@ -234,7 +234,5 @@ void Newton3OnOffTest::countFunctorCalls(autopas::ContainerOption containerOptio
 template <class ParticleFunctor, class Container, class Traversal>
 void Newton3OnOffTest::iterate(Container container, Traversal traversal, autopas::DataLayoutOption dataLayout,
                                autopas::Newton3Option newton3, ParticleFunctor *f) {
-  withStaticContainerType(container, [&](auto container) {
-    container->iteratePairwise(f, traversal.get(), newton3 == autopas::Newton3Option::enabled);
-  });
+  withStaticContainerType(container, [&](auto container) { container->iteratePairwise(f, traversal.get()); });
 }

--- a/tests/testAutopas/tests/containers/LinkedCellsVersusVerletClusterListsTest.cpp
+++ b/tests/testAutopas/tests/containers/LinkedCellsVersusVerletClusterListsTest.cpp
@@ -29,8 +29,8 @@ void LinkedCellsVersusVerletClusterListsTest::test(unsigned long numMolecules, d
       dummyTraversal({0, 0, 0}, &func);
   autopas::C08Traversal<FMCell, autopas::LJFunctor<Molecule, FMCell>, autopas::DataLayoutOption::aos, false>
       traversalLinkedLJ(_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), &func);
-  _verletLists.iteratePairwise(&func, &dummyTraversal, false);
-  _linkedCells.iteratePairwise(&func, &traversalLinkedLJ, false);
+  _verletLists.iteratePairwise(&func, &dummyTraversal);
+  _linkedCells.iteratePairwise(&func, &traversalLinkedLJ);
 
   std::vector<std::array<double, 3>> forcesVerlet(numMolecules), forcesLinked(numMolecules);
   // get and sort by id, skip id=0 to avoid dummy particles
@@ -59,8 +59,8 @@ void LinkedCellsVersusVerletClusterListsTest::test(unsigned long numMolecules, d
   autopas::FlopCounterFunctor<Molecule, FMCell> flopsVerlet(getCutoff()), flopsLinked(getCutoff());
   autopas::C08Traversal<FMCell, autopas::FlopCounterFunctor<Molecule, FMCell>, autopas::DataLayoutOption::aos, false>
       traversalFLOPS(_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), &flopsLinked);
-  _verletLists.iteratePairwise(&flopsVerlet, &traversalFLOPS, false);
-  _linkedCells.iteratePairwise(&flopsLinked, &traversalFLOPS, false);
+  _verletLists.iteratePairwise(&flopsVerlet, &traversalFLOPS);
+  _linkedCells.iteratePairwise(&flopsLinked, &traversalFLOPS);
 
   ASSERT_EQ(flopsLinked.getKernelCalls(), flopsVerlet.getKernelCalls());
 }

--- a/tests/testAutopas/tests/containers/LinkedCellsVersusVerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/LinkedCellsVersusVerletListsTest.cpp
@@ -36,8 +36,8 @@ void LinkedCellsVersusVerletListsTest::test(unsigned long numMolecules, double r
   autopas::C08Traversal<FMCell, decltype(func), dataLayoutOption, useNewton3> traversalLJ(
       _linkedCells->getCellBlock().getCellsPerDimensionWithHalo(), &func);
 
-  _verletLists->iteratePairwise(&func, &traversalLJV, useNewton3);
-  _linkedCells->iteratePairwise(&func, &traversalLJ, useNewton3);
+  _verletLists->iteratePairwise(&func, &traversalLJV);
+  _linkedCells->iteratePairwise(&func, &traversalLJ);
 
   auto itDirect = _verletLists->begin();
   auto itLinked = _linkedCells->begin();
@@ -69,8 +69,8 @@ void LinkedCellsVersusVerletListsTest::test(unsigned long numMolecules, double r
 
   autopas::TraversalVerlet<FMCell, decltype(flopsLinked), dataLayoutOption, useNewton3> traversalFLOPSVerlet(
       _verletLists->getCellsPerDimension(), &flopsVerlet);
-  _linkedCells->iteratePairwise(&flopsLinked, &traversalFLOPSLC, useNewton3);
-  _verletLists->iteratePairwise(&flopsVerlet, &traversalFLOPSVerlet, useNewton3);
+  _linkedCells->iteratePairwise(&flopsLinked, &traversalFLOPSLC);
+  _verletLists->iteratePairwise(&flopsVerlet, &traversalFLOPSVerlet);
 
   if (not useNewton3 and dataLayoutOption == autopas::DataLayoutOption::soa) {
     // special case if newton3 is disabled and soa are used: here linked cells will anyways partially use newton3 (for

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
@@ -36,5 +36,5 @@ TEST_F(VerletClusterListsTest, testVerletListBuild) {
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, false)).Times(AtLeast(1));
   autopas::C08Traversal<FPCell, MFunctor, autopas::DataLayoutOption::aos, false> dummyTraversal({0, 0, 0},
                                                                                                 &emptyFunctor);
-  verletLists.iteratePairwise(&emptyFunctor, &dummyTraversal, false);
+  verletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);
 }

--- a/tests/testAutopas/tests/containers/verletLists/VerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletLists/VerletListsTest.cpp
@@ -79,7 +79,7 @@ TEST_P(VerletListsTest, testVerletListBuild) {
 
   autopas::TraversalVerlet<FPCell, MFunctor, autopas::DataLayoutOption::aos, true> dummyTraversal({0, 0, 0},
                                                                                                   &emptyFunctor);
-  verletLists.iteratePairwise(&emptyFunctor, &dummyTraversal, true);
+  verletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);
 
   auto &list = verletLists.getVerletListsAoS();
 
@@ -112,7 +112,7 @@ TEST_P(VerletListsTest, testVerletListInSkin) {
 
   autopas::TraversalVerlet<FPCell, MFunctor, autopas::DataLayoutOption::aos, true> dummyTraversal({0, 0, 0},
                                                                                                   &mockFunctor);
-  verletLists.iteratePairwise(&mockFunctor, &dummyTraversal, true);
+  verletLists.iteratePairwise(&mockFunctor, &dummyTraversal);
 
   auto &list = verletLists.getVerletListsAoS();
 
@@ -145,9 +145,9 @@ TEST_P(VerletListsTest, testVerletListBuildTwice) {
 
   autopas::TraversalVerlet<FPCell, MFunctor, autopas::DataLayoutOption::aos, true> dummyTraversal({0, 0, 0},
                                                                                                   &emptyFunctor);
-  verletLists.iteratePairwise(&emptyFunctor, &dummyTraversal, true);
+  verletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);
 
-  verletLists.iteratePairwise(&emptyFunctor, &dummyTraversal, true);
+  verletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);
 
   auto &list = verletLists.getVerletListsAoS();
 
@@ -184,7 +184,7 @@ TEST_P(VerletListsTest, testVerletListBuildFarAway) {
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, true)).Times(AtLeast(1));
   autopas::TraversalVerlet<FPCell, MFunctor, autopas::DataLayoutOption::aos, true> dummyTraversal({0, 0, 0},
                                                                                                   &emptyFunctor);
-  verletLists.iteratePairwise(&emptyFunctor, &dummyTraversal, true);
+  verletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);
 
   auto &list = verletLists.getVerletListsAoS();
 
@@ -216,9 +216,9 @@ TEST_P(VerletListsTest, testVerletListBuildHalo) {
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, true)).Times(AtLeast(1));
   autopas::TraversalVerlet<FPCell, MFunctor, autopas::DataLayoutOption::aos, true> dummyTraversal({0, 0, 0},
                                                                                                   &emptyFunctor);
-  verletLists.iteratePairwise(&emptyFunctor, &dummyTraversal, true);
+  verletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);
 
-  verletLists.iteratePairwise(&emptyFunctor, &dummyTraversal, true);
+  verletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);
 
   auto &list = verletLists.getVerletListsAoS();
 
@@ -239,7 +239,7 @@ TEST_F(VerletListsTest, testRebuildFrequencyAlways) {
   const unsigned int numIterations = 4;
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(numIterations);
   for (unsigned int i = 0; i < numIterations; i++) {
-    mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal, true);
+    mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);
   }
 }
 
@@ -251,17 +251,17 @@ TEST_F(VerletListsTest, testRebuildFrequencyEvery3) {
                                                                                                   &emptyFunctor);
 
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal, true);  // 1
+  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);  // 1
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(0);
-  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal, true);
-  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal, true);
+  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);
+  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal, true);  // 2
+  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);  // 2
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(0);
-  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal, true);
-  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal, true);
+  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);
+  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal, true);  // 3
+  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);  // 3
 }
 
 TEST_F(VerletListsTest, testForceRebuild) {
@@ -282,33 +282,29 @@ TEST_F(VerletListsTest, testForceRebuild) {
                                                                                                   &emptyFunctor);
   // check that the second call does not need a rebuild
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal,
-                                  true);  // rebuild happens here
+  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);  // rebuild happens here
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(0);
-  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal, true);
+  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);
 
   // check that updateContainer() requires a rebuild
   EXPECT_CALL(mockVerletLists, updateContainer());
   mockVerletLists.updateContainer();
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal,
-                                  true);  // rebuild happens here
+  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);  // rebuild happens here
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(0);
-  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal, true);
+  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);
 
   // check that adding particles requires a rebuild
   Particle p({1.1, 1.1, 1.1}, {0., 0., 0.}, 1);
   EXPECT_CALL(mockVerletLists, addParticle(_));
   mockVerletLists.addParticle(p);
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal,
-                                  true);  // rebuild happens here
+  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);  // rebuild happens here
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(0);
-  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal, true);
-  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal, true);
+  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);
+  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal,
-                                  true);  // rebuild happens here
+  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);  // rebuild happens here
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(0);
 
   // check that adding halo particles requires a rebuild
@@ -316,8 +312,7 @@ TEST_F(VerletListsTest, testForceRebuild) {
   EXPECT_CALL(mockVerletLists, addHaloParticle(_));
   mockVerletLists.addHaloParticle(p2);
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal,
-                                  true);  // rebuild happens here
+  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);  // rebuild happens here
 
   // check that deleting particles requires a rebuild
   /// @todo: reenable once implemented
@@ -332,8 +327,7 @@ TEST_F(VerletListsTest, testForceRebuild) {
   // check that deleting halo particles requires a rebuild
   mockVerletLists.deleteHaloParticles();
   EXPECT_CALL(mockVerletLists, updateVerletListsAoS(true)).Times(1);
-  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal,
-                                  true);  // rebuild happens here
+  mockVerletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);  // rebuild happens here
 }
 
 TEST_P(VerletListsTest, testCheckNeighborListsAreValidAfterBuild) {
@@ -354,7 +348,7 @@ TEST_P(VerletListsTest, testCheckNeighborListsAreValidAfterBuild) {
   autopas::TraversalVerlet<FPCell, MFunctor, autopas::DataLayoutOption::aos, true> dummyTraversal({0, 0, 0},
                                                                                                   &emptyFunctor);
   // this will build the verlet list
-  verletLists.iteratePairwise(&emptyFunctor, &dummyTraversal, true);
+  verletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);
 
   // check validity - should return true
   EXPECT_TRUE(verletLists.checkNeighborListsAreValid());
@@ -377,7 +371,7 @@ TEST_P(VerletListsTest, testCheckNeighborListsAreValidAfterSmallMove) {
   autopas::TraversalVerlet<FPCell, MFunctor, autopas::DataLayoutOption::aos, true> dummyTraversal({0, 0, 0},
                                                                                                   &emptyFunctor);
   // this will build the verlet list
-  verletLists.iteratePairwise(&emptyFunctor, &dummyTraversal, true);
+  verletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);
 
   for (auto iter = verletLists.begin(); iter.isValid(); ++iter) {
     if (iter->getID() == 1) {
@@ -407,7 +401,7 @@ TEST_P(VerletListsTest, testCheckNeighborListsAreInvalidAfterMoveLarge) {
   autopas::TraversalVerlet<FPCell, MFunctor, autopas::DataLayoutOption::aos, true> dummyTraversal({0, 0, 0},
                                                                                                   &emptyFunctor);
   // this will build the verlet list
-  verletLists.iteratePairwise(&emptyFunctor, &dummyTraversal, true);
+  verletLists.iteratePairwise(&emptyFunctor, &dummyTraversal);
 
   for (auto iter = verletLists.begin(); iter.isValid(); ++iter) {
     if (iter->getID() == 1) {
@@ -588,7 +582,7 @@ TEST_P(VerletListsTest, LoadExtractSoA) {
   EXPECT_CALL(mockFunctor, SoALoaderVerlet(_, _, _)).Times(numCells);
   EXPECT_CALL(mockFunctor, SoAExtractorVerlet(_, _, _)).Times(numCells);
   EXPECT_CALL(mockFunctor, SoAFunctor(_, _, _, _, _)).Times(1);
-  verletLists.iteratePairwise(&mockFunctor, &dummyTraversal, false);
+  verletLists.iteratePairwise(&mockFunctor, &dummyTraversal);
 }
 
 TEST_P(VerletListsTest, LoadExtractSoALJ) {
@@ -604,7 +598,7 @@ TEST_P(VerletListsTest, LoadExtractSoALJ) {
   autopas::LJFunctor<Particle, FPCell> ljFunctor(cutoff, 1 /*epsilon*/, 1 /*sigma*/, 0 /*shift*/);
   autopas::TraversalVerlet<FPCell, autopas::LJFunctor<Particle, FPCell>, autopas::DataLayoutOption::soa, false>
       dummyTraversal({0, 0, 0}, &ljFunctor);
-  verletLists.iteratePairwise(&ljFunctor, &dummyTraversal, false);
+  verletLists.iteratePairwise(&ljFunctor, &dummyTraversal);
 }
 
 TEST_P(VerletListsTest, SoAvsAoSLJ) {
@@ -626,8 +620,8 @@ TEST_P(VerletListsTest, SoAvsAoSLJ) {
       dummyTraversal1({0, 0, 0}, &ljFunctor);
   autopas::TraversalVerlet<FPCell, autopas::LJFunctor<Particle, FPCell>, autopas::DataLayoutOption::soa, false>
       soaTraversal({0, 0, 0}, &ljFunctor);
-  verletLists1.iteratePairwise(&ljFunctor, &dummyTraversal1, false);
-  verletLists2.iteratePairwise(&ljFunctor, &soaTraversal, false);
+  verletLists1.iteratePairwise(&ljFunctor, &dummyTraversal1);
+  verletLists2.iteratePairwise(&ljFunctor, &soaTraversal);
 
   auto iter1 = verletLists1.begin();
   auto iter2 = verletLists2.begin();

--- a/tests/testAutopas/tests/containers/verletListsCells/VerletListsCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCells/VerletListsCellsTest.cpp
@@ -26,7 +26,7 @@ void applyFunctor(MockFunctor<Particle, FPCell> &functor, const double cellSizef
 
   autopas::C18TraversalVerlet<FPCell, MFunctor, autopas::DataLayoutOption::aos, true> traversal(
       verletLists.getCellsPerDimension(), &functor);
-  verletLists.iteratePairwise(&functor, &traversal, true);
+  verletLists.iteratePairwise(&functor, &traversal);
 
   std::vector<Particle *> list;
   for (auto iter = verletLists.begin(); iter.isValid(); ++iter) list.push_back(&*iter);

--- a/tests/testAutopas/tests/containers/verletListsCells/VerletListsCellsTraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCells/VerletListsCellsTraversalTest.cpp
@@ -34,11 +34,11 @@ std::vector<unsigned long> getKernelCallsAllTraversals(autopas::VerletListsCells
       traversalC18N3FLOPS(dim, &flopsC18N3);
   autopas::SlicedTraversalVerlet<FMCell, autopas::FlopCounterFunctor<Molecule, FMCell>, autopas::aos, true>
       traversalSliN3FLOPS(dim, &flopsSliN3);
-  verletListsCells.iteratePairwise(&flopsC01, &traversalC01FLOPS, false);
-  verletListsCells.iteratePairwise(&flopsC18, &traversalC18FLOPS, false);
-  verletListsCells.iteratePairwise(&flopsSli, &traversalSliFLOPS, false);
-  verletListsCells.iteratePairwise(&flopsC18N3, &traversalC18N3FLOPS, true);
-  verletListsCells.iteratePairwise(&flopsSliN3, &traversalSliN3FLOPS, true);
+  verletListsCells.iteratePairwise(&flopsC01, &traversalC01FLOPS);
+  verletListsCells.iteratePairwise(&flopsC18, &traversalC18FLOPS);
+  verletListsCells.iteratePairwise(&flopsSli, &traversalSliFLOPS);
+  verletListsCells.iteratePairwise(&flopsC18N3, &traversalC18N3FLOPS);
+  verletListsCells.iteratePairwise(&flopsSliN3, &traversalSliN3FLOPS);
 
   EXPECT_EQ(flopsC18.getKernelCalls(), flopsC01.getKernelCalls());
   EXPECT_EQ(flopsC18.getKernelCalls(), flopsSli.getKernelCalls());

--- a/tests/testAutopas/tests/sph/SPHTest.cpp
+++ b/tests/testAutopas/tests/sph/SPHTest.cpp
@@ -645,7 +645,7 @@ TEST_F(SPHTest, testSPHCalcHydroForceFunctorNewton3OnOff) {
                                autopas::DataLayoutOption::aos, true>                                                   \
           traversalLJVerlet(_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), &fnctr);                       \
                                                                                                                        \
-      _verletLists.iteratePairwise(&fnctr, &traversalLJVerlet, true);                                                  \
+      _verletLists.iteratePairwise(&fnctr, &traversalLJVerlet);                                                        \
       _linkedCells.iteratePairwise(&fnctr, &traversalLJ);                                                              \
     } else {                                                                                                           \
       autopas::C08Traversal<autopas::FullParticleCell<SPHParticle>, autopas::sph::functor,                             \
@@ -656,7 +656,7 @@ TEST_F(SPHTest, testSPHCalcHydroForceFunctorNewton3OnOff) {
           traversalLJVerlet(_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), &fnctr);                       \
                                                                                                                        \
       _verletLists.iteratePairwise(&fnctr, &traversalLJVerlet);                                                        \
-      _linkedCells.iteratePairwise(&fnctr, &traversalLJ, true);                                                        \
+      _linkedCells.iteratePairwise(&fnctr, &traversalLJ);                                                              \
     }                                                                                                                  \
     check;                                                                                                             \
   }


### PR DESCRIPTION
# Description
Removed newton 3 parameter from all iteratePairwise methods in the containers.

## Related Pull Requests

None

## Resolved Issues

None

# How Has This Been Tested?
Jenkins
