### PR TITLE
enable c++17

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Please keep in mind the following notes while working.
 
 ## C++
 ### General Notes
-* Cpp standard: C++14. If there is a piece of code, which could be done better using a newer standard, please add a comment like `@todo C++17` including the alternative version of the code. For now, we are stuck with C++14 due to the CUDA dependency.
+* Cpp standard: C++17. If there is a piece of code, which could be done better using a newer standard, please add a comment like `@todo C++20` including the alternative version of the code. For now, we are stuck with C++14 due to the CUDA dependency.
 * Pointers: Always use smart pointers when you are managing memory. Don't use `new` or `delete`.
 * OpenMP: Use AutoPas wrapper functions for OpenMP (`src/autopas/utils/WrapOpenMP.h`) instead of OpenMP functions to allow building without enabled OpenMP.
 * `#pragma once` instead of header guards.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Please keep in mind the following notes while working.
 
 ## C++
 ### General Notes
-* Cpp standard: C++17. If there is a piece of code, which could be done better using a newer standard, please add a comment like `@todo C++20` including the alternative version of the code. For now, we are stuck with C++14 due to the CUDA dependency.
+* Cpp standard: C++17. If there is a piece of code, which could be done better using a newer standard, please add a comment like `@todo C++20` including the alternative version of the code.
 * Pointers: Always use smart pointers when you are managing memory. Don't use `new` or `delete`.
 * OpenMP: Use AutoPas wrapper functions for OpenMP (`src/autopas/utils/WrapOpenMP.h`) instead of OpenMP functions to allow building without enabled OpenMP.
 * `#pragma once` instead of header guards.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,8 @@ cmake_policy(SET CMP0054 NEW)
 cmake_policy(SET CMP0057 NEW)
 cmake_policy(SET CMP0079 NEW)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CUDA_STANDARD 14)
 
 set(SUPPORTED_COMPILERS "GNU;Intel;Clang")
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline{
                             container('autopas-clang6-cmake-ninja-make'){
                                 sh "CC=clang CXX=clang++ cmake -G Ninja -DAUTOPAS_OPENMP=ON .."
                                 sh "ninja clangformat"
-                                sh "ninja cmakeformat"
+                                sh "ninja cmakeformat" 
                             }
                             script{
                                 // return 2 if files have been modified by clang-format, 0 otherwise

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline{
                             container('autopas-clang6-cmake-ninja-make'){
                                 sh "CC=clang CXX=clang++ cmake -G Ninja -DAUTOPAS_OPENMP=ON .."
                                 sh "ninja clangformat"
-                                sh "ninja cmakeformat" 
+                                sh "ninja cmakeformat"
                             }
                             script{
                                 // return 2 if files have been modified by clang-format, 0 otherwise

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Alternatively you can build the documentation on your own:
 ## Requirements
 * cmake 3.13 or newer
 * make (build-essentials) or ninja
-* a c++17 compiler (gcc7, clang6 and icpc 2018 are tested)
+* a c++17 compiler (gcc7, clang8 and icpc 2018 are tested)
 
 ## Building AutoPas
 build instructions for make:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Alternatively you can build the documentation on your own:
 ## Requirements
 * cmake 3.13 or newer
 * make (build-essentials) or ninja
-* a c++14 compiler (gcc7, clang6 and icpc 2018 are tested)
+* a c++17 compiler (gcc7, clang6 and icpc 2018 are tested)
 
 ## Building AutoPas
 build instructions for make:


### PR DESCRIPTION
# Description

Enables c++17 for host code compilation.
Cuda compilation is performed using c++14

## Related Pull Requests

- #194 
- #189 

## Resolved Issues

- [x] #211 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Jenkins
