### PR TITLE
mark libs as library in lgtm

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,3 +1,6 @@
+path_classifiers:
+  library:
+    - include: "libs/*"
 extraction:
   cpp:
     prepare:    # Customizable step used by all languages.


### PR DESCRIPTION
# Description

Mark the `libs` directory as library in `.lgtm.yml` to tell lgtm not to spawn errors found in the libraries.