### PR TITLE
Remove NULL and assert

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,6 +13,7 @@ Please keep in mind the following notes while working.
 * `#include` of files from within AutoPas shall be given with the full path (starting with `autopas/`) and using `""`. 
 * `constexpr` instead of `#define`. Use it wherever possible.
 * `const` wherever possible. 
+* `nullptr` instead of `NULL`.
 * Avoid `assert()` but use `autopas::utils::ExceptionHandler::exception("Descriptive error message")` instead.
 
 ### Code Style

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -325,7 +325,7 @@ void checkCustom() {
 
         // check that no file contains NULL or assert
         try{
-            // if .cpp or .h files do not contain a file comment, return 2
+            // if .cpp or .h files contain NULL or assert, return 2
             sh "grep -lrE '(NULL|[^_]assert)' . | grep -q '\\.cpp\\|\\.h' && exit 2 || exit 0"
         } catch (Exception e) {
             // change detected

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,30 +48,17 @@ pipeline{
                         }
                     },
                     "custom checks": {
+                        echo 'Testing src folder'
                         dir("src"){
-                            script{
-                                // check if all header files have a #pragma once
-                                try{
-                                    // if header files do not contain #pragma once, make build unstable
-                                    sh 'grep -L "#pragma once" -r . | grep -q "\\.h" && exit 2 || exit 0'
-                                } catch (Exception e) {
-                                    // change detected
-                                    echo 'all header include guards should be implemented using "#pragma once". Affected files:'
-                                    sh 'grep -L "#pragma once" -r . | grep "\\.h"'
-                                    sh "exit 1"
-                                }
-
-                                // check if all files are documented with @file or \file doxygen comments
-                                try{
-                                    // if .cpp or .h files do not contain a file comment, return 2
-                                    sh "grep '\\\\file\\|\\@file' -Lr . | grep -q '\\.cpp\\|\\.h' && exit 2 || exit 0"
-                                } catch (Exception e) {
-                                    // change detected
-                                    echo 'all .h and .cpp files should be documented with doxygen comments (@file)". Affected files:'
-                                    sh "grep '\\\\file\\|\\@file' -Lr . | grep '\\.cpp\\|\\.h'"
-                                    sh "exit 1"
-                                }
-                            }
+                            checkCustom()
+                        }
+                        echo 'Testing tests folder'
+                        dir("tests"){
+                            checkCustom()
+                        }
+                        echo 'Testing examples folder'
+                        dir("examples"){
+                            checkCustom()
                         }
                     }
                 )
@@ -308,6 +295,43 @@ pipeline{
         }
         aborted {
             echo "aborted"
+        }
+    }
+}
+
+void checkCustom() {
+    script{
+        // check if all header files have a #pragma once
+        try{
+            // if header files do not contain #pragma once, make build unstable
+            sh 'grep -L "#pragma once" -r . | grep -q "\\.h" && exit 2 || exit 0'
+        } catch (Exception e) {
+            // change detected
+            echo 'all header include guards should be implemented using "#pragma once". Affected files:'
+            sh 'grep -L "#pragma once" -r . | grep "\\.h"'
+            sh "exit 1"
+        }
+
+        // check if all files are documented with @file or \file doxygen comments
+        try{
+            // if .cpp or .h files do not contain a file comment, return 2
+            sh "grep '\\\\file\\|\\@file' -Lr . | grep -q '\\.cpp\\|\\.h' && exit 2 || exit 0"
+        } catch (Exception e) {
+            // change detected
+            echo 'all .h and .cpp files should be documented with doxygen comments (@file)". Affected files:'
+            sh "grep '\\\\file\\|\\@file' -Lr . | grep '\\.cpp\\|\\.h'"
+            sh "exit 1"
+        }
+
+        // check that no file contains NULL or assert
+        try{
+            // if .cpp or .h files do not contain a file comment, return 2
+            sh "grep -lrE '(NULL|[^_]assert)' . | grep -q '\\.cpp\\|\\.h' && exit 2 || exit 0"
+        } catch (Exception e) {
+            // change detected
+            echo 'Usage of NULL and assert is prohibited. Affected files:'
+            sh "grep -lrE '(NULL|[^_]assert)' . | grep '\\.cpp\\|\\.h'"
+            sh "exit 1"
         }
     }
 }

