### PR TITLE
Fix calculation of DirectSum (wrong sorting) and VerletListsCells (interactions with halo particle were skipped)

### DIFF
--- a/src/autopas/containers/cellPairTraversals/C18BasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/C18BasedTraversal.h
@@ -42,18 +42,20 @@ class C18BasedTraversal : public CBasedTraversal<ParticleCell, PairwiseFunctor, 
    * The main traversal of the C18Traversal.
    * @copydetails C01BasedTraversal::c01Traversal()
    */
-  template <typename LoopBody>
+  template <bool allCells = false, typename LoopBody>
   inline void c18Traversal(LoopBody &&loopBody);
 };
 
 template <class ParticleCell, class PairwiseFunctor, DataLayoutOption dataLayout, bool useNewton3>
-template <typename LoopBody>
+template <bool allCells, typename LoopBody>
 inline void C18BasedTraversal<ParticleCell, PairwiseFunctor, dataLayout, useNewton3>::c18Traversal(
     LoopBody &&loopBody) {
   const std::array<unsigned long, 3> stride = {2ul * this->_overlap[0] + 1ul, 2ul * this->_overlap[1] + 1ul,
                                                this->_overlap[2] + 1ul};
   auto end(this->_cellsPerDimension);
-  end[2] -= this->_overlap[2];
+  if (not allCells) {
+    end[2] -= this->_overlap[2];
+  }
   this->cTraversal(std::forward<LoopBody>(loopBody), end, stride);
 }
 

--- a/src/autopas/containers/cellPairTraversals/C18BasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/C18BasedTraversal.h
@@ -41,6 +41,9 @@ class C18BasedTraversal : public CBasedTraversal<ParticleCell, PairwiseFunctor, 
   /**
    * The main traversal of the C18Traversal.
    * @copydetails C01BasedTraversal::c01Traversal()
+   * @tparam allCells Defines whether or not to iterate over all cells with the loop body given as argument. By default
+   * it will not iterate over all cells and instead skip the last few cells, because they will be covered by the base
+   * step.
    */
   template <bool allCells = false, typename LoopBody>
   inline void c18Traversal(LoopBody &&loopBody);

--- a/src/autopas/containers/cellPairTraversals/C18BasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/C18BasedTraversal.h
@@ -40,10 +40,15 @@ class C18BasedTraversal : public CBasedTraversal<ParticleCell, PairwiseFunctor, 
  protected:
   /**
    * The main traversal of the C18Traversal.
+   *
    * @copydetails C01BasedTraversal::c01Traversal()
+   *
    * @tparam allCells Defines whether or not to iterate over all cells with the loop body given as argument. By default
-   * it will not iterate over all cells and instead skip the last few cells, because they will be covered by the base
-   * step.
+   * (allCells=false) it will not iterate over all cells and instead skip the last few cells, because they will be
+   * covered by the base step. If you plan to use the default base step of the traversal on this function, use
+   * allCells=false, if you plan to just iterate over all cells, e.g., to iterate over verlet lists saved within the
+   * cells, use allCells=true. For the c18 step if allCells is false, iteration will not occur over the last layer of
+   * cells (for overlap=1) (in x, y and z direction).
    */
   template <bool allCells = false, typename LoopBody>
   inline void c18Traversal(LoopBody &&loopBody);

