### PR TITLE
makes RegionParticleIterators use increased search Regions when using LinkedCells

### DIFF
--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -275,8 +275,8 @@ inline std::array<typename CellBlock3D<ParticleCell>::index_t, 3> CellBlock3D<Pa
   for (size_t dim = 0; dim < 3; dim++) {
     const long int value = (static_cast<long int>(floor((pos[dim] - _boxMin[dim]) * _cellLengthReciprocal[dim]))) +
                            _cellsPerInteractionLength;
-    const index_t nonnegativeValue = static_cast<index_t>(std::max(value, 0l));
-    const index_t nonLargerValue = std::min(nonnegativeValue, _cellsPerDimensionWithHalo[dim] - 1);
+    const index_t nonNegativeValue = static_cast<index_t>(std::max(value, 0l));
+    const index_t nonLargerValue = std::min(nonNegativeValue, _cellsPerDimensionWithHalo[dim] - 1);
     cellIndex[dim] = nonLargerValue;
 
     // this is a sanity check to prevent doubling of particles

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -116,12 +116,11 @@ class ParticleContainerInterface {
    * @param lowerCorner Lower corner of the region
    * @param higherCorner Higher corner of the region
    * @param behavior The behavior of the iterator (shall it iterate over halo particles as well?).
-   * @param incSearchRegion Whether to increase the search space (e.g. include more cells)
    * @return Iterator to iterate over all particles in a specific region.
    */
   virtual ParticleIteratorWrapper<Particle> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool incSearchRegion = false) = 0;
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) = 0;
 
   /**
    * Iterates over all particle pairs in the container.

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -132,10 +132,9 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
         new internal::ParticleIterator<Particle, ParticleCell>(&this->_cells, 0, &_cellBorderFlagManager, behavior));
   }
 
-  ParticleIteratorWrapper<Particle> getRegionIterator(const std::array<double, 3> &lowerCorner,
-                                                      const std::array<double, 3> &higherCorner,
-                                                      IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
-                                                      bool incSearchRegion = false) override {
+  ParticleIteratorWrapper<Particle> getRegionIterator(
+      const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
     std::vector<size_t> cellsOfInterest;
 
     switch (behavior) {

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -207,7 +207,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
     size_t startIndex;
     // this is needed when used through verlet lists since particles can move over cell borders.
     // only lower corner needed since we increase the upper corner anyways.
-    if (incSearchRegion) {
+    if (true) {
       startIndex = this->_cellBlock.get1DIndexOfPosition(ArrayMath::subScalar(lowerCorner, 1.0));
     } else {
       startIndex = this->_cellBlock.get1DIndexOfPosition(lowerCorner);

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -200,24 +200,12 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
         new internal::ParticleIterator<Particle, ParticleCell>(&this->_cells, 0, &_cellBlock, behavior));
   }
 
-  ParticleIteratorWrapper<Particle> getRegionIterator(const std::array<double, 3> &lowerCorner,
-                                                      const std::array<double, 3> &higherCorner,
-                                                      IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
-                                                      bool incSearchRegion = false) override {
-    size_t startIndex;
-    // this is needed when used through verlet lists since particles can move over cell borders.
-    // only lower corner needed since we increase the upper corner anyways.
-    if (true) {
-      startIndex = this->_cellBlock.get1DIndexOfPosition(ArrayMath::subScalar(lowerCorner, 1.0));
-    } else {
-      startIndex = this->_cellBlock.get1DIndexOfPosition(lowerCorner);
-    }
-    auto stopIndex = this->_cellBlock.get1DIndexOfPosition(higherCorner);
-
-    auto startIndex3D =
-        utils::ThreeDimensionalMapping::oneToThreeD(startIndex, this->_cellBlock.getCellsPerDimensionWithHalo());
-    auto stopIndex3D =
-        utils::ThreeDimensionalMapping::oneToThreeD(stopIndex, this->_cellBlock.getCellsPerDimensionWithHalo());
+  ParticleIteratorWrapper<Particle> getRegionIterator(
+      const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
+    // We increase the search region by skin, as particles can move over cell borders.
+    auto startIndex3D = this->_cellBlock.get3DIndexOfPosition(ArrayMath::subScalar(lowerCorner, this->getSkin()));
+    auto stopIndex3D = this->_cellBlock.get3DIndexOfPosition(ArrayMath::addScalar(higherCorner, this->getSkin()));
 
     size_t numCellsOfInterest = (stopIndex3D[0] - startIndex3D[0] + 1) * (stopIndex3D[1] - startIndex3D[1] + 1) *
                                 (stopIndex3D[2] - startIndex3D[2] + 1);

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -144,10 +144,9 @@ class VerletClusterLists : public ParticleContainer<Particle, FullParticleCell<P
         new internal::ParticleIterator<Particle, FullParticleCell<Particle>>(&this->_clusters));
   }
 
-  ParticleIteratorWrapper<Particle> getRegionIterator(const std::array<double, 3> &lowerCorner,
-                                                      const std::array<double, 3> &higherCorner,
-                                                      IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
-                                                      bool incSearchRegion = false) override {
+  ParticleIteratorWrapper<Particle> getRegionIterator(
+      const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
     // @todo implement this if bounding boxes are here
     autopas::utils::ExceptionHandler::exception("VerletClusterLists.getRegionIterator not yet implemented.");
     return ParticleIteratorWrapper<Particle>();

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -169,11 +169,10 @@ class VerletListsLinkedBase : public ParticleContainer<Particle, FullParticleCel
   /**
    * @copydoc autopas::ParticleContainerInterface::getRegionIterator()
    */
