### PR TITLE
remove ParticleCell template from TraversalSelectorInfo

### DIFF
--- a/examples/sphDiagramGeneration/sph-diagram-generation.cpp
+++ b/examples/sphDiagramGeneration/sph-diagram-generation.cpp
@@ -198,7 +198,7 @@ template <class Container, class Functor>
 void measureContainer(Container *cont, Functor *func, int numParticles, int numIterations, bool useNewton3) {
   using CellType = autopas::FullParticleCell<autopas::sph::SPHParticle>;
   // initialize to dummy values
-  autopas::TraversalSelectorInfo<CellType> traversalInfo = cont->getTraversalSelectorInfo();
+  auto traversalInfo = cont->getTraversalSelectorInfo();
   std::cout << "Cells: " << traversalInfo.dims[0] << " x " << traversalInfo.dims[1] << " x " << traversalInfo.dims[2]
             << std::endl;
   auto traversalType = autopas::TraversalOption::dummyTraversal;

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -196,7 +196,7 @@ class ParticleContainerInterface {
    * Generates a traversal selector info for this container.
    * @return Traversal selector info for this container.
    */
-  virtual TraversalSelectorInfo<ParticleCell> getTraversalSelectorInfo() = 0;
+  virtual TraversalSelectorInfo getTraversalSelectorInfo() = 0;
 
   /**
    * Generates a list of all traversals that are theoretically applicable to this container.

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -124,9 +124,9 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
     return outlierFound;
   }
 
-  TraversalSelectorInfo<ParticleCell> getTraversalSelectorInfo() override {
+  TraversalSelectorInfo getTraversalSelectorInfo() override {
     // direct sum technically consists of two cells (owned + halo)
-    return TraversalSelectorInfo<ParticleCell>({2, 0, 0});
+    return TraversalSelectorInfo({2, 0, 0});
   }
 
   ParticleIteratorWrapper<Particle> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -190,8 +190,8 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
   }
 
   TraversalSelectorInfo getTraversalSelectorInfo() override {
-    return TraversalSelectorInfo(this->getCellBlock().getCellsPerDimensionWithHalo(),
-                                               this->getInteractionLength(), this->getCellBlock().getCellLength());
+    return TraversalSelectorInfo(this->getCellBlock().getCellsPerDimensionWithHalo(), this->getInteractionLength(),
+                                 this->getCellBlock().getCellLength());
   }
 
   ParticleIteratorWrapper<Particle> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -189,8 +189,8 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
     return outlierFound;
   }
 
-  TraversalSelectorInfo<ParticleCell> getTraversalSelectorInfo() override {
-    return TraversalSelectorInfo<ParticleCell>(this->getCellBlock().getCellsPerDimensionWithHalo(),
+  TraversalSelectorInfo getTraversalSelectorInfo() override {
+    return TraversalSelectorInfo(this->getCellBlock().getCellsPerDimensionWithHalo(),
                                                this->getInteractionLength(), this->getCellBlock().getCellLength());
   }
 

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -130,8 +130,8 @@ class VerletClusterLists : public ParticleContainer<Particle, FullParticleCell<P
     return false;
   }
 
-  TraversalSelectorInfo<FullParticleCell<Particle>> getTraversalSelectorInfo() override {
-    return TraversalSelectorInfo<FullParticleCell<Particle>>(_cellsPerDim);
+  TraversalSelectorInfo getTraversalSelectorInfo() override {
+    return TraversalSelectorInfo(_cellsPerDim);
   }
 
   ParticleIteratorWrapper<Particle> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -130,9 +130,7 @@ class VerletClusterLists : public ParticleContainer<Particle, FullParticleCell<P
     return false;
   }
 
-  TraversalSelectorInfo getTraversalSelectorInfo() override {
-    return TraversalSelectorInfo(_cellsPerDim);
-  }
+  TraversalSelectorInfo getTraversalSelectorInfo() override { return TraversalSelectorInfo(_cellsPerDim); }
 
   ParticleIteratorWrapper<Particle> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
     return ParticleIteratorWrapper<Particle>(

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -187,8 +187,8 @@ class VerletListsLinkedBase : public ParticleContainer<Particle, FullParticleCel
    * Generates a traversal selector info for this container.
    * @return Traversal selector info for this container.
    */
-  TraversalSelectorInfo<ParticleCell> getTraversalSelectorInfo() override {
-    return TraversalSelectorInfo<ParticleCell>(this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo());
+  TraversalSelectorInfo getTraversalSelectorInfo() override {
+    return TraversalSelectorInfo(this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo());
   }
 
  protected:

--- a/src/autopas/selectors/TraversalSelector.h
+++ b/src/autopas/selectors/TraversalSelector.h
@@ -136,8 +136,8 @@ TraversalSelector<ParticleCell>::generateTraversal(TraversalOption traversalType
 template <class ParticleCell>
 template <class PairwiseFunctor>
 std::unique_ptr<TraversalInterface> TraversalSelector<ParticleCell>::generateTraversal(
-    TraversalOption traversalType, PairwiseFunctor &pairwiseFunctor,
-    const TraversalSelectorInfo &traversalInfo, DataLayoutOption dataLayout, Newton3Option newton3) {
+    TraversalOption traversalType, PairwiseFunctor &pairwiseFunctor, const TraversalSelectorInfo &traversalInfo,
+    DataLayoutOption dataLayout, Newton3Option newton3) {
   switch (dataLayout) {
     case DataLayoutOption::aos: {
       if (newton3 == Newton3Option::enabled) {

--- a/src/autopas/selectors/TraversalSelector.h
+++ b/src/autopas/selectors/TraversalSelector.h
@@ -52,7 +52,7 @@ class TraversalSelector {
    */
   template <class PairwiseFunctor, DataLayoutOption dataLayout, bool useNewton3>
   static std::unique_ptr<CellPairTraversal<ParticleCell, dataLayout, useNewton3>> generateTraversal(
-      TraversalOption traversalType, PairwiseFunctor &pairwiseFunctor, const TraversalSelectorInfo<ParticleCell> &info);
+      TraversalOption traversalType, PairwiseFunctor &pairwiseFunctor, const TraversalSelectorInfo &info);
 
   /**
    * Generates a given Traversal for the given properties. Requires less templates but only returns a TraversalInterface
@@ -68,7 +68,7 @@ class TraversalSelector {
   template <class PairwiseFunctor>
   static std::unique_ptr<TraversalInterface> generateTraversal(TraversalOption traversalType,
                                                                PairwiseFunctor &pairwiseFunctor,
-                                                               const TraversalSelectorInfo<ParticleCell> &info,
+                                                               const TraversalSelectorInfo &info,
                                                                DataLayoutOption dataLayout, Newton3Option useNewton3);
 };
 
@@ -76,7 +76,7 @@ template <class ParticleCell>
 template <class PairwiseFunctor, DataLayoutOption dataLayout, bool useNewton3>
 std::unique_ptr<CellPairTraversal<ParticleCell, dataLayout, useNewton3>>
 TraversalSelector<ParticleCell>::generateTraversal(TraversalOption traversalType, PairwiseFunctor &pairwiseFunctor,
-                                                   const TraversalSelectorInfo<ParticleCell> &info) {
+                                                   const TraversalSelectorInfo &info) {
   switch (traversalType) {
     // Direct sum
     case TraversalOption::directSumTraversal: {
@@ -137,7 +137,7 @@ template <class ParticleCell>
 template <class PairwiseFunctor>
 std::unique_ptr<TraversalInterface> TraversalSelector<ParticleCell>::generateTraversal(
     TraversalOption traversalType, PairwiseFunctor &pairwiseFunctor,
-    const TraversalSelectorInfo<ParticleCell> &traversalInfo, DataLayoutOption dataLayout, Newton3Option newton3) {
+    const TraversalSelectorInfo &traversalInfo, DataLayoutOption dataLayout, Newton3Option newton3) {
   switch (dataLayout) {
     case DataLayoutOption::aos: {
       if (newton3 == Newton3Option::enabled) {

--- a/src/autopas/selectors/TraversalSelectorInfo.h
+++ b/src/autopas/selectors/TraversalSelectorInfo.h
@@ -12,7 +12,6 @@ namespace autopas {
  * Info for traversals of a specific container.
  * @tparam ParticleCell
  */
-template <class ParticleCell>
 class TraversalSelectorInfo {
  public:
   /**

--- a/src/autopas/selectors/TraversalSelectorInfo.h
+++ b/src/autopas/selectors/TraversalSelectorInfo.h
@@ -10,7 +10,6 @@
 namespace autopas {
 /**
  * Info for traversals of a specific container.
- * @tparam ParticleCell
  */
 class TraversalSelectorInfo {
  public:

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.cpp
@@ -24,7 +24,7 @@ void testTraversal(autopas::TraversalOption traversalOption, bool useN3, const s
 
   NumThreadGuard(4);
 
-  autopas::TraversalSelectorInfo<FPCell> tsi(edgeLength, cutoff);
+  autopas::TraversalSelectorInfo tsi(edgeLength, cutoff);
   std::unique_ptr<autopas::TraversalInterface> traversal;
   if (useN3 and traversalOption != autopas::TraversalOption::c01) {
     traversal = autopas::TraversalSelector<FPCell>::template generateTraversal<TraversalTest::CountFunctor,

--- a/tests/testAutopas/tests/selectors/TraversalSelectorTest.cpp
+++ b/tests/testAutopas/tests/selectors/TraversalSelectorTest.cpp
@@ -16,7 +16,7 @@ TEST_F(TraversalSelectorTest, testSelectAndGetCurrentTraversal) {
 
   // this should be high enough so that sliced is still valid for the current processors thread count.
   constexpr size_t domainSize = 900;
-  autopas::TraversalSelectorInfo<FPCell> traversalSelectorInfo({domainSize, domainSize, domainSize});
+  autopas::TraversalSelectorInfo traversalSelectorInfo({domainSize, domainSize, domainSize});
 
   // expect an exception if nothing is selected yet
   EXPECT_THROW(


### PR DESCRIPTION
# Description

Removes the unnecessary ParticleCell template from TraversalSelectorInfo

## Resolved Issues

- [x] fixes #284 