### PR TITLE
Functor refactoring

### DIFF
--- a/src/autopas/containers/linkedCells/traversals/C01Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/C01Traversal.h
@@ -107,7 +107,7 @@ class C01Traversal
    */
   template <std::size_t... I>
   inline constexpr void appendNeeded(ParticleCell &cell, ParticleCell &appendCell, std::index_sequence<I...>) {
-    cell._particleSoABuffer.template append<PairwiseFunctor::neededAttr[I]...>(appendCell._particleSoABuffer);
+    cell._particleSoABuffer.template append<PairwiseFunctor::getNeededAttr()[I]...>(appendCell._particleSoABuffer);
   }
 
   /**
@@ -200,7 +200,7 @@ inline void C01Traversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3, 
           const unsigned long otherIndex = baseIndex + offset.first;
           ParticleCell &otherCell = cells[otherIndex];
           appendNeeded(combinationSlice[offsetSlice], otherCell,
-                       std::make_index_sequence<PairwiseFunctor::neededAttr.size()>{});
+                       std::make_index_sequence<PairwiseFunctor::getNeededAttr().size()>{});
         }
       }
     } else {
@@ -224,7 +224,7 @@ inline void C01Traversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3, 
           const unsigned long otherIndex = baseIndex + _cellOffsets[i][offsetIndex].first;
           ParticleCell &otherCell = cells[otherIndex];
           appendNeeded(combinationSlice[slice], otherCell,
-                       std::make_index_sequence<PairwiseFunctor::neededAttr.size()>{});
+                       std::make_index_sequence<PairwiseFunctor::getNeededAttr().size()>{});
         }
       }
 
@@ -234,7 +234,7 @@ inline void C01Traversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3, 
         const unsigned long otherIndex = baseIndex + offset.first;
         ParticleCell &otherCell = cells[otherIndex];
         appendNeeded(combinationSlice[currentSlice], otherCell,
-                     std::make_index_sequence<PairwiseFunctor::neededAttr.size()>{});
+                     std::make_index_sequence<PairwiseFunctor::getNeededAttr().size()>{});
       }
 
       ++currentSlice %= cOffSize;

--- a/src/autopas/containers/linkedCells/traversals/C01Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/C01Traversal.h
@@ -112,7 +112,8 @@ class C01Traversal
   }
 
   /**
-   * Resizes all buffers needed for combined SoA buffers.
+   * Resizes all buffers needed for combined SoA buffers (_combinationSlices, _currentSlices) to fit the current number
+   * of threads and cell offsets (= _cellOffsets.size()).
    */
   void resizeBuffers();
 

--- a/src/autopas/containers/linkedCells/traversals/C01Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/C01Traversal.h
@@ -296,8 +296,8 @@ inline void C01Traversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3, 
   if (not this->isApplicable()) {
     if constexpr (combineSoA) {
       utils::ExceptionHandler::exception(
-          "The C01 traversal with combined SoA buffers cannot work with enabled newton3 (unless only one thread is "
-          "used) and data layout AoS!");
+          "The C01 traversal with combined SoA buffers cannot work with data layout AoS and enabled newton3 (unless "
+          "only one thread is used)!");
     } else {
       utils::ExceptionHandler::exception(
           "The C01 traversal cannot work with enabled newton3 (unless only one thread is used)!");

--- a/src/autopas/containers/linkedCells/traversals/C01Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/C01Traversal.h
@@ -107,7 +107,8 @@ class C01Traversal
    */
   template <std::size_t... I>
   inline constexpr void appendNeeded(ParticleCell &cell, ParticleCell &appendCell, std::index_sequence<I...>) {
-    cell._particleSoABuffer.template append<PairwiseFunctor::getNeededAttr()[I]...>(appendCell._particleSoABuffer);
+    cell._particleSoABuffer.template append<std::get<I>(PairwiseFunctor::getNeededAttr(std::false_type()))...>(
+        appendCell._particleSoABuffer);
   }
 
   /**
@@ -200,7 +201,7 @@ inline void C01Traversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3, 
           const unsigned long otherIndex = baseIndex + offset.first;
           ParticleCell &otherCell = cells[otherIndex];
           appendNeeded(combinationSlice[offsetSlice], otherCell,
-                       std::make_index_sequence<PairwiseFunctor::getNeededAttr().size()>{});
+                       std::make_index_sequence<PairwiseFunctor::getNeededAttr(std::false_type()).size()>{});
         }
       }
     } else {
@@ -224,7 +225,7 @@ inline void C01Traversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3, 
           const unsigned long otherIndex = baseIndex + _cellOffsets[i][offsetIndex].first;
           ParticleCell &otherCell = cells[otherIndex];
           appendNeeded(combinationSlice[slice], otherCell,
-                       std::make_index_sequence<PairwiseFunctor::getNeededAttr().size()>{});
+                       std::make_index_sequence<PairwiseFunctor::getNeededAttr(std::false_type()).size()>{});
         }
       }
 
@@ -234,7 +235,7 @@ inline void C01Traversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3, 
         const unsigned long otherIndex = baseIndex + offset.first;
         ParticleCell &otherCell = cells[otherIndex];
         appendNeeded(combinationSlice[currentSlice], otherCell,
-                     std::make_index_sequence<PairwiseFunctor::getNeededAttr().size()>{});
+                     std::make_index_sequence<PairwiseFunctor::getNeededAttr(std::false_type()).size()>{});
       }
 
       ++currentSlice %= cOffSize;

--- a/src/autopas/containers/linkedCells/traversals/C01Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/C01Traversal.h
@@ -200,7 +200,7 @@ inline void C01Traversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3, 
           const unsigned long otherIndex = baseIndex + offset.first;
           ParticleCell &otherCell = cells[otherIndex];
           appendNeeded(combinationSlice[offsetSlice], otherCell,
-                       std::make_index_sequence<std::size(PairwiseFunctor::neededAttr)>{});
+                       std::make_index_sequence<PairwiseFunctor::neededAttr.size()>{});
         }
       }
     } else {
@@ -224,7 +224,7 @@ inline void C01Traversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3, 
           const unsigned long otherIndex = baseIndex + _cellOffsets[i][offsetIndex].first;
           ParticleCell &otherCell = cells[otherIndex];
           appendNeeded(combinationSlice[slice], otherCell,
-                       std::make_index_sequence<std::size(PairwiseFunctor::neededAttr)>{});
+                       std::make_index_sequence<PairwiseFunctor::neededAttr.size()>{});
         }
       }
 
@@ -233,7 +233,8 @@ inline void C01Traversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3, 
       for (const auto &offset : _cellOffsets.back()) {
         const unsigned long otherIndex = baseIndex + offset.first;
         ParticleCell &otherCell = cells[otherIndex];
-        combinationSlice[currentSlice]._particleSoABuffer.append(otherCell._particleSoABuffer);
+        appendNeeded(combinationSlice[currentSlice], otherCell,
+                     std::make_index_sequence<PairwiseFunctor::neededAttr.size()>{});
       }
 
       ++currentSlice %= cOffSize;

--- a/src/autopas/containers/linkedCells/traversals/C18Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/C18Traversal.h
@@ -176,14 +176,14 @@ void C18Traversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>::proces
 
   ParticleCell &baseCell = cells[baseIndex];
   offsetArray_t &offsets = this->_cellOffsets[yArray][xArray];
-  for (const auto &offset : offsets) {
-    unsigned long otherIndex = baseIndex + offset.first;
+  for (auto const &[offset, r] : offsets) {
+    unsigned long otherIndex = baseIndex + offset;
     ParticleCell &otherCell = cells[otherIndex];
 
     if (baseIndex == otherIndex) {
       this->_cellFunctor.processCell(baseCell);
     } else {
-      this->_cellFunctor.processCellPair(baseCell, otherCell, offset.second);
+      this->_cellFunctor.processCellPair(baseCell, otherCell, r);
     }
   }
 }

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
@@ -195,18 +195,7 @@ class VerletListHelpers {
              /*AttributeNames::id,     AttributeNames::posX,   AttributeNames::posY,
               AttributeNames::posZ*/};
 