-  ParticleIteratorWrapper<Particle> getRegionIterator(const std::array<double, 3> &lowerCorner,
-                                                      const std::array<double, 3> &higherCorner,
-                                                      IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
-                                                      bool incSearchRegion = false) override {
-    return _linkedCells.getRegionIterator(lowerCorner, higherCorner, behavior, true);
+  ParticleIteratorWrapper<Particle> getRegionIterator(
+      const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
+    return _linkedCells.getRegionIterator(lowerCorner, higherCorner, behavior);
   }
 
   /**

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
@@ -10,9 +10,7 @@
 constexpr double cutoff = 1.;
 constexpr double skin = 0.2;
 constexpr std::array<double, 3> boxMin{0., 0., 0.};
-constexpr std::array<double, 3> haloBoxMin{0. - skin - cutoff, 0. - skin - cutoff, 0. - skin - cutoff};
 constexpr std::array<double, 3> boxMax{10., 10., 10.};
-constexpr std::array<double, 3> haloBoxMax{10. + skin + cutoff, 10. + skin + cutoff, 10. + skin + cutoff};
 constexpr double eps = 1.;
 constexpr double sigma = 1.;
 constexpr double shift = 0.1;
@@ -335,117 +333,6 @@ TEST_P(AutoPasInterfaceTest, SimulatonLoopTest) {
       throw;
     }
   }
-}
-
-/**
- * Tests the addition and iteration over particles.
- * @param containerOption
- */
-void testAdditionAndIteration(testingTuple options) {
-  // create AutoPas object
-  autopas::AutoPas<Molecule, FMCell> autoPas;
-
-  auto containerOption = std::get<0>(std::get<0>(options));
-  auto traversalOption = std::get<1>(std::get<0>(options));
-  auto dataLayoutOption = std::get<1>(options);
-  auto newton3Option = std::get<2>(options);
-  auto cellSizeOption = std::get<3>(options);
-
-  autoPas.setAllowedContainers(std::set<autopas::ContainerOption>{containerOption});
-  autoPas.setAllowedTraversals(std::set<autopas::TraversalOption>{traversalOption});
-  autoPas.setAllowedDataLayouts(std::set<autopas::DataLayoutOption>{dataLayoutOption});
-  autoPas.setAllowedNewton3Options(std::set<autopas::Newton3Option>{newton3Option});
-  autoPas.setAllowedCellSizeFactors(autopas::NumberSetFinite<double>(std::set<double>({cellSizeOption})));
-
-  defaultInit(autoPas);
-
-  auto getPossible1DPositions = [&](double min, double max) -> auto {
-    // ensure that all particles are at most skin away from halo!
-    return std::array<double, 6>{min - cutoff, min, min + skin, max - skin, max, max + cutoff - 1e-3};
-  };
-  size_t id = 0;
-  for (auto x : getPossible1DPositions(boxMin[0], boxMax[0])) {
-    for (auto y : getPossible1DPositions(boxMin[1], boxMax[1])) {
-      for (auto z : getPossible1DPositions(boxMin[2], boxMax[2])) {
-        std::array<double, 3> pos{x, y, z};
-        Molecule p(pos, {0., 0., 0.}, id);
-        ++id;
-        // add the two particles!
-        if (autopas::utils::inBox(pos, boxMin, boxMax)) {
-          autoPas.addParticle(p);
-        } else {
-          autoPas.addOrUpdateHaloParticle(p);
-        }
-      }
-    }
-  }
-  {
-    size_t count = 0;
-    for (auto iter = autoPas.begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
-      ++count;
-      EXPECT_TRUE(iter->isOwned());
-    }
-
-    EXPECT_EQ(count, 3 * 3 * 3);
-  }
-
-  // check number of halo particles
-  {
-    size_t count = 0;
-    for (auto iter = autoPas.begin(autopas::IteratorBehavior::haloOnly); iter.isValid(); ++iter) {
-      ++count;
-      EXPECT_FALSE(iter->isOwned());
-    }
-
-    EXPECT_EQ(count, 6 * 6 * 6 - 3 * 3 * 3);
-  }
-
-  // check number of particles
-  {
-    size_t count = 0;
-    for (auto iter = autoPas.begin(autopas::IteratorBehavior::haloAndOwned); iter.isValid(); ++iter) {
-      ++count;
-    }
-    EXPECT_EQ(count, 6 * 6 * 6);
-  }
-
-  // check number of halo particles for region iterator
-  {
-    size_t count = 0;
-    for (auto iter = autoPas.getRegionIterator(haloBoxMin, haloBoxMax, autopas::IteratorBehavior::haloOnly);
-         iter.isValid(); ++iter) {
-      ++count;
-      EXPECT_FALSE(iter->isOwned());
-    }
-
-    EXPECT_EQ(count, 6 * 6 * 6 - 3 * 3 * 3);
-  }
-
-  // check number of particles for region iterator
-  {
-    size_t count = 0;
-    for (auto iter = autoPas.getRegionIterator(haloBoxMin, haloBoxMax, autopas::IteratorBehavior::haloAndOwned);
-         iter.isValid(); ++iter) {
-      ++count;
-    }
-    EXPECT_EQ(count, 6 * 6 * 6);
-  }
-
-  // check number of owned particles for region iterator
-  {
-    size_t count = 0;
-    for (auto iter = autoPas.getRegionIterator(haloBoxMin, haloBoxMax, autopas::IteratorBehavior::ownedOnly);
-         iter.isValid(); ++iter) {
-      ++count;
-    }
-
-    EXPECT_EQ(count, 3 * 3 * 3);
-  }
-}
-
-TEST_P(AutoPasInterfaceTest, ParticleAdditionAndIteratorTestNormal) {
-  auto options = GetParam();
-  testAdditionAndIteration(options);
 }
 
 using ::testing::Combine;

--- a/tests/testAutopas/tests/autopasInterface/IteratorTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/IteratorTest.cpp
@@ -1,0 +1,150 @@
+/**
+ * @file IteratorTest.cpp
+ * @author seckler
+ * @date 22.07.19
+ */
+
+#include "IteratorTest.h"
+#include "testingHelpers/commonTypedefs.h"
+
+constexpr double cutoff = 1.;
+constexpr double skin = 0.2;
+constexpr std::array<double, 3> boxMin{0., 0., 0.};
+constexpr std::array<double, 3> haloBoxMin{0. - skin - cutoff, 0. - skin - cutoff, 0. - skin - cutoff};
+constexpr std::array<double, 3> boxMax{10., 10., 10.};
+constexpr std::array<double, 3> haloBoxMax{10. + skin + cutoff, 10. + skin + cutoff, 10. + skin + cutoff};
+
+template <typename AutoPasT>
+void defaultInit(AutoPasT &autoPas) {
+  autoPas.setBoxMin(boxMin);
+  autoPas.setBoxMax(boxMax);
+  autoPas.setCutoff(cutoff);
+  autoPas.setVerletSkin(skin);
+  autoPas.setVerletRebuildFrequency(2);
+  autoPas.setNumSamples(2);
+  // init autopas
+  autoPas.init();
+}
+
+/**
+ * Tests the addition and iteration over particles.
+ * @param containerOption
+ */
+void testAdditionAndIteration(testingTuple options) {
+  // create AutoPas object
+  autopas::AutoPas<Molecule, FMCell> autoPas;
+
+  auto containerOption = std::get<0>(options);
+
+  auto cellSizeOption = std::get<1>(options);
+
+  autoPas.setAllowedContainers(std::set<autopas::ContainerOption>{containerOption});
+  autoPas.setAllowedCellSizeFactors(autopas::NumberSetFinite<double>(std::set<double>({cellSizeOption})));
+
+  defaultInit(autoPas);
+
+  auto getPossible1DPositions = [&](double min, double max) -> auto {
+    // ensure that all particles are at most skin away from halo!
+    return std::array<double, 6>{min - cutoff, min, min + skin, max - skin, max, max + cutoff - 1e-3};
+  };
+  size_t id = 0;
+  for (auto x : getPossible1DPositions(boxMin[0], boxMax[0])) {
+    for (auto y : getPossible1DPositions(boxMin[1], boxMax[1])) {
+      for (auto z : getPossible1DPositions(boxMin[2], boxMax[2])) {
+        std::array<double, 3> pos{x, y, z};
+        Molecule p(pos, {0., 0., 0.}, id);
+        ++id;
+        // add the two particles!
+        if (autopas::utils::inBox(pos, boxMin, boxMax)) {
+          autoPas.addParticle(p);
+        } else {
+          autoPas.addOrUpdateHaloParticle(p);
+        }
+      }
+    }
+  }
+  {
+    size_t count = 0;
+    for (auto iter = autoPas.begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
+      ++count;
+      EXPECT_TRUE(iter->isOwned());
+    }
+
+    EXPECT_EQ(count, 3 * 3 * 3);
+  }
+
+  // check number of halo particles
+  {
+    size_t count = 0;
+    for (auto iter = autoPas.begin(autopas::IteratorBehavior::haloOnly); iter.isValid(); ++iter) {
+      ++count;
+      EXPECT_FALSE(iter->isOwned());
+    }
+
+    EXPECT_EQ(count, 6 * 6 * 6 - 3 * 3 * 3);
+  }
+
+  // check number of particles
+  {
+    size_t count = 0;
+    for (auto iter = autoPas.begin(autopas::IteratorBehavior::haloAndOwned); iter.isValid(); ++iter) {
+      ++count;
+    }
+    EXPECT_EQ(count, 6 * 6 * 6);
+  }
+
+  // check number of halo particles for region iterator
+  {
+    size_t count = 0;
+    for (auto iter = autoPas.getRegionIterator(haloBoxMin, haloBoxMax, autopas::IteratorBehavior::haloOnly);
+         iter.isValid(); ++iter) {
+      ++count;
+      EXPECT_FALSE(iter->isOwned());
+    }
+
+    EXPECT_EQ(count, 6 * 6 * 6 - 3 * 3 * 3);
+  }
+
+  // check number of particles for region iterator
+  {
+    size_t count = 0;
+    for (auto iter = autoPas.getRegionIterator(haloBoxMin, haloBoxMax, autopas::IteratorBehavior::haloAndOwned);
+         iter.isValid(); ++iter) {
+      ++count;
+    }
+    EXPECT_EQ(count, 6 * 6 * 6);
+  }
+
+  // check number of owned particles for region iterator
+  {
+    size_t count = 0;
+    for (auto iter = autoPas.getRegionIterator(haloBoxMin, haloBoxMax, autopas::IteratorBehavior::ownedOnly);
+         iter.isValid(); ++iter) {
+      ++count;
+    }
+
+    EXPECT_EQ(count, 3 * 3 * 3);
+  }
+}
+
+TEST_P(IteratorTest, ParticleAdditionAndIteratorTestNormal) {
+  auto options = GetParam();
+  testAdditionAndIteration(options);
+}
+
+using ::testing::Combine;
+using ::testing::UnorderedElementsAreArray;
+using ::testing::Values;
+using ::testing::ValuesIn;
+
+INSTANTIATE_TEST_SUITE_P(Generated, IteratorTest,
+                        // proper indent
+                        Combine(ValuesIn([]() -> std::set<autopas::ContainerOption> {
+                                  auto allContainerOptions = autopas::allContainerOptions;
+                                  /// @TODO no verletClusterLists yet, so we erase it for now.
+                                  allContainerOptions.erase(
+                                      allContainerOptions.find(autopas::ContainerOption::verletClusterLists));
+                                  return allContainerOptions;
+                                }()),
+                                Values(0.5, 1., 1.5)),
+                        IteratorTest::PrintToStringParamName());

--- a/tests/testAutopas/tests/autopasInterface/IteratorTest.h
+++ b/tests/testAutopas/tests/autopasInterface/IteratorTest.h
@@ -1,0 +1,29 @@
+/**
+ * @file IteratorTest.h
+ * @author seckler
+ * @date 22.07.19
+ */
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <tuple>
+#include "autopas/AutoPas.h"
+
+using testingTuple = std::tuple<autopas::ContainerOption, double /*cell size factor*/>;
+
+class IteratorTest : public testing::Test, public ::testing::WithParamInterface<testingTuple> {
+ public:
+  struct PrintToStringParamName {
+    template <class ParamType>
+    std::string operator()(const testing::TestParamInfo<ParamType> &info) const {
+      auto inputTuple = static_cast<ParamType>(info.param);
+      std::string str;
+      str += autopas::utils::StringUtils::to_string(std::get<0>(inputTuple)) + "_";
+      str += std::string{"cellSizeFactor"} + autopas::utils::StringUtils::to_string(std::get<1>(inputTuple));
+      std::replace(str.begin(), str.end(), '-', '_');
+      std::replace(str.begin(), str.end(), '.', '_');
+      return str;
+    }
+  };
+};


### PR DESCRIPTION
# Description

The cells the RegionParticleIterator iterates through are now always selected using a by the skin increased search region. This is needed for the verlet like interface.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] add an extra test
- [x] ls1 mardyn
