### PR TITLE
Use archer with clang8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -164,18 +164,6 @@ pipeline{
                         }
                     }
                 }
-                stage("thread sanitizer") {
-                    steps{
-                        container('autopas-gcc7-cmake-make') {
-                            dir("build-threadsanitizer"){
-                                // this is for simple testing of our threading libraries.
-                                sh "cmake -DCMAKE_BUILD_TYPE=Debug -DAUTOPAS_ENABLE_THREAD_SANITIZER=ON .."
-                                sh "make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
-                                sh './tests/testAutopas/runTests'
-                            }
-                        }
-                    }
-                }
                 stage("clang openmp") {
                     steps{
                         container('autopas-clang6-cmake-ninja-make'){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -217,14 +217,17 @@ pipeline{
                 }
                 stage("archer") {
                     steps{
-                        container('autopas-archer'){
+                        container('autopas-archer-clang-8'){
                             dir("build-archer"){
-                                sh "CXXFLAGS=-Wno-pass-failed CC=clang-archer CXX=clang-archer++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_USE_VECTORIZATION=OFF .."
+                                sh """
+                                    CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
+                                     -DAUTOPAS_USE_VECTORIZATION=OFF -DAUTOPAS_OPENMP=ON -DAUTOPAS_ENABLE_THREAD_SANITIZER=ON ..
+                                   """
                                 sh "ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
-                                sh 'export TSAN_OPTIONS="ignore_noninstrumented_modules=1" && export ARCHER_OPTIONS="print_ompt_counters=1" && ctest --verbose'
+                                sh 'ctest --verbose'
                             }
                             dir("build-archer/examples"){
-                                sh 'export TSAN_OPTIONS="ignore_noninstrumented_modules=1" && export ARCHER_OPTIONS="print_ompt_counters=1" && ctest -C checkExamples -j8 --verbose'
+                                sh 'ctest -C checkExamples -j8 --verbose'
                             }
                         }
                     }

--- a/cmake/modules/OpenMP.cmake
+++ b/cmake/modules/OpenMP.cmake
@@ -12,7 +12,7 @@ elseif (AUTOPAS_OPENMP)
         AND
             NOT
             (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-             AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 6)
+             AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 6)
              )
     )
         message(


### PR DESCRIPTION
# Description

adapts jenkinsfile to a clang compiler that includes the archer library in libomp.

## Resolved Issues

- [ ] possibly resolves some false positives detected recently.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] locally with master
- [ ] Jenkins
- [ ] locally with branch that produced false positives
