### PR TITLE
fix all tuning-strategies using the last measured time

### DIFF
--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -143,7 +143,7 @@ class AutoTuner {
         // if this was the last sample:
         if (_samples.size() == _maxSamples) {
           auto reducedValue = OptimumSelector::optimumValue(_samples, _selectorStrategy);
-          _tuningStrategy->addEvidence(time);
+          _tuningStrategy->addEvidence(reducedValue);
 
           // print config, times and reduced value
           if (autopas::Logger::get()->level() <= autopas::Logger::LogLevel::debug) {


### PR DESCRIPTION
reducedValue from OptimumSelector::optimumValue() was not used properly, instead the tuningstrategies were always only using the last measured time.