### PR TITLE
fix thread guards

### DIFF
--- a/tests/testAutopas/tests/containers/linkedCells/traversals/SlicedTraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/SlicedTraversalTest.cpp
@@ -17,7 +17,7 @@ void testSlicedTraversal(const std::array<size_t, 3> &edgeLength, unsigned long 
 
   GridGenerator::fillWithParticles<autopas::Particle>(cells, edgeLength);
 
-  NumThreadGuard(4);
+  NumThreadGuard numThreadGuard(4);
 
   autopas::SlicedTraversal<FPCell, MFunctor, autopas::DataLayoutOption::aos, true> slicedTraversal(edgeLength, &functor,
                                                                                                    overlap);
@@ -39,7 +39,7 @@ TEST_F(SlicedTraversalTest, testTraversalCubeShrink) {
 }
 
 TEST_F(SlicedTraversalTest, testIsApplicableTooSmall) {
-  NumThreadGuard(4);
+  NumThreadGuard numThreadGuard(4);
 
   autopas::SlicedTraversal<FPCell, MFunctor, autopas::DataLayoutOption::aos, true> slicedTraversal({1, 1, 1}, nullptr);
 
@@ -47,7 +47,7 @@ TEST_F(SlicedTraversalTest, testIsApplicableTooSmall) {
 }
 
 TEST_F(SlicedTraversalTest, testIsApplicableShrinkable) {
-  NumThreadGuard(4);
+  NumThreadGuard numThreadGuard(4);
 
   autopas::SlicedTraversal<FPCell, MFunctor, autopas::DataLayoutOption::aos, true> slicedTraversal({5, 5, 5}, nullptr);
 
@@ -55,7 +55,7 @@ TEST_F(SlicedTraversalTest, testIsApplicableShrinkable) {
 }
 
 TEST_F(SlicedTraversalTest, testIsApplicableOk) {
-  NumThreadGuard(4);
+  NumThreadGuard numThreadGuard(4);
 
   autopas::SlicedTraversal<FPCell, MFunctor, autopas::DataLayoutOption::aos, true> slicedTraversal({11, 11, 11},
                                                                                                    nullptr);
@@ -64,7 +64,7 @@ TEST_F(SlicedTraversalTest, testIsApplicableOk) {
 }
 
 TEST_F(SlicedTraversalTest, testIsApplicableOkOnlyOneDim) {
-  NumThreadGuard(4);
+  NumThreadGuard numThreadGuard(4);
 
   autopas::SlicedTraversal<FPCell, MFunctor, autopas::DataLayoutOption::aos, true> slicedTraversal({1, 1, 11}, nullptr);
 

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalRaceConditionTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalRaceConditionTest.cpp
@@ -30,7 +30,7 @@ TEST_F(TraversalRaceConditionTest, testRCNonDeterministic) {
   std::array<double, 3> boxMax = {(double)particlesPerDimension[0], (double)particlesPerDimension[1],
                                   (double)particlesPerDimension[2]};
 
-  NumThreadGuard(8);
+  NumThreadGuard numThreadGuard (8);
 
   /// @todo: test all containers similar to Newton3OnOffTest
   for (auto &container : {autopas::ContainerOption::linkedCells}) {

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalRaceConditionTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalRaceConditionTest.cpp
@@ -30,7 +30,7 @@ TEST_F(TraversalRaceConditionTest, testRCNonDeterministic) {
   std::array<double, 3> boxMax = {(double)particlesPerDimension[0], (double)particlesPerDimension[1],
                                   (double)particlesPerDimension[2]};
 
-  NumThreadGuard numThreadGuard (8);
+  NumThreadGuard numThreadGuard(8);
 
   /// @todo: test all containers similar to Newton3OnOffTest
   for (auto &container : {autopas::ContainerOption::linkedCells}) {

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.cpp
@@ -22,7 +22,7 @@ void testTraversal(autopas::TraversalOption traversalOption, bool useN3, const s
 
   GridGenerator::fillWithParticles<autopas::Particle>(cells, edgeLength);
 
-  NumThreadGuard(4);
+  NumThreadGuard numThreadGuard(4);
 
   autopas::TraversalSelectorInfo<FPCell> tsi(edgeLength, cutoff);
   std::unique_ptr<autopas::TraversalInterface> traversal;

--- a/tests/testAutopas/tests/containers/verletListsCells/VerletListsCellsTraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCells/VerletListsCellsTraversalTest.cpp
@@ -60,7 +60,7 @@ std::vector<unsigned long> getKernelCallsAllTraversals(autopas::VerletListsCells
  * @param numMolecules number of molecules in the container
  */
 void VerletListsCellsTraversalTest::test(unsigned long numMolecules) {
-  NumThreadGuard(1);
+  NumThreadGuard numThreadGuard(1);
 
   RandomGenerator::fillWithParticles(_verletListsCells, autopas::MoleculeLJ({0., 0., 0.}, {0., 0., 0.}, 0),
                                      numMolecules);


### PR DESCRIPTION
# Description

NumThreadGuard was always used without a name, so they were destroyed immediately, without guarding anything.

This is now fixed.