### PR TITLE
make updateContainer also return whether the container was updated

### DIFF
--- a/examples/sph-mpi/sph-main-mpi.cpp
+++ b/examples/sph-mpi/sph-main-mpi.cpp
@@ -525,11 +525,12 @@ int main(int argc, char *argv[]) {
     leapfrogFullDrift(sphSystem, dt);  // changes position
 
     // 1.2.1 positions have changed, so the container needs to be updated!
-    auto invalidParticles = sphSystem.updateContainer();
+    auto [invalidParticles, updated] = sphSystem.updateContainer();
 
-    // 1.2.2 adjust positions based on boundary conditions (here: periodic)
-    periodicBoundaryUpdate(sphSystem, comm, invalidParticles, globalBoxMin, globalBoxMax);
-
+    if (updated) {
+      // 1.2.2 adjust positions based on boundary conditions (here: periodic)
+      periodicBoundaryUpdate(sphSystem, comm, invalidParticles, globalBoxMin, globalBoxMax);
+    }
     // 1.3 Leap frog: predict
     leapfrogPredict(sphSystem, dt);
     // 1.4 Calculate density, pressure and hydrodynamic forces

--- a/examples/sph/sph-main.cpp
+++ b/examples/sph/sph-main.cpp
@@ -340,11 +340,12 @@ int main() {
     leapfrogFullDrift(sphSystem, dt);
 
     // 1.2.1 positions have changed, so the container needs to be updated!
-    auto invalidParticles = sphSystem.updateContainer();
+    auto [invalidParticles, updated] = sphSystem.updateContainer();
 
-    // 1.2.2 adjust positions based on boundary conditions (here: periodic)
-    addEnteringParticles(sphSystem, invalidParticles);
-
+    if (updated) {
+      // 1.2.2 adjust positions based on boundary conditions (here: periodic)
+      addEnteringParticles(sphSystem, invalidParticles);
+    }
     // 1.3 Leap frog: predict
     leapfrogPredict(sphSystem, dt);
     // 1.4 Calculate density, pressure and hydrodynamic forces

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -109,10 +109,13 @@ class AutoPas {
    * no longer belong into the container will be returned, the lists will be invalidated. If the internal container is
    * still valid and a rebuild of the container is not forced, this will return an empty list of particles and nothing
    * else will happen.
-   * @return A vector of invalid particles that do no belong in the current container.
+   * @return A pair of a vector of invalid particles that do no belong in the current container and a bool that
+   * specifies whether the container was updated. If the bool is false, the vector will be an empty vector. If the
+   * returned bool evaluates to true, the vector can both be empty or non-empty, depending on whether particles have
+   * left the container or not.
    */
   AUTOPAS_WARN_UNUSED_RESULT
-  std::vector<Particle> updateContainer() { return _logicHandler->updateContainer(false); }
+  std::pair<std::vector<Particle>, bool> updateContainer() { return _logicHandler->updateContainer(false); }
 
   /**
    * Forces a container update.
@@ -121,7 +124,7 @@ class AutoPas {
    * @return A vector of invalid particles that do no belong in the current container.
    */
   AUTOPAS_WARN_UNUSED_RESULT
-  std::vector<Particle> updateContainerForced() { return _logicHandler->updateContainer(true); }
+  std::vector<Particle> updateContainerForced() { return std::get<0>(_logicHandler->updateContainer(true)); }
 
   /**
    * Adds a particle to the container.

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -34,14 +34,14 @@ class LogicHandler {
    * @param forced specifies whether an update of the container is enforced.
    */
   AUTOPAS_WARN_UNUSED_RESULT
-  std::vector<Particle> updateContainer(bool forced) {
+  std::pair<std::vector<Particle>, bool> updateContainer(bool forced) {
     if (not isContainerValid() or forced) {
       AutoPasLog(debug, "Initiating container update.");
       _containerIsValid = false;
-      return std::move(_autoTuner.getContainer()->updateContainer());
+      return std::make_pair(std::move(_autoTuner.getContainer()->updateContainer()), true);
     } else {
       AutoPasLog(debug, "Skipping container update.");
-      return std::vector<Particle>{};
+      return std::make_pair(std::vector<Particle>{}, false);
     }
   }
 

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
@@ -149,16 +149,17 @@ void addHaloParticles(autopas::AutoPas<Molecule, FMCell> &autoPas, std::vector<M
 template <typename Functor>
 void doSimulationLoop(autopas::AutoPas<Molecule, FMCell> &autoPas, Functor *functor) {
   // 1. update Container; return value is vector of invalid == leaving particles!
-  auto invalidParticles = autoPas.updateContainer();
+  auto [invalidParticles, updated] = autoPas.updateContainer();
 
-  // 2. leaving and entering particles
-  const auto &sendLeavingParticles = invalidParticles;
-  // 2b. get+add entering particles (addParticle)
-  const auto &enteringParticles = convertToEnteringParticles(sendLeavingParticles);
-  auto numAdded = addEnteringParticles(autoPas, enteringParticles);
+  if (updated) {
+    // 2. leaving and entering particles
+    const auto &sendLeavingParticles = invalidParticles;
+    // 2b. get+add entering particles (addParticle)
+    const auto &enteringParticles = convertToEnteringParticles(sendLeavingParticles);
+    auto numAdded = addEnteringParticles(autoPas, enteringParticles);
 
-  EXPECT_EQ(numAdded, enteringParticles.size());
-
+    EXPECT_EQ(numAdded, enteringParticles.size());
+  }
   // 3. halo particles
   // 3a. identify and send inner particles that are in the halo of other autopas instances or itself.
   auto sendHaloParticles = identifyAndSendHaloParticles(autoPas);
@@ -175,25 +176,27 @@ template <typename Functor>
 void doSimulationLoop(autopas::AutoPas<Molecule, FMCell> &autoPas1, autopas::AutoPas<Molecule, FMCell> &autoPas2,
                       Functor *functor1, Functor *functor2) {
   // 1. update Container; return value is vector of invalid = leaving particles!
-  auto invalidParticles1 = autoPas1.updateContainer();
-  auto invalidParticles2 = autoPas2.updateContainer();
+  auto [invalidParticles1, updated1] = autoPas1.updateContainer();
+  auto [invalidParticles2, updated2] = autoPas2.updateContainer();
 
-  // 2. leaving and entering particles
-  const auto &sendLeavingParticles1 = invalidParticles1;
-  const auto &sendLeavingParticles2 = invalidParticles2;
-  // 2b. get+add entering particles (addParticle)
-  const auto &enteringParticles2 = convertToEnteringParticles(sendLeavingParticles1);
-  const auto &enteringParticles1 = convertToEnteringParticles(sendLeavingParticles2);
+  ASSERT_EQ(updated1, updated2);
+  if (updated1) {
+    // 2. leaving and entering particles
+    const auto &sendLeavingParticles1 = invalidParticles1;
+    const auto &sendLeavingParticles2 = invalidParticles2;
+    // 2b. get+add entering particles (addParticle)
+    const auto &enteringParticles2 = convertToEnteringParticles(sendLeavingParticles1);
+    const auto &enteringParticles1 = convertToEnteringParticles(sendLeavingParticles2);
 
-  // the particles may either still be in the same container (just going over periodic boundaries) or in the other.
-  size_t numAdded = 0;
-  numAdded += addEnteringParticles(autoPas1, enteringParticles1);
-  numAdded += addEnteringParticles(autoPas1, enteringParticles2);
-  numAdded += addEnteringParticles(autoPas2, enteringParticles1);
-  numAdded += addEnteringParticles(autoPas2, enteringParticles2);
+    // the particles may either still be in the same container (just going over periodic boundaries) or in the other.
+    size_t numAdded = 0;
+    numAdded += addEnteringParticles(autoPas1, enteringParticles1);
+    numAdded += addEnteringParticles(autoPas1, enteringParticles2);
+    numAdded += addEnteringParticles(autoPas2, enteringParticles1);
+    numAdded += addEnteringParticles(autoPas2, enteringParticles2);
 
-  ASSERT_EQ(numAdded, enteringParticles1.size() + enteringParticles2.size());
-
+    ASSERT_EQ(numAdded, enteringParticles1.size() + enteringParticles2.size());
+  }
   // 3. halo particles
   // 3a. identify and send inner particles that are in the halo of other autopas instances or itself.
   auto sendHaloParticles1 = identifyAndSendHaloParticles(autoPas1);


### PR DESCRIPTION
introduces bool that specifies whether the container within autopas was rebuild on updateContainer. This bool is returned together with the vector of invalid particles as a pair on a call to AutoPas::updateContainer()


Needed for a couple of different reasons. 
- performance: the possibility to neglect a leaving particle exchange
- correctness: it is now clear to the outside caller what the state of autopas is.