### PR TITLE
Add generic to_string function, Bug fix NumberSet

### DIFF
--- a/cmake/modules/other-compileroptions.cmake
+++ b/cmake/modules/other-compileroptions.cmake
@@ -22,11 +22,16 @@ target_compile_options(
         $<$<AND:$<NOT:$<BOOL:${AUTOPAS_ENABLE_FAST_MATH}>>,$<CXX_COMPILER_ID:Intel>>:$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=>-fp-model
         precise>
         # Warnings:
-        # no warnings for intel because it's mainly spam
-        $<$<CXX_COMPILER_ID:GNU>:$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=>-Wsuggest-override
+        # no warnings for intel because it's mainly spam, but we disable one, because of a compiler
+        # bug:
+        # https://software.intel.com/en-us/forums/intel-c-compiler/topic/814098
+        $<$<CXX_COMPILER_ID:Intel>:$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=>-wd13212>
+        $<$<CXX_COMPILER_ID:GNU>:
+        $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=>-Wsuggest-override
         $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=>-Wall
         $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=>-Wno-unused-variable
-        $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=>-Wno-unused-function>
+        $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=>-Wno-unused-function
+        >
         $<$<CXX_COMPILER_ID:Clang>:$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=>-Wall>
         # @TODO clean up code with -Weffc++
 )

--- a/examples/sph/sph-main.cpp
+++ b/examples/sph/sph-main.cpp
@@ -9,6 +9,7 @@
 #include <iostream>
 #include "autopas/AutoPas.h"
 #include "autopas/sph/autopassph.h"
+#include "autopas/utils/ArrayUtils.h"
 
 typedef autopas::AutoPas<autopas::sph::SPHParticle, autopas::FullParticleCell<autopas::sph::SPHParticle>>
     AutoPasContainer;
