### PR TITLE
Bayesian Search: Change FeatureVector diff

### DIFF
--- a/src/autopas/containers/verletClusterLists/VerletClusterCellsParticleIterator.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterCellsParticleIterator.h
@@ -86,7 +86,8 @@ class VerletClusterCellsParticleIterator : public ParticleIteratorInterfaceImpl<
   bool isValid() const override { return _cellId < _vectorOfCells->size(); }
 
   /**
-   * @copydoc ParticleIteratorInterface::deleteCurrentParticle()
+   * Deletes the current particle.
+   * @note This function is disabled for const iterators.
    */
   void deleteCurrentParticleImpl() override {
     if constexpr (modifiable) {

--- a/src/autopas/iterators/ParticleIterator.h
+++ b/src/autopas/iterators/ParticleIterator.h
@@ -139,7 +139,8 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle, modifiab
 
  protected:
   /**
-   * @copydoc ParticleIteratorInterface::deleteCurrentParticle()
+   * Deletes the current particle.
+   * @note This function is disabled for const iterators.
    */
   inline void deleteCurrentParticleImpl() override {
     if (_iteratorWithinOneCell.isValid()) {

--- a/src/autopas/selectors/FeatureVector.h
+++ b/src/autopas/selectors/FeatureVector.h
@@ -48,7 +48,10 @@ class FeatureVector : public Configuration {
   FeatureVector(Configuration conf) : Configuration(conf) {}
 
   /**
-   * Distance between two FeatureVectors
+   * Distance between two FeatureVectors.
+   * Since there is no real ordering all discrete options are assumed to have a distance 
+   * of one to each other.
+   * This function ignores the container dimension since it is encoded in the traversal.
    * @param other
    * @return
    */

--- a/src/autopas/selectors/FeatureVector.h
+++ b/src/autopas/selectors/FeatureVector.h
@@ -54,7 +54,7 @@ class FeatureVector : public Configuration {
    */
   Eigen::VectorXd operator-(const FeatureVector &other) const {
     Eigen::VectorXd result(featureSpaceDims);
-    result << cellSizeFactor, traversal == other.traversal ? 0. : 1., dataLayout == other.dataLayout ? 0. : 1.,
+    result << cellSizeFactor - other.cellSizeFactor, traversal == other.traversal ? 0. : 1., dataLayout == other.dataLayout ? 0. : 1.,
         newton3 == other.newton3 ? 0. : 1.;
 
     return result;

--- a/src/autopas/selectors/FeatureVector.h
+++ b/src/autopas/selectors/FeatureVector.h
@@ -49,7 +49,7 @@ class FeatureVector : public Configuration {
 
   /**
    * Distance between two FeatureVectors.
-   * Since there is no real ordering all discrete options are assumed to have a distance 
+   * Since there is no real ordering all discrete options are assumed to have a distance
    * of one to each other.
    * This function ignores the container dimension since it is encoded in the traversal.
    * @param other

--- a/src/autopas/selectors/FeatureVector.h
+++ b/src/autopas/selectors/FeatureVector.h
@@ -52,13 +52,12 @@ class FeatureVector : public Configuration {
    * @param other
    * @return
    */
-  FeatureVector operator-(const FeatureVector &other) const {
-    ContainerOption co = ContainerOption((traversal == other.traversal) ? 0 : 1);
-    double cfs = (cellSizeFactor - other.cellSizeFactor);
-    TraversalOption to = TraversalOption((traversal == other.traversal) ? 0 : 1);
-    DataLayoutOption dlo = DataLayoutOption((dataLayout == other.dataLayout) ? 0 : 1);
-    Newton3Option n3o = Newton3Option((newton3 == other.newton3) ? 0 : 1);
-    return FeatureVector(co, cfs, to, dlo, n3o);
+  Eigen::VectorXd operator-(const FeatureVector &other) const {
+    Eigen::VectorXd result(featureSpaceDims);
+    result << cellSizeFactor, traversal == other.traversal ? 0. : 1., dataLayout == other.dataLayout ? 0. : 1.,
+        newton3 == other.newton3 ? 0. : 1.;
+
+    return result;
   }
 
   /**

--- a/src/autopas/selectors/FeatureVector.h
+++ b/src/autopas/selectors/FeatureVector.h
@@ -54,8 +54,8 @@ class FeatureVector : public Configuration {
    */
   Eigen::VectorXd operator-(const FeatureVector &other) const {
     Eigen::VectorXd result(featureSpaceDims);
-    result << cellSizeFactor - other.cellSizeFactor, traversal == other.traversal ? 0. : 1., dataLayout == other.dataLayout ? 0. : 1.,
-        newton3 == other.newton3 ? 0. : 1.;
+    result << cellSizeFactor - other.cellSizeFactor, traversal == other.traversal ? 0. : 1.,
+        dataLayout == other.dataLayout ? 0. : 1., newton3 == other.newton3 ? 0. : 1.;
 
     return result;
   }

--- a/tests/testAutopas/tests/selectors/tuningStrategy/BayesianSearchTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/BayesianSearchTest.cpp
@@ -91,7 +91,7 @@ TEST_F(BayesianSearchTest, testFindBest) {
   while (bayesSearch.tune()) {
     autopas::FeatureVector current(bayesSearch.getCurrentConfiguration());
 
-    Eigen::VectorXd diff = static_cast<Eigen::VectorXd>(best - current);
+    Eigen::VectorXd diff = best - current;
     double distanceSquared = diff.array().square().sum();
     long dummyTime = static_cast<long>(654321 * distanceSquared);
 


### PR DESCRIPTION
# Description

Changes the return type of the - operator of FeatureVector to Eigen::VectorXd. This seems reasonable since the previously returned feature vector was only used to be cast to a Eigen::VectorXd. Also with #348 the construction of invalid options will not be possible anymore.

## Related Pull Requests

- #348

## ~Resolved Issues~

# How Has This Been Tested?

- [ ] Tested by Jan :)
