### PR TITLE
Provide type aliases for the iterator types

### DIFF
--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -40,13 +40,13 @@ class AutoPas {
    * Define the iterator_t for simple use, also from the outside.
    * Helps to, e.g., wrap the AutoPas iterators
    */
-  using iterator_t = autopas::ParticleIteratorWrapper<Particle, true>;
+  using iterator_t = typename autopas::IteratorTraits<Particle>::iterator_t;
 
   /**
    * Define the const_iterator_t for simple use, also from the outside.
    * Helps to, e.g., wrap the AutoPas iterators
    */
-  using const_iterator_t = autopas::ParticleIteratorWrapper<Particle, false>;
+  using const_iterator_t = typename autopas::IteratorTraits<Particle>::const_iterator_t;
 
   /**
    * Constructor for the autopas class.

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -37,6 +37,18 @@ template <class Particle, class ParticleCell>
 class AutoPas {
  public:
   /**
+   * Define the iterator_t for simple use, also from the outside.
+   * Helps to, e.g., wrap the AutoPas iterators
+   */
+  using iterator_t = autopas::ParticleIteratorWrapper<Particle, true>;
+
+  /**
+   * Define the const_iterator_t for simple use, also from the outside.
+   * Helps to, e.g., wrap the AutoPas iterators
+   */
+  using const_iterator_t = autopas::ParticleIteratorWrapper<Particle, false>;
+
+  /**
    * Constructor for the autopas class.
    * @param logOutputStream Stream where log output should go to. Default is std::out.
    */
@@ -180,7 +192,7 @@ class AutoPas {
    * particles, or both.
    * @return iterator to the first particle.
    */
-  autopas::ParticleIteratorWrapper<Particle, true> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) {
+  iterator_t begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) {
     return _logicHandler->begin(behavior);
   }
 
@@ -188,8 +200,7 @@ class AutoPas {
    * @copydoc begin()
    * @note const version
    */
-  autopas::ParticleIteratorWrapper<Particle, false> begin(
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const {
+  const_iterator_t begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const {
     return std::as_const(*_logicHandler).begin(behavior);
   }
 
@@ -197,10 +208,7 @@ class AutoPas {
    * @copydoc begin()
    * @note cbegin will guarantee to return a const_iterator.
    */
-  autopas::ParticleIteratorWrapper<Particle, false> cbegin(
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const {
-    return begin(behavior);
-  }
+  const_iterator_t cbegin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const { return begin(behavior); }
 
   /**
    * End of the iterator.
@@ -219,9 +227,8 @@ class AutoPas {
    * particles, or both.
    * @return iterator to iterate over all particles in a specific region
    */
-  autopas::ParticleIteratorWrapper<Particle, true> getRegionIterator(
-      std::array<double, 3> lowerCorner, std::array<double, 3> higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) {
+  iterator_t getRegionIterator(std::array<double, 3> lowerCorner, std::array<double, 3> higherCorner,
+                               IteratorBehavior behavior = IteratorBehavior::haloAndOwned) {
     return _logicHandler->getRegionIterator(lowerCorner, higherCorner, behavior);
   }
 
@@ -229,9 +236,8 @@ class AutoPas {
    * @copydoc getRegionIterator()
    * @note const version
    */
-  autopas::ParticleIteratorWrapper<Particle, false> getRegionIterator(
-      std::array<double, 3> lowerCorner, std::array<double, 3> higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const {
+  const_iterator_t getRegionIterator(std::array<double, 3> lowerCorner, std::array<double, 3> higherCorner,
+                                     IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const {
     return _logicHandler->getRegionIterator(lowerCorner, higherCorner, behavior);
   }
 

--- a/src/autopas/iterators/ParticleIteratorWrapper.h
+++ b/src/autopas/iterators/ParticleIteratorWrapper.h
@@ -102,4 +102,22 @@ class ParticleIteratorWrapper : public ParticleIteratorInterface<Particle, modif
   std::unique_ptr<autopas::internal::ParticleIteratorInterfaceImpl<Particle, modifiable>> _particleIterator;
 };
 
+/**
+ * Provides type aliases for iterator types, to provide a fixed interface that is not influenced by changes in the
+ * iterator classes.
+ * @tparam Particle The type of the particle.
+ */
+template <typename Particle>
+class IteratorTraits {
+ public:
+  /**
+   * Alias for normal (non-const) iterator.
+   */
+  using iterator_t = autopas::ParticleIteratorWrapper<Particle, true>;
+  /**
+   * Alias for const iterator.
+   */
+  using const_iterator_t = autopas::ParticleIteratorWrapper<Particle, false>;
+};
+
 }  // namespace autopas


### PR DESCRIPTION
# Description

This PR adds type aliases for the iterator types.
This prevents internal changes inside of AutoPas to propagate to the outside and thus provides a more stable interface.

## Related Pull Requests

- #350 changes like these.

## Resolved Issues

- [x] Stable interface regarding iterators.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] ls1-mardyn can now use the stable interface, tested also compilation of ls1.
