### PR TITLE
optimize getNearbyHaloCells function in CellBlock3D 

### DIFF
--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -193,12 +193,7 @@ class CellBlock3D : public CellBorderAndFlagManager {
 
     auto lowIndex3D = get3DIndexOfPosition(ArrayMath::subScalar(position, allowedDistance));
     auto highIndex3D = get3DIndexOfPosition(ArrayMath::addScalar(position, allowedDistance));
-
-    // squeeze to proper domain.
-    for (size_t i = 0; i < 3; ++i) {
-      lowIndex3D[i] = std::max(lowIndex3D[i], 0ul);
-      highIndex3D[i] = std::min(highIndex3D[i], _cellsPerDimensionWithHalo[i] - 1);
-    }
+    // these indices are (already) at least 0 and at most _cellsPerDimensionWithHalo[i]-1
 
     auto currentIndex = lowIndex3D;
 

--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -12,6 +12,7 @@
 #include <numeric>
 #include <vector>
 #include "autopas/containers/CellBorderAndFlagManager.h"
+#include "autopas/utils/ArrayMath.h"
 #include "autopas/utils/ExceptionHandler.h"
 #include "autopas/utils/ThreeDimensionalMapping.h"
 #include "autopas/utils/inBox.h"
@@ -172,61 +173,45 @@ class CellBlock3D : public CellBorderAndFlagManager {
    */
   std::vector<ParticleCell *> getNearbyHaloCells(const std::array<double, 3> &position, double allowedDistance) {
     auto index3d = get3DIndexOfPosition(position);
-    std::array<int, 3> diff = {0, 0, 0};
-    auto currentIndex = index3d;
 
     std::vector<ParticleCell *> closeHaloCells;
 
-    {
-      // always add the cell the particle is currently in first, for that we test if it is a halo cell.
-      bool isPossibleHaloCell = false;
-      for (int i = 0; i < 3; i++) {
-        isPossibleHaloCell |= currentIndex[i] < _cellsPerInteractionLength ||
-                              currentIndex[i] >= _cellsPerDimensionWithHalo[i] - _cellsPerInteractionLength;
+    auto isHaloCell = [&](const auto &index) {
+      for (size_t i = 0; i < 3; ++i) {
+        if (index[i] < _cellsPerInteractionLength or
+            index[i] >= _cellsPerDimensionWithHalo[i] - _cellsPerInteractionLength) {
+          return true;
+        }
       }
-      if (isPossibleHaloCell) {
-        closeHaloCells.push_back(&getCell(currentIndex));
-      }
+      return false;
+    };
+
+    // always add the cell the particle is currently in first, for that we test if it is a halo cell.
+    if (isHaloCell(index3d)) {
+      closeHaloCells.push_back(&getCell(index3d));
     }
 
-    // possible optimization: skip some of these loops by splitting the closeness check over all loops.
-    // i.e. check with diff[0] first, if it is already bad: skip inner loops.
-    for (diff[0] = -1; diff[0] < 2; diff[0]++) {
-      currentIndex[0] = index3d[0] + diff[0];
-      for (diff[1] = -1; diff[1] < 2; diff[1]++) {
-        currentIndex[1] = index3d[1] + diff[1];
-        for (diff[2] = -1; diff[2] < 2; diff[2]++) {
-          if (diff[0] == 0 and diff[1] == 0 and diff[2] == 0) {
+    auto lowIndex3D = get3DIndexOfPosition(ArrayMath::subScalar(position, allowedDistance));
+    auto highIndex3D = get3DIndexOfPosition(ArrayMath::addScalar(position, allowedDistance));
+
+    // squeeze to proper domain.
+    for (size_t i = 0; i < 3; ++i) {
+      lowIndex3D[i] = std::max(lowIndex3D[i], 0ul);
+      highIndex3D[i] = std::min(highIndex3D[i], _cellsPerDimensionWithHalo[i] - 1);
+    }
+
+    auto currentIndex = lowIndex3D;
+
+    for (currentIndex[0] = lowIndex3D[0]; currentIndex[0] <= highIndex3D[0]; ++currentIndex[0]) {
+      for (currentIndex[1] = lowIndex3D[1]; currentIndex[1] <= highIndex3D[1]; ++currentIndex[1]) {
+        for (currentIndex[2] = lowIndex3D[2]; currentIndex[2] <= highIndex3D[2]; ++currentIndex[2]) {
+          // we have already added the cell which normally would belong to the particle, so skip here:
+          if (currentIndex == index3d) {
             continue;
-            // we have already added the cell which normally would belong to the particle.
           }
-          currentIndex[2] = index3d[2] + diff[2];
-          // check if there exists a cell with the specified coordinates
-          bool isPossibleHaloCell = false;
-          bool isValidCell = true;
-          for (int i = 0; i < 3; i++) {
-            isPossibleHaloCell |= currentIndex[i] < _cellsPerInteractionLength ||
-                                  currentIndex[i] >= _cellsPerDimensionWithHalo[i] - _cellsPerInteractionLength;
-            isValidCell &= currentIndex[i] < _cellsPerDimensionWithHalo[i] && currentIndex[i] >= 0;
-          }
-          if (isPossibleHaloCell && isValidCell) {
-            std::array<double, 3> boxMin{}, boxMax{};
-            getCellBoundingBox(index3d, boxMin, boxMax);
-            bool close = true;
-            for (int i = 0; i < 3; i++) {
-              if (diff[i] < 0) {
-                if (position[i] - boxMax[i] > allowedDistance) {
-                  close = false;
-                }
-              } else if (diff[i] > 0) {
-                if (boxMin[i] - position[i] > allowedDistance) {
-                  close = false;
-                }
-              }
-            }
-            if (close) {
-              closeHaloCells.push_back(&getCell(currentIndex));
-            }
+          // we need to return the cell is it is a halo cell.
+          if (isHaloCell(currentIndex)) {
+            closeHaloCells.push_back(&getCell(currentIndex));
           }
         }
       }


### PR DESCRIPTION
getNearbyHaloCells will now always return the most likely cell, i.e., the cell directly related to the particle position first.

# Description
This function is used within updateHaloParticle of the Linked-Cells algorithm. Thus having the most likely cell first saves a large amount of instructions (see below).


# How Has This Been Tested?

Profiling using ls1-mardyn

- [x] Within ls1-mardyn:
   without optimization: 24B instructions in this function
   with optimization: 3.3B instructions in this function
   ![image](https://user-images.githubusercontent.com/38119442/62457523-56679480-b77b-11e9-981d-f8df0c919979.png)
