### PR TITLE
Remove "Particle" template parameter

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,6 +14,7 @@ Please keep in mind the following notes while working.
 * `constexpr` instead of `#define`. Use it wherever possible.
 * `const` wherever possible. 
 * `nullptr` instead of `NULL`.
+* `using` instead of `typedef`.
 * Avoid `assert()` but use `autopas::utils::ExceptionHandler::exception("Descriptive error message")` instead.
 
 ### Code Style

--- a/examples/benchmark-cuda/main.cpp
+++ b/examples/benchmark-cuda/main.cpp
@@ -72,8 +72,8 @@ int main(int argc, char **argv) {
   double epsilon = 2.0;
   double sigma = 0.4;
 
-  DirectSum<MyMolecule, FullParticleCell<MyMolecule>> dir(boxMin, boxMax, cutoff, skin);
-  LinkedCells<MyMolecule, FullParticleCell<MyMolecule>> lc(boxMin, boxMax, cutoff, skin);
+  DirectSum<FullParticleCell<MyMolecule>> dir(boxMin, boxMax, cutoff, skin);
+  LinkedCells<FullParticleCell<MyMolecule>> lc(boxMin, boxMax, cutoff, skin);
 
   fillSpaceWithGrid<>(dir, boxMin, boxMax, 0.8, numParticles);
   fillSpaceWithGrid<>(lc, boxMin, boxMax, 0.8, numParticles);

--- a/examples/sph-traversals/sph-traversals.cpp
+++ b/examples/sph-traversals/sph-traversals.cpp
@@ -15,9 +15,8 @@ template <class Container, class Traversal>
 void measureContainer(Container *cont, autopas::sph::SPHCalcDensityFunctor *func, Traversal *traversal,
                       int numParticles, int numIterations, bool useNewton3);
 
-void addParticles(
-    autopas::LinkedCells<autopas::sph::SPHParticle, autopas::FullParticleCell<autopas::sph::SPHParticle>> &sph_system,
-    int numParticles) {
+void addParticles(autopas::LinkedCells<autopas::FullParticleCell<autopas::sph::SPHParticle>> &sph_system,
+                  int numParticles) {
   // Place SPH particles
 
   srand(10032);  // fixed seedpoint
@@ -109,8 +108,8 @@ int main(int argc, char *argv[]) {
     exit(2);
   }
 
-  autopas::LinkedCells<autopas::sph::SPHParticle, autopas::FullParticleCell<autopas::sph::SPHParticle>> lcCont(
-      boxMin, boxMax, cutoff, skin * cutoff);
+  autopas::LinkedCells<autopas::FullParticleCell<autopas::sph::SPHParticle>> lcCont(boxMin, boxMax, cutoff,
+                                                                                    skin * cutoff);
   autopas::VerletListsCells<autopas::sph::SPHParticle> verletCellContc08(
       boxMin, boxMax, cutoff, autopas::TraversalOption::c08, skin * cutoff, rebuildFrequency);
   autopas::VerletListsCells<autopas::sph::SPHParticle> verletCellContc18(

--- a/examples/sphDiagramGeneration/sph-diagram-generation.cpp
+++ b/examples/sphDiagramGeneration/sph-diagram-generation.cpp
@@ -19,9 +19,8 @@ template <class Container, class Functor, class Traversal>
 void measureContainerTraversal(Container *cont, Functor *func, Traversal *traversal, int numParticles,
                                int numIterations);
 
-void addParticles(
-    autopas::LinkedCells<autopas::sph::SPHParticle, autopas::FullParticleCell<autopas::sph::SPHParticle>> &sph_system,
-    int numParticles) {
+void addParticles(autopas::LinkedCells<autopas::FullParticleCell<autopas::sph::SPHParticle>> &sph_system,
+                  int numParticles) {
   // Place SPH particles
 
   srand(42);  // fixed seedpoint
@@ -135,10 +134,10 @@ int main(int argc, char *argv[]) {
 
   std::cout << "rebuildFrequency " << rebuildFrequency << " currently unused!" << std::endl;
 
-  autopas::LinkedCells<autopas::sph::SPHParticle, autopas::FullParticleCell<autopas::sph::SPHParticle>> lcCont(
-      boxMin, boxMax, cutoff, skin * cutoff);
-  autopas::DirectSum<autopas::sph::SPHParticle, autopas::FullParticleCell<autopas::sph::SPHParticle>> dirCont(
-      boxMin, boxMax, cutoff, skin * cutoff);
+  autopas::LinkedCells<autopas::FullParticleCell<autopas::sph::SPHParticle>> lcCont(boxMin, boxMax, cutoff,
+                                                                                    skin * cutoff);
+  autopas::DirectSum<autopas::FullParticleCell<autopas::sph::SPHParticle>> dirCont(boxMin, boxMax, cutoff,
+                                                                                   skin * cutoff);
   autopas::VerletLists<autopas::sph::SPHParticle> verletCont(boxMin, boxMax, cutoff, skin * cutoff);
   autopas::VerletListsCells<autopas::sph::SPHParticle> verletCellCont(boxMin, boxMax, cutoff,
                                                                       autopas::TraversalOption::c08, skin * cutoff);

--- a/src/autopas/containers/ParticleContainer.h
+++ b/src/autopas/containers/ParticleContainer.h
@@ -21,22 +21,11 @@ namespace autopas {
 /**
  * The ParticleContainer class stores particles in some object and provides
  * methods to iterate over its particles.
- * @tparam Particle Class for particles
  * @tparam ParticleCell Class for the particle cells
  */
-template <class Particle, class ParticleCell, class SoAArraysType = typename Particle::SoAArraysType>
-class ParticleContainer : public ParticleContainerInterface<Particle, ParticleCell> {
+template <class ParticleCell, class SoAArraysType = typename ParticleCell::ParticleType::SoAArraysType>
+class ParticleContainer : public ParticleContainerInterface<ParticleCell> {
  public:
-  /**
-   *  Type of the Particle.
-   */
-  typedef Particle ParticleType;
-
-  /**
-   * Type of the ParticleCell.
-   */
-  typedef ParticleCell ParticleCellType;
-
   /**
    * Constructor of ParticleContainer
    * @param boxMin

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -32,12 +32,12 @@ class ParticleContainerInterface {
   /**
    *  Type of the Particle.
    */
-  typedef typename ParticleCell::ParticleType ParticleType;
+  using ParticleType = typename ParticleCell::ParticleType;
 
   /**
    * Type of the ParticleCell.
    */
-  typedef ParticleCell ParticleCellType;
+  using ParticleCellType = ParticleCell;
 
   /**
    * Default constructor

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -26,9 +26,19 @@ namespace autopas {
  *
  * @tparam Particle Class for particles
  */
-template <class Particle, class ParticleCell>
+template <class ParticleCell>
 class ParticleContainerInterface {
  public:
+  /**
+   *  Type of the Particle.
+   */
+  typedef typename ParticleCell::ParticleType ParticleType;
+
+  /**
+   * Type of the ParticleCell.
+   */
+  typedef ParticleCell ParticleCellType;
+
   /**
    * Default constructor
    */
@@ -64,20 +74,20 @@ class ParticleContainerInterface {
    * Adds a particle to the container.
    * @param p The particle to be added.
    */
-  virtual void addParticle(Particle &p) = 0;
+  virtual void addParticle(ParticleType &p) = 0;
 
   /**
    * Adds a particle to the container that lies in the halo region of the container.
    * @param haloParticle Particle to be added.
    */
-  virtual void addHaloParticle(Particle &haloParticle) = 0;
+  virtual void addHaloParticle(ParticleType &haloParticle) = 0;
 
   /**
    * Update a halo particle of the container with the given haloParticle.
    * @param haloParticle Particle to be updated.
    * @return Returns true if the particle was updated, false if no particle could be found.
    */
-  virtual bool updateHaloParticle(Particle &haloParticle) = 0;
+  virtual bool updateHaloParticle(ParticleType &haloParticle) = 0;
 
   /**
    * Rebuilds the neighbor lists.
@@ -108,7 +118,7 @@ class ParticleContainerInterface {
    * @return Iterator to the first particle.
    * @todo implement IteratorBehavior.
    */
-  virtual ParticleIteratorWrapper<Particle> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) = 0;
+  virtual ParticleIteratorWrapper<ParticleType> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) = 0;
 
   /**
    * Iterate over all particles in a specified region
@@ -118,7 +128,7 @@ class ParticleContainerInterface {
    * @param behavior The behavior of the iterator (shall it iterate over halo particles as well?).
    * @return Iterator to iterate over all particles in a specific region.
    */
-  virtual ParticleIteratorWrapper<Particle> getRegionIterator(
+  virtual ParticleIteratorWrapper<ParticleType> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) = 0;
 
@@ -189,7 +199,7 @@ class ParticleContainerInterface {
    * @return A vector of invalid particles that do not belong into the container.
    */
   AUTOPAS_WARN_UNUSED_RESULT
-  virtual std::vector<Particle> updateContainer() = 0;
+  virtual std::vector<ParticleType> updateContainer() = 0;
 
   /**
    * Check whether a container is valid, i.e. whether it is safe to use

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -24,7 +24,7 @@ namespace autopas {
  * It defines method interfaces for addition and deletion of particles, accessing general container
  * properties and creating iterators.
  *
- * @tparam Particle Class for particles
+ * @tparam ParticleCell Class for particle cells.
  */
 template <class ParticleCell>
 class ParticleContainerInterface {

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -53,6 +53,9 @@ class DirectSum : public ParticleContainer<ParticleCell> {
 
   ContainerOption getContainerType() const override { return ContainerOption::directSum; }
 
+  /**
+   * @copydoc ParticleContainerInterface::addParticle()
+   */
   void addParticle(ParticleType &p) override {
     if (utils::inBox(p.getR(), this->getBoxMin(), this->getBoxMax())) {
       getCell().addParticle(p);
@@ -62,12 +65,18 @@ class DirectSum : public ParticleContainer<ParticleCell> {
     }
   }
 
-  void addHaloParticle(ParticleType &p) override {
-    ParticleType p_copy = p;
+  /**
+   * @copydoc ParticleContainerInterface::addHaloParticle()
+   */
+  void addHaloParticle(ParticleType &haloParticle) override {
+    ParticleType p_copy = haloParticle;
     p_copy.setOwned(false);
     getHaloCell().addParticle(p_copy);
   }
 
+  /**
+   * @copydoc ParticleContainerInterface::updateHaloParticle()
+   */
   bool updateHaloParticle(ParticleType &haloParticle) override {
     ParticleType pCopy = haloParticle;
     pCopy.setOwned(false);

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -37,7 +37,7 @@ class DirectSum : public ParticleContainer<ParticleCell> {
   /**
    *  Type of the Particle.
    */
-  typedef typename ParticleCell::ParticleType ParticleType;
+  using ParticleType = typename ParticleContainer<ParticleCell>::ParticleType;
 
   /**
    * Constructor of the DirectSum class

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -29,12 +29,16 @@ namespace autopas {
  * Interactions are calculated directly, such that each particle interacts with
  * every other particle.
  * Use this class only if you have a very small amount of particles at hand.
- * @tparam Particle type of the particles to be stored
  * @tparam ParticleCell type of the cell that stores the particle
  */
-template <class Particle, class ParticleCell>
-class DirectSum : public ParticleContainer<Particle, ParticleCell> {
+template <class ParticleCell>
+class DirectSum : public ParticleContainer<ParticleCell> {
  public:
+  /**
+   *  Type of the Particle.
+   */
+  typedef typename ParticleCell::ParticleType ParticleType;
+
   /**
    * Constructor of the DirectSum class
    * @param boxMin
@@ -43,13 +47,13 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
    * @param skin
    */
   DirectSum(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, double cutoff, double skin)
-      : ParticleContainer<Particle, ParticleCell>(boxMin, boxMax, cutoff, skin), _cellBorderFlagManager() {
+      : ParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skin), _cellBorderFlagManager() {
     this->_cells.resize(2);
   }
 
   ContainerOption getContainerType() override { return ContainerOption::directSum; }
 
-  void addParticle(Particle &p) override {
+  void addParticle(ParticleType &p) override {
     if (utils::inBox(p.getR(), this->getBoxMin(), this->getBoxMax())) {
       getCell()->addParticle(p);
     } else {
@@ -58,14 +62,14 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
     }
   }
 
-  void addHaloParticle(Particle &p) override {
-    Particle p_copy = p;
+  void addHaloParticle(ParticleType &p) override {
+    ParticleType p_copy = p;
     p_copy.setOwned(false);
     getHaloCell()->addParticle(p_copy);
   }
 
-  bool updateHaloParticle(Particle &haloParticle) override {
-    Particle pCopy = haloParticle;
+  bool updateHaloParticle(ParticleType &haloParticle) override {
+    ParticleType pCopy = haloParticle;
     pCopy.setOwned(false);
     return internal::checkParticleInCellAndUpdateByIDAndPosition(*getHaloCell(), pCopy, this->getSkin());
   }
@@ -95,10 +99,10 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
   }
 
   AUTOPAS_WARN_UNUSED_RESULT
-  std::vector<Particle> updateContainer() override {
+  std::vector<ParticleType> updateContainer() override {
     // first we delete halo particles, as we don't want them here.
     deleteHaloParticles();
-    std::vector<Particle> invalidParticles{};
+    std::vector<ParticleType> invalidParticles{};
     for (auto iter = getCell()->begin(); iter.isValid(); ++iter) {
       if (utils::notInBox(iter->getR(), this->getBoxMin(), this->getBoxMax())) {
         invalidParticles.push_back(*iter);
@@ -127,12 +131,12 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
     return TraversalSelectorInfo({2, 0, 0});
   }
 
-  ParticleIteratorWrapper<Particle> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
-    return ParticleIteratorWrapper<Particle>(
-        new internal::ParticleIterator<Particle, ParticleCell>(&this->_cells, 0, &_cellBorderFlagManager, behavior));
+  ParticleIteratorWrapper<ParticleType> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
+    return ParticleIteratorWrapper<ParticleType>(new internal::ParticleIterator<ParticleType, ParticleCell>(
+        &this->_cells, 0, &_cellBorderFlagManager, behavior));
   }
 
-  ParticleIteratorWrapper<Particle> getRegionIterator(
+  ParticleIteratorWrapper<ParticleType> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
     std::vector<size_t> cellsOfInterest;
@@ -149,7 +153,7 @@ class DirectSum : public ParticleContainer<Particle, ParticleCell> {
         break;
     }
 
-    return ParticleIteratorWrapper<Particle>(new internal::RegionParticleIterator<Particle, ParticleCell>(
+    return ParticleIteratorWrapper<ParticleType>(new internal::RegionParticleIterator<ParticleType, ParticleCell>(
         &this->_cells, lowerCorner, higherCorner, cellsOfInterest, &_cellBorderFlagManager, behavior));
   }
 

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -55,6 +55,9 @@ class LinkedCells : public ParticleContainer<ParticleCell, SoAArraysType> {
 
   ContainerOption getContainerType() const override { return ContainerOption::linkedCells; }
 
+  /**
+   * @copydoc ParticleContainerInterface::addParticle()
+   */
   void addParticle(ParticleType &p) override {
     bool inBox = autopas::utils::inBox(p.getR(), this->getBoxMin(), this->getBoxMax());
     if (inBox) {
@@ -66,6 +69,9 @@ class LinkedCells : public ParticleContainer<ParticleCell, SoAArraysType> {
     }
   }
 
+  /**
+   * @copydoc ParticleContainerInterface::addHaloParticle()
+   */
   void addHaloParticle(ParticleType &haloParticle) override {
     ParticleType pCopy = haloParticle;
     pCopy.setOwned(false);
@@ -73,6 +79,9 @@ class LinkedCells : public ParticleContainer<ParticleCell, SoAArraysType> {
     cell.addParticle(pCopy);
   }
 
+  /**
+   * @copydoc ParticleContainerInterface::updateHaloParticle()
+   */
   bool updateHaloParticle(ParticleType &haloParticle) override {
     ParticleType pCopy = haloParticle;
     pCopy.setOwned(false);

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -28,13 +28,17 @@ namespace autopas {
  * These cells dimensions are at least as large as the given cutoff radius,
  * therefore short-range interactions only need to be calculated between
  * particles in neighboring cells.
- * @tparam Particle type of the particles that need to be stored
  * @tparam ParticleCell type of the ParticleCells that are used to store the particles
  * @tparam SoAArraysType type of the SoA, needed for verlet lists
  */
-template <class Particle, class ParticleCell, class SoAArraysType = typename Particle::SoAArraysType>
-class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysType> {
+template <class ParticleCell, class SoAArraysType = typename ParticleCell::ParticleType::SoAArraysType>
+class LinkedCells : public ParticleContainer<ParticleCell, SoAArraysType> {
  public:
+  /**
+   *  Type of the Particle.
+   */
+  typedef typename ParticleCell::ParticleType ParticleType;
+
   /**
    * Constructor of the LinkedCells class
    * @param boxMin
@@ -46,12 +50,12 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
    */
   LinkedCells(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
               const double skin, const double cellSizeFactor = 1.0)
-      : ParticleContainer<Particle, ParticleCell, SoAArraysType>(boxMin, boxMax, cutoff, skin),
+      : ParticleContainer<ParticleCell, SoAArraysType>(boxMin, boxMax, cutoff, skin),
         _cellBlock(this->_cells, boxMin, boxMax, cutoff + skin, cellSizeFactor) {}
 
   ContainerOption getContainerType() override { return ContainerOption::linkedCells; }
 
-  void addParticle(Particle &p) override {
+  void addParticle(ParticleType &p) override {
     bool inBox = autopas::utils::inBox(p.getR(), this->getBoxMin(), this->getBoxMax());
     if (inBox) {
       ParticleCell &cell = _cellBlock.getContainingCell(p.getR());
@@ -62,15 +66,15 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
     }
   }
 
-  void addHaloParticle(Particle &haloParticle) override {
-    Particle pCopy = haloParticle;
+  void addHaloParticle(ParticleType &haloParticle) override {
+    ParticleType pCopy = haloParticle;
     pCopy.setOwned(false);
     ParticleCell &cell = _cellBlock.getContainingCell(pCopy.getR());
     cell.addParticle(pCopy);
   }
 
-  bool updateHaloParticle(Particle &haloParticle) override {
-    Particle pCopy = haloParticle;
+  bool updateHaloParticle(ParticleType &haloParticle) override {
+    ParticleType pCopy = haloParticle;
     pCopy.setOwned(false);
     auto cells = _cellBlock.getNearbyHaloCells(pCopy.getR(), this->getSkin());
     for (auto cellptr : cells) {
@@ -112,15 +116,15 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
   }
 
   AUTOPAS_WARN_UNUSED_RESULT
-  std::vector<Particle> updateContainer() override {
+  std::vector<ParticleType> updateContainer() override {
     this->deleteHaloParticles();
-    std::vector<Particle> invalidParticles;
+    std::vector<ParticleType> invalidParticles;
 #ifdef AUTOPAS_OPENMP
 #pragma omp parallel
 #endif  // AUTOPAS_OPENMP
     {
       // private for each thread!
-      std::vector<Particle> myInvalidParticles, myInvalidNotOwnedParticles;
+      std::vector<ParticleType> myInvalidParticles, myInvalidNotOwnedParticles;
 #ifdef AUTOPAS_OPENMP
 #pragma omp for
 #endif  // AUTOPAS_OPENMP
@@ -195,12 +199,12 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
                                  this->getCellBlock().getCellLength());
   }
 
-  ParticleIteratorWrapper<Particle> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
-    return ParticleIteratorWrapper<Particle>(
-        new internal::ParticleIterator<Particle, ParticleCell>(&this->_cells, 0, &_cellBlock, behavior));
+  ParticleIteratorWrapper<ParticleType> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
+    return ParticleIteratorWrapper<ParticleType>(
+        new internal::ParticleIterator<ParticleType, ParticleCell>(&this->_cells, 0, &_cellBlock, behavior));
   }
 
-  ParticleIteratorWrapper<Particle> getRegionIterator(
+  ParticleIteratorWrapper<ParticleType> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
     // We increase the search region by skin, as particles can move over cell borders.
@@ -221,7 +225,7 @@ class LinkedCells : public ParticleContainer<Particle, ParticleCell, SoAArraysTy
       }
     }
 
-    return ParticleIteratorWrapper<Particle>(new internal::RegionParticleIterator<Particle, ParticleCell>(
+    return ParticleIteratorWrapper<ParticleType>(new internal::RegionParticleIterator<ParticleType, ParticleCell>(
         &this->_cells, lowerCorner, higherCorner, cellsOfInterest, &_cellBlock, behavior));
   }
 

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -37,7 +37,7 @@ class LinkedCells : public ParticleContainer<ParticleCell, SoAArraysType> {
   /**
    *  Type of the Particle.
    */
-  typedef typename ParticleCell::ParticleType ParticleType;
+  using ParticleType = typename ParticleContainer<ParticleCell>::ParticleType;
 
   /**
    * Constructor of the LinkedCells class

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -95,6 +95,9 @@ class VerletClusterLists : public ParticleContainer<FullParticleCell<Particle>> 
     autopas::utils::ExceptionHandler::exception("VerletClusterLists.addHaloParticle not yet implemented.");
   }
 
+  /**
+   * @copydoc autopas::ParticleContainerInterface::updateHaloParticle()
+   */
   bool updateHaloParticle(Particle &haloParticle) override { throw std::runtime_error("not yet implemented"); }
 
   /**

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -29,7 +29,7 @@ class VerletClustersTraversalInterface;
  * @tparam Particle
  */
 template <class Particle>
-class VerletClusterLists : public ParticleContainer<Particle, FullParticleCell<Particle>> {
+class VerletClusterLists : public ParticleContainer<FullParticleCell<Particle>> {
   /**
    * the index type to access the particle cells
    */
@@ -49,7 +49,7 @@ class VerletClusterLists : public ParticleContainer<Particle, FullParticleCell<P
    */
   VerletClusterLists(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, double cutoff,
                      double skin = 0, int clusterSize = 4)
-      : ParticleContainer<Particle, FullParticleCell<Particle>>(boxMin, boxMax, cutoff, skin),
+      : ParticleContainer<FullParticleCell<Particle>>(boxMin, boxMax, cutoff, skin),
         _clusterSize(clusterSize),
         _numClusters(0),
         _boxMin(boxMin),

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -22,7 +22,7 @@ namespace autopas {
  * @tparam LinkedSoAArraysType SoAArraysType used by the linked cells container
  */
 template <class Particle, class LinkedParticleCell, class LinkedSoAArraysType = typename Particle::SoAArraysType>
-class VerletListsLinkedBase : public ParticleContainer<Particle, FullParticleCell<Particle>> {
+class VerletListsLinkedBase : public ParticleContainer<FullParticleCell<Particle>> {
   typedef FullParticleCell<Particle> ParticleCell;
 
  public:
@@ -40,7 +40,7 @@ class VerletListsLinkedBase : public ParticleContainer<Particle, FullParticleCel
   VerletListsLinkedBase(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
                         const double skin, const std::set<TraversalOption> &applicableTraversals,
                         const double cellSizeFactor)
-      : ParticleContainer<Particle, FullParticleCell<Particle>>(boxMin, boxMax, cutoff, skin),
+      : ParticleContainer<FullParticleCell<Particle>>(boxMin, boxMax, cutoff, skin),
         _linkedCells(boxMin, boxMax, cutoff, skin, std::max(1.0, cellSizeFactor)) {
     if (cellSizeFactor < 1.0) {
       AutoPasLog(debug, "VerletListsLinkedBase: CellSizeFactor smaller 1 detected. Set to 1.");
@@ -193,7 +193,7 @@ class VerletListsLinkedBase : public ParticleContainer<Particle, FullParticleCel
 
  protected:
   /// internal linked cells storage, handles Particle storage and used to build verlet lists
-  LinkedCells<Particle, LinkedParticleCell, LinkedSoAArraysType> _linkedCells;
+  LinkedCells<LinkedParticleCell, LinkedSoAArraysType> _linkedCells;
 
   /// specifies if the neighbor list is currently valid
   bool _neighborListIsValid{false};

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -23,7 +23,7 @@ namespace autopas {
  */
 template <class Particle, class LinkedParticleCell, class LinkedSoAArraysType = typename Particle::SoAArraysType>
 class VerletListsLinkedBase : public ParticleContainer<FullParticleCell<Particle>> {
-  typedef FullParticleCell<Particle> ParticleCell;
+  using ParticleCell = FullParticleCell<Particle>;
 
  public:
   /**

--- a/src/autopas/containers/verletListsCellBased/verletLists/neighborLists/VerletNeighborListInterface.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/neighborLists/VerletNeighborListInterface.h
@@ -37,7 +37,7 @@ class VerletNeighborListInterface {
    * @param linkedCells The linked cells to use for building the neighbor list.
    * @param useNewton3 If true, use newton 3 for the neighbor list.
    */
-  virtual void buildNeighborList(LinkedCells<Particle, typename VerletListHelpers<Particle>::VerletListParticleCellType,
+  virtual void buildNeighborList(LinkedCells<typename VerletListHelpers<Particle>::VerletListParticleCellType,
                                              typename VerletListHelpers<Particle>::SoAArraysType> &linkedCells,
                                  bool useNewton3) = 0;
 

--- a/src/autopas/containers/verletListsCellBased/verletLists/neighborLists/asBuild/VerletNeighborListAsBuild.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/neighborLists/asBuild/VerletNeighborListAsBuild.h
@@ -82,7 +82,7 @@ class VerletNeighborListAsBuild : public VerletNeighborListInterface<Particle>, 
    * It executes C08 on the passed LinkedCells container and saves the resulting pairs in the neighbor list, remembering
    * the thread and current color for each pair.
    */
-  void buildNeighborList(LinkedCells<Particle, typename VerletListHelpers<Particle>::VerletListParticleCellType,
+  void buildNeighborList(LinkedCells<typename VerletListHelpers<Particle>::VerletListParticleCellType,
                                      typename VerletListHelpers<Particle>::SoAArraysType> &linkedCells,
                          bool useNewton3) override {
     _soaListIsValid = false;
@@ -277,7 +277,7 @@ class VerletNeighborListAsBuild : public VerletNeighborListInterface<Particle>, 
   /**
    * The LinkedCells object this neighbor list should use to build.
    */
-  LinkedCells<Particle, typename VerletListHelpers<Particle>::VerletListParticleCellType,
+  LinkedCells<typename VerletListHelpers<Particle>::VerletListParticleCellType,
               typename VerletListHelpers<Particle>::SoAArraysType> *_baseLinkedCells;
 
   /**

--- a/src/autopas/containers/verletListsCellBased/verletLists/traversals/TraversalVerlet.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/traversals/TraversalVerlet.h
@@ -28,8 +28,7 @@ class TraversalVerlet
       public VerletTraversalInterface<
           typename VerletListHelpers<typename ParticleCell::ParticleType>::VerletListParticleCellType> {
   using Particle = typename ParticleCell::ParticleType;
-  typedef
-      typename VerletListHelpers<typename ParticleCell::ParticleType>::VerletListParticleCellType LinkedParticleCell;
+  using LinkedParticleCell = typename VerletListHelpers<Particle>::VerletListParticleCellType;
 
  public:
   /**

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -76,7 +76,7 @@ class AutoTuner {
    * Getter for the current container.
    * @return Smart pointer to the current container.
    */
-  std::shared_ptr<autopas::ParticleContainer<Particle, ParticleCell>> getContainer() {
+  std::shared_ptr<autopas::ParticleContainer<ParticleCell>> getContainer() {
     return _containerSelector.getCurrentContainer();
   }
 

--- a/src/autopas/selectors/ContainerSelector.h
+++ b/src/autopas/selectors/ContainerSelector.h
@@ -54,7 +54,7 @@ class ContainerSelector {
    * Getter for the optimal container. If no container is chosen yet the first allowed is selected.
    * @return Smartpointer to the optimal container.
    */
-  std::shared_ptr<autopas::ParticleContainer<Particle, ParticleCell>> getCurrentContainer();
+  std::shared_ptr<autopas::ParticleContainer<ParticleCell>> getCurrentContainer();
 
  private:
   /**
@@ -63,30 +63,28 @@ class ContainerSelector {
    * @param containerInfo additional parameter for the container
    * @return smartpointer to new container
    */
-  std::unique_ptr<autopas::ParticleContainer<Particle, ParticleCell>> generateContainer(
-      ContainerOption containerChoice, ContainerSelectorInfo containerInfo);
+  std::unique_ptr<autopas::ParticleContainer<ParticleCell>> generateContainer(ContainerOption containerChoice,
+                                                                              ContainerSelectorInfo containerInfo);
 
   std::array<double, 3> _boxMin, _boxMax;
   double _cutoff;
-  std::shared_ptr<autopas::ParticleContainer<Particle, ParticleCell>> _currentContainer;
+  std::shared_ptr<autopas::ParticleContainer<ParticleCell>> _currentContainer;
   ContainerSelectorInfo _currentInfo;
 };
 
 template <class Particle, class ParticleCell>
-std::unique_ptr<autopas::ParticleContainer<Particle, ParticleCell>>
-ContainerSelector<Particle, ParticleCell>::generateContainer(ContainerOption containerChoice,
-                                                             ContainerSelectorInfo containerInfo) {
-  std::unique_ptr<autopas::ParticleContainer<Particle, ParticleCell>> container;
+std::unique_ptr<autopas::ParticleContainer<ParticleCell>> ContainerSelector<Particle, ParticleCell>::generateContainer(
+    ContainerOption containerChoice, ContainerSelectorInfo containerInfo) {
+  std::unique_ptr<autopas::ParticleContainer<ParticleCell>> container;
 
   switch (containerChoice) {
     case directSum: {
-      container =
-          std::make_unique<DirectSum<Particle, ParticleCell>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin);
+      container = std::make_unique<DirectSum<ParticleCell>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin);
       break;
     }
     case linkedCells: {
-      container = std::make_unique<LinkedCells<Particle, ParticleCell>>(
-          _boxMin, _boxMax, _cutoff, containerInfo.verletSkin, containerInfo.cellSizeFactor);
+      container = std::make_unique<LinkedCells<ParticleCell>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin,
+                                                              containerInfo.cellSizeFactor);
       break;
     }
     case verletLists: {
@@ -132,7 +130,7 @@ ContainerSelector<Particle, ParticleCell>::generateContainer(ContainerOption con
 }
 
 template <class Particle, class ParticleCell>
-std::shared_ptr<autopas::ParticleContainer<Particle, ParticleCell>>
+std::shared_ptr<autopas::ParticleContainer<ParticleCell>>
 ContainerSelector<Particle, ParticleCell>::getCurrentContainer() {
   if (_currentContainer == nullptr) {
     autopas::utils::ExceptionHandler::exception(

--- a/tests/testAutopas/tests/containers/CudaTraversalVersusDirectSumTest.cpp
+++ b/tests/testAutopas/tests/containers/CudaTraversalVersusDirectSumTest.cpp
@@ -27,7 +27,7 @@ std::array<double, 3> CudaTraversalVersusDirectSumTest::randomPosition(const std
 
 void CudaTraversalVersusDirectSumTest::fillContainerWithMolecules(
     unsigned long numMolecules,
-    autopas::ParticleContainer<autopas::MoleculeLJ, autopas::FullParticleCell<autopas::MoleculeLJ>> &cont) const {
+    autopas::ParticleContainer<autopas::FullParticleCell<autopas::MoleculeLJ>> &cont) const {
   srand(42);  // fixed seedpoint
 
   std::array<double, 3> boxMin(cont.getBoxMin()), boxMax(cont.getBoxMax());

--- a/tests/testAutopas/tests/containers/CudaTraversalVersusDirectSumTest.h
+++ b/tests/testAutopas/tests/containers/CudaTraversalVersusDirectSumTest.h
@@ -31,11 +31,11 @@ class CudaTraversalVersusDirectSumTest : public AutoPasTestBase {
 
   void fillContainerWithMolecules(
       unsigned long numMolecules,
-      autopas::ParticleContainer<autopas::MoleculeLJ, autopas::FullParticleCell<autopas::MoleculeLJ>> &cont) const;
+      autopas::ParticleContainer<autopas::FullParticleCell<autopas::MoleculeLJ>> &cont) const;
 
   template <bool useNewton3>
   void test(unsigned long numMolecules, double rel_err_tolerance);
 
-  autopas::DirectSum<autopas::MoleculeLJ, autopas::FullParticleCell<autopas::MoleculeLJ>> _directSum;
-  autopas::LinkedCells<autopas::MoleculeLJ, autopas::FullParticleCell<autopas::MoleculeLJ>> _linkedCells;
+  autopas::DirectSum<autopas::FullParticleCell<autopas::MoleculeLJ>> _directSum;
+  autopas::LinkedCells<autopas::FullParticleCell<autopas::MoleculeLJ>> _linkedCells;
 };

--- a/tests/testAutopas/tests/containers/LinkedCellsVersusDirectSumTest.h
+++ b/tests/testAutopas/tests/containers/LinkedCellsVersusDirectSumTest.h
@@ -26,6 +26,6 @@ class LinkedCellsVersusDirectSumTest : public AutoPasTestBase {
  protected:
   void test(unsigned long numMolecules, double rel_err_tolerance);
 
-  autopas::DirectSum<autopas::MoleculeLJ, autopas::FullParticleCell<autopas::MoleculeLJ>> _directSum;
-  autopas::LinkedCells<autopas::MoleculeLJ, autopas::FullParticleCell<autopas::MoleculeLJ>> _linkedCells;
+  autopas::DirectSum<autopas::FullParticleCell<autopas::MoleculeLJ>> _directSum;
+  autopas::LinkedCells<autopas::FullParticleCell<autopas::MoleculeLJ>> _linkedCells;
 };

--- a/tests/testAutopas/tests/containers/LinkedCellsVersusVarVerletListsTest.h
+++ b/tests/testAutopas/tests/containers/LinkedCellsVersusVarVerletListsTest.h
@@ -33,7 +33,7 @@ class LinkedCellsVersusVarVerletListsTest : public AutoPasTestBase {
   void test(unsigned long numMolecules, double rel_err_tolerance, std::array<double, 3> boxMax);
 
   using vltype = autopas::VarVerletLists<autopas::MoleculeLJ, autopas::VerletNeighborListAsBuild<autopas::MoleculeLJ>>;
-  using lctype = autopas::LinkedCells<autopas::MoleculeLJ, autopas::FullParticleCell<autopas::MoleculeLJ>>;
+  using lctype = autopas::LinkedCells<autopas::FullParticleCell<autopas::MoleculeLJ>>;
   std::unique_ptr<vltype> _verletLists;
   std::unique_ptr<lctype> _linkedCells;
 };

--- a/tests/testAutopas/tests/containers/LinkedCellsVersusVerletClusterListsTest.h
+++ b/tests/testAutopas/tests/containers/LinkedCellsVersusVerletClusterListsTest.h
@@ -30,5 +30,5 @@ class LinkedCellsVersusVerletClusterListsTest : public AutoPasTestBase {
             std::array<double, 3> boxMax);
 
   using Verlet = autopas::VerletClusterLists<autopas::MoleculeLJ>;
-  using Linked = autopas::LinkedCells<autopas::MoleculeLJ, autopas::FullParticleCell<autopas::MoleculeLJ>>;
+  using Linked = autopas::LinkedCells<autopas::FullParticleCell<autopas::MoleculeLJ>>;
 };

--- a/tests/testAutopas/tests/containers/LinkedCellsVersusVerletListsCellsTest.h
+++ b/tests/testAutopas/tests/containers/LinkedCellsVersusVerletListsCellsTest.h
@@ -29,7 +29,7 @@ class LinkedCellsVersusVerletListsCellsTest : public AutoPasTestBase {
   void test(unsigned long numMolecules, double rel_err_tolerance);
 
   using vltype = autopas::VerletListsCells<autopas::MoleculeLJ>;
-  using lctype = autopas::LinkedCells<autopas::MoleculeLJ, autopas::FullParticleCell<autopas::MoleculeLJ>>;
+  using lctype = autopas::LinkedCells<autopas::FullParticleCell<autopas::MoleculeLJ>>;
   std::unique_ptr<vltype> _verletListsCells;
   std::unique_ptr<lctype> _linkedCells;
 };

--- a/tests/testAutopas/tests/containers/LinkedCellsVersusVerletListsTest.h
+++ b/tests/testAutopas/tests/containers/LinkedCellsVersusVerletListsTest.h
@@ -31,7 +31,7 @@ class LinkedCellsVersusVerletListsTest : public AutoPasTestBase {
   void test(unsigned long numMolecules, double rel_err_tolerance, std::array<double, 3> boxMax);
 
   using vltype = autopas::VerletLists<autopas::MoleculeLJ>;
-  using lctype = autopas::LinkedCells<autopas::MoleculeLJ, autopas::FullParticleCell<autopas::MoleculeLJ>>;
+  using lctype = autopas::LinkedCells<autopas::FullParticleCell<autopas::MoleculeLJ>>;
   std::unique_ptr<vltype> _verletLists;
   std::unique_ptr<lctype> _linkedCells;
 };

--- a/tests/testAutopas/tests/containers/directSum/DirectSumContainerTest.cpp
+++ b/tests/testAutopas/tests/containers/directSum/DirectSumContainerTest.cpp
@@ -7,8 +7,7 @@
 #include "DirectSumContainerTest.h"
 
 TEST_F(DirectSumContainerTest, testParticleAdding) {
-  autopas::DirectSum<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> directSum(
-      {0., 0., 0.}, {10., 10., 10.}, 1., 0.);
+  autopas::DirectSum<autopas::FullParticleCell<autopas::Particle>> directSum({0., 0., 0.}, {10., 10., 10.}, 1., 0.);
   int id = 1;
   for (double x : {-.5, 0., 5., 9.999, 10., 10.5}) {
     for (double y : {-.5, 0., 5., 9.999, 10., 10.5}) {
@@ -28,8 +27,7 @@ TEST_F(DirectSumContainerTest, testParticleAdding) {
 }
 
 TEST_F(DirectSumContainerTest, testGetNumParticles) {
-  autopas::DirectSum<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> directSum(
-      {0., 0., 0.}, {10., 10., 10.}, 1., 0.);
+  autopas::DirectSum<autopas::FullParticleCell<autopas::Particle>> directSum({0., 0., 0.}, {10., 10., 10.}, 1., 0.);
   EXPECT_EQ(directSum.getNumParticles(), 0);
 
   std::array<double, 3> r = {2, 2, 2};
@@ -44,8 +42,7 @@ TEST_F(DirectSumContainerTest, testGetNumParticles) {
 }
 
 TEST_F(DirectSumContainerTest, testDeleteAllParticles) {
-  autopas::DirectSum<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> directSum(
-      {0., 0., 0.}, {10., 10., 10.}, 1., 0.);
+  autopas::DirectSum<autopas::FullParticleCell<autopas::Particle>> directSum({0., 0., 0.}, {10., 10., 10.}, 1., 0.);
   EXPECT_EQ(directSum.getNumParticles(), 0);
 
   std::array<double, 3> r = {2, 2, 2};
@@ -66,7 +63,7 @@ TEST_F(DirectSumContainerTest, testIsContainerUpdateNeeded) {
   std::array<double, 3> boxMin{0, 0, 0};
   std::array<double, 3> boxMax{10, 10, 10};
   double cutoff = 1.;
-  autopas::DirectSum<Particle, FPCell> container(boxMin, boxMax, cutoff, 0.);
+  autopas::DirectSum<FPCell> container(boxMin, boxMax, cutoff, 0.);
 
   EXPECT_FALSE(container.isContainerUpdateNeeded());
 
@@ -84,8 +81,7 @@ TEST_F(DirectSumContainerTest, testIsContainerUpdateNeeded) {
 }
 
 TEST_F(DirectSumContainerTest, testUpdateContainerCloseToBoundary) {
-  autopas::DirectSum<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> directSum(
-      {0., 0., 0.}, {10., 10., 10.}, 1., 0.);
+  autopas::DirectSum<autopas::FullParticleCell<autopas::Particle>> directSum({0., 0., 0.}, {10., 10., 10.}, 1., 0.);
   int id = 1;
   for (double x : {0., 5., 9.999}) {
     for (double y : {0., 5., 9.999}) {
@@ -131,8 +127,7 @@ TEST_F(DirectSumContainerTest, testUpdateContainerCloseToBoundary) {
 }
 
 TEST_F(DirectSumContainerTest, testUpdateContainerHalo) {
-  autopas::DirectSum<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> directSum({0., 0., 0.},
-                                                                                                {3., 3., 3.}, 1., 0.);
+  autopas::DirectSum<autopas::FullParticleCell<autopas::Particle>> directSum({0., 0., 0.}, {3., 3., 3.}, 1., 0.);
 
   autopas::Particle p({-0.5, -0.5, -0.5}, {0, 0, 0}, 42);
   directSum.addHaloParticle(p);

--- a/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
@@ -128,8 +128,8 @@ TEST_F(LinkedCellsTest, testIsContainerUpdateNeeded) {
 }
 
 TEST_F(LinkedCellsTest, testUpdateContainer) {
-  autopas::LinkedCells<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> linkedCells(
-      {0., 0., 0.}, {3., 3., 3.}, 1., 0., 1.);
+  autopas::LinkedCells<autopas::FullParticleCell<autopas::Particle>> linkedCells({0., 0., 0.}, {3., 3., 3.}, 1., 0.,
+                                                                                 1.);
 
   autopas::Particle p1({0.5, 0.5, 0.5}, {0, 0, 0}, 0);
   autopas::Particle p2({1.5, 1.5, 1.5}, {0, 0, 0}, 1);
@@ -240,8 +240,8 @@ TEST_F(LinkedCellsTest, testUpdateContainerCloseToBoundary) {
 }
 
 TEST_F(LinkedCellsTest, testUpdateContainerHalo) {
-  autopas::LinkedCells<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> linkedCells(
-      {0., 0., 0.}, {3., 3., 3.}, 1., 0., 1.);
+  autopas::LinkedCells<autopas::FullParticleCell<autopas::Particle>> linkedCells({0., 0., 0.}, {3., 3., 3.}, 1., 0.,
+                                                                                 1.);
 
   autopas::Particle p({-0.5, -0.5, -0.5}, {0, 0, 0}, 42);
   linkedCells.addHaloParticle(p);

--- a/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.h
@@ -17,5 +17,5 @@ class LinkedCellsTest : public AutoPasTestBase {
   LinkedCellsTest();
 
  protected:
-  autopas::LinkedCells<Particle, FPCell> _linkedCells;
+  autopas::LinkedCells<FPCell> _linkedCells;
 };

--- a/tests/testAutopas/tests/iterators/ParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/ParticleIteratorTest.cpp
@@ -345,7 +345,7 @@ void testContainerIteratorBehavior(Container &container, Molecule &mol, Molecule
 }
 
 TEST_F(ParticleIteratorTest, testIteratorBehaviorDirectSum) {
-  DirectSum<MoleculeLJ, FullParticleCell<MoleculeLJ>> ds({0., 0., 0.}, {10., 10., 10.}, 3, 0.);
+  DirectSum<FullParticleCell<MoleculeLJ>> ds({0., 0., 0.}, {10., 10., 10.}, 3, 0.);
   MoleculeLJ mol({1., 1., 1.}, {0., 0., 0.}, 1);
   ds.addParticle(mol);
   MoleculeLJ haloMol({-1., 1., 1.}, {0., 0., 0.}, 2);
@@ -355,7 +355,7 @@ TEST_F(ParticleIteratorTest, testIteratorBehaviorDirectSum) {
 }
 
 TEST_F(ParticleIteratorTest, testIteratorBehaviorLinkedCells) {
-  LinkedCells<MoleculeLJ, FullParticleCell<MoleculeLJ>> linkedCells({0., 0., 0.}, {10., 10., 10.}, 3, 0., 1.);
+  LinkedCells<FullParticleCell<MoleculeLJ>> linkedCells({0., 0., 0.}, {10., 10., 10.}, 3, 0., 1.);
   MoleculeLJ mol({1., 1., 1.}, {0., 0., 0.}, 1);
   linkedCells.addParticle(mol);
   MoleculeLJ haloMol({-1., 1., 1.}, {0., 0., 0.}, 2);

--- a/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
@@ -12,7 +12,7 @@ using namespace autopas;
 /********************************** Linked Cells Tests **********************************/
 
 TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIterator) {
-  LinkedCells<TouchableParticle, FullParticleCell<TouchableParticle>> lcContainer(_boxMin, _boxMax, _cutoff, 0., 1.);
+  LinkedCells<FullParticleCell<TouchableParticle>> lcContainer(_boxMin, _boxMax, _cutoff, 0., 1.);
 
   // add a number of particles
   RandomGenerator::fillWithParticles(lcContainer, TouchableParticle({0., 0., 0.}, 0));
@@ -28,7 +28,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIterator) {
 }
 
 void RegionParticleIteratorTest::testLinkedCellsRegionParticleIteratorBehaviorOwned() {
-  LinkedCells<TouchableParticle, FullParticleCell<TouchableParticle>> lcContainer(_boxMin, _boxMax, _cutoff, 0., 1.);
+  LinkedCells<FullParticleCell<TouchableParticle>> lcContainer(_boxMin, _boxMax, _cutoff, 0., 1.);
 
   // add a number of particles
   RandomGenerator::fillWithParticles(lcContainer, TouchableParticle({0., 0., 0.}, 0), 100);
@@ -88,7 +88,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehavior
 #endif
 
 void RegionParticleIteratorTest::testLinkedCellsRegionParticleIteratorBehaviorHalo() {
-  LinkedCells<TouchableParticle, FullParticleCell<TouchableParticle>> lcContainer(_boxMin, _boxMax, _cutoff, 0., 1.);
+  LinkedCells<FullParticleCell<TouchableParticle>> lcContainer(_boxMin, _boxMax, _cutoff, 0., 1.);
 
   // add a number of particles
   RandomGenerator::fillWithParticles(lcContainer, TouchableParticle({0., 0., 0.}, 0), 100);
@@ -162,7 +162,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorBehavior
 #endif
 
 TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorEmpty) {
-  LinkedCells<TouchableParticle, FullParticleCell<TouchableParticle>> lcContainer(_boxMin, _boxMax, _cutoff, 0., 1.);
+  LinkedCells<FullParticleCell<TouchableParticle>> lcContainer(_boxMin, _boxMax, _cutoff, 0., 1.);
 
   // add no particles
 
@@ -182,7 +182,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorEmpty) {
 }
 
 TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorCopyConstructor) {
-  LinkedCells<TouchableParticle, FullParticleCell<TouchableParticle>> lcContainer(_boxMin, _boxMax, _cutoff, 0., 1.);
+  LinkedCells<FullParticleCell<TouchableParticle>> lcContainer(_boxMin, _boxMax, _cutoff, 0., 1.);
 
   // add a number of particles
   RandomGenerator::fillWithParticles(lcContainer, TouchableParticle({0., 0., 0.}, 0));
@@ -208,7 +208,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorCopyCons
 }
 
 TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorCopyAssignment) {
-  LinkedCells<TouchableParticle, FullParticleCell<TouchableParticle>> lcContainer(_boxMin, _boxMax, _cutoff, 0., 1.);
+  LinkedCells<FullParticleCell<TouchableParticle>> lcContainer(_boxMin, _boxMax, _cutoff, 0., 1.);
 
   // add a number of particles
   RandomGenerator::fillWithParticles(lcContainer, TouchableParticle({0., 0., 0.}, 0));
@@ -248,7 +248,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorCopyAssi
  */
 TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorSparseDomain) {
   // box goes from {0,0,0} to {5,5,5} + one halo layer
-  LinkedCells<TouchableParticle, FullParticleCell<TouchableParticle>> lcContainer(_boxMin, _boxMax, _cutoff, 0., 1.);
+  LinkedCells<FullParticleCell<TouchableParticle>> lcContainer(_boxMin, _boxMax, _cutoff, 0., 1.);
 
   size_t idShouldTouch = 0;
   TouchableParticle p({0, 0, 0}, idShouldTouch);
@@ -302,7 +302,7 @@ TEST_F(RegionParticleIteratorTest, testLinkedCellsRegionParticleIteratorSparseDo
 
 TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorSparseDomain) {
   // box goes from {0,0,0} to {5,5,5} + one halo layer
-  DirectSum<TouchableParticle, FullParticleCell<TouchableParticle>> dsContainer(_boxMin, _boxMax, _cutoff, 0.);
+  DirectSum<FullParticleCell<TouchableParticle>> dsContainer(_boxMin, _boxMax, _cutoff, 0.);
 
   size_t idShouldTouch = 0;
   TouchableParticle p({0, 0, 0}, idShouldTouch);
@@ -352,7 +352,7 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorSparseDoma
 }
 
 TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIterator) {
-  DirectSum<TouchableParticle, FullParticleCell<TouchableParticle>> container(_boxMin, _boxMax, _cutoff, 0.);
+  DirectSum<FullParticleCell<TouchableParticle>> container(_boxMin, _boxMax, _cutoff, 0.);
 
   // add a number of particles
   RandomGenerator::fillWithParticles(container, TouchableParticle({0., 0., 0.}, 0));
@@ -379,7 +379,7 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIterator) {
 }
 
 TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorBehaviorOwned) {
-  DirectSum<TouchableParticle, FullParticleCell<TouchableParticle>> container(_boxMin, _boxMax, _cutoff, 0.);
+  DirectSum<FullParticleCell<TouchableParticle>> container(_boxMin, _boxMax, _cutoff, 0.);
 
   // add a number of particles
   RandomGenerator::fillWithParticles(container, TouchableParticle({0., 0., 0.}, 0), 100);
@@ -410,7 +410,7 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorBehaviorOw
 }
 
 TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorBehaviorHalo) {
-  DirectSum<TouchableParticle, FullParticleCell<TouchableParticle>> container(_boxMin, _boxMax, _cutoff, 0.);
+  DirectSum<FullParticleCell<TouchableParticle>> container(_boxMin, _boxMax, _cutoff, 0.);
 
   // add a number of particles
   RandomGenerator::fillWithParticles(container, TouchableParticle({0., 0., 0.}, 0), 100);
@@ -444,7 +444,7 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorBehaviorHa
 }
 
 TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorEmpty) {
-  DirectSum<TouchableParticle, FullParticleCell<TouchableParticle>> container(_boxMin, _boxMax, _cutoff, 0.);
+  DirectSum<FullParticleCell<TouchableParticle>> container(_boxMin, _boxMax, _cutoff, 0.);
 
   // add no particles
 
@@ -473,7 +473,7 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorEmpty) {
 }
 
 TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorCopyConstructor) {
-  DirectSum<TouchableParticle, FullParticleCell<TouchableParticle>> container(_boxMin, _boxMax, _cutoff, 0.);
+  DirectSum<FullParticleCell<TouchableParticle>> container(_boxMin, _boxMax, _cutoff, 0.);
 
   // add a number of particles
   RandomGenerator::fillWithParticles(container, TouchableParticle({0., 0., 0.}, 0));
@@ -499,7 +499,7 @@ TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorCopyConstr
 }
 
 TEST_F(RegionParticleIteratorTest, testDirectSumRegionParticleIteratorCopyAssignment) {
-  DirectSum<TouchableParticle, FullParticleCell<TouchableParticle>> container(_boxMin, _boxMax, _cutoff, 0.);
+  DirectSum<FullParticleCell<TouchableParticle>> container(_boxMin, _boxMax, _cutoff, 0.);
 
   // add a number of particles
   RandomGenerator::fillWithParticles(container, TouchableParticle({0., 0., 0.}, 0));

--- a/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.h
+++ b/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.h
@@ -24,7 +24,7 @@ class TouchableParticle : public autopas::Particle {
 
 class RegionParticleIteratorTest : public AutoPasTestBase {
  public:
-  typedef autopas::LinkedCells<TouchableParticle, autopas::FullParticleCell<TouchableParticle>> LCTouch;
+  typedef autopas::LinkedCells<autopas::FullParticleCell<TouchableParticle>> LCTouch;
 
   RegionParticleIteratorTest()
       : _boxMin{0., 0., 0.}, _boxMax{5., 5., 5.}, _regionMin{1., 1., 1.}, _regionMax{3., 3., 3.}, _cutoff{.9} {}

--- a/tests/testAutopas/tests/sph/SPHTest.cpp
+++ b/tests/testAutopas/tests/sph/SPHTest.cpp
@@ -612,10 +612,9 @@ TEST_F(SPHTest, testSPHCalcHydroForceFunctorNewton3OnOff) {
   EXPECT_NEAR(sphParticle4.getDt(), sphParticle2.getDt(), 1e-10);
 }
 
-void densityCheck(
-    autopas::VerletLists<autopas::sph::SPHParticle> &verletLists,
-    autopas::LinkedCells<autopas::sph::SPHParticle, autopas::FullParticleCell<autopas::sph::SPHParticle>> &linkedCells,
-    size_t numMolecules, double rel_err_tolerance) {
+void densityCheck(autopas::VerletLists<autopas::sph::SPHParticle> &verletLists,
+                  autopas::LinkedCells<autopas::FullParticleCell<autopas::sph::SPHParticle>> &linkedCells,
+                  size_t numMolecules, double rel_err_tolerance) {
   std::vector<double> densityVerlet(numMolecules), densityLinked(numMolecules);
   /* get and sort by id, the */
   for (auto it = verletLists.begin(); it.isValid(); ++it) {
@@ -644,10 +643,9 @@ void hydroInit(autopas::VerletLists<autopas::sph::SPHParticle> &verletLists) {
   }
 };
 
-void hydroCheck(
-    autopas::VerletLists<autopas::sph::SPHParticle> &verletLists,
-    autopas::LinkedCells<autopas::sph::SPHParticle, autopas::FullParticleCell<autopas::sph::SPHParticle>> &linkedCells,
-    size_t numMolecules, double rel_err_tolerance) {
+void hydroCheck(autopas::VerletLists<autopas::sph::SPHParticle> &verletLists,
+                autopas::LinkedCells<autopas::FullParticleCell<autopas::sph::SPHParticle>> &linkedCells,
+                size_t numMolecules, double rel_err_tolerance) {
   std::vector<double> vsigmaxVerlet(numMolecules), vsigmaxLinked(numMolecules);
   std::vector<double> engdotVerlet(numMolecules), engdotLinked(numMolecules);
   std::vector<std::array<double, 3>> accVerlet(numMolecules), accLinked(numMolecules);
@@ -683,8 +681,8 @@ void testVerLetVsLC(FunctorType &fnctr, InitType init, CheckType check, autopas:
   using autopas::sph::SPHParticle;
 
   autopas::VerletLists<SPHParticle> _verletLists({0., 0., 0.}, {5., 5., 5.}, cutoff, 0.5);
-  autopas::LinkedCells<SPHParticle, autopas::FullParticleCell<SPHParticle>> _linkedCells({0., 0., 0.}, {5., 5., 5.},
-                                                                                         cutoff, 0.5, 1.);
+  autopas::LinkedCells<autopas::FullParticleCell<SPHParticle>> _linkedCells({0., 0., 0.}, {5., 5., 5.}, cutoff, 0.5,
+                                                                            1.);
 
   autopas::sph::SPHParticle defaultSPHParticle({0., 0., 0.}, {1., .5, .25}, 1, 2.5,
                                                cutoff / autopas::sph::SPHKernels::getKernelSupportRadius(), 0.6);


### PR DESCRIPTION
# Description

Remove redundant "Particle" template parameter from all container classes.

## Related Issues

- #323 (not completely resolved)

# How Has This Been Tested?

- [x] Jenkins
