### PR TITLE
Disable the C04SoATraversal for cell size factors < 1.

### DIFF
--- a/src/autopas/containers/linkedCells/traversals/C04SoATraversal.h
+++ b/src/autopas/containers/linkedCells/traversals/C04SoATraversal.h
@@ -52,9 +52,14 @@ class C04SoATraversal : public C04BasedTraversal<ParticleCell, PairwiseFunctor, 
 
   /**
    * c04SoA traversals are only usable with DataLayout SoA.
+   * @note Currently there is a bug when cellsize factor is smaller than 1:
+   * https://github.com/AutoPas/AutoPas/issues/354
    * @return
    */
-  bool isApplicable() const override { return DataLayout == DataLayoutOption::soa; }
+  bool isApplicable() const override {
+    return DataLayout == DataLayoutOption::soa and
+           (this->_overlap[0] == 1 and this->_overlap[1] == 1 and this->_overlap[2] == 1);
+  }
 
  private:
   C04SoACellHandler<ParticleCell, PairwiseFunctor, DataLayout, useNewton3> _cellHandler;


### PR DESCRIPTION
# Description

Disable the C04SoATraversal for cell size factors < 1.
This should be reverted as soon as https://github.com/AutoPas/AutoPas/issues/354 is fixed.

## Related Pull Requests

- fix in progress: #364 

## Resolved Issues

- not resolved but suppresses: #354 

# How Has This Been Tested?

- [x] existing unit tests