@@ -64,8 +65,8 @@ double getTimeStepGlobal(AutoPasContainer &sphSystem) {
   for (auto part = sphSystem.begin(autopas::IteratorBehavior::ownedOnly); part.isValid(); ++part) {
     part->calcDt();
     if (part->getDt() < 0.002) {
-      std::cout << "small time step for particle " << part->getID() << " at [" << part->getR()[0] << ", "
-                << part->getR()[1] << ", " << part->getR()[2] << "]" << std::endl;
+      std::cout << "small time step for particle " << part->getID() << " at ["
+                << autopas::ArrayUtils::to_string(part->getR()) << "]" << std::endl;
     }
     dt = std::min(dt, part->getDt());
   }
@@ -178,7 +179,7 @@ void updateHaloParticles(AutoPasContainer &sphSystem) {
       for (diff[2] = -1; diff[2] < 2; diff[2]++) {
         if (not diff[0] and not diff[1] and not diff[2]) {
           // at least one dimension has to be non-zero
-          std::cout << "skipping diff: " << diff[0] << ", " << diff[1] << ", " << diff[2] << std::endl;
+          std::cout << "skipping diff: " << autopas::ArrayUtils::to_string(diff) << std::endl;
           continue;
         }
         // figure out from where we get our halo particles

--- a/src/autopas/containers/linkedCells/traversals/C01Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/C01Traversal.h
@@ -11,6 +11,7 @@
 #include "autopas/options/DataLayoutOption.h"
 #include "autopas/pairwiseFunctors/CellFunctor.h"
 #include "autopas/utils/ArrayMath.h"
+#include "autopas/utils/ArrayUtils.h"
 #include "autopas/utils/WrapOpenMP.h"
 
 namespace autopas {
@@ -164,7 +165,7 @@ inline void C01Traversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3, 
         const double distSquare = ArrayMath::dot(pos, pos);
         if (distSquare <= interactionLengthSquare) {
           const long currentOffset = utils::ThreeDimensionalMapping::threeToOneD(
-              x, y, z, ArrayMath::static_cast_array<long>(this->_cellsPerDimension));
+              x, y, z, ArrayUtils::static_cast_array<long>(this->_cellsPerDimension));
           const bool containCurrentOffset =
               std::any_of(_cellOffsets[x + this->_overlap[0]].cbegin(), _cellOffsets[x + this->_overlap[0]].cend(),
                           [currentOffset](const auto &e) { return e.first == currentOffset; });
@@ -173,7 +174,7 @@ inline void C01Traversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3, 
           }
           for (long ix = x; ix <= std::abs(x); ++ix) {
             const long offset = utils::ThreeDimensionalMapping::threeToOneD(
-                ix, y, z, ArrayMath::static_cast_array<long>(this->_cellsPerDimension));
+                ix, y, z, ArrayUtils::static_cast_array<long>(this->_cellsPerDimension));
             const size_t index = ix + this->_overlap[0];
             if (y == 0l and z == 0l) {
               // make sure center of slice is always at the beginning

--- a/src/autopas/containers/linkedCells/traversals/C04Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/C04Traversal.h
@@ -44,7 +44,7 @@ class C04Traversal : public C08BasedTraversal<ParticleCell, PairwiseFunctor, Dat
       : C08BasedTraversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>(dims, pairwiseFunctor,
                                                                                  interactionLength, cellLength),
         _cellHandler(pairwiseFunctor, this->_cellsPerDimension, interactionLength, cellLength, this->_overlap),
-        _end(ArrayMath::subScalar(ArrayMath::static_cast_array<long>(this->_cellsPerDimension), 1l)) {
+        _end(ArrayMath::subScalar(ArrayUtils::static_cast_array<long>(this->_cellsPerDimension), 1l)) {
     computeOffsets32Pack();
   }
 
@@ -132,7 +132,7 @@ void C04Traversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>::proces
     std::vector<ParticleCell> &cells, const std::array<long, 3> &base3DIndex) {
   using utils::ThreeDimensionalMapping::threeToOneD;
   std::array<long, 3> index;
-  const std::array<long, 3> signedDims = ArrayMath::static_cast_array<long>(this->_cellsPerDimension);
+  const std::array<long, 3> signedDims = ArrayUtils::static_cast_array<long>(this->_cellsPerDimension);
 
   for (auto Offset32Pack : _cellOffsets32Pack) {
     // compute 3D index

--- a/src/autopas/containers/linkedCells/traversals/C18Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/C18Traversal.h
@@ -10,6 +10,7 @@
 #include "autopas/containers/cellPairTraversals/C18BasedTraversal.h"
 #include "autopas/options/DataLayoutOption.h"
 #include "autopas/pairwiseFunctors/CellFunctor.h"
+#include "autopas/utils/ArrayUtils.h"
 #include "autopas/utils/ThreeDimensionalMapping.h"
 #include "autopas/utils/WrapOpenMP.h"
 
@@ -115,7 +116,7 @@ class C18Traversal : public C18BasedTraversal<ParticleCell, PairwiseFunctor, Dat
 template <class ParticleCell, class PairwiseFunctor, DataLayoutOption DataLayout, bool useNewton3>
 inline void C18Traversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>::computeOffsets() {
   _cellOffsets.resize(2 * this->_overlap[1] + 1, std::vector<offsetArray_t>(2 * this->_overlap[0] + 1));
-  const std::array<long, 3> _overlap_s = ArrayMath::static_cast_array<long>(this->_overlap);
+  const std::array<long, 3> _overlap_s = ArrayUtils::static_cast_array<long>(this->_overlap);
 
   const auto interactionLengthSquare(this->_interactionLength * this->_interactionLength);
 
@@ -123,7 +124,7 @@ inline void C18Traversal<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>:
     for (long y = -_overlap_s[1]; y <= _overlap_s[1]; ++y) {
       for (long x = -_overlap_s[0]; x <= _overlap_s[0]; ++x) {
         const long offset = utils::ThreeDimensionalMapping::threeToOneD(
-            x, y, z, ArrayMath::static_cast_array<long>(this->_cellsPerDimension));
+            x, y, z, ArrayUtils::static_cast_array<long>(this->_cellsPerDimension));
 
         if (offset < 0l) {
           continue;

--- a/src/autopas/utils/ArrayMath.h
+++ b/src/autopas/utils/ArrayMath.h
@@ -23,7 +23,7 @@ namespace autopas::ArrayMath {
  * @return a + b
  */
 template <class T, std::size_t SIZE>
-constexpr std::array<T, SIZE> add(const std::array<T, SIZE> &a, const std::array<T, SIZE> &b) {
+[[nodiscard]] constexpr std::array<T, SIZE> add(const std::array<T, SIZE> &a, const std::array<T, SIZE> &b) {
   std::array<T, SIZE> result{};
   for (std::size_t d = 0; d < SIZE; ++d) {
     result[d] = a[d] + b[d];
@@ -40,7 +40,7 @@ constexpr std::array<T, SIZE> add(const std::array<T, SIZE> &a, const std::array
  * @return a - b
  */
 template <class T, std::size_t SIZE>
-constexpr std::array<T, SIZE> sub(const std::array<T, SIZE> &a, const std::array<T, SIZE> &b) {
+[[nodiscard]] constexpr std::array<T, SIZE> sub(const std::array<T, SIZE> &a, const std::array<T, SIZE> &b) {
   std::array<T, SIZE> result{};
   for (std::size_t d = 0; d < SIZE; ++d) {
     result[d] = a[d] - b[d];
@@ -57,7 +57,7 @@ constexpr std::array<T, SIZE> sub(const std::array<T, SIZE> &a, const std::array
  * @return element-wise multiplication of a and b
  */
 template <class T, std::size_t SIZE>
-constexpr std::array<T, SIZE> mul(const std::array<T, SIZE> &a, const std::array<T, SIZE> &b) {
+[[nodiscard]] constexpr std::array<T, SIZE> mul(const std::array<T, SIZE> &a, const std::array<T, SIZE> &b) {
   std::array<T, SIZE> result{};
   for (std::size_t d = 0; d < SIZE; ++d) {
     result[d] = a[d] * b[d];
@@ -74,7 +74,7 @@ constexpr std::array<T, SIZE> mul(const std::array<T, SIZE> &a, const std::array
  * @return array who's elements are a[i]+s
  */
 template <class T, std::size_t SIZE>
-constexpr std::array<T, SIZE> addScalar(const std::array<T, SIZE> &a, T s) {
+[[nodiscard]] constexpr std::array<T, SIZE> addScalar(const std::array<T, SIZE> &a, T s) {
   std::array<T, SIZE> result{};
   for (std::size_t d = 0; d < SIZE; ++d) {
     result[d] = a[d] + s;
@@ -91,7 +91,7 @@ constexpr std::array<T, SIZE> addScalar(const std::array<T, SIZE> &a, T s) {
  * @return array who's elements are a[i]-s
  */
 template <class T, std::size_t SIZE>
-constexpr std::array<T, SIZE> subScalar(const std::array<T, SIZE> &a, T s) {
+[[nodiscard]] constexpr std::array<T, SIZE> subScalar(const std::array<T, SIZE> &a, T s) {
   std::array<T, SIZE> result{};
   for (std::size_t d = 0; d < SIZE; ++d) {
     result[d] = a[d] - s;
@@ -108,7 +108,7 @@ constexpr std::array<T, SIZE> subScalar(const std::array<T, SIZE> &a, T s) {
  * @return array who's elements are a[i]*s
  */
 template <class T, std::size_t SIZE>
-constexpr std::array<T, SIZE> mulScalar(const std::array<T, SIZE> &a, T s) {
+[[nodiscard]] constexpr std::array<T, SIZE> mulScalar(const std::array<T, SIZE> &a, T s) {
   std::array<T, SIZE> result{};
   for (std::size_t d = 0; d < SIZE; ++d) {
     result[d] = a[d] * s;
@@ -126,7 +126,7 @@ constexpr std::array<T, SIZE> mulScalar(const std::array<T, SIZE> &a, T s) {
  * @return dot product of a and b
  */
 template <class T, std::size_t SIZE>
-constexpr T dot(const std::array<T, SIZE> &a, const std::array<T, SIZE> &b) {
+[[nodiscard]] constexpr T dot(const std::array<T, SIZE> &a, const std::array<T, SIZE> &b) {
   auto result = static_cast<T>(0.0);
   for (std::size_t d = 0; d < SIZE; ++d) {
     result += a[d] * b[d];
@@ -142,7 +142,7 @@ constexpr T dot(const std::array<T, SIZE> &a, const std::array<T, SIZE> &b) {
  * @return normalized array of a
  */
 template <class T, std::size_t SIZE>
-constexpr std::array<T, SIZE> normalize(const std::array<T, SIZE> &a) {
+[[nodiscard]] constexpr std::array<T, SIZE> normalize(const std::array<T, SIZE> &a) {
   const T length = std::sqrt(dot(a, a));
   return mulScalar(a, static_cast<T>(1) / length);
 }

--- a/src/autopas/utils/ArrayMath.h
+++ b/src/autopas/utils/ArrayMath.h
@@ -135,23 +135,6 @@ constexpr T dot(const std::array<T, SIZE> &a, const std::array<T, SIZE> &b) {
 }
 
 /**
- * Creates a new array by performing an element-wise static_cast<>.
- * @tparam output_t Output type.
- * @tparam input_t Input type.
- * @tparam SIZE Size of the array.
- * @param a Input array.
- * @return Array of type std::array<output_t, SIZE>.
- */
-template <class output_t, class input_t, std::size_t SIZE>
-constexpr std::array<output_t, SIZE> static_cast_array(const std::array<input_t, SIZE> &a) {
-  std::array<output_t, SIZE> result{};
-  for (std::size_t d = 0; d < SIZE; ++d) {
-    result[d] = static_cast<output_t>(a[d]);
-  }
-  return result;
-}
-
-/**
  * Generates a normalized array (|a| = 1).
  * @tparam T floating point type
  * @tparam SIZE size of the array
@@ -162,29 +145,6 @@ template <class T, std::size_t SIZE>
 constexpr std::array<T, SIZE> normalize(const std::array<T, SIZE> &a) {
   const T length = std::sqrt(dot(a, a));
   return mulScalar(a, static_cast<T>(1) / length);
-}
-
-/**
- * Generates a string representation of a container which fulfills the Container requirement (provide cbegin and cend).
- * @tparam T Type of Container.
- * @param a Container.
- * @param delimiter String delimiter.
- * @return String representation of a.
- */
-template <class T>
-std::string to_string(const T &a, const std::string &delimiter = ", ") {
-  auto it = std::cbegin(a);
-  const auto end = std::cend(a);
-  if (it == end) {
-    return "";
-  }
-  std::ostringstream strStream;
-  strStream << *it;
-  for (++it; it != end; ++it) {
-    strStream << delimiter << *it;
-  }
-
-  return strStream.str();
 }
 
 }  // namespace autopas::ArrayMath

--- a/src/autopas/utils/ArrayMath.h
+++ b/src/autopas/utils/ArrayMath.h
@@ -10,6 +10,7 @@
 #include <array>
 #include <cmath>
 #include <numeric>
+#include <sstream>
 
 namespace autopas::ArrayMath {
 
@@ -161,6 +162,29 @@ template <class T, std::size_t SIZE>
 constexpr std::array<T, SIZE> normalize(const std::array<T, SIZE> &a) {
   const T length = std::sqrt(dot(a, a));
   return mulScalar(a, static_cast<T>(1) / length);
+}
+
+/**
+ * Generates a string representation of a container which fulfills the Container requirement (provide cbegin and cend).
+ * @tparam T Type of Container.
+ * @param a Container.
+ * @param delimiter String delimiter.
+ * @return String representation of a.
+ */
+template <class T>
+std::string to_string(const T &a, const std::string &delimiter = ", ") {
+  auto it = std::cbegin(a);
+  const auto end = std::cend(a);
+  if (it == end) {
+    return "";
+  }
+  std::ostringstream strStream;
+  strStream << *it;
+  for (++it; it != end; ++it) {
+    strStream << delimiter << *it;
+  }
+
+  return strStream.str();
 }
 
 }  // namespace autopas::ArrayMath

--- a/src/autopas/utils/ArrayUtils.h
+++ b/src/autopas/utils/ArrayUtils.h
@@ -1,7 +1,7 @@
 /**
  * @file ArrayUtils.h
  *
- . @date 11.07.2019.
+ * @date 11.07.2019.
  * @author C.Menges
  */
 

--- a/src/autopas/utils/ArrayUtils.h
+++ b/src/autopas/utils/ArrayUtils.h
@@ -21,7 +21,7 @@ namespace autopas::ArrayUtils {
  * @return Array of type std::array<output_t, SIZE>.
  */
 template <class output_t, class input_t, std::size_t SIZE>
-constexpr std::array<output_t, SIZE> static_cast_array(const std::array<input_t, SIZE> &a) {
+[[nodiscard]] constexpr std::array<output_t, SIZE> static_cast_array(const std::array<input_t, SIZE> &a) {
   std::array<output_t, SIZE> result{};
   for (std::size_t d = 0; d < SIZE; ++d) {
     result[d] = static_cast<output_t>(a[d]);
@@ -37,7 +37,7 @@ constexpr std::array<output_t, SIZE> static_cast_array(const std::array<input_t,
  * @return String representation of a.
  */
 template <class T>
-std::string to_string(T &&a, const std::string &delimiter = ", ") {
+[[nodiscard]] std::string to_string(T &&a, const std::string &delimiter = ", ") {
   auto it = std::cbegin(a);
   const auto end = std::cend(a);
   if (it == end) {

--- a/src/autopas/utils/ArrayUtils.h
+++ b/src/autopas/utils/ArrayUtils.h
@@ -1,0 +1,55 @@
+/**
+ * @file ArrayUtils.h
+ *
+ . @date 11.07.2019.
+ * @author C.Menges
+ */
+
+#pragma once
+
+#include <array>
+#include <sstream>
+
+namespace autopas::ArrayUtils {
+
+/**
+ * Creates a new array by performing an element-wise static_cast<>.
+ * @tparam output_t Output type.
+ * @tparam input_t Input type.
+ * @tparam SIZE Size of the array.
+ * @param a Input array.
+ * @return Array of type std::array<output_t, SIZE>.
+ */
+template <class output_t, class input_t, std::size_t SIZE>
+constexpr std::array<output_t, SIZE> static_cast_array(const std::array<input_t, SIZE> &a) {
+  std::array<output_t, SIZE> result{};
+  for (std::size_t d = 0; d < SIZE; ++d) {
+    result[d] = static_cast<output_t>(a[d]);
+  }
+  return result;
+}
+
+/**
+ * Generates a string representation of a container which fulfills the Container requirement (provide cbegin and cend).
+ * @tparam T Type of Container.
+ * @param a Container.
+ * @param delimiter String delimiter.
+ * @return String representation of a.
+ */
+template <class T>
+std::string to_string(T &&a, const std::string &delimiter = ", ") {
+  auto it = std::cbegin(a);
+  const auto end = std::cend(a);
+  if (it == end) {
+    return "";
+  }
+  std::ostringstream strStream;
+  strStream << *it;
+  for (++it; it != end; ++it) {
+    strStream << delimiter << *it;
+  }
+
+  return strStream.str();
+}
+
+}  // namespace autopas::ArrayUtils

--- a/src/autopas/utils/NumberSet.h
+++ b/src/autopas/utils/NumberSet.h
@@ -9,6 +9,7 @@
 #include <set>
 #include <sstream>
 #include <vector>
+#include "autopas/utils/ArrayMath.h"
 #include "autopas/utils/ExceptionHandler.h"
 #include "autopas/utils/Random.h"
 
@@ -107,17 +108,7 @@ class NumberSetFinite : public NumberSet<Number> {
 
   std::unique_ptr<NumberSet<Number>> clone() const override { return std::make_unique<NumberSetFinite>(*this); }
 
-  operator std::string() const override {
-    auto it = _set.begin();
-    std::stringstream ss;
-    ss << "{" << *it;
-    for (++it; it != _set.end(); ++it) {
-      ss << ", " << *it;
-    }
-    ss << "}";
-
-    return ss.str();
-  }
+  operator std::string() const override { return "{" + ArrayMath::to_string(_set) + "}"; }
 
   inline bool isEmpty() const override { return _set.empty(); }
   inline bool isFinite() const override { return true; }
@@ -164,7 +155,7 @@ class NumberInterval : public NumberSet<Number> {
   std::unique_ptr<NumberSet<Number>> clone() const override { return std::make_unique<NumberInterval>(*this); }
 
   operator std::string() const override {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "[" << _min << ", " << _max << "]";
     return ss.str();
   }

--- a/src/autopas/utils/NumberSet.h
+++ b/src/autopas/utils/NumberSet.h
@@ -10,6 +10,7 @@
 #include <sstream>
 #include <vector>
 #include "autopas/utils/ArrayMath.h"
+#include "autopas/utils/ArrayUtils.h"
 #include "autopas/utils/ExceptionHandler.h"
 #include "autopas/utils/Random.h"
 
@@ -108,7 +109,7 @@ class NumberSetFinite : public NumberSet<Number> {
 
   std::unique_ptr<NumberSet<Number>> clone() const override { return std::make_unique<NumberSetFinite>(*this); }
 
-  operator std::string() const override { return "{" + ArrayMath::to_string(_set) + "}"; }
+  operator std::string() const override { return "{" + ArrayUtils::to_string(_set) + "}"; }
 
   inline bool isEmpty() const override { return _set.empty(); }
   inline bool isFinite() const override { return true; }

--- a/src/autopas/utils/NumberSet.h
+++ b/src/autopas/utils/NumberSet.h
@@ -9,7 +9,6 @@
 #include <set>
 #include <sstream>
 #include <vector>
-#include "autopas/utils/ArrayMath.h"
 #include "autopas/utils/ArrayUtils.h"
 #include "autopas/utils/ExceptionHandler.h"
 #include "autopas/utils/Random.h"

--- a/tests/testAutopas/tests/containers/CellBlock3DTest.cpp
+++ b/tests/testAutopas/tests/containers/CellBlock3DTest.cpp
@@ -6,6 +6,7 @@
 
 #include "CellBlock3DTest.h"
 #include "testingHelpers/GridGenerator.h"
+#include "autopas/utils/ArrayUtils.h"
 
 void testIndex(autopas::internal::CellBlock3D<autopas::FullParticleCell<autopas::MoleculeLJ>> &cellBlock,
                std::array<double, 3> &start, std::array<double, 3> &dr, std::array<int, 3> &numParts) {
@@ -14,7 +15,7 @@ void testIndex(autopas::internal::CellBlock3D<autopas::FullParticleCell<autopas:
   unsigned long counter = 0ul;
   for (auto &m : mesh) {
     unsigned long index = cellBlock.get1DIndexOfPosition(m);
-    ASSERT_EQ(index, counter) << "Pos: [" << m[0] << ", " << m[1] << ", " << m[2] << "]";
+    ASSERT_EQ(index, counter) << "Pos: [" << autopas::ArrayUtils::to_string(m) << "]";
     ++counter;
   }
 }

--- a/tests/testAutopas/tests/containers/CellBlock3DTest.cpp
+++ b/tests/testAutopas/tests/containers/CellBlock3DTest.cpp
@@ -5,8 +5,8 @@
  */
 
 #include "CellBlock3DTest.h"
-#include "testingHelpers/GridGenerator.h"
 #include "autopas/utils/ArrayUtils.h"
+#include "testingHelpers/GridGenerator.h"
 
 void testIndex(autopas::internal::CellBlock3D<autopas::FullParticleCell<autopas::MoleculeLJ>> &cellBlock,
                std::array<double, 3> &start, std::array<double, 3> &dr, std::array<int, 3> &numParts) {

--- a/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
@@ -4,6 +4,7 @@
  * @date 03.04.18
  */
 #include "RegionParticleIteratorTest.h"
+#include "autopas/utils/ArrayUtils.h"
 #include "autopas/utils/WrapOpenMP.h"
 
 using namespace autopas;
@@ -105,9 +106,8 @@ void RegionParticleIteratorTest::testLinkedCellsRegionParticleIteratorBehaviorHa
     iterator->touch();
     bool isInRegionOfInterest = utils::inBox(iterator->getR(), testRegionMin, _regionMax);
     bool isInHalo = not utils::inBox(iterator->getR(), _boxMin, _boxMax);
-    EXPECT_TRUE(isInRegionOfInterest and isInHalo)
-        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
-        << " in thread: " << autopas_get_thread_num() << std::endl;
+    EXPECT_TRUE(isInRegionOfInterest and isInHalo) << " particle at [" << ArrayUtils::to_string(iterator->getR()) << "]"
+                                                   << " in thread: " << autopas_get_thread_num() << std::endl;
   }
 
   // check the touch using the normal iterator (needed to check whether no particle was forgotten)
@@ -117,8 +117,7 @@ void RegionParticleIteratorTest::testLinkedCellsRegionParticleIteratorBehaviorHa
     bool isInRegionOfInterest = utils::inBox(iterator->getR(), testRegionMin, _regionMax);
     bool isInHalo = not utils::inBox(iterator->getR(), _boxMin, _boxMax);
     EXPECT_EQ(isInRegionOfInterest and isInHalo ? 1 : 0, iterator->getNumTouched())
-        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
-        << std::endl;
+        << " particle at [" << ArrayUtils::to_string(iterator->getR()) << "]" << std::endl;
   }
 }
 
@@ -204,8 +203,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorCopyCons
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
     EXPECT_EQ(utils::inBox(iterator->getR(), _regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched())
-        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
-        << std::endl;
+        << " particle at [" << ArrayUtils::to_string(iterator->getR()) << "]" << std::endl;
   }
 }
 
@@ -241,8 +239,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorCopyAssi
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
     EXPECT_EQ(utils::inBox(iterator->getR(), _regionMin, _regionMax) ? 3 : 0, iterator->getNumTouched())
-        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
-        << std::endl;
+        << " particle at [" << ArrayUtils::to_string(iterator->getR()) << "]" << std::endl;
   }
 }
 
@@ -295,8 +292,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorSparseDo
   // no openmp for check!
   for (auto iterator = lcContainer.begin(); iterator.isValid(); ++iterator) {
     EXPECT_EQ(utils::inBox(iterator->getR(), regionOfInterstMin, regionOfInterstMax) ? 1 : 0, iterator->getNumTouched())
-        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
-        << std::endl;
+        << " particle at [" << ArrayUtils::to_string(iterator->getR()) << "]" << std::endl;
     ++particlesChecked;
   }
   EXPECT_EQ(particlesChecked, idShouldTouch + idShouldNotTouch - idOffset);
@@ -349,8 +345,7 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorSparseDoma
   int particlesChecked = 0;
   for (auto iterator = dsContainer.begin(); iterator.isValid(); ++iterator) {
     EXPECT_EQ(utils::inBox(iterator->getR(), regionOfInterstMin, regionOfInterstMax) ? 1 : 0, iterator->getNumTouched())
-        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
-        << std::endl;
+        << " particle at [" << ArrayUtils::to_string(iterator->getR()) << "]" << std::endl;
     ++particlesChecked;
   }
   EXPECT_EQ(particlesChecked, idShouldTouch + idShouldNotTouch - idOffset);
@@ -379,7 +374,7 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIterator) {
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
     EXPECT_EQ(utils::inBox(iterator->getR(), _regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched())
-        << "at: [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]";
+        << "at: [" << ArrayUtils::to_string(iterator->getR()) << "]";
   }
 }
 
@@ -410,8 +405,7 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorBehaviorOw
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
     EXPECT_EQ(utils::inBox(iterator->getR(), _boxMin, _regionMax) ? 1 : 0, iterator->getNumTouched())
-        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
-        << std::endl;
+        << " particle at [" << ArrayUtils::to_string(iterator->getR()) << "]" << std::endl;
   }
 }
 
@@ -445,8 +439,7 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorBehaviorHa
                   ? (utils::inBox(iterator->getR(), _boxMin, _regionMax) ? 0 : 1)
                   : 0,
               iterator->getNumTouched())
-        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
-        << std::endl;
+        << " particle at [" << ArrayUtils::to_string(iterator->getR()) << "]" << std::endl;
   }
 }
 
@@ -473,8 +466,7 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorEmpty) {
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
     EXPECT_EQ(utils::inBox(iterator->getR(), _regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched())
-        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
-        << std::endl;
+        << " particle at [" << ArrayUtils::to_string(iterator->getR()) << "]" << std::endl;
     i++;
   }
   EXPECT_EQ(i, 0);
@@ -502,8 +494,7 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorCopyConstr
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
     EXPECT_EQ(utils::inBox(iterator->getR(), _regionMin, _regionMax) ? 1 : 0, iterator->getNumTouched())
-        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
-        << std::endl;
+        << " particle at [" << ArrayUtils::to_string(iterator->getR()) << "]" << std::endl;
   }
 }
 
@@ -539,8 +530,7 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorCopyAssign
     //              << "] touched:" << iterator->getNumTouched() << std::endl;
 
     EXPECT_EQ(utils::inBox(iterator->getR(), _regionMin, _regionMax) ? 3 : 0, iterator->getNumTouched())
-        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
-        << std::endl;
+        << " particle at [" << ArrayUtils::to_string(iterator->getR()) << "]" << std::endl;
   }
 }
 
@@ -601,8 +591,7 @@ TEST_F(RegionParticleIteratorTest, testVerletRegionParticleIteratorSparseDomain)
   int particlesChecked = 0;
   for (auto iterator = vlContainer.begin(); iterator.isValid(); ++iterator) {
     EXPECT_EQ(utils::inBox(iterator->getR(), regionOfInterstMin, regionOfInterstMax) ? 1 : 0, iterator->getNumTouched())
-        << " particle at [" << iterator->getR()[0] << ", " << iterator->getR()[1] << ", " << iterator->getR()[2] << "]"
-        << std::endl;
+        << " particle at [" << ArrayUtils::to_string(iterator->getR()) << "]" << std::endl;
     ++particlesChecked;
   }
   EXPECT_EQ(particlesChecked, idShouldTouch + idShouldNotTouch - idOffset);
@@ -613,12 +602,12 @@ void RegionParticleIteratorTest::checkTouches(LCTouch &lcContainer, std::array<d
   int numTouches = 0;
   // check the touch. Iterating over cells provides more debug info than normal iterator.
   for (size_t cellId = 0; cellId < lcContainer.getCells().size(); ++cellId) {
-    auto cellId3D = utils::ThreeDimensionalMapping::oneToThreeD(cellId, {7, 7, 7});
+    const auto cellId3D = utils::ThreeDimensionalMapping::oneToThreeD(cellId, {7, 7, 7});
     for (auto pIter = lcContainer.getCells()[cellId].begin(); pIter.isValid(); ++pIter) {
       ++numTouches;
       EXPECT_EQ(utils::inBox(pIter->getR(), regionMin, regionMax) ? 1 : 0, pIter->getNumTouched())
-          << "at: [" << pIter->getR()[0] << ", " << pIter->getR()[1] << ", " << pIter->getR()[2] << "]" << std::endl
-          << "in cell: " << cellId << " [" << cellId3D[0] << " | " << cellId3D[1] << " | " << cellId3D[2] << "]";
+          << "at: [" << ArrayUtils::to_string(pIter->getR()) << "]" << std::endl
+          << "in cell: " << cellId << " [" << ArrayUtils::to_string(cellId3D) << "]";
     }
   }
   EXPECT_GE(numTouches, 0) << "No Particles were checked!";

--- a/tests/testAutopas/tests/utils/ArrayMathTest.cpp
+++ b/tests/testAutopas/tests/utils/ArrayMathTest.cpp
@@ -104,3 +104,20 @@ TEST(ArrayMathTest, teststatic_cast_array) {
     static_assert(std::is_same<decltype(out), std::array<double, 3>>::value, "Type mismatch");
   }
 }
+
+TEST(ArrayMathTest, testto_string) {
+  std::array<size_t, 0> emptyContainer;
+  EXPECT_EQ("", ArrayMath::to_string(emptyContainer));
+
+  std::array<size_t, 3> arrayContainer{1, 2, 3};
+  EXPECT_EQ("1, 2, 3", ArrayMath::to_string(arrayContainer));
+  EXPECT_EQ("1x2x3", ArrayMath::to_string(arrayContainer, "x"));
+
+  std::vector<size_t> vectorContainer{1, 2, 3};
+  EXPECT_EQ("1, 2, 3", ArrayMath::to_string(vectorContainer));
+  EXPECT_EQ("1x2x3", ArrayMath::to_string(vectorContainer, "x"));
+
+  std::basic_string bStringContainer("123");
+  EXPECT_EQ("1, 2, 3", ArrayMath::to_string(bStringContainer));
+  EXPECT_EQ("1x2x3", ArrayMath::to_string(bStringContainer, "x"));
+}

--- a/tests/testAutopas/tests/utils/ArrayMathTest.cpp
+++ b/tests/testAutopas/tests/utils/ArrayMathTest.cpp
@@ -90,34 +90,3 @@ TEST(ArrayMathTest, testNormalize) {
     ASSERT_DOUBLE_EQ(result[d], correctResult[d]);
   }
 }
-
-TEST(ArrayMathTest, teststatic_cast_array) {
-  {
-    std::array<long, 3> in({1l, 2l, 3l});
-    auto out = ArrayMath::static_cast_array<unsigned long>(in);
-    static_assert(std::is_same<decltype(out), std::array<unsigned long, 3>>::value, "Type mismatch");
-  }
-
-  {
-    std::array<long, 3> in({1l, 2l, 3l});
-    auto out = ArrayMath::static_cast_array<double>(in);
-    static_assert(std::is_same<decltype(out), std::array<double, 3>>::value, "Type mismatch");
-  }
-}
-
-TEST(ArrayMathTest, testto_string) {
-  std::array<size_t, 0> emptyContainer;
-  EXPECT_EQ("", ArrayMath::to_string(emptyContainer));
-
-  std::array<size_t, 3> arrayContainer{1, 2, 3};
-  EXPECT_EQ("1, 2, 3", ArrayMath::to_string(arrayContainer));
-  EXPECT_EQ("1x2x3", ArrayMath::to_string(arrayContainer, "x"));
-
-  std::vector<size_t> vectorContainer{1, 2, 3};
-  EXPECT_EQ("1, 2, 3", ArrayMath::to_string(vectorContainer));
-  EXPECT_EQ("1x2x3", ArrayMath::to_string(vectorContainer, "x"));
-
-  std::basic_string bStringContainer("123");
-  EXPECT_EQ("1, 2, 3", ArrayMath::to_string(bStringContainer));
-  EXPECT_EQ("1x2x3", ArrayMath::to_string(bStringContainer, "x"));
-}

--- a/tests/testAutopas/tests/utils/ArrayUtilsTest.cpp
+++ b/tests/testAutopas/tests/utils/ArrayUtilsTest.cpp
@@ -1,0 +1,41 @@
+/**
+ * @file ArrayUtilsTest.cpp
+ * @author tchipev
+ * @date 19.01.18
+ */
+
+#include <gtest/gtest.h>
+#include "autopas/utils/ArrayUtils.h"
+
+using namespace autopas;
+
+TEST(ArrayUtilsTest, teststatic_cast_array) {
+  {
+    std::array<long, 3> in({1l, 2l, 3l});
+    auto out = ArrayUtils::static_cast_array<unsigned long>(in);
+    static_assert(std::is_same<decltype(out), std::array<unsigned long, 3>>::value, "Type mismatch");
+  }
+
+  {
+    std::array<long, 3> in({1l, 2l, 3l});
+    auto out = ArrayUtils::static_cast_array<double>(in);
+    static_assert(std::is_same<decltype(out), std::array<double, 3>>::value, "Type mismatch");
+  }
+}
+
+TEST(ArrayUtilsTest, testto_string) {
+  std::array<size_t, 0> emptyContainer;
+  EXPECT_EQ("", ArrayUtils::to_string(emptyContainer));
+
+  std::array<size_t, 3> arrayContainer{1, 2, 3};
+  EXPECT_EQ("1, 2, 3", ArrayUtils::to_string(arrayContainer));
+  EXPECT_EQ("1x2x3", ArrayUtils::to_string(arrayContainer, "x"));
+
+  std::vector<size_t> vectorContainer{1, 2, 3};
+  EXPECT_EQ("1, 2, 3", ArrayUtils::to_string(vectorContainer));
+  EXPECT_EQ("1x2x3", ArrayUtils::to_string(vectorContainer, "x"));
+
+  std::basic_string bStringContainer("123");
+  EXPECT_EQ("1, 2, 3", ArrayUtils::to_string(bStringContainer));
+  EXPECT_EQ("1x2x3", ArrayUtils::to_string(bStringContainer, "x"));
+}

--- a/tests/testAutopas/tests/utils/NumberSetTest.cpp
+++ b/tests/testAutopas/tests/utils/NumberSetTest.cpp
@@ -133,3 +133,15 @@ TEST(NumberSetTest, testClone) {
   ASSERT_EQ(clone->getMin(), set.getMin());
   ASSERT_EQ(clone->getMax(), set.getMax());
 }
+
+TEST(NumberSetTest, testStringRepresentation) {
+  // Empty set
+  NumberSetFinite<double> emptyfSet;
+  NumberSet<double> &emptySet = emptyfSet;
+  EXPECT_EQ("{}", static_cast<std::string>(emptySet));
+
+  // Filled set
+  NumberSetFinite<double> fSet({1., 2., 3.});
+  NumberSet<double> &Set = fSet;
+  EXPECT_EQ("{1, 2, 3}", static_cast<std::string>(Set));
+}


### PR DESCRIPTION
# Description

This PR adds a generic `to_string` function to `ArrayMath`, which can convert all containers (`cbegin` + `cend` are required) to a string representation (really helpful for debugging). 
It also fixes a bug in `NumberSet`. If the set was empty, the string conversion method never terminated.

# How Has This Been Tested?

- [x] New test cases
- [x] Jenkins
