### PR TITLE
enable range-based for loops for AutoPas objects

### DIFF
--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -185,6 +185,13 @@ class AutoPas {
   }
 
   /**
+   * End of the iterator.
+   * This returns a bool, which is false to allow range-based for loops.
+   * @return false
+   */
+  [[nodiscard]] constexpr bool end() const { return false; }
+
+  /**
    * iterate over all particles in a specified region
    * for(auto iter = container.getRegionIterator(lowCorner,
    * highCorner);iter.isValid();++iter)

--- a/src/autopas/iterators/ParticleIteratorWrapper.h
+++ b/src/autopas/iterators/ParticleIteratorWrapper.h
@@ -71,6 +71,22 @@ class ParticleIteratorWrapper : public ParticleIteratorInterface<Particle> {
     }
   }
 
+  /**
+   * Equality operator that compares with a bool.
+   * Needed to be able to compare with AutoPas::end().
+   * @param input normally: AutoPas::end()
+   * @return true if isValid == input, false otherwise.
+   */
+  bool operator==(const bool &input) const { return isValid() == input; }
+
+  /**
+   * Inequality operator that compares with a bool.
+   * Needed to be able to compare with end().
+   * @param input normally: autoPas.end()
+   * @return true if isValid != input, false otherwise.
+   */
+  bool operator!=(const bool &input) const { return not(*this == input); }
+
  private:
   std::unique_ptr<autopas::internal::ParticleIteratorInterfaceImpl<Particle>> _particleIterator;
 };

--- a/tests/testAutopas/tests/autopasInterface/IteratorTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/IteratorTest.cpp
@@ -189,9 +189,73 @@ void testAdditionAndIteration(testingTuple options) {
   checkRegionIteratorForAllParticles(autoPas, autopas::IteratorBehavior::haloAndOwned);
 }
 
+/**
+ * Tests the equivalence of the range-based for loop with the normal for loop using isValid
+ * @param containerOption
+ */
+void testRangeBasedIterator(testingTuple options) {
+  // create AutoPas object
+  autopas::AutoPas<Molecule, FMCell> autoPas;
+
+  auto containerOption = std::get<0>(options);
+
+  auto cellSizeOption = std::get<1>(options);
+
+  autoPas.setAllowedContainers(std::set<autopas::ContainerOption>{containerOption});
+  autoPas.setAllowedCellSizeFactors(autopas::NumberSetFinite<double>(std::set<double>({cellSizeOption})));
+
+  defaultInit(autoPas);
+
+  constexpr size_t numParticles1dTotal = 10;
+  auto getPossible1DPositions = [&](double min, double max) -> auto {
+    return std::array<double, numParticles1dTotal>{min - cutoff - skin + 1e-10,
+                                                   min - cutoff,
+                                                   min - skin / 4,
+                                                   min,
+                                                   min + skin / 4,
+                                                   max - skin / 4,
+                                                   max,
+                                                   max + skin / 4,
+                                                   max + cutoff,
+                                                   max + cutoff + skin - 1e-10};
+    // ensure that all particles are at most skin away from halo!
+  };
+
+  size_t id = 0;
+  for (auto x : getPossible1DPositions(boxMin[0], boxMax[0])) {
+    for (auto y : getPossible1DPositions(boxMin[1], boxMax[1])) {
+      for (auto z : getPossible1DPositions(boxMin[2], boxMax[2])) {
+        std::array<double, 3> pos{x, y, z};
+        Molecule p(pos, {0., 0., 0.}, id);
+        ++id;
+        // add the two particles!
+        if (autopas::utils::inBox(pos, boxMin, boxMax)) {
+          autoPas.addParticle(p);
+        } else {
+          autoPas.addOrUpdateHaloParticle(p);
+        }
+      }
+    }
+  }
+
+  for (Particle &particle : autoPas) {
+    particle.setF({42., 42., 42.});
+  }
+
+  for (auto iter = autoPas.begin(); iter.isValid(); ++iter) {
+    decltype(iter->getF()) comparison = {42., 42., 42};
+    ASSERT_EQ(iter->getF(), comparison);
+  }
+}
+
 TEST_P(IteratorTest, ParticleAdditionAndIteratorTestNormal) {
   auto options = GetParam();
   testAdditionAndIteration(options);
+}
+
+TEST_P(IteratorTest, RangeBasedIterator) {
+  auto options = GetParam();
+  testRangeBasedIterator(options);
 }
 
 using ::testing::Combine;


### PR DESCRIPTION
# Description

Enables range-based for loops for an AutoPas object by implementing:
- [x] the end() method for the AutoPas container
- [x] `==` and `!=` comparison of the ParticleIteratorWrapper with a bool

## Resolved Issues

- fixes #342 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] New Test in AutoPas
