### PR TITLE
ignore data race from #285

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Alternatively you can build the documentation on your own:
 * `make doc_doxygen`
 
 ## Requirements
-* cmake 3.13 or newer
+* cmake 3.14 or newer
 * make (build-essentials) or ninja
-* a c++17 compiler (gcc7, clang8 and icpc 2018 are tested)
+* a c++17 compiler (gcc7, clang8 and icpc 2019 are tested)
 
 ## Building AutoPas
 build instructions for make:

--- a/src/autopas/pairwiseFunctors/LJFunctor.h
+++ b/src/autopas/pairwiseFunctors/LJFunctor.h
@@ -146,8 +146,15 @@ class LJFunctor : public Functor<Particle, ParticleCell, typename Particle::SoAA
    * @copydoc Functor::SoAFunctor(SoA<SoAArraysType> &soa, bool newton3)
    * This functor ignores will use a newton3 like traversing of the soa, however, it still needs to know about newton3
    * to use it correctly for the global values.
+   * @todo: Remove __attribute__((no_sanitize_thread)) when #285 is fixed.
    */
-  void SoAFunctor(SoA<SoAArraysType> &soa, bool newton3) override {
+  void
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+      __attribute__((no_sanitize_thread))
+#endif
+#endif
+      SoAFunctor(SoA<SoAArraysType> &soa, bool newton3) override {
     if (soa.getNumParticles() == 0) return;
 
     const auto *const __restrict__ xptr = soa.template begin<Particle::AttributeNames::posX>();


### PR DESCRIPTION
adds ignore to SoAFunctor() for the thread sanitizer to block a data race currently detected in C01Traversal using the combined mechanism, see #285

## Related Issues
- blocks data race from #285
