### PR TITLE
c++17 cleanup

### DIFF
--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -119,9 +119,7 @@ class AutoPas {
    * @return A vector of invalid particles that do no belong in the current container.
    */
   AUTOPAS_WARN_UNUSED_RESULT
-  std::vector<Particle> updateContainerForced() {
-    return _logicHandler->updateContainer(true);
-  }
+  std::vector<Particle> updateContainerForced() { return _logicHandler->updateContainer(true); }
 
   /**
    * Adds a particle to the container.

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -109,7 +109,8 @@ class AutoPas {
    * else will happen.
    * @return A vector of invalid particles that do no belong in the current container.
    */
-  std::vector<Particle> AUTOPAS_WARN_UNUSED_RESULT updateContainer() { return _logicHandler->updateContainer(false); }
+  AUTOPAS_WARN_UNUSED_RESULT
+  std::vector<Particle> updateContainer() { return _logicHandler->updateContainer(false); }
 
   /**
    * Forces a container update.
@@ -117,7 +118,8 @@ class AutoPas {
    * into the container.
    * @return A vector of invalid particles that do no belong in the current container.
    */
-  std::vector<Particle> AUTOPAS_WARN_UNUSED_RESULT updateContainerForced() {
+  AUTOPAS_WARN_UNUSED_RESULT
+  std::vector<Particle> updateContainerForced() {
     return _logicHandler->updateContainer(true);
   }
 

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -33,7 +33,8 @@ class LogicHandler {
    * @copydoc AutoPas::updateContainer()
    * @param forced specifies whether an update of the container is enforced.
    */
-  std::vector<Particle> AUTOPAS_WARN_UNUSED_RESULT updateContainer(bool forced) {
+  AUTOPAS_WARN_UNUSED_RESULT
+  std::vector<Particle> updateContainer(bool forced) {
     if (not isContainerValid() or forced) {
       AutoPasLog(debug, "Initiating container update.");
       _containerIsValid = false;

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -183,7 +183,8 @@ class ParticleContainerInterface {
    * container, if necessary.
    * @return A vector of invalid particles that do not belong into the container.
    */
-  virtual std::vector<Particle> AUTOPAS_WARN_UNUSED_RESULT updateContainer() = 0;
+  AUTOPAS_WARN_UNUSED_RESULT
+  virtual std::vector<Particle> updateContainer() = 0;
 
   /**
    * Check whether a container is valid, i.e. whether it is safe to use

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -97,7 +97,8 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
     traversal->endTraversal(this->_cells);
   }
 
-  std::vector<Particle> AUTOPAS_WARN_UNUSED_RESULT updateContainer() override {
+  AUTOPAS_WARN_UNUSED_RESULT
+  std::vector<Particle> updateContainer() override {
     // first we delete halo particles, as we don't want them here.
     deleteHaloParticles();
     std::vector<Particle> invalidParticles{};

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -111,7 +111,8 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
     traversal->endTraversal(this->_cells);
   }
 
-  std::vector<Particle> AUTOPAS_WARN_UNUSED_RESULT updateContainer() override {
+  AUTOPAS_WARN_UNUSED_RESULT
+  std::vector<Particle> updateContainer() override {
     this->deleteHaloParticles();
     std::vector<Particle> invalidParticles;
 #ifdef AUTOPAS_OPENMP

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -107,7 +107,8 @@ class VerletClusterLists : public ParticleContainer<Particle, FullParticleCell<P
   /**
    * @copydoc VerletLists::updateContainer()
    */
-  std::vector<Particle> AUTOPAS_WARN_UNUSED_RESULT updateContainer() override {
+  AUTOPAS_WARN_UNUSED_RESULT
+  std::vector<Particle> updateContainer() override {
     AutoPasLog(debug, "updating container");
     // first delete all particles
     this->deleteHaloParticles();

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -92,7 +92,8 @@ class VerletListsLinkedBase : public ParticleContainer<Particle, FullParticleCel
    * @copydoc autopas::ParticleContainerInterface::updateContainer()
    * @note This function invalidates the neighbor lists.
    */
-  std::vector<Particle> AUTOPAS_WARN_UNUSED_RESULT updateContainer() override {
+  AUTOPAS_WARN_UNUSED_RESULT
+  std::vector<Particle> updateContainer() override {
     AutoPasLog(debug, "updating container");
     _neighborListIsValid = false;
     return _linkedCells.updateContainer();

--- a/src/autopas/utils/AlignedAllocator.h
+++ b/src/autopas/utils/AlignedAllocator.h
@@ -20,8 +20,9 @@ namespace autopas {
 
 /**
  * Default size for a cache line.
+ * @todo C++17: replace value by std::hardware_destructive_interference_size
+ * not yet possible: as of 27.06.2019 this(P0154R1) is in neither libstc++ (gnu) nor libc++ (clang)
  */
-// @todo C++17: replace value by std::hardware_destructive_interference_size
 constexpr unsigned int DEFAULT_CACHE_LINE_SIZE{64};
 
 /**

--- a/src/autopas/utils/AutoPasMacros.h
+++ b/src/autopas/utils/AutoPasMacros.h
@@ -6,15 +6,8 @@
 
 #pragma once
 
-#if defined(__GNUC__) or defined(__clang__)
 /**
- * For gcc + clang: warn if return value is not used.
- * @todo c++17: __attribute__((warn_unused_result)) should be replaced with [[nodiscard]]
+ * Highly encourages the compiler to produce a warning if the return value is ignored.
+ * @note: this is c++17
  */
-#define AUTOPAS_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
-#else
-/**
- * empty if not gnu
- */
-#define AUTOPAS_WARN_UNUSED_RESULT
-#endif
+#define AUTOPAS_WARN_UNUSED_RESULT [[nodiscard]]

--- a/src/autopas/utils/SoA.h
+++ b/src/autopas/utils/SoA.h
@@ -218,10 +218,8 @@ class SoA {
   // actual implementation of append
   template <std::size_t... Is>
   void append_impl(utils::SoAStorage<SoAArraysType> &valArrays, std::index_sequence<Is...>) {
-    // @TODO: This is a rather bad solution, but necessary since C++14 lacks fold expressions
-    // @TODO: C++17: replace by (appendSingleArray<Is>(valArrays),...);
-    int unusedArray[] = {(appendSingleArray<Is>(valArrays), 0)...};
-    (void)unusedArray;  // avoid unused variable warning
+    // fold expression
+    (appendSingleArray<Is>(valArrays), ...);
   }
 
   // ------------- members ---------------

--- a/tests/testAutopas/mocks/MockVerletLists.h
+++ b/tests/testAutopas/mocks/MockVerletLists.h
@@ -37,7 +37,8 @@ class MockVerletLists : public autopas::VerletLists<Particle> {
 
   void addParticleVerletLists(Particle &p) { autopas::VerletLists<Particle>::addParticle(p); }
   void addHaloParticleVerletLists(Particle &p) { autopas::VerletLists<Particle>::addHaloParticle(p); }
-  std::vector<Particle> AUTOPAS_WARN_UNUSED_RESULT updateContainerVerletLists() {
+  AUTOPAS_WARN_UNUSED_RESULT
+  std::vector<Particle> updateContainerVerletLists() {
     return autopas::VerletLists<Particle>::updateContainer();
   }
 

--- a/tests/testAutopas/mocks/MockVerletLists.h
+++ b/tests/testAutopas/mocks/MockVerletLists.h
@@ -38,9 +38,7 @@ class MockVerletLists : public autopas::VerletLists<Particle> {
   void addParticleVerletLists(Particle &p) { autopas::VerletLists<Particle>::addParticle(p); }
   void addHaloParticleVerletLists(Particle &p) { autopas::VerletLists<Particle>::addHaloParticle(p); }
   AUTOPAS_WARN_UNUSED_RESULT
-  std::vector<Particle> updateContainerVerletLists() {
-    return autopas::VerletLists<Particle>::updateContainer();
-  }
+  std::vector<Particle> updateContainerVerletLists() { return autopas::VerletLists<Particle>::updateContainer(); }
 
   friend class VerletListsTest_testRebuildFrequencyAlways_Test;
   friend class VerletListsTest_testRebuildFrequencyEvery3_Test;


### PR DESCRIPTION
# Description

Implements some c++17 changes, to make the code more readable or work better.

- [x] Use fold expression in SoA.h
- [x] Use `[[nodiscard]]` instead of `__attribute__((warn_unused_result))`
- cannot use std::hardware_destructive_interference_size, as this can only be found in the microsoft library, see: P0154R1 in https://en.cppreference.com/w/cpp/compiler_support#cpp17