-    constexpr static std::array<int, 3> computedAttr{AttributeNames::forceX, AttributeNames::forceY,
-                                                     AttributeNames::forceZ};
-    /**
-     * SoAExtractor for verlet list generation.
-     * Currently empty.
-     * @param cell
-     * @param soa
-     * @param offset
-     */
-    void SoAExtractor(ParticleCell_t &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override {
-      // nothing yet...
-    }
+    constexpr static std::array<int, 0> computedAttr{/*nothing yet...*/};
 
    private:
     AoS_verletlist_storage_type &_verletListsAoS;

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
@@ -36,7 +36,7 @@ class VerletListHelpers {
    * This functor can generate verlet lists using the typical pairwise
    * traversal.
    */
-  class VerletListGeneratorFunctor : public autopas::Functor<Particle, VerletListParticleCellType, SoAArraysType> {
+  class VerletListGeneratorFunctor : public Functor<Particle, VerletListParticleCellType, SoAArraysType> {
     typedef VerletListParticleCellType ParticleCell_t;
 
    public:
@@ -169,7 +169,9 @@ class VerletListHelpers {
      * @param offset
      */
     void SoALoader(ParticleCell<Particle> &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override {
-      assert(offset == 0);
+      if (offset > 0) {
+        utils::ExceptionHandler::exception("VerletListGeneratorFunctor: requires offset > 0");
+      }
       soa.resizeArrays(cell.numParticles());
 
       if (cell.numParticles() == 0) return;
@@ -217,7 +219,7 @@ class VerletListHelpers {
    * @tparam ParticleCell
    */
   template <class ParticleCell>
-  class VerletListValidityCheckerFunctor : public autopas::Functor<Particle, ParticleCell, SoAArraysType> {
+  class VerletListValidityCheckerFunctor : public Functor<Particle, ParticleCell, SoAArraysType> {
    public:
     /**
      * Constructor

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
@@ -36,8 +36,9 @@ class VerletListHelpers {
    * This functor can generate verlet lists using the typical pairwise
    * traversal.
    */
-  class VerletListGeneratorFunctor : public autopas::Functor<Particle, VerletListParticleCellType, SoAArraysType> {
-    typedef VerletListParticleCellType ParticleCell;
+  class VerletListGeneratorFunctor
+      : public autopas::Functor<Particle, VerletListParticleCellType, SoAArraysType, VerletListGeneratorFunctor> {
+    typedef VerletListParticleCellType ParticleCell_t;
 
    public:
     /**
@@ -166,7 +167,7 @@ class VerletListHelpers {
      * @param soa
      * @param offset
      */
-    void SoALoader(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override {
+    void SoALoader(ParticleCell<Particle> &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override {
       assert(offset == 0);
       soa.resizeArrays(cell.numParticles());
 
@@ -188,6 +189,12 @@ class VerletListHelpers {
       }
     }
 
+    constexpr static std::array<int, 0> neededAttr{
+             /*AttributeNames::id,     AttributeNames::posX,   AttributeNames::posY,
+              AttributeNames::posZ*/};
+
+    constexpr static std::array<int, 3> computedAttr{AttributeNames::forceX, AttributeNames::forceY,
+                                                     AttributeNames::forceZ};
     /**
      * SoAExtractor for verlet list generation.
      * Currently empty.
@@ -195,7 +202,7 @@ class VerletListHelpers {
      * @param soa
      * @param offset
      */
-    void SoAExtractor(ParticleCell &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override {
+    void SoAExtractor(ParticleCell_t &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override {
       // nothing yet...
     }
 

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
@@ -36,8 +36,7 @@ class VerletListHelpers {
    * This functor can generate verlet lists using the typical pairwise
    * traversal.
    */
-  class VerletListGeneratorFunctor
-      : public autopas::Functor<Particle, VerletListParticleCellType, SoAArraysType, VerletListGeneratorFunctor> {
+  class VerletListGeneratorFunctor : public autopas::Functor<Particle, VerletListParticleCellType, SoAArraysType> {
     typedef VerletListParticleCellType ParticleCell_t;
 
    public:
@@ -47,7 +46,7 @@ class VerletListHelpers {
      * @param cutoffskin
      */
     VerletListGeneratorFunctor(AoS_verletlist_storage_type &verletListsAoS, double cutoffskin)
-        : Functor<Particle, VerletListParticleCellType, SoAArraysType, VerletListGeneratorFunctor>(cutoffskin),
+        : Functor<Particle, VerletListParticleCellType, SoAArraysType>(cutoffskin),
           _verletListsAoS(verletListsAoS),
           _cutoffskinsquared(cutoffskin * cutoffskin) {}
 
@@ -191,11 +190,17 @@ class VerletListHelpers {
       }
     }
 
-    constexpr static std::array<int, 0> neededAttr{
-             /*AttributeNames::ptr,     AttributeNames::posX,   AttributeNames::posY,
-              AttributeNames::posZ*/};
+    /**
+     * Attributes needed for computation.
+     * @note This attribute is not used be Functor to load values into the SoA buffer.
+     */
+    constexpr static const std::array<AttributeNames, 4> neededAttr{AttributeNames::ptr, AttributeNames::posX,
+                                                                    AttributeNames::posY, AttributeNames::posZ};
 
-    constexpr static std::array<int, 0> computedAttr{/*nothing yet...*/};
+    /**
+     * Attributes computed by this functor.
+     */
+    constexpr static const std::array<AttributeNames, 0> computedAttr{/*nothing yet...*/};
 
    private:
     AoS_verletlist_storage_type &_verletListsAoS;

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
@@ -193,16 +193,19 @@ class VerletListHelpers {
     }
 
     /**
-     * Attributes needed for computation.
-     * @note This attribute is not used be Functor to load values into the SoA buffer.
+     * @copydoc Functor::getNeededAttr()
      */
-    constexpr static const std::array<AttributeNames, 4> neededAttr{AttributeNames::ptr, AttributeNames::posX,
-                                                                    AttributeNames::posY, AttributeNames::posZ};
+    constexpr static const std::array<typename Particle::AttributeNames, 4> getNeededAttr() {
+      return std::array<typename Particle::AttributeNames, 4>{AttributeNames::ptr, AttributeNames::posX,
+                                                              AttributeNames::posY, AttributeNames::posZ};
+    }
 
     /**
-     * Attributes computed by this functor.
+     * @copydoc Functor::getComputedAttr()
      */
-    constexpr static const std::array<AttributeNames, 0> computedAttr{/*nothing yet...*/};
+    constexpr static const std::array<typename Particle::AttributeNames, 0> getComputedAttr() {
+      return std::array<typename Particle::AttributeNames, 0>{/*Nothing*/};
+    }
 
    private:
     AoS_verletlist_storage_type &_verletListsAoS;

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
@@ -24,10 +24,10 @@ class VerletListHelpers {
   typedef std::unordered_map<Particle *, std::vector<Particle *>> AoS_verletlist_storage_type;
 
   /// typedef for soa's of verlet list's linked cells (only id and position needs to be stored)
-  typedef utils::SoAType<size_t, double, double, double>::Type SoAArraysType;
+  typedef typename utils::SoAType<Particle *, double, double, double>::Type SoAArraysType;
 
   /// attributes for soa's of verlet list's linked cells (only id and position needs to be stored)
-  enum AttributeNames : int { id, posX, posY, posZ };
+  enum AttributeNames : int { ptr, posX, posY, posZ };
 
   /// typedef for verlet-list particle cell type
   typedef FullParticleCell<Particle, SoAArraysType> VerletListParticleCellType;
@@ -88,14 +88,14 @@ class VerletListHelpers {
     void SoAFunctor(SoA<SoAArraysType> &soa, bool newton3) override {
       if (soa.getNumParticles() == 0) return;
 
-      auto **const __restrict__ idptr = reinterpret_cast<Particle **const>(soa.begin<AttributeNames::id>());
-      double *const __restrict__ xptr = soa.begin<AttributeNames::posX>();
-      double *const __restrict__ yptr = soa.begin<AttributeNames::posY>();
-      double *const __restrict__ zptr = soa.begin<AttributeNames::posZ>();
+      auto **const __restrict__ ptrptr = soa.template begin<AttributeNames::ptr>();
+      double *const __restrict__ xptr = soa.template begin<AttributeNames::posX>();
+      double *const __restrict__ yptr = soa.template begin<AttributeNames::posY>();
+      double *const __restrict__ zptr = soa.template begin<AttributeNames::posZ>();
 
       size_t numPart = soa.getNumParticles();
       for (unsigned int i = 0; i < numPart; ++i) {
-        auto &currentList = _verletListsAoS.at(idptr[i]);
+        auto &currentList = _verletListsAoS.at(ptrptr[i]);
 
         for (unsigned int j = i + 1; j < numPart; ++j) {
           const double drx = xptr[i] - xptr[j];
@@ -109,10 +109,10 @@ class VerletListHelpers {
           const double dr2 = drx2 + dry2 + drz2;
 
           if (dr2 < _cutoffskinsquared) {
-            currentList.push_back(idptr[j]);
+            currentList.push_back(ptrptr[j]);
             if (not newton3) {
               // we need this here, as SoAFunctor(soa) will only be called once for both newton3=true and false.
-              _verletListsAoS.at(idptr[j]).push_back(idptr[i]);
+              _verletListsAoS.at(ptrptr[j]).push_back(ptrptr[i]);
             }
           }
         }
@@ -128,19 +128,19 @@ class VerletListHelpers {
     void SoAFunctor(SoA<SoAArraysType> &soa1, SoA<SoAArraysType> &soa2, bool /*newton3*/) override {
       if (soa1.getNumParticles() == 0 || soa2.getNumParticles() == 0) return;
 
-      auto **const __restrict__ id1ptr = reinterpret_cast<Particle **const>(soa1.begin<AttributeNames::id>());
-      double *const __restrict__ x1ptr = soa1.begin<AttributeNames::posX>();
-      double *const __restrict__ y1ptr = soa1.begin<AttributeNames::posY>();
-      double *const __restrict__ z1ptr = soa1.begin<AttributeNames::posZ>();
+      auto **const __restrict__ ptr1ptr = soa1.template begin<AttributeNames::ptr>();
+      double *const __restrict__ x1ptr = soa1.template begin<AttributeNames::posX>();
+      double *const __restrict__ y1ptr = soa1.template begin<AttributeNames::posY>();
+      double *const __restrict__ z1ptr = soa1.template begin<AttributeNames::posZ>();
 
-      auto **const __restrict__ id2ptr = reinterpret_cast<Particle **const>(soa2.begin<AttributeNames::id>());
-      double *const __restrict__ x2ptr = soa2.begin<AttributeNames::posX>();
-      double *const __restrict__ y2ptr = soa2.begin<AttributeNames::posY>();
-      double *const __restrict__ z2ptr = soa2.begin<AttributeNames::posZ>();
+      auto **const __restrict__ ptr2ptr = soa2.template begin<AttributeNames::ptr>();
+      double *const __restrict__ x2ptr = soa2.template begin<AttributeNames::posX>();
+      double *const __restrict__ y2ptr = soa2.template begin<AttributeNames::posY>();
+      double *const __restrict__ z2ptr = soa2.template begin<AttributeNames::posZ>();
 
       size_t numPart1 = soa1.getNumParticles();
       for (unsigned int i = 0; i < numPart1; ++i) {
-        auto &currentList = _verletListsAoS.at(id1ptr[i]);
+        auto &currentList = _verletListsAoS.at(ptr1ptr[i]);
 
         size_t numPart2 = soa2.getNumParticles();
 
@@ -156,7 +156,7 @@ class VerletListHelpers {
           const double dr2 = drx2 + dry2 + drz2;
 
           if (dr2 < _cutoffskinsquared) {
-            currentList.push_back(id2ptr[j]);
+            currentList.push_back(ptr2ptr[j]);
           }
         }
       }
@@ -175,16 +175,16 @@ class VerletListHelpers {
 
       if (cell.numParticles() == 0) return;
 
-      unsigned long *const __restrict__ idptr = soa.begin<AttributeNames::id>();
-      double *const __restrict__ xptr = soa.begin<AttributeNames::posX>();
-      double *const __restrict__ yptr = soa.begin<AttributeNames::posY>();
-      double *const __restrict__ zptr = soa.begin<AttributeNames::posZ>();
+      auto *const __restrict__ ptrptr = soa.template begin<AttributeNames::ptr>();
+      double *const __restrict__ xptr = soa.template begin<AttributeNames::posX>();
+      double *const __restrict__ yptr = soa.template begin<AttributeNames::posY>();
+      double *const __restrict__ zptr = soa.template begin<AttributeNames::posZ>();
 
       auto cellIter = cell.begin();
       // load particles in SoAs
       for (size_t i = 0; cellIter.isValid(); ++cellIter, ++i) {
         Particle *pptr = &(*cellIter);
-        idptr[i] = reinterpret_cast<std::uintptr_t>(pptr);
+        ptrptr[i] = pptr;
         xptr[i] = cellIter->getR()[0];
         yptr[i] = cellIter->getR()[1];
         zptr[i] = cellIter->getR()[2];
@@ -192,7 +192,7 @@ class VerletListHelpers {
     }
 
     constexpr static std::array<int, 0> neededAttr{
-             /*AttributeNames::id,     AttributeNames::posX,   AttributeNames::posY,
+             /*AttributeNames::ptr,     AttributeNames::posX,   AttributeNames::posY,
               AttributeNames::posZ*/};
 
     constexpr static std::array<int, 0> computedAttr{/*nothing yet...*/};

--- a/src/autopas/pairwiseFunctors/FlopCounterFunctor.h
+++ b/src/autopas/pairwiseFunctors/FlopCounterFunctor.h
@@ -333,12 +333,6 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell, typename Parti
   constexpr static std::array<typename Particle::AttributeNames, 0> computedAttr{/*Nothing*/};
 
   /**
-   * Empty SoAExtractor.
-   * Nothing to be done yet.
-   */
-  AUTOPAS_FUNCTOR_SOAEXTRACTOR(, , , )
-
-  /**
    * get the hit rate of the pair-wise interaction, i.e. the ratio of the number
    * of kernel calls compared to the number of distance calculations
    * @return the hit rate

--- a/src/autopas/pairwiseFunctors/FlopCounterFunctor.h
+++ b/src/autopas/pairwiseFunctors/FlopCounterFunctor.h
@@ -328,15 +328,19 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell, typename Parti
   }
 
   /**
-   * Attributes needed for computation.
+   * @copydoc Functor::getNeededAttr()
    */
-  constexpr static const std::array<typename Particle::AttributeNames, 3> neededAttr{
-      Particle::AttributeNames::posX, Particle::AttributeNames::posY, Particle::AttributeNames::posZ};
+  constexpr static const std::array<typename Particle::AttributeNames, 3> getNeededAttr() {
+    return std::array<typename Particle::AttributeNames, 3>{
+        Particle::AttributeNames::posX, Particle::AttributeNames::posY, Particle::AttributeNames::posZ};
+  }
 
   /**
-   * Attributes computed by this functor.
+   * @copydoc Functor::getComputedAttr()
    */
-  constexpr static const std::array<typename Particle::AttributeNames, 0> computedAttr{/*Nothing*/};
+  constexpr static const std::array<typename Particle::AttributeNames, 0> getComputedAttr() {
+    return std::array<typename Particle::AttributeNames, 0>{/*Nothing*/};
+  }
 
   /**
    * get the hit rate of the pair-wise interaction, i.e. the ratio of the number

--- a/src/autopas/pairwiseFunctors/FlopCounterFunctor.h
+++ b/src/autopas/pairwiseFunctors/FlopCounterFunctor.h
@@ -336,6 +336,13 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell, typename Parti
   }
 
   /**
+   * @copydoc Functor::getNeededAttr(std::false_type)
+   */
+  constexpr static const std::array<typename Particle::AttributeNames, 3> getNeededAttr(std::false_type) {
+    return getNeededAttr();
+  }
+
+  /**
    * @copydoc Functor::getComputedAttr()
    */
   constexpr static const std::array<typename Particle::AttributeNames, 0> getComputedAttr() {

--- a/src/autopas/pairwiseFunctors/FlopCounterFunctor.h
+++ b/src/autopas/pairwiseFunctors/FlopCounterFunctor.h
@@ -38,7 +38,7 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell> {
    * @param cutoffRadius the cutoff radius
    */
   explicit FlopCounterFunctor<Particle, ParticleCell>(double cutoffRadius)
-      : autopas::Functor<Particle, ParticleCell>(),
+      : Functor<Particle, ParticleCell>(),
         _cutoffSquare(cutoffRadius * cutoffRadius),
         _distanceCalculations(0ul),
         _kernelCalls(0ul) {}

--- a/src/autopas/pairwiseFunctors/FlopCounterFunctor.h
+++ b/src/autopas/pairwiseFunctors/FlopCounterFunctor.h
@@ -327,10 +327,16 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell, typename Parti
 #endif
   }
 
-  constexpr static std::array<typename Particle::AttributeNames, 3> neededAttr{
+  /**
+   * Attributes needed for computation.
+   */
+  constexpr static const std::array<typename Particle::AttributeNames, 3> neededAttr{
       Particle::AttributeNames::posX, Particle::AttributeNames::posY, Particle::AttributeNames::posZ};
 
-  constexpr static std::array<typename Particle::AttributeNames, 0> computedAttr{/*Nothing*/};
+  /**
+   * Attributes computed by this functor.
+   */
+  constexpr static const std::array<typename Particle::AttributeNames, 0> computedAttr{/*Nothing*/};
 
   /**
    * get the hit rate of the pair-wise interaction, i.e. the ratio of the number

--- a/src/autopas/pairwiseFunctors/FlopCounterFunctor.h
+++ b/src/autopas/pairwiseFunctors/FlopCounterFunctor.h
@@ -343,6 +343,11 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell> {
                               zptr[i] = cellIter->getR()[2];
                             })
 
+  constexpr static std::array<typename Particle::AttributeNames, 3> neededAttr{
+      Particle::AttributeNames::posX, Particle::AttributeNames::posY, Particle::AttributeNames::posZ};
+
+  constexpr static std::array<typename Particle::AttributeNames, 0> computedAttr{/*Nothing*/};
+
   /**
    * Empty SoAExtractor.
    * Nothing to be done yet.

--- a/src/autopas/pairwiseFunctors/Functor.h
+++ b/src/autopas/pairwiseFunctors/Functor.h
@@ -27,6 +27,7 @@ class VerletListHelpers;
 namespace internal {
 /**
  * Dummy class to provide empty arrays.
+ * This class is needed to provide a default argument to the implementation type (Impl_t) template parameter of Functor.
  * @tparam Particle
  */
 template <class Particle>

--- a/src/autopas/pairwiseFunctors/Functor.h
+++ b/src/autopas/pairwiseFunctors/Functor.h
@@ -30,11 +30,17 @@ namespace internal {
  * @tparam Particle
  */
 template <class Particle>
-class Dummy {
+class Dummy final {
  public:
-  constexpr static std::array<typename Particle::AttributeNames, 0> neededAttr{};
+  /**
+   * Attributes needed for computation.
+   */
+  constexpr static const std::array<typename Particle::AttributeNames, 0> neededAttr{};
 
-  constexpr static std::array<typename Particle::AttributeNames, 0> computedAttr{};
+  /**
+   * Attributes computed by this functor.
+   */
+  constexpr static const std::array<typename Particle::AttributeNames, 0> computedAttr{};
 };
 }  // namespace internal
 

--- a/src/autopas/pairwiseFunctors/Functor.h
+++ b/src/autopas/pairwiseFunctors/Functor.h
@@ -301,7 +301,6 @@ class Functor {
    */
   template <typename cell_t, std::size_t... I>
   void SoAExtractorImpl(cell_t &cell, ::autopas::SoA<SoAArraysType> &soa, size_t offset, std::index_sequence<I...>) {
-    soa.resizeArrays(offset + cell.numParticles());
 
     if (cell.numParticles() == 0) return;
 

--- a/src/autopas/pairwiseFunctors/Functor.h
+++ b/src/autopas/pairwiseFunctors/Functor.h
@@ -282,7 +282,8 @@ class Functor {
 
     if (cell.numParticles() == 0) return;
 
-    auto const pointer = std::make_tuple(soa.template begin<Impl_t::neededAttr[I]>()...);
+    // maybe_unused necessary because gcc doesnt understand that pointer is used later
+    [[maybe_unused]] auto const pointer = std::make_tuple(soa.template begin<Impl_t::neededAttr[I]>()...);
 
     auto cellIter = cell.begin();
     // load particles in SoAs
@@ -304,7 +305,8 @@ class Functor {
 
     if (cell.numParticles() == 0) return;
 
-    auto const pointer = std::make_tuple(soa.template begin<Impl_t::computedAttr[I]>()...);
+    // maybe_unused necessary because gcc doesnt understand that pointer is used later
+    [[maybe_unused]] auto const pointer = std::make_tuple(soa.template begin<Impl_t::computedAttr[I]>()...);
 
     auto cellIter = cell.begin();
     // load particles in SoAs

--- a/src/autopas/pairwiseFunctors/Functor.h
+++ b/src/autopas/pairwiseFunctors/Functor.h
@@ -33,14 +33,18 @@ template <class Particle>
 class Dummy final {
  public:
   /**
-   * Attributes needed for computation.
+   * @copydoc Functor::getNeededAttr()
    */
-  constexpr static const std::array<typename Particle::AttributeNames, 0> neededAttr{};
+  constexpr static const std::array<typename Particle::AttributeNames, 0> getNeededAttr() {
+    return std::array<typename Particle::AttributeNames, 0>{};
+  }
 
   /**
-   * Attributes computed by this functor.
+   * @copydoc Functor::getComputedAttr()
    */
-  constexpr static const std::array<typename Particle::AttributeNames, 0> computedAttr{};
+  constexpr static const std::array<typename Particle::AttributeNames, 0> getComputedAttr() {
+    return std::array<typename Particle::AttributeNames, 0>{};
+  }
 };
 }  // namespace internal
 
@@ -96,16 +100,22 @@ class Functor {
   }
 
   /**
-   * Attributes needed for computation.
-   * @note Should be shadowed by child class.
+   * Get attributes needed for computation.
+   * @return Attributes needed for computation.
+   * @todo C++20: make this function virtual
    */
-  constexpr static const std::array<typename Particle::AttributeNames, 0> neededAttr{};
+  constexpr static const std::array<typename Particle::AttributeNames, 0> getNeededAttr() {
+    return std::array<typename Particle::AttributeNames, 0>{};
+  }
 
   /**
-   * Attributes computed by this functor.
-   * @note Should be shadowed by child class.
+   * Get attributes computed by this functor.
+   * @return Attributes computed by this functor.
+   * @todo C++20: make this function virtual
    */
-  constexpr static const std::array<typename Particle::AttributeNames, 0> computedAttr{};
+  constexpr static const std::array<typename Particle::AttributeNames, 0> getComputedAttr() {
+    return std::array<typename Particle::AttributeNames, 0>{};
+  }
 
   /**
    * @brief Functor for structure of arrays (SoA)
@@ -219,7 +229,7 @@ class Functor {
    * to the SoA with the specified offset.
    */
   virtual void SoALoader(ParticleCell<Particle> &cell, ::autopas::SoA<SoAArraysType> &soa, size_t offset = 0) {
-    SoALoaderImpl(cell, soa, offset, std::make_index_sequence<Impl_t::neededAttr.size()>{});
+    SoALoaderImpl(cell, soa, offset, std::make_index_sequence<Impl_t::getNeededAttr().size()>{});
   }
 
   /**
@@ -231,7 +241,7 @@ class Functor {
    * extracted starting at offset.
    */
   virtual void SoAExtractor(ParticleCell<Particle> &cell, ::autopas::SoA<SoAArraysType> &soa, size_t offset = 0) {
-    SoAExtractorImpl(cell, soa, offset, std::make_index_sequence<Impl_t::computedAttr.size()>{});
+    SoAExtractorImpl(cell, soa, offset, std::make_index_sequence<Impl_t::getComputedAttr().size()>{});
   }
 
   /**
@@ -305,7 +315,7 @@ class Functor {
      * in the following loop.
      */
     // maybe_unused necessary because gcc doesnt understand that pointer is used later
-    [[maybe_unused]] auto const pointer = std::make_tuple(soa.template begin<Impl_t::neededAttr[I]>()...);
+    [[maybe_unused]] auto const pointer = std::make_tuple(soa.template begin<Impl_t::getNeededAttr()[I]>()...);
 
     auto cellIter = cell.begin();
     // load particles in SoAs
@@ -317,7 +327,7 @@ class Functor {
        * ((std::get<0>(pointer)[i] = cellIter->template get<Impl_t::neededAttr[0]>()),
        * (std::get<1>(pointer)[i] = cellIter->template get<Impl_t::neededAttr[1]>()))
        */
-      ((std::get<I>(pointer)[i] = cellIter->template get<Impl_t::neededAttr[I]>()), ...);
+      ((std::get<I>(pointer)[i] = cellIter->template get<Impl_t::getNeededAttr()[I]>()), ...);
     }
   }
 
@@ -338,7 +348,7 @@ class Functor {
      * in the following loop.
      */
     // maybe_unused necessary because gcc doesnt understand that pointer is used later
-    [[maybe_unused]] auto const pointer = std::make_tuple(soa.template begin<Impl_t::computedAttr[I]>()...);
+    [[maybe_unused]] auto const pointer = std::make_tuple(soa.template begin<Impl_t::getComputedAttr()[I]>()...);
 
     auto cellIter = cell.begin();
     // write values in SoAs back to particles
@@ -351,7 +361,7 @@ class Functor {
        * (cellIter->template set<Impl_t::computedAttr[0]>(std::get<0>(pointer)[i]),
        * cellIter->template set<Impl_t::computedAttr[1]>(std::get<1>(pointer)[i]))
        */
-      (cellIter->template set<Impl_t::computedAttr[I]>(std::get<I>(pointer)[i]), ...);
+      (cellIter->template set<Impl_t::getComputedAttr()[I]>(std::get<I>(pointer)[i]), ...);
     }
   }
 

--- a/src/autopas/pairwiseFunctors/Functor.h
+++ b/src/autopas/pairwiseFunctors/Functor.h
@@ -204,14 +204,6 @@ class Functor {
     SoALoaderImpl(cell, soa, offset, std::make_index_sequence<Impl_t::neededAttr.size()>{});
   }
 
-  /** @copydoc SoALoader(ParticleCell &cell, ::autopas::SoA<SoAArraysType> &soa, size_t offset) */
-  /*template <typename cell_t>
-  void SoALoader(cell_t &cell,
-                 ::autopas::SoA<SoAArraysType> &soa, size_t offset = 0, typename std::enable_if_t<not
-  std::is_same<cell_t, ParticleCell_t>::value> = 0) { SoALoaderImpl(cell, soa, offset,
-  std::make_index_sequence<Impl_t::neededAttr.size()>{});
-  }*/
-
   /**
    * @brief Copies the data stored in the soa back into the cell.
    *

--- a/src/autopas/pairwiseFunctors/Functor.h
+++ b/src/autopas/pairwiseFunctors/Functor.h
@@ -109,6 +109,15 @@ class Functor {
   }
 
   /**
+   * Get attributes needed for computation without N3 optimization.
+   * @return Attributes needed for computation.
+   * @todo C++20: make this function virtual
+   */
+  constexpr static const std::array<typename Particle::AttributeNames, 0> getNeededAttr(std::false_type) {
+    return Impl_t::getNeededAttr();
+  }
+
+  /**
    * Get attributes computed by this functor.
    * @return Attributes computed by this functor.
    * @todo C++20: make this function virtual

--- a/src/autopas/pairwiseFunctors/Functor.h
+++ b/src/autopas/pairwiseFunctors/Functor.h
@@ -96,6 +96,18 @@ class Functor {
   }
 
   /**
+   * Attributes needed for computation.
+   * @note Should be shadowed by child class.
+   */
+  constexpr static const std::array<typename Particle::AttributeNames, 0> neededAttr{};
+
+  /**
+   * Attributes computed by this functor.
+   * @note Should be shadowed by child class.
+   */
+  constexpr static const std::array<typename Particle::AttributeNames, 0> computedAttr{};
+
+  /**
    * @brief Functor for structure of arrays (SoA)
    *
    * This functor should calculate the forces or any other pair-wise interaction

--- a/src/autopas/pairwiseFunctors/Functor.h
+++ b/src/autopas/pairwiseFunctors/Functor.h
@@ -302,7 +302,6 @@ class Functor {
    */
   template <typename cell_t, std::size_t... I>
   void SoAExtractorImpl(cell_t &cell, ::autopas::SoA<SoAArraysType> &soa, size_t offset, std::index_sequence<I...>) {
-
     if (cell.numParticles() == 0) return;
 
     // maybe_unused necessary because gcc doesnt understand that pointer is used later

--- a/src/autopas/pairwiseFunctors/LJFunctor.h
+++ b/src/autopas/pairwiseFunctors/LJFunctor.h
@@ -150,13 +150,7 @@ class LJFunctor
    * to use it correctly for the global values.
    * @todo: Remove __attribute__((no_sanitize_thread)) when #285 is fixed.
    */
-  void
-#if defined(__has_feature)
-#if __has_feature(thread_sanitizer)
-      __attribute__((no_sanitize_thread))
-#endif
-#endif
-      SoAFunctor(SoA<SoAArraysType> &soa, bool newton3) override {
+  void SoAFunctor(SoA<SoAArraysType> &soa, bool newton3) override {
     if (soa.getNumParticles() == 0) return;
 
     const auto *const __restrict__ xptr = soa.template begin<Particle::AttributeNames::posX>();

--- a/src/autopas/pairwiseFunctors/LJFunctor.h
+++ b/src/autopas/pairwiseFunctors/LJFunctor.h
@@ -521,13 +521,15 @@ class LJFunctor
   /**
    * @copydoc Functor::getNeededAttr()
    */
-  constexpr static const auto getNeededAttr() {
+  constexpr static const std::array<typename Particle::AttributeNames,
+                                    (useNewton3 == FunctorN3Modes::Newton3Off) ? 5 : 8>
+  getNeededAttr() {
     if constexpr (useNewton3 == FunctorN3Modes::Newton3Off) {
-      return std::array<typename Particle::AttributeNames, 8>{
+      return std::array<typename Particle::AttributeNames, 5>{
           Particle::AttributeNames::id, Particle::AttributeNames::posX, Particle::AttributeNames::posY,
           Particle::AttributeNames::posZ, Particle::AttributeNames::owned};
     } else {
-      return std::array<typename Particle::AttributeNames, 11>{
+      return std::array<typename Particle::AttributeNames, 8>{
           Particle::AttributeNames::id,     Particle::AttributeNames::posX,   Particle::AttributeNames::posY,
           Particle::AttributeNames::forceX, Particle::AttributeNames::forceY, Particle::AttributeNames::forceZ,
           Particle::AttributeNames::posZ,   Particle::AttributeNames::owned};

--- a/src/autopas/pairwiseFunctors/LJFunctor.h
+++ b/src/autopas/pairwiseFunctors/LJFunctor.h
@@ -519,17 +519,28 @@ class LJFunctor
   }
 
   /**
-   * Attributes needed for computation.
+   * @copydoc Functor::getNeededAttr()
    */
-  constexpr static const std::array<typename Particle::AttributeNames, 8> neededAttr{
-      Particle::AttributeNames::id, Particle::AttributeNames::posX, Particle::AttributeNames::posY,
-      Particle::AttributeNames::posZ, Particle::AttributeNames::owned};
+  constexpr static const auto getNeededAttr() {
+    if constexpr (useNewton3 == FunctorN3Modes::Newton3Off) {
+      return std::array<typename Particle::AttributeNames, 8>{
+          Particle::AttributeNames::id, Particle::AttributeNames::posX, Particle::AttributeNames::posY,
+          Particle::AttributeNames::posZ, Particle::AttributeNames::owned};
+    } else {
+      return std::array<typename Particle::AttributeNames, 11>{
+          Particle::AttributeNames::id,     Particle::AttributeNames::posX,   Particle::AttributeNames::posY,
+          Particle::AttributeNames::forceX, Particle::AttributeNames::forceY, Particle::AttributeNames::forceZ,
+          Particle::AttributeNames::posZ,   Particle::AttributeNames::owned};
+    }
+  }
 
   /**
-   * Attributes computed by this functor.
+   * @copydoc Functor::getComputedAttr()
    */
-  constexpr static const std::array<typename Particle::AttributeNames, 3> computedAttr{
-      Particle::AttributeNames::forceX, Particle::AttributeNames::forceY, Particle::AttributeNames::forceZ};
+  constexpr static const std::array<typename Particle::AttributeNames, 3> getComputedAttr() {
+    return std::array<typename Particle::AttributeNames, 3>{
+        Particle::AttributeNames::forceX, Particle::AttributeNames::forceY, Particle::AttributeNames::forceZ};
+  }
 
   /**
    * Get the number of flops used per kernel call. This should count the

--- a/src/autopas/pairwiseFunctors/LJFunctor.h
+++ b/src/autopas/pairwiseFunctors/LJFunctor.h
@@ -148,7 +148,6 @@ class LJFunctor
    * @copydoc Functor::SoAFunctor(SoA<SoAArraysType> &soa, bool newton3)
    * This functor ignores will use a newton3 like traversing of the soa, however, it still needs to know about newton3
    * to use it correctly for the global values.
-   * @todo: Remove __attribute__((no_sanitize_thread)) when #285 is fixed.
    */
   void SoAFunctor(SoA<SoAArraysType> &soa, bool newton3) override {
     if (soa.getNumParticles() == 0) return;

--- a/src/autopas/pairwiseFunctors/LJFunctor.h
+++ b/src/autopas/pairwiseFunctors/LJFunctor.h
@@ -533,33 +533,6 @@ class LJFunctor
       Particle::AttributeNames::forceX, Particle::AttributeNames::forceY, Particle::AttributeNames::forceZ};
 
   /**
-   * soaextractor
-   * @param cell
-   * @param soa
-   * @param offset
-   */
-  AUTOPAS_FUNCTOR_SOAEXTRACTOR(cell, soa, offset,
-                               // body start
-                               if (soa.getNumParticles() == 0) return;
-
-                               auto cellIter = cell.begin();
-
-#ifndef NDEBUG
-                               auto *const __restrict__ idptr = soa.template begin<Particle::AttributeNames::id>();
-#endif
-
-                               auto *const __restrict__ fxptr = soa.template begin<Particle::AttributeNames::forceX>();
-                               auto *const __restrict__ fyptr = soa.template begin<Particle::AttributeNames::forceY>();
-                               auto *const __restrict__ fzptr = soa.template begin<Particle::AttributeNames::forceZ>();
-
-                               for (size_t i = offset; cellIter.isValid(); ++i, ++cellIter) {
-                                 assert(idptr[i] == cellIter->getID());
-                                 cellIter->template set<Particle::AttributeNames::forceX>(fxptr[i]);
-                                 cellIter->template set<Particle::AttributeNames::forceY>(fyptr[i]);
-                                 cellIter->template set<Particle::AttributeNames::forceZ>(fzptr[i]);
-                               })
-
-  /**
    * Get the number of flops used per kernel call. This should count the
    * floating point operations needed for two particles that lie within a cutoff
    * radius.

--- a/src/autopas/pairwiseFunctors/LJFunctor.h
+++ b/src/autopas/pairwiseFunctors/LJFunctor.h
@@ -540,14 +540,14 @@ class LJFunctor : public Functor<Particle, ParticleCell, typename Particle::SoAA
                             auto cellIter = cell.begin();
                             // load particles in SoAs
                             for (size_t i = offset; cellIter.isValid(); ++cellIter, ++i) {
-                              idptr[i] = cellIter->getID();
-                              xptr[i] = cellIter->getR()[0];
-                              yptr[i] = cellIter->getR()[1];
-                              zptr[i] = cellIter->getR()[2];
-                              fxptr[i] = cellIter->getF()[0];
-                              fyptr[i] = cellIter->getF()[1];
-                              fzptr[i] = cellIter->getF()[2];
-                              ownedptr[i] = cellIter->isOwned() ? 1. : 0.;
+                              idptr[i] = cellIter->template get<Particle::AttributeNames::id>();
+                              xptr[i] = cellIter->template get<Particle::AttributeNames::posX>();
+                              yptr[i] = cellIter->template get<Particle::AttributeNames::posY>();
+                              zptr[i] = cellIter->template get<Particle::AttributeNames::posZ>();
+                              fxptr[i] = cellIter->template get<Particle::AttributeNames::forceX>();
+                              fyptr[i] = cellIter->template get<Particle::AttributeNames::forceY>();
+                              fzptr[i] = cellIter->template get<Particle::AttributeNames::forceZ>();
+                              ownedptr[i] = cellIter->template get<Particle::AttributeNames::owned>();
                             })
 
   /**

--- a/src/autopas/pairwiseFunctors/LJFunctor.h
+++ b/src/autopas/pairwiseFunctors/LJFunctor.h
@@ -572,7 +572,9 @@ class LJFunctor : public Functor<Particle, ParticleCell, typename Particle::SoAA
 
                                for (size_t i = offset; cellIter.isValid(); ++i, ++cellIter) {
                                  assert(idptr[i] == cellIter->getID());
-                                 cellIter->setF({fxptr[i], fyptr[i], fzptr[i]});
+                                 cellIter->template set<Particle::AttributeNames::forceX>(fxptr[i]);
+                                 cellIter->template set<Particle::AttributeNames::forceY>(fyptr[i]);
+                                 cellIter->template set<Particle::AttributeNames::forceZ>(fzptr[i]);
                                })
 
   /**

--- a/src/autopas/pairwiseFunctors/LJFunctor.h
+++ b/src/autopas/pairwiseFunctors/LJFunctor.h
@@ -522,9 +522,8 @@ class LJFunctor
    * Attributes needed for computation.
    */
   constexpr static const std::array<typename Particle::AttributeNames, 8> neededAttr{
-      Particle::AttributeNames::id,     Particle::AttributeNames::posX,   Particle::AttributeNames::posY,
-      Particle::AttributeNames::posZ,   Particle::AttributeNames::forceX, Particle::AttributeNames::forceY,
-      Particle::AttributeNames::forceZ, Particle::AttributeNames::owned};
+      Particle::AttributeNames::id, Particle::AttributeNames::posX, Particle::AttributeNames::posY,
+      Particle::AttributeNames::posZ, Particle::AttributeNames::owned};
 
   /**
    * Attributes computed by this functor.

--- a/src/autopas/pairwiseFunctors/LJFunctor.h
+++ b/src/autopas/pairwiseFunctors/LJFunctor.h
@@ -524,12 +524,18 @@ class LJFunctor
 #endif
   }
 
-  constexpr static std::array<typename Particle::AttributeNames, 8> neededAttr{
+  /**
+   * Attributes needed for computation.
+   */
+  constexpr static const std::array<typename Particle::AttributeNames, 8> neededAttr{
       Particle::AttributeNames::id,     Particle::AttributeNames::posX,   Particle::AttributeNames::posY,
       Particle::AttributeNames::posZ,   Particle::AttributeNames::forceX, Particle::AttributeNames::forceY,
       Particle::AttributeNames::forceZ, Particle::AttributeNames::owned};
 
-  constexpr static std::array<typename Particle::AttributeNames, 3> computedAttr{
+  /**
+   * Attributes computed by this functor.
+   */
+  constexpr static const std::array<typename Particle::AttributeNames, 3> computedAttr{
       Particle::AttributeNames::forceX, Particle::AttributeNames::forceY, Particle::AttributeNames::forceZ};
 
   /**

--- a/src/autopas/pairwiseFunctors/LJFunctor.h
+++ b/src/autopas/pairwiseFunctors/LJFunctor.h
@@ -26,7 +26,7 @@ namespace autopas {
 /**
  * Newton 3 modes for the LJFunctor.
  */
-enum FunctorN3Modes {
+enum class FunctorN3Modes {
   Newton3Only,
   Newton3Off,
   Both,

--- a/src/autopas/pairwiseFunctors/LJFunctor.h
+++ b/src/autopas/pairwiseFunctors/LJFunctor.h
@@ -875,7 +875,7 @@ class LJFunctor
   // make sure of the size of AoSThreadData
   // static_assert(sizeof(AoSThreadData) % 64 == 0, "AoSThreadData has wrong size");
 
-  floatPrecision _cutoffsquare, _epsilon24, _sigmasquare, _shift6;
+  const floatPrecision _cutoffsquare, _epsilon24, _sigmasquare, _shift6;
 
   // sum of the potential energy, only calculated if calculateGlobals is true
   floatPrecision _upotSum;

--- a/src/autopas/pairwiseFunctors/LJFunctor.h
+++ b/src/autopas/pairwiseFunctors/LJFunctor.h
@@ -557,6 +557,14 @@ class LJFunctor : public Functor<Particle, ParticleCell, typename Particle::SoAA
                               ownedptr[i] = cellIter->template get<Particle::AttributeNames::owned>();
                             })
 
+  constexpr static std::array<typename Particle::AttributeNames, 8> neededAttr{
+      Particle::AttributeNames::id,     Particle::AttributeNames::posX,   Particle::AttributeNames::posY,
+      Particle::AttributeNames::posZ,   Particle::AttributeNames::forceX, Particle::AttributeNames::forceY,
+      Particle::AttributeNames::forceZ, Particle::AttributeNames::owned};
+
+  constexpr static std::array<typename Particle::AttributeNames, 3> computedAttr{
+      Particle::AttributeNames::forceX, Particle::AttributeNames::forceY, Particle::AttributeNames::forceZ};
+
   /**
    * soaextractor
    * @param cell

--- a/src/autopas/pairwiseFunctors/LJFunctor.h
+++ b/src/autopas/pairwiseFunctors/LJFunctor.h
@@ -521,19 +521,20 @@ class LJFunctor
   /**
    * @copydoc Functor::getNeededAttr()
    */
-  constexpr static const std::array<typename Particle::AttributeNames,
-                                    (useNewton3 == FunctorN3Modes::Newton3Off) ? 5 : 8>
-  getNeededAttr() {
-    if constexpr (useNewton3 == FunctorN3Modes::Newton3Off) {
-      return std::array<typename Particle::AttributeNames, 5>{
-          Particle::AttributeNames::id, Particle::AttributeNames::posX, Particle::AttributeNames::posY,
-          Particle::AttributeNames::posZ, Particle::AttributeNames::owned};
-    } else {
-      return std::array<typename Particle::AttributeNames, 8>{
-          Particle::AttributeNames::id,     Particle::AttributeNames::posX,   Particle::AttributeNames::posY,
-          Particle::AttributeNames::forceX, Particle::AttributeNames::forceY, Particle::AttributeNames::forceZ,
-          Particle::AttributeNames::posZ,   Particle::AttributeNames::owned};
-    }
+  constexpr static const std::array<typename Particle::AttributeNames, 8> getNeededAttr() {
+    return std::array<typename Particle::AttributeNames, 8>{
+        Particle::AttributeNames::id,     Particle::AttributeNames::posX,   Particle::AttributeNames::posY,
+        Particle::AttributeNames::posZ,   Particle::AttributeNames::forceX, Particle::AttributeNames::forceY,
+        Particle::AttributeNames::forceZ, Particle::AttributeNames::owned};
+  }
+
+  /**
+   * @copydoc Functor::getNeededAttr(std::false_type)
+   */
+  constexpr static const std::array<typename Particle::AttributeNames, 5> getNeededAttr(std::false_type) {
+    return std::array<typename Particle::AttributeNames, 5>{
+        Particle::AttributeNames::id, Particle::AttributeNames::posX, Particle::AttributeNames::posY,
+        Particle::AttributeNames::posZ, Particle::AttributeNames::owned};
   }
 
   /**

--- a/src/autopas/pairwiseFunctors/LJFunctorAVX.h
+++ b/src/autopas/pairwiseFunctors/LJFunctorAVX.h
@@ -452,31 +452,6 @@ class LJFunctorAVX
 
   constexpr static std::array<typename Particle::AttributeNames, 3> computedAttr{
       Particle::AttributeNames::forceX, Particle::AttributeNames::forceY, Particle::AttributeNames::forceZ};
-  /**
-   * soaextractor
-   * @param cell
-   * @param soa
-   * @param offset
-   */
-  AUTOPAS_FUNCTOR_SOAEXTRACTOR(
-      cell, soa, offset,
-      // body start
-      if (soa.getNumParticles() == 0) return;
-
-      auto cellIter = cell.begin();
-
-#ifndef NDEBUG
-      auto *const __restrict__ idptr = soa.template begin<Particle::AttributeNames::id>();
-#endif
-
-      double *const __restrict__ fxptr = soa.template begin<Particle::AttributeNames::forceX>();
-      double *const __restrict__ fyptr = soa.template begin<Particle::AttributeNames::forceY>();
-      double *const __restrict__ fzptr = soa.template begin<Particle::AttributeNames::forceZ>();
-
-      for (size_t i = offset; cellIter.isValid(); ++i, ++cellIter) {
-        assert(idptr[i] == cellIter->getID());
-        cellIter->setF({fxptr[i], fyptr[i], fzptr[i]});
-      })
 
   /**
    * Get the number of flops used per kernel call. This should count the

--- a/src/autopas/pairwiseFunctors/LJFunctorAVX.h
+++ b/src/autopas/pairwiseFunctors/LJFunctorAVX.h
@@ -473,6 +473,13 @@ class LJFunctorAVX : public Functor<Particle, ParticleCell, typename Particle::S
                               ownedptr[i] = cellIter->isOwned() ? 1. : 0.;
                             })
 
+  constexpr static std::array<typename Particle::AttributeNames, 8> neededAttr{
+      Particle::AttributeNames::id,     Particle::AttributeNames::posX,   Particle::AttributeNames::posY,
+      Particle::AttributeNames::posZ,   Particle::AttributeNames::forceX, Particle::AttributeNames::forceY,
+      Particle::AttributeNames::forceZ, Particle::AttributeNames::owned};
+
+  constexpr static std::array<typename Particle::AttributeNames, 3> computedAttr{
+      Particle::AttributeNames::forceX, Particle::AttributeNames::forceY, Particle::AttributeNames::forceZ};
   /**
    * soaextractor
    * @param cell

--- a/src/autopas/pairwiseFunctors/LJFunctorAVX.h
+++ b/src/autopas/pairwiseFunctors/LJFunctorAVX.h
@@ -445,12 +445,18 @@ class LJFunctorAVX
     utils::ExceptionHandler::exception("Verlet SoA functor not implemented!");
   }
 
-  constexpr static std::array<typename Particle::AttributeNames, 8> neededAttr{
+  /**
+   * Attributes needed for computation.
+   */
+  constexpr static const std::array<typename Particle::AttributeNames, 8> neededAttr{
       Particle::AttributeNames::id,     Particle::AttributeNames::posX,   Particle::AttributeNames::posY,
       Particle::AttributeNames::posZ,   Particle::AttributeNames::forceX, Particle::AttributeNames::forceY,
       Particle::AttributeNames::forceZ, Particle::AttributeNames::owned};
 
-  constexpr static std::array<typename Particle::AttributeNames, 3> computedAttr{
+  /**
+   * Attributes computed by this functor.
+   */
+  constexpr static const std::array<typename Particle::AttributeNames, 3> computedAttr{
       Particle::AttributeNames::forceX, Particle::AttributeNames::forceY, Particle::AttributeNames::forceZ};
 
   /**

--- a/src/autopas/pairwiseFunctors/LJFunctorAVX.h
+++ b/src/autopas/pairwiseFunctors/LJFunctorAVX.h
@@ -448,13 +448,15 @@ class LJFunctorAVX
   /**
    * @copydoc Functor::getNeededAttr()
    */
-  constexpr static const auto getNeededAttr() {
+  constexpr static const std::array<typename Particle::AttributeNames,
+                                    (useNewton3 == FunctorN3Modes::Newton3Off) ? 5 : 8>
+  getNeededAttr() {
     if constexpr (useNewton3 == FunctorN3Modes::Newton3Off) {
-      return std::array<typename Particle::AttributeNames, 8>{
+      return std::array<typename Particle::AttributeNames, 5>{
           Particle::AttributeNames::id, Particle::AttributeNames::posX, Particle::AttributeNames::posY,
           Particle::AttributeNames::posZ, Particle::AttributeNames::owned};
     } else {
-      return std::array<typename Particle::AttributeNames, 11>{
+      return std::array<typename Particle::AttributeNames, 8>{
           Particle::AttributeNames::id,     Particle::AttributeNames::posX,   Particle::AttributeNames::posY,
           Particle::AttributeNames::forceX, Particle::AttributeNames::forceY, Particle::AttributeNames::forceZ,
           Particle::AttributeNames::posZ,   Particle::AttributeNames::owned};

--- a/src/autopas/pairwiseFunctors/LJFunctorAVX.h
+++ b/src/autopas/pairwiseFunctors/LJFunctorAVX.h
@@ -70,7 +70,7 @@ class LJFunctorAVX
     }
   }
 #else
-      : Functor<Particle, ParticleCell>(cutoff),
+      : Functor<Particle, ParticleCell, SoAArraysType, LJFunctorAVX<Particle, ParticleCell>>(cutoff),
         _one{0},
         _masks{0, 0, 0},
         _cutoffsquare{0},

--- a/src/autopas/pairwiseFunctors/LJFunctorAVX.h
+++ b/src/autopas/pairwiseFunctors/LJFunctorAVX.h
@@ -446,18 +446,28 @@ class LJFunctorAVX
   }
 
   /**
-   * Attributes needed for computation.
+   * @copydoc Functor::getNeededAttr()
    */
-  constexpr static const std::array<typename Particle::AttributeNames, 8> neededAttr{
-      Particle::AttributeNames::id,     Particle::AttributeNames::posX,   Particle::AttributeNames::posY,
-      Particle::AttributeNames::posZ,   Particle::AttributeNames::forceX, Particle::AttributeNames::forceY,
-      Particle::AttributeNames::forceZ, Particle::AttributeNames::owned};
+  constexpr static const auto getNeededAttr() {
+    if constexpr (useNewton3 == FunctorN3Modes::Newton3Off) {
+      return std::array<typename Particle::AttributeNames, 8>{
+          Particle::AttributeNames::id, Particle::AttributeNames::posX, Particle::AttributeNames::posY,
+          Particle::AttributeNames::posZ, Particle::AttributeNames::owned};
+    } else {
+      return std::array<typename Particle::AttributeNames, 11>{
+          Particle::AttributeNames::id,     Particle::AttributeNames::posX,   Particle::AttributeNames::posY,
+          Particle::AttributeNames::forceX, Particle::AttributeNames::forceY, Particle::AttributeNames::forceZ,
+          Particle::AttributeNames::posZ,   Particle::AttributeNames::owned};
+    }
+  }
 
   /**
-   * Attributes computed by this functor.
+   * @copydoc Functor::getComputedAttr()
    */
-  constexpr static const std::array<typename Particle::AttributeNames, 3> computedAttr{
-      Particle::AttributeNames::forceX, Particle::AttributeNames::forceY, Particle::AttributeNames::forceZ};
+  constexpr static const std::array<typename Particle::AttributeNames, 3> getComputedAttr() {
+    return std::array<typename Particle::AttributeNames, 3>{
+        Particle::AttributeNames::forceX, Particle::AttributeNames::forceY, Particle::AttributeNames::forceZ};
+  }
 
   /**
    * Get the number of flops used per kernel call. This should count the

--- a/src/autopas/pairwiseFunctors/LJFunctorAVX.h
+++ b/src/autopas/pairwiseFunctors/LJFunctorAVX.h
@@ -448,19 +448,20 @@ class LJFunctorAVX
   /**
    * @copydoc Functor::getNeededAttr()
    */
-  constexpr static const std::array<typename Particle::AttributeNames,
-                                    (useNewton3 == FunctorN3Modes::Newton3Off) ? 5 : 8>
-  getNeededAttr() {
-    if constexpr (useNewton3 == FunctorN3Modes::Newton3Off) {
-      return std::array<typename Particle::AttributeNames, 5>{
-          Particle::AttributeNames::id, Particle::AttributeNames::posX, Particle::AttributeNames::posY,
-          Particle::AttributeNames::posZ, Particle::AttributeNames::owned};
-    } else {
-      return std::array<typename Particle::AttributeNames, 8>{
-          Particle::AttributeNames::id,     Particle::AttributeNames::posX,   Particle::AttributeNames::posY,
-          Particle::AttributeNames::forceX, Particle::AttributeNames::forceY, Particle::AttributeNames::forceZ,
-          Particle::AttributeNames::posZ,   Particle::AttributeNames::owned};
-    }
+  constexpr static const std::array<typename Particle::AttributeNames, 8> getNeededAttr() {
+    return std::array<typename Particle::AttributeNames, 8>{
+        Particle::AttributeNames::id,     Particle::AttributeNames::posX,   Particle::AttributeNames::posY,
+        Particle::AttributeNames::posZ,   Particle::AttributeNames::forceX, Particle::AttributeNames::forceY,
+        Particle::AttributeNames::forceZ, Particle::AttributeNames::owned};
+  }
+
+  /**
+   * @copydoc Functor::getNeededAttr(std::false_type)
+   */
+  constexpr static const std::array<typename Particle::AttributeNames, 5> getNeededAttr(std::false_type) {
+    return std::array<typename Particle::AttributeNames, 5>{
+        Particle::AttributeNames::id, Particle::AttributeNames::posX, Particle::AttributeNames::posY,
+        Particle::AttributeNames::posZ, Particle::AttributeNames::owned};
   }
 
   /**

--- a/src/autopas/particles/ParticleBase.h
+++ b/src/autopas/particles/ParticleBase.h
@@ -183,6 +183,34 @@ class ParticleBase {
   typedef typename autopas::utils::SoAType<idType, floatType, floatType, floatType, floatType, floatType, floatType,
                                            floatType>::Type SoAArraysType;
 
+  /**
+   * Getter, which allows access to an attribute using the corresponding attribute name (defined in AttributeNames).
+   * @tparam attribute Attribute name.
+   * @return Value of the requested attribute.
+   * @note The value of owned is return as floating point number (true = 1.0, false = 0.0).
+   */
+  template <AttributeNames attribute>
+  constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() const {
+    switch (attribute) {
+      case AttributeNames::id:
+        return getID();
+      case AttributeNames::posX:
+        return getR()[0];
+      case AttributeNames::posY:
+        return getR()[1];
+      case AttributeNames::posZ:
+        return getR()[2];
+      case AttributeNames::forceX:
+        return getF()[0];
+      case AttributeNames::forceY:
+        return getF()[1];
+      case AttributeNames::forceZ:
+        return getF()[2];
+      case AttributeNames::owned:
+        return isOwned() ? 1. : 0.;
+    }
+  }
+
 #if defined(AUTOPAS_CUDA)
   /**
    * The type for storage arrays for Cuda

--- a/src/autopas/particles/ParticleBase.h
+++ b/src/autopas/particles/ParticleBase.h
@@ -211,6 +211,42 @@ class ParticleBase {
     }
   }
 
+  /**
+   * Setter, which allows set an attribute using the corresponding attribute name (defined in AttributeNames).
+   * @tparam attribute Attribute name.
+   * @param value New value of the requested attribute.
+   * @note The value of owned is extracted from a floating point number (true = 1.0, false = 0.0).
+   */
+  template <AttributeNames attribute>
+  constexpr void set(typename std::tuple_element<attribute, SoAArraysType>::type::value_type value) {
+    switch (attribute) {
+      case AttributeNames::id:
+        setID(value);
+        break;
+      case AttributeNames::posX:
+        _r[0] = value;
+        break;
+      case AttributeNames::posY:
+        _r[1] = value;
+        break;
+      case AttributeNames::posZ:
+        _r[2] = value;
+        break;
+      case AttributeNames::forceX:
+        _f[0] = value;
+        break;
+      case AttributeNames::forceY:
+        _f[1] = value;
+        break;
+      case AttributeNames::forceZ:
+        _f[2] = value;
+        break;
+      case AttributeNames::owned:
+        setOwned(value == 1.);
+        break;
+    }
+  }
+
 #if defined(AUTOPAS_CUDA)
   /**
    * The type for storage arrays for Cuda

--- a/src/autopas/particles/ParticleBase.h
+++ b/src/autopas/particles/ParticleBase.h
@@ -208,6 +208,9 @@ class ParticleBase {
         return getF()[2];
       case AttributeNames::owned:
         return isOwned() ? 1. : 0.;
+      default:
+        utils::ExceptionHandler::exception("ParticleBase::get: unknown attribute");
+        return 0;
     }
   }
 

--- a/src/autopas/sph/SPHCalcDensityFunctor.h
+++ b/src/autopas/sph/SPHCalcDensityFunctor.h
@@ -218,11 +218,18 @@ class SPHCalcDensityFunctor
     }
   }
 
-  constexpr static std::array<typename Particle::AttributeNames, 6> neededAttr{
+  /**
+   * Attributes needed for computation.
+   */
+  constexpr static const std::array<typename Particle::AttributeNames, 6> neededAttr{
       Particle::AttributeNames::mass, Particle::AttributeNames::posX, Particle::AttributeNames::posY,
       Particle::AttributeNames::posZ, Particle::AttributeNames::smth, Particle::AttributeNames::density};
 
-  constexpr static std::array<typename Particle::AttributeNames, 1> computedAttr{Particle::AttributeNames::density};
+  /**
+   * Attributes computed by this functor.
+   */
+  constexpr static const std::array<typename Particle::AttributeNames, 1> computedAttr{
+      Particle::AttributeNames::density};
 };
 }  // namespace sph
 }  // namespace autopas

--- a/src/autopas/sph/SPHCalcDensityFunctor.h
+++ b/src/autopas/sph/SPHCalcDensityFunctor.h
@@ -219,17 +219,20 @@ class SPHCalcDensityFunctor
   }
 
   /**
-   * Attributes needed for computation.
+   * @copydoc Functor::getNeededAttr()
    */
-  constexpr static const std::array<typename Particle::AttributeNames, 6> neededAttr{
-      Particle::AttributeNames::mass, Particle::AttributeNames::posX, Particle::AttributeNames::posY,
-      Particle::AttributeNames::posZ, Particle::AttributeNames::smth, Particle::AttributeNames::density};
+  constexpr static const std::array<typename SPHParticle::AttributeNames, 6> getNeededAttr() {
+    return std::array<typename Particle::AttributeNames, 6>{
+        Particle::AttributeNames::mass, Particle::AttributeNames::posX, Particle::AttributeNames::posY,
+        Particle::AttributeNames::posZ, Particle::AttributeNames::smth, Particle::AttributeNames::density};
+  }
 
   /**
-   * Attributes computed by this functor.
+   * @copydoc Functor::getComputedAttr()
    */
-  constexpr static const std::array<typename Particle::AttributeNames, 1> computedAttr{
-      Particle::AttributeNames::density};
+  constexpr static const std::array<typename SPHParticle::AttributeNames, 1> getComputedAttr() {
+    return std::array<typename Particle::AttributeNames, 1>{Particle::AttributeNames::density};
+  }
 };
 }  // namespace sph
 }  // namespace autopas

--- a/src/autopas/sph/SPHCalcDensityFunctor.h
+++ b/src/autopas/sph/SPHCalcDensityFunctor.h
@@ -16,7 +16,8 @@ namespace sph {
  * Class that defines the density functor.
  * It is used to calculate the density based on the given SPH kernel.
  */
-class SPHCalcDensityFunctor : public Functor<SPHParticle, FullParticleCell<SPHParticle>> {
+class SPHCalcDensityFunctor
+    : public Functor<SPHParticle, FullParticleCell<SPHParticle>, SPHParticle::SoAArraysType, SPHCalcDensityFunctor> {
  public:
   /// particle type
   typedef SPHParticle Particle;
@@ -212,39 +213,6 @@ class SPHCalcDensityFunctor : public Functor<SPHParticle, FullParticleCell<SPHPa
       densityptr[i] += densacc;
     }
   }
-
-  /**
-   * SoALoader for SPHCalcDensityFunctor.
-   * Loads mass, position, smoothing length and density.
-   * @param cell
-   * @param soa
-   * @param offset
-   */
-  AUTOPAS_FUNCTOR_SOALOADER(cell, soa, offset, {
-    // @todo it is probably better to resize the soa only once, before calling
-    // SoALoader (verlet-list only)
-    soa.resizeArrays(offset + cell.numParticles());
-
-    if (cell.numParticles() == 0) return;
-
-    double *const __restrict__ massptr = soa.begin<Particle::AttributeNames::mass>();
-    double *const __restrict__ xptr = soa.begin<Particle::AttributeNames::posX>();
-    double *const __restrict__ yptr = soa.begin<Particle::AttributeNames::posY>();
-    double *const __restrict__ zptr = soa.begin<Particle::AttributeNames::posZ>();
-    double *const __restrict__ smthptr = soa.begin<Particle::AttributeNames::smth>();
-    double *const __restrict__ densptr = soa.begin<Particle::AttributeNames::density>();
-
-    auto cellIter = cell.begin();
-    // load particles in SoAs
-    for (size_t i = offset; cellIter.isValid(); ++cellIter, ++i) {
-      massptr[i] = cellIter->getMass();
-      xptr[i] = cellIter->getR()[0];
-      yptr[i] = cellIter->getR()[1];
-      zptr[i] = cellIter->getR()[2];
-      smthptr[i] = cellIter->getSmoothingLength();
-      densptr[i] = cellIter->getDensity();
-    }
-  })
 
   constexpr static std::array<typename Particle::AttributeNames, 6> neededAttr{
       Particle::AttributeNames::mass, Particle::AttributeNames::posX, Particle::AttributeNames::posY,

--- a/src/autopas/sph/SPHCalcDensityFunctor.h
+++ b/src/autopas/sph/SPHCalcDensityFunctor.h
@@ -246,6 +246,12 @@ class SPHCalcDensityFunctor : public Functor<SPHParticle, FullParticleCell<SPHPa
     }
   })
 
+  constexpr static std::array<typename Particle::AttributeNames, 6> neededAttr{
+      Particle::AttributeNames::mass, Particle::AttributeNames::posX, Particle::AttributeNames::posY,
+      Particle::AttributeNames::posZ, Particle::AttributeNames::smth, Particle::AttributeNames::density};
+
+  constexpr static std::array<typename Particle::AttributeNames, 1> computedAttr{Particle::AttributeNames::density};
+
   /**
    * SoAExtractor for SPHCalcDensityFunctor.
    * Extracts density.

--- a/src/autopas/sph/SPHCalcDensityFunctor.h
+++ b/src/autopas/sph/SPHCalcDensityFunctor.h
@@ -228,6 +228,15 @@ class SPHCalcDensityFunctor
   }
 
   /**
+   * @copydoc Functor::getNeededAttr(std::false_type)
+   */
+  constexpr static const std::array<typename SPHParticle::AttributeNames, 5> getNeededAttr(std::false_type) {
+    return std::array<typename Particle::AttributeNames, 5>{
+        Particle::AttributeNames::mass, Particle::AttributeNames::posX, Particle::AttributeNames::posY,
+        Particle::AttributeNames::posZ, Particle::AttributeNames::smth};
+  }
+
+  /**
    * @copydoc Functor::getComputedAttr()
    */
   constexpr static const std::array<typename SPHParticle::AttributeNames, 1> getComputedAttr() {

--- a/src/autopas/sph/SPHCalcDensityFunctor.h
+++ b/src/autopas/sph/SPHCalcDensityFunctor.h
@@ -223,25 +223,6 @@ class SPHCalcDensityFunctor
       Particle::AttributeNames::posZ, Particle::AttributeNames::smth, Particle::AttributeNames::density};
 
   constexpr static std::array<typename Particle::AttributeNames, 1> computedAttr{Particle::AttributeNames::density};
-
-  /**
-   * SoAExtractor for SPHCalcDensityFunctor.
-   * Extracts density.
-   * @param cell
-   * @param soa
-   * @param offset
-   */
-  AUTOPAS_FUNCTOR_SOAEXTRACTOR(cell, soa, offset, {
-    // function body
-    if (cell.numParticles() == 0) return;
-    double *const __restrict__ densptr = soa.begin<Particle::AttributeNames::density>();
-
-    auto cellIter = cell.begin();
-    // load particles in SoAs
-    for (size_t i = offset; cellIter.isValid(); ++cellIter, ++i) {
-      cellIter->setDensity(densptr[i]);
-    }
-  })
 };
 }  // namespace sph
 }  // namespace autopas

--- a/src/autopas/sph/SPHCalcHydroForceFunctor.h
+++ b/src/autopas/sph/SPHCalcHydroForceFunctor.h
@@ -464,26 +464,29 @@ class SPHCalcHydroForceFunctor
   }
 
   /**
-   * Attributes needed for computation.
+   * @copydoc Functor::getNeededAttr()
    */
-  constexpr static const std::array<typename autopas::sph::SPHParticle::AttributeNames, 16> neededAttr{
-      autopas::sph::SPHParticle::AttributeNames::mass,     autopas::sph::SPHParticle::AttributeNames::density,
-      autopas::sph::SPHParticle::AttributeNames::smth,     autopas::sph::SPHParticle::AttributeNames::soundSpeed,
-      autopas::sph::SPHParticle::AttributeNames::pressure, autopas::sph::SPHParticle::AttributeNames::vsigmax,
-      autopas::sph::SPHParticle::AttributeNames::engDot,   autopas::sph::SPHParticle::AttributeNames::posX,
-      autopas::sph::SPHParticle::AttributeNames::posY,     autopas::sph::SPHParticle::AttributeNames::posZ,
-      autopas::sph::SPHParticle::AttributeNames::velX,     autopas::sph::SPHParticle::AttributeNames::velY,
-      autopas::sph::SPHParticle::AttributeNames::velZ,     autopas::sph::SPHParticle::AttributeNames::accX,
-      autopas::sph::SPHParticle::AttributeNames::accY,     autopas::sph::SPHParticle::AttributeNames::accZ};
+  constexpr static const std::array<typename SPHParticle::AttributeNames, 16> getNeededAttr() {
+    ///@todo distinguish between N3 and notN3
+    return std::array<typename SPHParticle::AttributeNames, 16>{
+        SPHParticle::AttributeNames::mass,     SPHParticle::AttributeNames::density,
+        SPHParticle::AttributeNames::smth,     SPHParticle::AttributeNames::soundSpeed,
+        SPHParticle::AttributeNames::pressure, SPHParticle::AttributeNames::vsigmax,
+        SPHParticle::AttributeNames::engDot,   SPHParticle::AttributeNames::posX,
+        SPHParticle::AttributeNames::posY,     SPHParticle::AttributeNames::posZ,
+        SPHParticle::AttributeNames::velX,     SPHParticle::AttributeNames::velY,
+        SPHParticle::AttributeNames::velZ,     SPHParticle::AttributeNames::accX,
+        SPHParticle::AttributeNames::accY,     SPHParticle::AttributeNames::accZ};
+  }
 
   /**
-   * Attributes computed by this functor.
+   * @copydoc Functor::getComputedAttr()
    */
-  constexpr static const std::array<typename autopas::sph::SPHParticle::AttributeNames, 5> computedAttr{
-      autopas::sph::SPHParticle::AttributeNames::vsigmax, autopas::sph::SPHParticle::AttributeNames::engDot,
-      autopas::sph::SPHParticle::AttributeNames::accX,    autopas::sph::SPHParticle::AttributeNames::accY,
-      autopas::sph::SPHParticle::AttributeNames::accZ,
-  };
+  constexpr static const std::array<typename sph::SPHParticle::AttributeNames, 5> getComputedAttr() {
+    return std::array<typename SPHParticle::AttributeNames, 5>{
+        SPHParticle::AttributeNames::vsigmax, SPHParticle::AttributeNames::engDot, SPHParticle::AttributeNames::accX,
+        SPHParticle::AttributeNames::accY, SPHParticle::AttributeNames::accZ};
+  }
 
   /**
    * Get the number of floating point operations used in one full kernel call

--- a/src/autopas/sph/SPHCalcHydroForceFunctor.h
+++ b/src/autopas/sph/SPHCalcHydroForceFunctor.h
@@ -466,7 +466,7 @@ class SPHCalcHydroForceFunctor
   /**
    * Attributes needed for computation.
    */
-  constexpr static const std::array<typename Particle::AttributeNames, 16> neededAttr{
+  constexpr static const std::array<typename autopas::sph::SPHParticle::AttributeNames, 16> neededAttr{
       autopas::sph::SPHParticle::AttributeNames::mass,     autopas::sph::SPHParticle::AttributeNames::density,
       autopas::sph::SPHParticle::AttributeNames::smth,     autopas::sph::SPHParticle::AttributeNames::soundSpeed,
       autopas::sph::SPHParticle::AttributeNames::pressure, autopas::sph::SPHParticle::AttributeNames::vsigmax,
@@ -479,7 +479,7 @@ class SPHCalcHydroForceFunctor
   /**
    * Attributes computed by this functor.
    */
-  constexpr static const std::array<typename Particle::AttributeNames, 5> computedAttr{
+  constexpr static const std::array<typename autopas::sph::SPHParticle::AttributeNames, 5> computedAttr{
       autopas::sph::SPHParticle::AttributeNames::vsigmax, autopas::sph::SPHParticle::AttributeNames::engDot,
       autopas::sph::SPHParticle::AttributeNames::accX,    autopas::sph::SPHParticle::AttributeNames::accY,
       autopas::sph::SPHParticle::AttributeNames::accZ,

--- a/src/autopas/sph/SPHCalcHydroForceFunctor.h
+++ b/src/autopas/sph/SPHCalcHydroForceFunctor.h
@@ -480,32 +480,6 @@ class SPHCalcHydroForceFunctor
   };
 
   /**
-   * SoAExtractor for SPHCalcDensityFunctor.
-   * Extracts vsigmax, acceleration and engdot.
-   * @param cell
-   * @param soa
-   * @param offset
-   */
-  AUTOPAS_FUNCTOR_SOAEXTRACTOR(cell, soa, offset, {
-    // function body
-    if (cell.numParticles() == 0) return;
-
-    double *const __restrict__ vsigmaxPtr = soa.begin<Particle::AttributeNames::vsigmax>();
-    double *const __restrict__ engDotPtr = soa.begin<Particle::AttributeNames::engDot>();
-    double *const __restrict__ accXPtr = soa.begin<Particle::AttributeNames::accX>();
-    double *const __restrict__ accYPtr = soa.begin<Particle::AttributeNames::accY>();
-    double *const __restrict__ accZPtr = soa.begin<Particle::AttributeNames::accZ>();
-
-    auto cellIter = cell.begin();
-    // load particles in SoAs
-    for (size_t i = offset; cellIter.isValid(); ++cellIter, ++i) {
-      cellIter->setVSigMax(vsigmaxPtr[i]);
-      cellIter->setEngDot(engDotPtr[i]);
-      cellIter->setAcceleration({accXPtr[i], accYPtr[i], accZPtr[i]});
-    }
-  })
-
-  /**
    * Get the number of floating point operations used in one full kernel call
    * @return the number of floating point operations
    */

--- a/src/autopas/sph/SPHCalcHydroForceFunctor.h
+++ b/src/autopas/sph/SPHCalcHydroForceFunctor.h
@@ -480,6 +480,20 @@ class SPHCalcHydroForceFunctor
   }
 
   /**
+   * @copydoc Functor::getNeededAttr(std::false_type)
+   */
+  constexpr static const std::array<typename SPHParticle::AttributeNames, 11> getNeededAttr(std::false_type) {
+    ///@todo distinguish between N3 and notN3
+    return std::array<typename SPHParticle::AttributeNames, 11>{
+        SPHParticle::AttributeNames::mass,     SPHParticle::AttributeNames::density,
+        SPHParticle::AttributeNames::smth,     SPHParticle::AttributeNames::soundSpeed,
+        SPHParticle::AttributeNames::pressure, SPHParticle::AttributeNames::posX,
+        SPHParticle::AttributeNames::posY,     SPHParticle::AttributeNames::posZ,
+        SPHParticle::AttributeNames::velX,     SPHParticle::AttributeNames::velY,
+        SPHParticle::AttributeNames::velZ};
+  }
+
+  /**
    * @copydoc Functor::getComputedAttr()
    */
   constexpr static const std::array<typename sph::SPHParticle::AttributeNames, 5> getComputedAttr() {

--- a/src/autopas/sph/SPHCalcHydroForceFunctor.h
+++ b/src/autopas/sph/SPHCalcHydroForceFunctor.h
@@ -463,7 +463,10 @@ class SPHCalcHydroForceFunctor
     }
   }
 
-  constexpr static std::array<typename Particle::AttributeNames, 16> neededAttr{
+  /**
+   * Attributes needed for computation.
+   */
+  constexpr static const std::array<typename Particle::AttributeNames, 16> neededAttr{
       autopas::sph::SPHParticle::AttributeNames::mass,     autopas::sph::SPHParticle::AttributeNames::density,
       autopas::sph::SPHParticle::AttributeNames::smth,     autopas::sph::SPHParticle::AttributeNames::soundSpeed,
       autopas::sph::SPHParticle::AttributeNames::pressure, autopas::sph::SPHParticle::AttributeNames::vsigmax,
@@ -473,7 +476,10 @@ class SPHCalcHydroForceFunctor
       autopas::sph::SPHParticle::AttributeNames::velZ,     autopas::sph::SPHParticle::AttributeNames::accX,
       autopas::sph::SPHParticle::AttributeNames::accY,     autopas::sph::SPHParticle::AttributeNames::accZ};
 
-  constexpr static std::array<typename Particle::AttributeNames, 5> computedAttr{
+  /**
+   * Attributes computed by this functor.
+   */
+  constexpr static const std::array<typename Particle::AttributeNames, 5> computedAttr{
       autopas::sph::SPHParticle::AttributeNames::vsigmax, autopas::sph::SPHParticle::AttributeNames::engDot,
       autopas::sph::SPHParticle::AttributeNames::accX,    autopas::sph::SPHParticle::AttributeNames::accY,
       autopas::sph::SPHParticle::AttributeNames::accZ,

--- a/src/autopas/sph/SPHCalcHydroForceFunctor.h
+++ b/src/autopas/sph/SPHCalcHydroForceFunctor.h
@@ -16,7 +16,8 @@ namespace sph {
  * Class that defines the hydrodynamic force functor.
  * It is used to calculate the force based on the given SPH kernels.
  */
-class SPHCalcHydroForceFunctor : public Functor<SPHParticle, FullParticleCell<SPHParticle>> {
+class SPHCalcHydroForceFunctor
+    : public Functor<SPHParticle, FullParticleCell<SPHParticle>, SPHParticle::SoAArraysType, SPHCalcHydroForceFunctor> {
  public:
   /// particle type
   typedef SPHParticle Particle;
@@ -457,60 +458,6 @@ class SPHCalcHydroForceFunctor : public Functor<SPHParticle, FullParticleCell<SP
       vsigmaxptr[i] = std::max(localvsigmax, vsigmaxptr[i]);
     }
   }
-
-  /**
-   * SoALoader for SPHCalcDensityFunctor.
-   * Loads mass, position, smoothing length, density, velocity, speed of sound, pressure, vsigmax, acceleration and
-   * engdot.
-   * @param cell
-   * @param soa
-   * @param offset
-   */
-  AUTOPAS_FUNCTOR_SOALOADER(cell, soa, offset, {
-    // @todo it is probably better to resize the soa only once, before calling
-    // SoALoader (verlet-list only)
-    soa.resizeArrays(offset + cell.numParticles());
-
-    if (cell.numParticles() == 0) return;
-
-    double *const __restrict__ massptr = soa.begin<autopas::sph::SPHParticle::AttributeNames::mass>();
-    double *const __restrict__ densityptr = soa.begin<autopas::sph::SPHParticle::AttributeNames::density>();
-    double *const __restrict__ smthlngthptr = soa.begin<autopas::sph::SPHParticle::AttributeNames::smth>();
-    double *const __restrict__ soundSpeedptr = soa.begin<autopas::sph::SPHParticle::AttributeNames::soundSpeed>();
-    double *const __restrict__ pressureptr = soa.begin<autopas::sph::SPHParticle::AttributeNames::pressure>();
-    double *const __restrict__ vsigmaxptr = soa.begin<autopas::sph::SPHParticle::AttributeNames::vsigmax>();
-    double *const __restrict__ engDotptr = soa.begin<autopas::sph::SPHParticle::AttributeNames::engDot>();
-    double *const __restrict__ xptr = soa.begin<autopas::sph::SPHParticle::AttributeNames::posX>();
-    double *const __restrict__ yptr = soa.begin<autopas::sph::SPHParticle::AttributeNames::posY>();
-    double *const __restrict__ zptr = soa.begin<autopas::sph::SPHParticle::AttributeNames::posZ>();
-    double *const __restrict__ velXptr = soa.begin<autopas::sph::SPHParticle::AttributeNames::velX>();
-    double *const __restrict__ velYptr = soa.begin<autopas::sph::SPHParticle::AttributeNames::velY>();
-    double *const __restrict__ velZptr = soa.begin<autopas::sph::SPHParticle::AttributeNames::velZ>();
-    double *const __restrict__ accXptr = soa.begin<autopas::sph::SPHParticle::AttributeNames::accX>();
-    double *const __restrict__ accYptr = soa.begin<autopas::sph::SPHParticle::AttributeNames::accY>();
-    double *const __restrict__ accZptr = soa.begin<autopas::sph::SPHParticle::AttributeNames::accZ>();
-
-    auto cellIter = cell.begin();
-    // load particles in SoAs
-    for (size_t i = offset; cellIter.isValid(); ++cellIter, ++i) {
-      massptr[i] = cellIter->getMass();
-      densityptr[i] = cellIter->getDensity();
-      smthlngthptr[i] = cellIter->getSmoothingLength();
-      soundSpeedptr[i] = cellIter->getSoundSpeed();
-      pressureptr[i] = cellIter->getPressure();
-      vsigmaxptr[i] = cellIter->getVSigMax();
-      engDotptr[i] = cellIter->getEngDot();
-      xptr[i] = cellIter->getR()[0];
-      yptr[i] = cellIter->getR()[1];
-      zptr[i] = cellIter->getR()[2];
-      velXptr[i] = cellIter->getV()[0];
-      velYptr[i] = cellIter->getV()[1];
-      velZptr[i] = cellIter->getV()[2];
-      accXptr[i] = cellIter->getAcceleration()[0];
-      accYptr[i] = cellIter->getAcceleration()[1];
-      accZptr[i] = cellIter->getAcceleration()[2];
-    }
-  })
 
   constexpr static std::array<typename Particle::AttributeNames, 16> neededAttr{
       autopas::sph::SPHParticle::AttributeNames::mass,     autopas::sph::SPHParticle::AttributeNames::density,

--- a/src/autopas/sph/SPHCalcHydroForceFunctor.h
+++ b/src/autopas/sph/SPHCalcHydroForceFunctor.h
@@ -512,6 +512,22 @@ class SPHCalcHydroForceFunctor : public Functor<SPHParticle, FullParticleCell<SP
     }
   })
 
+  constexpr static std::array<typename Particle::AttributeNames, 16> neededAttr{
+      autopas::sph::SPHParticle::AttributeNames::mass,     autopas::sph::SPHParticle::AttributeNames::density,
+      autopas::sph::SPHParticle::AttributeNames::smth,     autopas::sph::SPHParticle::AttributeNames::soundSpeed,
+      autopas::sph::SPHParticle::AttributeNames::pressure, autopas::sph::SPHParticle::AttributeNames::vsigmax,
+      autopas::sph::SPHParticle::AttributeNames::engDot,   autopas::sph::SPHParticle::AttributeNames::posX,
+      autopas::sph::SPHParticle::AttributeNames::posY,     autopas::sph::SPHParticle::AttributeNames::posZ,
+      autopas::sph::SPHParticle::AttributeNames::velX,     autopas::sph::SPHParticle::AttributeNames::velY,
+      autopas::sph::SPHParticle::AttributeNames::velZ,     autopas::sph::SPHParticle::AttributeNames::accX,
+      autopas::sph::SPHParticle::AttributeNames::accY,     autopas::sph::SPHParticle::AttributeNames::accZ};
+
+  constexpr static std::array<typename Particle::AttributeNames, 5> computedAttr{
+      autopas::sph::SPHParticle::AttributeNames::vsigmax, autopas::sph::SPHParticle::AttributeNames::engDot,
+      autopas::sph::SPHParticle::AttributeNames::accX,    autopas::sph::SPHParticle::AttributeNames::accY,
+      autopas::sph::SPHParticle::AttributeNames::accZ,
+  };
+
   /**
    * SoAExtractor for SPHCalcDensityFunctor.
    * Extracts vsigmax, acceleration and engdot.

--- a/src/autopas/sph/SPHParticle.h
+++ b/src/autopas/sph/SPHParticle.h
@@ -443,6 +443,9 @@ class SPHParticle : public autopas::Particle {
         return getAcceleration()[2];
       case AttributeNames::engDot:
         return getEngDot();
+      default:
+        utils::ExceptionHandler::exception("SPHParticle::get: unknown attribute");
+        return 0;
     }
   }
 

--- a/src/autopas/sph/SPHParticle.h
+++ b/src/autopas/sph/SPHParticle.h
@@ -446,6 +446,65 @@ class SPHParticle : public autopas::Particle {
     }
   }
 
+  /**
+   * Setter, which allows set an attribute using the corresponding attribute name (defined in AttributeNames).
+   * @tparam attribute Attribute name.
+   * @param value New value of the requested attribute.
+   */
+  template <AttributeNames attribute>
+  constexpr void set(typename std::tuple_element<attribute, SoAArraysType>::type::value_type value) {
+    switch (attribute) {
+      case AttributeNames::mass:
+        setMass(value);
+        break;
+      case AttributeNames::posX:
+        _r[0] = value;
+        break;
+      case AttributeNames::posY:
+        _r[1] = value;
+        break;
+      case AttributeNames::posZ:
+        _r[2] = value;
+        break;
+      case AttributeNames::smth:
+        setSmoothingLength(value);
+        break;
+      case AttributeNames::density:
+        setDensity(value);
+        break;
+      case AttributeNames::velX:
+        _v[0] = value;
+        break;
+      case AttributeNames::velY:
+        _v[1] = value;
+        break;
+      case AttributeNames::velZ:
+        _v[2] = value;
+        break;
+      case AttributeNames::soundSpeed:
+        setSoundSpeed(value);
+        break;
+      case AttributeNames::pressure:
+        setPressure(value);
+        break;
+      case AttributeNames::vsigmax:
+        setVSigMax(value);
+        break;
+      case AttributeNames::accX:
+        _acc[0] = value;
+        break;
+      case AttributeNames::accY:
+        _acc[1] = value;
+        break;
+      case AttributeNames::accZ:
+        _acc[2] = value;
+        break;
+      case AttributeNames::engDot:
+        setEngDot(value);
+        break;
+    }
+  }
+
  private:
   double _density;   // density
   double _pressure;  // pressure

--- a/src/autopas/sph/SPHParticle.h
+++ b/src/autopas/sph/SPHParticle.h
@@ -403,6 +403,49 @@ class SPHParticle : public autopas::Particle {
   typedef autopas::utils::SoAType<double, double, double, double, double, double, double, double, double, double,
                                   double, double, double, double, double, double>::Type SoAArraysType;
 
+  /**
+   * Getter, which allows access to an attribute using the corresponding attribute name (defined in AttributeNames).
+   * @tparam attribute Attribute name.
+   * @return Value of the requested attribute.
+   */
+  template <AttributeNames attribute>
+  constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() const {
+    switch (attribute) {
+      case AttributeNames::mass:
+        return getMass();
+      case AttributeNames::posX:
+        return getR()[0];
+      case AttributeNames::posY:
+        return getR()[1];
+      case AttributeNames::posZ:
+        return getR()[2];
+      case AttributeNames::smth:
+        return getSmoothingLength();
+      case AttributeNames::density:
+        return getDensity();
+      case AttributeNames::velX:
+        return getV()[0];
+      case AttributeNames::velY:
+        return getV()[1];
+      case AttributeNames::velZ:
+        return getV()[2];
+      case AttributeNames::soundSpeed:
+        return getSoundSpeed();
+      case AttributeNames::pressure:
+        return getPressure();
+      case AttributeNames::vsigmax:
+        return getVSigMax();
+      case AttributeNames::accX:
+        return getAcceleration()[0];
+      case AttributeNames::accY:
+        return getAcceleration()[1];
+      case AttributeNames::accZ:
+        return getAcceleration()[2];
+      case AttributeNames::engDot:
+        return getEngDot();
+    }
+  }
+
  private:
   double _density;   // density
   double _pressure;  // pressure

--- a/src/autopas/utils/SoA.h
+++ b/src/autopas/utils/SoA.h
@@ -68,7 +68,7 @@ class SoA {
   }
 
   /**
-   * @brief Appends the other SoA buffer.
+   * Appends the other SoA buffer to this.
    * @param other Other buffer.
    */
   void append(SoA<SoAArraysType> &other) {
@@ -78,7 +78,7 @@ class SoA {
   }
 
   /**
-   * @brief Appends the specified attributes from the other SoA buffer.
+   * Appends the specified attributes from the other SoA buffer to this.
    * @tparam attributes Attributes to append.
    * @param other Other buffer.
    */

--- a/src/autopas/utils/SoA.h
+++ b/src/autopas/utils/SoA.h
@@ -68,13 +68,26 @@ class SoA {
   }
 
   /**
-   * @brief Writes / updates values of attributes for a specific particle.
-   * Appends the other SoA buffer.
-   * @param other other buffer.
+   * @brief Appends the other SoA buffer.
+   * @param other Other buffer.
    */
   void append(SoA<SoAArraysType> &other) {
     if (other.getNumParticles() > 0) {
       append_impl(other.soaStorage, std::make_index_sequence<std::tuple_size<SoAArraysType>::value>{});
+    }
+  }
+
+  /**
+   * @brief Appends the specified attributes from the other SoA buffer.
+   * @tparam attributes Attributes to append.
+   * @param other Other buffer.
+   */
+  template <int... attributes>
+  void append(SoA<SoAArraysType> &other) {
+    if (other.getNumParticles() > 0) {
+      const auto newSize = getNumParticles() + other.getNumParticles();
+      append_impl(other.soaStorage, std::index_sequence<attributes...>{});
+      resizeArrays(newSize);
     }
   }
 

--- a/tests/testAutopas/mocks/MockFunctor.h
+++ b/tests/testAutopas/mocks/MockFunctor.h
@@ -8,6 +8,7 @@
 
 #include <gmock/gmock.h>
 #include "autopas/autopasIncludes.h"
+#include "autopas/cells/ParticleCell.h"
 #include "autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h"
 #if defined(AUTOPAS_CUDA)
 #include "autopas/utils/CudaSoA.h"
@@ -20,8 +21,8 @@
 #pragma GCC diagnostic ignored "-Wsuggest-override"
 #endif
 
-template <class Particle, class ParticleCell>
-class MockFunctor : public autopas::Functor<Particle, ParticleCell> {
+template <class Particle, class ParticleCell_t>
+class MockFunctor : public autopas::Functor<Particle, ParticleCell_t> {
  public:
   // virtual void AoSFunctor(Particle &i, Particle &j, bool newton3)
   MOCK_METHOD3_T(AoSFunctor, void(Particle &i, Particle &j, bool newton3));
@@ -41,16 +42,17 @@ class MockFunctor : public autopas::Functor<Particle, ParticleCell> {
 
   // virtual void SoALoader(ParticleCell &cell, autopas::SoA &soa, size_t
   // offset=0) {}
-  MOCK_METHOD2_T(SoALoader, void(ParticleCell &cell, autopas::SoA<typename Particle::SoAArraysType> &soa));
-  MOCK_METHOD3_T(SoALoader,
-                 void(ParticleCell &cell, autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset));
+  MOCK_METHOD2_T(SoALoader,
+                 void(autopas::ParticleCell<Particle> &cell, autopas::SoA<typename Particle::SoAArraysType> &soa));
+  MOCK_METHOD3_T(SoALoader, void(autopas::ParticleCell<Particle> &cell,
+                                 autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset));
 
   MOCK_METHOD3_T(SoALoaderVerlet, void(typename autopas::VerletListHelpers<Particle>::VerletListParticleCellType &cell,
                                        autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset));
 
   template <typename /*dummy*/ = void,
             typename = std::enable_if_t<not std::is_same<
-                typename autopas::VerletListHelpers<Particle>::VerletListParticleCellType, ParticleCell>::value>>
+                typename autopas::VerletListHelpers<Particle>::VerletListParticleCellType, ParticleCell_t>::value>>
   void SoALoader(typename autopas::VerletListHelpers<Particle>::VerletListParticleCellType &cell,
                  autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset = 0) {
     SoALoaderVerlet(cell, soa, offset);
@@ -58,16 +60,16 @@ class MockFunctor : public autopas::Functor<Particle, ParticleCell> {
 
   // virtual void SoAExtractor(ParticleCell &cell, autopas::SoA &soa, size_t
   // offset=0) {}
-  MOCK_METHOD2_T(SoAExtractor, void(ParticleCell &cell, autopas::SoA<typename Particle::SoAArraysType> &soa));
+  MOCK_METHOD2_T(SoAExtractor, void(ParticleCell_t &cell, autopas::SoA<typename Particle::SoAArraysType> &soa));
   MOCK_METHOD3_T(SoAExtractor,
-                 void(ParticleCell &cell, autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset));
+                 void(ParticleCell_t &cell, autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset));
 
   MOCK_METHOD3_T(SoAExtractorVerlet,
                  void(typename autopas::VerletListHelpers<Particle>::VerletListParticleCellType &cell,
                       autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset));
 
   template <typename = std::enable_if_t<not std::is_same<
-                typename autopas::VerletListHelpers<Particle>::VerletListParticleCellType, ParticleCell>::value>>
+                typename autopas::VerletListHelpers<Particle>::VerletListParticleCellType, ParticleCell_t>::value>>
   void SoAExtractor(typename autopas::VerletListHelpers<Particle>::VerletListParticleCellType &cell,
                     autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset = 0) {
     SoAExtractorVerlet(cell, soa, offset);

--- a/tests/testAutopas/mocks/MockFunctor.h
+++ b/tests/testAutopas/mocks/MockFunctor.h
@@ -62,9 +62,10 @@ class MockFunctor : public autopas::Functor<Particle, ParticleCell_t> {
 
   // virtual void SoAExtractor(ParticleCell &cell, autopas::SoA &soa, size_t
   // offset=0) {}
-  MOCK_METHOD2_T(SoAExtractor, void(ParticleCell_t &cell, autopas::SoA<typename Particle::SoAArraysType> &soa));
-  MOCK_METHOD3_T(SoAExtractor,
-                 void(ParticleCell_t &cell, autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset));
+  MOCK_METHOD2_T(SoAExtractor,
+                 void(autopas::ParticleCell<Particle> &cell, autopas::SoA<typename Particle::SoAArraysType> &soa));
+  MOCK_METHOD3_T(SoAExtractor, void(autopas::ParticleCell<Particle> &cell,
+                                    autopas::SoA<typename Particle::SoAArraysType> &soa, size_t offset));
 
   MOCK_METHOD3_T(SoAExtractorVerlet,
                  void(typename autopas::VerletListHelpers<Particle>::VerletListParticleCellType &cell,

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalRaceConditionTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalRaceConditionTest.h
@@ -66,8 +66,6 @@ class TraversalRaceConditionTest : public AutoPasTestBase {
       j.subF(f);
     }
 
-    AUTOPAS_FUNCTOR_SOAEXTRACTOR(, , , );
-
    private:
     const double _cutoffSquare;
   };

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalRaceConditionTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalRaceConditionTest.h
@@ -64,8 +64,6 @@ class TraversalRaceConditionTest : public AutoPasTestBase {
 
     AUTOPAS_FUNCTOR_SOAEXTRACTOR(, , , );
 
-    AUTOPAS_FUNCTOR_SOALOADER(, , , );
-
    private:
     // in a grid with separation 1 this includes all neighbors with a Chebyshev
     // distance of 1

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.h
@@ -70,9 +70,6 @@ class TraversalTest : public AutoPasTestBase,
     // countFunc isn't a real function. It's just a declaration which is used to count the number of interactions.
     MOCK_METHOD1(countFunc, void(unsigned long id));
 
-    // The following definitions are needed to fullfill requirements of autopas::functor
-    AUTOPAS_FUNCTOR_SOAEXTRACTOR(, , , );
-
    private:
     floatType _cutoffSquare;
   };

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.h
@@ -76,8 +76,6 @@ class TraversalTest : public AutoPasTestBase,
     // The following definitions are needed to fullfill requirements of autopas::functor
     AUTOPAS_FUNCTOR_SOAEXTRACTOR(, , , );
 
-    AUTOPAS_FUNCTOR_SOALOADER(, , , );
-
    private:
     double cutoffSquare;
   };


### PR DESCRIPTION
# Description

Functors now explicitly declare which values are computed and which values are needed. 
- [x] add specialized methods to `ParticleBase` which identify attributes by using the corresponding attribute name (enum)
  - [x] add getter
  - [x] add setter
- [x] remove `#define`
  - [x] `#define AUTOPAS_FUNCTOR_SOALOADER`
  - [x] `#define AUTOPAS_FUNCTOR_SOAEXTRACTOR`
- [x] move `SoALoader`/`SoAExtractor` to class `Functor`
- [x] ~~C04SoA: only write necessary values~~ (Will be done in another PR)
- [x] C01 (combined SoA buffers): only write necessary values (#285)
- [x] use more C++17 in traversals

## Related Pull Requests

- #274 (base branch)

## Resolved Issues

- [x] closes #285

# How Has This Been Tested?

- [x] Jenkins