--- a/src/autopas/containers/cellPairTraversals/CBasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/CBasedTraversal.h
@@ -89,9 +89,9 @@ class CBasedTraversal : public CellPairTraversal<ParticleCell> {
    * @tparam LoopBody type of the loop body
    * @param loopBody The body of the loop as a function. Normally a lambda function, that takes as as parameters
    * (x,y,z). If you need additional input from outside, please use captures (by reference).
-   * @param end 3D index until interactions are processed (exclusive)
-   * @param stride dimension of stride (depends on coloring)
-   * @param offset initial offset
+   * @param end 3D index until interactions are processed (exclusive).
+   * @param stride Distance (in cells) to the next cell of the same color.
+   * @param offset initial offset (in cells) in which cell to start the traversal.
    */
   template <typename LoopBody>
   inline void cTraversal(LoopBody &&loopBody, const std::array<unsigned long, 3> &end,

--- a/src/autopas/containers/cellPairTraversals/SlicedBasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/SlicedBasedTraversal.h
@@ -111,10 +111,15 @@ class SlicedBasedTraversal : public CellPairTraversal<ParticleCell> {
 
   /**
    * The main traversal of the sliced traversal.
+   *
    * @copydetails C01BasedTraversal::c01Traversal()
+   *
    * @tparam allCells Defines whether or not to iterate over all cells with the loop body given as argument. By default
-   * it will not iterate over all cells and instead skip the last few cells, because they will be covered by the base
-   * step.
+   * (allCells=false) it will not iterate over all cells and instead skip the last few cells, because they will be
+   * covered by the base step. If you plan to use the default base step of the traversal on this function, use
+   * allCells=false, if you plan to just iterate over all cells, e.g., to iterate over verlet lists saved within the
+   * cells, use allCells=true. For the sliced step if allCells is false, iteration will not occur over the last layer of
+   * cells (for _overlap=1) (in x, y and z direction).
    */
   template <bool allCells = false, typename LoopBody>
   inline void slicedTraversal(LoopBody &&loopBody);

--- a/src/autopas/containers/cellPairTraversals/SlicedBasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/SlicedBasedTraversal.h
@@ -112,6 +112,9 @@ class SlicedBasedTraversal : public CellPairTraversal<ParticleCell> {
   /**
    * The main traversal of the sliced traversal.
    * @copydetails C01BasedTraversal::c01Traversal()
+   * @tparam allCells Defines whether or not to iterate over all cells with the loop body given as argument. By default
+   * it will not iterate over all cells and instead skip the last few cells, because they will be covered by the base
+   * step.
    */
   template <bool allCells = false, typename LoopBody>
   inline void slicedTraversal(LoopBody &&loopBody);

--- a/src/autopas/containers/linkedCells/traversals/C04SoACellHandler.h
+++ b/src/autopas/containers/linkedCells/traversals/C04SoACellHandler.h
@@ -352,7 +352,7 @@ inline void C04SoACellHandler<ParticleCell, PairwiseFunctor, DataLayout, useNewt
   int id = 0;
   for (unsigned long x = 0ul; x <= _overlap[0]; ++x) {
     for (unsigned long y = 0ul; y <= _overlap[1]; ++y) {
-      for (unsigned long z = 0ul; z <= _overlap[2]; ++z, ++id) {
+      for (unsigned long z = 0ul; z <= _overlap[2]; ++z) {
         const unsigned long offset = cellOffsets[ov1_squared * x + ov1 * y];
         // origin
         {

--- a/src/autopas/containers/linkedCells/traversals/C04SoACellHandler.h
+++ b/src/autopas/containers/linkedCells/traversals/C04SoACellHandler.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <error.h>
 #include "autopas/containers/cellPairTraversals/CellPairTraversal.h"
 #include "autopas/utils/ThreeDimensionalMapping.h"
 
@@ -139,10 +138,10 @@ class C04SoACellHandler {
    * @param bufferSlice Index of slice in combinationSlice (source)
    * @param cellSlice Index of slice in _baseOffsets (destination)
    */
-  void writeBufferIntoCell(std::vector<ParticleCell> &cells, const unsigned long baseIndex,
+  void writeBufferIntoCell(std::vector<ParticleCell> &cells, unsigned long baseIndex,
                            std::vector<ParticleCell> &combinationSlice,
                            std::vector<std::vector<unsigned long>> &combinationSlicesOffsets,
-                           const unsigned long bufferSlice, const unsigned long cellSlice);
+                           unsigned long bufferSlice, unsigned long cellSlice);
 
   /**
    * Writes cell content into buffer.
@@ -153,10 +152,10 @@ class C04SoACellHandler {
    * @param bufferSlice Index of slice in combinationSlice (destination)
    * @param cellSlice Index of slice in _baseOffsets (source)
    */
-  void writeCellIntoBuffer(const std::vector<ParticleCell> &cells, const unsigned long baseIndex,
+  void writeCellIntoBuffer(const std::vector<ParticleCell> &cells, unsigned long baseIndex,
                            std::vector<ParticleCell> &combinationSlice,
                            std::vector<std::vector<unsigned long>> &combinationSlicesOffsets,
-                           const unsigned int bufferSlice, const unsigned int cellSlice);
+                           unsigned int bufferSlice, unsigned int cellSlice);
 
   /**
    * Creates offset intervals (stored in offset) from cellPairOffsets

--- a/src/autopas/containers/linkedCells/traversals/C08CellHandler.h
+++ b/src/autopas/containers/linkedCells/traversals/C08CellHandler.h
@@ -83,12 +83,12 @@ class C08CellHandler {
   const double _interactionLength;
 
   /**
-   * cell length in CellBlock3D.
+   * Cell length in CellBlock3D.
    */
   const std::array<double, 3> _cellLength;
 
   /**
-   * overlap of interacting cells. Array allows asymmetric cell sizes.
+   * Overlap of interacting cells. Array allows asymmetric cell sizes.
    */
   const std::array<unsigned long, 3> _overlap;
 };

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/C18TraversalVerlet.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/C18TraversalVerlet.h
@@ -57,7 +57,7 @@ class C18TraversalVerlet : public C18BasedTraversal<ParticleCell, PairwiseFuncto
 
 template <class ParticleCell, class PairwiseFunctor, DataLayoutOption DataLayout, bool useNewton3>
 inline void C18TraversalVerlet<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>::traverseParticlePairs() {
-  this->c18Traversal([&](unsigned long x, unsigned long y, unsigned long z) {
+  this->template c18Traversal</*allCells*/ true>([&](unsigned long x, unsigned long y, unsigned long z) {
     unsigned long baseIndex = utils::ThreeDimensionalMapping::threeToOneD(x, y, z, this->_cellsPerDimension);
     this->template iterateVerletListsCell<PairwiseFunctor, useNewton3>(*(this->_verletList), baseIndex, _functor);
   });

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/SlicedTraversalVerlet.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/SlicedTraversalVerlet.h
@@ -63,7 +63,7 @@ class SlicedTraversalVerlet : public SlicedBasedTraversal<ParticleCell, Pairwise
 
 template <class ParticleCell, class PairwiseFunctor, DataLayoutOption DataLayout, bool useNewton3>
 inline void SlicedTraversalVerlet<ParticleCell, PairwiseFunctor, DataLayout, useNewton3>::traverseParticlePairs() {
-  this->slicedTraversal([&](unsigned long x, unsigned long y, unsigned long z) {
+  this->template slicedTraversal</*allCells*/ true>([&](unsigned long x, unsigned long y, unsigned long z) {
     auto baseIndex = utils::ThreeDimensionalMapping::threeToOneD(x, y, z, this->_cellsPerDimension);
     this->template iterateVerletListsCell<PairwiseFunctor, useNewton3>(*(this->_verletList), baseIndex, _functor);
   });

--- a/src/autopas/pairwiseFunctors/CellFunctor.h
+++ b/src/autopas/pairwiseFunctors/CellFunctor.h
@@ -50,8 +50,8 @@ class CellFunctor {
    * Process the interactions between the particles of cell1 with particles of cell2.
    * @param cell1
    * @param cell2
-   * @param sortingDirection Normalized vector connecting centers of cell1 and cell2. If no parameter or {0, 0, 0} is given, sorting
-   * will be disabled.
+   * @param sortingDirection Normalized vector connecting centers of cell1 and cell2. If no parameter or {0, 0, 0} is
+   * given, sorting will be disabled.
    */
   void processCellPair(ParticleCell &cell1, ParticleCell &cell2,
                        const std::array<double, 3> &sortingDirection = {0., 0., 0.});

--- a/src/autopas/pairwiseFunctors/CellFunctor.h
+++ b/src/autopas/pairwiseFunctors/CellFunctor.h
@@ -50,10 +50,11 @@ class CellFunctor {
    * Process the interactions between the particles of cell1 with particles of cell2.
    * @param cell1
    * @param cell2
-   * @param sortingDirection Normalized vector connecting centers of cell1 and cell2. If no parameter is given, sorting will be
-   * disabled.
+   * @param sortingDirection Normalized vector connecting centers of cell1 and cell2. If no parameter is given, sorting
+   * will be disabled.
    */
-  void processCellPair(ParticleCell &cell1, ParticleCell &cell2, const std::array<double, 3> &sortingDirection = {0., 0., 0.});
+  void processCellPair(ParticleCell &cell1, ParticleCell &cell2,
+                       const std::array<double, 3> &sortingDirection = {0., 0., 0.});
 
  private:
   /**

--- a/src/autopas/pairwiseFunctors/CellFunctor.h
+++ b/src/autopas/pairwiseFunctors/CellFunctor.h
@@ -50,7 +50,7 @@ class CellFunctor {
    * Process the interactions between the particles of cell1 with particles of cell2.
    * @param cell1
    * @param cell2
-   * @param sortingDirection Normalized vector connecting centers of cell1 and cell2. If no parameter is given, sorting
+   * @param sortingDirection Normalized vector connecting centers of cell1 and cell2. If no parameter or {0, 0, 0} is given, sorting
    * will be disabled.
    */
   void processCellPair(ParticleCell &cell1, ParticleCell &cell2,

--- a/src/autopas/pairwiseFunctors/CellFunctor.h
+++ b/src/autopas/pairwiseFunctors/CellFunctor.h
@@ -51,10 +51,9 @@ class CellFunctor {
    * Process the interactions between the particles of cell1 with particles of cell2.
    * @param cell1
    * @param cell2
-   * @param r Normalized vector connecting centers of cell1 and cell2. If no parameter is given, a default value is used
-   * which is always applicable.
+   * @param r Normalized vector connecting centers of cell1 and cell2. If no parameter is given, sorting will be disabled.
    */
-  void processCellPair(ParticleCell &cell1, ParticleCell &cell2, const std::array<double, 3> &r = {1., 0., 0.});
+  void processCellPair(ParticleCell &cell1, ParticleCell &cell2, const std::array<double, 3> &r = {0., 0., 0.});
 
  private:
   /**

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
@@ -328,7 +328,7 @@ void testSimulationLoop(testingTuple options) {
  * This test checks the correct calculation of an AutoPas container, where:
  * The container owns 26 particles, that lie with a distance of 0.25 away from the centers of the faces and edges, as
  * well as from the corners of the box. They always lie on a straight line `a` from these points to the center of the
- * box. In addition the container owns 26 halo particles that lie outside of the container on the same line `a` with a
+ * box. Additionally, the container owns 26 halo particles that lie outside of the container on the same line `a` with a
  * distance of 0.5 from the owned particle.
  * No additional halo exchange is simulated in this test.
  * @param options

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
@@ -224,7 +224,7 @@ void doAssertions(autopas::AutoPas<Molecule, FMCell> &autoPas, Functor *functor,
 
   for (auto &mol : molecules) {
     EXPECT_NEAR(autopas::ArrayMath::dot(mol.getF(), mol.getF()), 390144. * 390144., 1.)
-        << "wrong force calculated.";  // this value should be correct already
+        << "wrong force calculated for particle: " << mol.toString();  // this value should be correct already
   }
 
   EXPECT_NEAR(functor->getUpot(), 16128.1 * numParticles / 2., 1e-5) << "wrong upot calculated";

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
@@ -224,7 +224,7 @@ void doAssertions(autopas::AutoPas<Molecule, FMCell> &autoPas, Functor *functor,
 
   for (auto &mol : molecules) {
     EXPECT_NEAR(autopas::ArrayMath::dot(mol.getF(), mol.getF()), 390144. * 390144., 1.)
-        << "wrong force calculated for particle: " << mol.toString();  // this value should be correct already
+        << "wrong force calculated for particle: " << mol.toString();
   }
 
   EXPECT_NEAR(functor->getUpot(), 16128.1 * numParticles / 2., 1e-5) << "wrong upot calculated";

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
@@ -394,8 +394,11 @@ TEST_P(AutoPasInterfaceTest, SimulatonLoopTest) {
   }
 }
 
+/**
+ * This test checks the correct behavior of the AutoPas interface with respect to halo calculations, see also the
+ * comments of testHaloCalculation() for a more detailed description.
+ */
 TEST_P(AutoPasInterfaceTest, HaloCalculationTest) {
-  // this test checks the correct behavior of the autopas interface.
   auto options = GetParam();
   try {
     testHaloCalculation(options);

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
@@ -212,22 +212,23 @@ void doSimulationLoop(autopas::AutoPas<Molecule, FMCell> &autoPas1, autopas::Aut
 }
 
 template <typename Functor>
-void doAssertions(autopas::AutoPas<Molecule, FMCell> &autoPas, Functor *functor) {
-  std::array<Molecule, 2> molecules{};
+void doAssertions(autopas::AutoPas<Molecule, FMCell> &autoPas, Functor *functor, unsigned long numParticlesExpected) {
+  std::vector<Molecule> molecules(numParticlesExpected);
   size_t numParticles = 0;
   for (auto iter = autoPas.begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
-    ASSERT_LT(numParticles, 2) << "Too many particles owned by this container.";
+    ASSERT_LT(numParticles, numParticlesExpected) << "Too many particles owned by this container.";
     molecules[numParticles++] = *iter;
   }
-  ASSERT_EQ(numParticles, 2) << "The container should own exactly two particles!";
+  ASSERT_EQ(numParticles, numParticlesExpected)
+      << "The container should own exactly " << numParticlesExpected << " particles!";
 
   for (auto &mol : molecules) {
-    EXPECT_DOUBLE_EQ(autopas::ArrayMath::dot(mol.getF(), mol.getF()), 390144. * 390144)
+    EXPECT_NEAR(autopas::ArrayMath::dot(mol.getF(), mol.getF()), 390144. * 390144., 1.)
         << "wrong force calculated.";  // this value should be correct already
   }
 
-  EXPECT_DOUBLE_EQ(functor->getUpot(), 16128.1) << "wrong upot calculated";
-  EXPECT_DOUBLE_EQ(functor->getVirial(), 195072.) << "wrong virial calculated";
+  EXPECT_NEAR(functor->getUpot(), 16128.1 * numParticles / 2., 1e-5) << "wrong upot calculated";
+  EXPECT_NEAR(functor->getVirial(), 195072. * numParticles / 2., 1e-5) << "wrong virial calculated";
 }
 
 template <typename Functor>
@@ -253,10 +254,7 @@ void doAssertions(autopas::AutoPas<Molecule, FMCell> &autoPas1, autopas::AutoPas
   EXPECT_DOUBLE_EQ(functor1->getVirial() + functor2->getVirial(), 195072.) << "wrong virial calculated";
 }
 
-void testSimulationLoop(testingTuple options) {
-  // create AutoPas object
-  autopas::AutoPas<Molecule, FMCell> autoPas;
-
+void setFromOptions(const testingTuple &options, autopas::AutoPas<Molecule, FMCell> &autoPas) {
   auto containerOption = std::get<0>(std::get<0>(options));
   auto traversalOption = std::get<1>(std::get<0>(options));
   auto dataLayoutOption = std::get<1>(options);
@@ -268,6 +266,13 @@ void testSimulationLoop(testingTuple options) {
   autoPas.setAllowedDataLayouts({dataLayoutOption});
   autoPas.setAllowedNewton3Options({newton3Option});
   autoPas.setAllowedCellSizeFactors(autopas::NumberSetFinite<double>(std::set<double>({cellSizeOption})));
+}
+
+void testSimulationLoop(testingTuple options) {
+  // create AutoPas object
+  autopas::AutoPas<Molecule, FMCell> autoPas;
+
+  setFromOptions(options, autoPas);
 
   defaultInit(autoPas);
 
@@ -291,7 +296,7 @@ void testSimulationLoop(testingTuple options) {
   // do first simulation loop
   doSimulationLoop(autoPas, &functor);
 
-  doAssertions(autoPas, &functor);
+  doAssertions(autoPas, &functor, 2);
 
   // update positions a bit (outside of domain!) + reset F
   {
@@ -305,7 +310,7 @@ void testSimulationLoop(testingTuple options) {
   // do second simulation loop
   doSimulationLoop(autoPas, &functor);
 
-  doAssertions(autoPas, &functor);
+  doAssertions(autoPas, &functor, 2);
 
   // no position update this time, but resetF!
   {
@@ -316,7 +321,59 @@ void testSimulationLoop(testingTuple options) {
   // do third simulation loop, tests rebuilding of container.
   doSimulationLoop(autoPas, &functor);
 
-  doAssertions(autoPas, &functor);
+  doAssertions(autoPas, &functor, 2);
+}
+
+/**
+ * This test checks the correct calculation of an AutoPas container, where:
+ * The container owns 26 particles, that lie with a distance of 0.25 away from the centers of the faces and edges, as
+ * well as from the corners of the box. They always lie on a straight line `a` from these points to the center of the
+ * box. In addition the container owns 26 halo particles that lie outside of the container on the same line `a` with a
+ * distance of 0.5 from the owned particle.
+ * No additional halo exchange is simulated in this test.
+ * @param options
+ */
+void testHaloCalculation(testingTuple options) {
+  // create AutoPas object
+  autopas::AutoPas<Molecule, FMCell> autoPas;
+
+  setFromOptions(options, autoPas);
+
+  defaultInit(autoPas);
+
+  // create particle pairs with distance .5
+  double distance = .5;
+  unsigned long id = 0;
+  for (int x_diff : {-1, 0, 1}) {
+    for (int y_diff : {-1, 0, 1}) {
+      for (int z_diff : {-1, 0, 1}) {
+        if (x_diff == 0 and y_diff == 0 and z_diff == 0) {
+          continue;
+        }
+        double mul = 5.;
+        double mid = 5.;
+        std::array<double, 3> edge{x_diff * mul + mid, y_diff * mul + mid, z_diff * mul + mid};
+
+        std::array<double, 3> diff = {x_diff * 1., y_diff * 1., z_diff * 1.};
+        diff = autopas::ArrayMath::mulScalar(autopas::ArrayMath::normalize(diff), distance / 2.);
+
+        auto pos1 = autopas::ArrayMath::sub(edge, diff);
+        auto pos2 = autopas::ArrayMath::add(edge, diff);
+
+        Molecule particle1(pos1, {0., 0., 0.}, id++);
+        autoPas.addParticle(particle1);
+        Molecule particle2(pos2, {0., 0., 0.}, id++);
+        autoPas.addOrUpdateHaloParticle(particle2);
+      }
+    }
+  }
+
+  autopas::LJFunctor<Molecule, FMCell, autopas::FunctorN3Modes::Both, true /*calculate globals*/> functor(cutoff, eps,
+                                                                                                          sigma, shift);
+
+  autoPas.iteratePairwise(&functor);
+
+  doAssertions(autoPas, &functor, 26);
 }
 
 TEST_P(AutoPasInterfaceTest, SimulatonLoopTest) {
@@ -324,6 +381,22 @@ TEST_P(AutoPasInterfaceTest, SimulatonLoopTest) {
   auto options = GetParam();
   try {
     testSimulationLoop(options);
+  } catch (autopas::utils::ExceptionHandler::AutoPasException &autoPasException) {
+    std::string str = autoPasException.what();
+    if (str.find("Trying to execute a traversal that is not applicable") != std::string::npos) {
+      GTEST_SKIP() << "skipped with exception: " << autoPasException.what() << std::endl;
+    } else {
+      // rethrow
+      throw;
+    }
+  }
+}
+
+TEST_P(AutoPasInterfaceTest, HaloCalculationTest) {
+  // this test checks the correct behavior of the autopas interface.
+  auto options = GetParam();
+  try {
+    testHaloCalculation(options);
   } catch (autopas::utils::ExceptionHandler::AutoPasException &autoPasException) {
     std::string str = autoPasException.what();
     if (str.find("Trying to execute a traversal that is not applicable") != std::string::npos) {

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
@@ -346,7 +346,9 @@ void testHaloCalculation(testingTuple options) {
   unsigned long id = 0;
   for (int x_diff : {-1, 0, 1}) {
     for (int y_diff : {-1, 0, 1}) {
+      //    for (int y_diff : {0}) {
       for (int z_diff : {-1, 0, 1}) {
+        //      for (int z_diff : {0}) {
         if (x_diff == 0 and y_diff == 0 and z_diff == 0) {
           continue;
         }


### PR DESCRIPTION
# Description

- Fixes inappropriate sorting directions being used in some cases. (mainly DirectSum, but possibly also verlet lists)
- Fixes VerletListsCellsTraversal not iterating over verlet lists of some halo cells (#355)

## Resolved Issues

- [x] fixes #352 
- [x] fixes #355 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Using ls1 mardyn
- [x] Additional Test for AutoPas that includes checking of halos