--- a/src/autopas/cells/FullParticleCell.h
+++ b/src/autopas/cells/FullParticleCell.h
@@ -70,7 +70,9 @@ class FullParticleCell : public ParticleCell<Particle> {
 
   void deleteByIndex(size_t index) override {
     particlesLock.lock();
-    assert(index < numParticles());
+    if (index >= numParticles()) {
+      utils::ExceptionHandler::exception("Index out of range (range: [0, {}[, index: {})", numParticles(), index);
+    }
 
     if (index < numParticles() - 1) {
       std::swap(_particles[index], _particles[numParticles() - 1]);

--- a/src/autopas/cells/RMMParticleCell2T.h
+++ b/src/autopas/cells/RMMParticleCell2T.h
@@ -53,8 +53,9 @@ class RMMParticleCell2T : public ParticleCell<Particle> {
   void clear() override { _particleSoABuffer.clear(); }
 
   void deleteByIndex(size_t index) override {
-    assert(index >= 0 and index < numParticles());
-    assert(numParticles() > 0);
+    if (index >= numParticles()) {
+      utils::ExceptionHandler::exception("Index out of range (range: [0, {}[, index: {})", numParticles(), index);
+    }
     if (index < numParticles() - 1) {
       _particleSoABuffer.swap(index, numParticles() - 1);
     }

--- a/src/autopas/containers/verletListsCellBased/verletLists/neighborLists/asBuild/AsBuildPairGeneratorFunctor.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/neighborLists/asBuild/AsBuildPairGeneratorFunctor.h
@@ -148,7 +148,9 @@ class AsBuildPairGeneratorFunctor
    * @param offset
    */
   void SoALoader(ParticleCell<Particle> &cell, SoA<SoAArraysType> &soa, size_t offset = 0) override {
-    assert(offset == 0);
+    if (offset != 0ul) {
+      utils::ExceptionHandler::exception("offset must be 0, is: {}", offset);
+    }
     soa.resizeArrays(cell.numParticles());
 
     if (cell.numParticles() == 0) return;

--- a/src/autopas/pairwiseFunctors/Functor.h
+++ b/src/autopas/pairwiseFunctors/Functor.h
@@ -286,7 +286,7 @@ class Functor {
    * Provides an interface for traversals to directly access Cuda Functions
    * @return Pointer to CudaWrapper of the Functor
    */
-  virtual CudaWrapperInterface<typename Particle::ParticleFloatingPointType> *getCudaWrapper() { return NULL; }
+  virtual CudaWrapperInterface<typename Particle::ParticleFloatingPointType> *getCudaWrapper() { return nullptr; }
 
   /**
    * Creates Cuda SoA object containing all the relevant pointers from the generic Cuda SoA

--- a/src/autopas/utils/SoA.h
+++ b/src/autopas/utils/SoA.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <algorithm>
-#include <cassert>
 #include <initializer_list>
 #include <map>
 #include <tuple>

--- a/src/autopas/utils/WrapOpenMP.h
+++ b/src/autopas/utils/WrapOpenMP.h
@@ -16,7 +16,6 @@
  * Extend when necessary.
  */
 
-#include <cassert>
 #if defined(AUTOPAS_OPENMP)
 #include <omp.h>
 #else

--- a/tests/testAutopas/testingHelpers/NumThreadGuard.h
+++ b/tests/testAutopas/testingHelpers/NumThreadGuard.h
@@ -4,6 +4,8 @@
  * @date 14.04.2019
  */
 
+#pragma once
+
 #ifdef AUTOPAS_OPENMP
 #include <omp.h>
 #endif


### PR DESCRIPTION
# Description

This PR removes all occurrences of `NULL` and `assert` in `.h` and `.cpp` files. Custom checks were added to Jenkins prevent insertion of those constructs. In addition, all custom checks were extended to also cover `tests` and `examples`. Contribution guidelines were updated accordingly.

# How Has This Been Tested?

- [x] Jenkins
