### PR TITLE
Fix nvcc + clang not compiling

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,6 @@ pipeline{
                             dir("build-cuda") {
                                 sh "cmake -DAUTOPAS_ENABLE_CUDA=ON .."
                                 sh "make -j 4 > buildlog-cuda.txt 2>&1 || (cat buildlog-cuda.txt && exit 1)"
-                                sh "cat buildlog-cuda.txt"
                                 sh "./tests/testAutopas/runTests"
                             }
                             dir('build-cuda/examples') {
@@ -87,6 +86,26 @@ pipeline{
                     post{
                         always{
                             warnings canComputeNew: false, categoriesPattern: '', defaultEncoding: '', excludePattern: '', healthy: '', includePattern: '', messagesPattern: '', parserConfigurations: [[parserName: 'GNU Make + GNU C Compiler (gcc)', pattern: 'build*/buildlog-cuda.txt']], unHealthy: '', unstableTotalAll: '0', unstableTotalHigh: '0', unstableTotalLow: '0', unstableTotalNormal: '0'
+                        }
+                    }
+                }
+                stage('gpu cloud - clang') {
+                    agent { label 'openshift-autoscale-gpu' }
+                    steps{
+                        container('cuda-10') {
+                            dir("build-cuda") {
+                                sh "CC=clang CXX=clang++ cmake -DAUTOPAS_ENABLE_CUDA=ON .."
+                                sh "make -j 4 > buildlog-cuda-clang.txt 2>&1 || (cat buildlog-cuda-clang.txt && exit 1)"
+                                sh "./tests/testAutopas/runTests"
+                            }
+                            dir('build-cuda/examples') {
+                                sh "ctest -C checkExamples -j8 --verbose"
+                            }
+                        }
+                    }
+                    post{
+                        always{
+                            warnings canComputeNew: false, categoriesPattern: '', defaultEncoding: '', excludePattern: '', healthy: '', includePattern: '', messagesPattern: '', parserConfigurations: [[parserName: 'GNU Make + GNU C Compiler (gcc)', pattern: 'build*/buildlog-cuda-clang.txt']], unHealthy: '', unstableTotalAll: '0', unstableTotalHigh: '0', unstableTotalLow: '0', unstableTotalNormal: '0'
                         }
                     }
                 }

--- a/cmake/modules/cuda.cmake
+++ b/cmake/modules/cuda.cmake
@@ -43,10 +43,12 @@ if (AUTOPAS_ENABLE_CUDA)
         autopas
         PUBLIC
             # architecture flags and -Xcompiler to prepend to -fopenmp
-            $<$<COMPILE_LANGUAGE:CUDA>:$<$<STREQUAL:${CMAKE_BUILD_TYPE},Debug>:-lineinfo
-            -pg>
-            -gencode
-            arch=compute_${CUDA_COMPUTE_CAPABILITY},code=sm_${CUDA_COMPUTE_CAPABILITY}
-            $<$<BOOL:${AUTOPAS_OPENMP}>:-Xcompiler>>
+            $<$<COMPILE_LANGUAGE:CUDA>:
+              -ccbin=${CMAKE_CXX_COMPILER}
+              $<$<STREQUAL:${CMAKE_BUILD_TYPE},Debug>:-lineinfo -pg>
+              -gencode arch=compute_${CUDA_COMPUTE_CAPABILITY},code=sm_${CUDA_COMPUTE_CAPABILITY}
+              #$<$<BOOL:${AUTOPAS_OPENMP}>:-Xcompiler>
+            >
     )
+
 endif ()

--- a/cmake/modules/cuda.cmake
+++ b/cmake/modules/cuda.cmake
@@ -42,15 +42,13 @@ if (AUTOPAS_ENABLE_CUDA)
     target_compile_options(
         autopas
         PUBLIC
-            # architecture flags
-            $<$<COMPILE_LANGUAGE:CUDA>:
-              # specify host compiler
-              -ccbin=${CMAKE_CXX_COMPILER}
-              # add debug flags
-              $<$<STREQUAL:${CMAKE_BUILD_TYPE},Debug>:-lineinfo -pg>
-              # notify nvcc of compute capability 
-              -gencode arch=compute_${CUDA_COMPUTE_CAPABILITY},code=sm_${CUDA_COMPUTE_CAPABILITY}
-            >
+            # specify host compiler
+            $<$<COMPILE_LANGUAGE:CUDA>:-ccbin=${CMAKE_CXX_COMPILER}>
+            # add debug flags
+            $<$<COMPILE_LANGUAGE:CUDA>:$<$<STREQUAL:${CMAKE_BUILD_TYPE},Debug>:-lineinfo -pg>>
+            # notify nvcc of compute capability
+            $<$<COMPILE_LANGUAGE:CUDA>:-gencode
+            arch=compute_${CUDA_COMPUTE_CAPABILITY},code=sm_${CUDA_COMPUTE_CAPABILITY}>
     )
 
 endif ()

--- a/cmake/modules/cuda.cmake
+++ b/cmake/modules/cuda.cmake
@@ -42,12 +42,14 @@ if (AUTOPAS_ENABLE_CUDA)
     target_compile_options(
         autopas
         PUBLIC
-            # architecture flags and -Xcompiler to prepend to -fopenmp
+            # architecture flags
             $<$<COMPILE_LANGUAGE:CUDA>:
+              # specify host compiler
               -ccbin=${CMAKE_CXX_COMPILER}
+              # add debug flags
               $<$<STREQUAL:${CMAKE_BUILD_TYPE},Debug>:-lineinfo -pg>
+              # notify nvcc of compute capability 
               -gencode arch=compute_${CUDA_COMPUTE_CAPABILITY},code=sm_${CUDA_COMPUTE_CAPABILITY}
-              #$<$<BOOL:${AUTOPAS_OPENMP}>:-Xcompiler>
             >
     )
 

--- a/cmake/modules/other-compileroptions.cmake
+++ b/cmake/modules/other-compileroptions.cmake
@@ -17,7 +17,7 @@ target_compile_options(
         # fast math for better vectorization
         $<$<AND:$<BOOL:${AUTOPAS_ENABLE_FAST_MATH}>,$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>>:$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=>-ffast-math>
         # Clang: set OpenMP version to 4.5
-        $<$<CXX_COMPILER_ID:Clang>:-fopenmp-version=45>
+        $<$<CXX_COMPILER_ID:Clang>:$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=>-fopenmp-version=45>
         # INTEL: per default fast math is on. Disable via fp-model precise
         $<$<AND:$<NOT:$<BOOL:${AUTOPAS_ENABLE_FAST_MATH}>>,$<CXX_COMPILER_ID:Intel>>:$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=>-fp-model
         precise>

--- a/tests/testAutopas/tests/pairwiseFunctors/LJFunctorCudaTest.cpp
+++ b/tests/testAutopas/tests/pairwiseFunctors/LJFunctorCudaTest.cpp
@@ -222,8 +222,8 @@ TEST_P(LJFunctorCudaTest, testLJFunctorVSLJFunctorCuda) {
 }
 
 INSTANTIATE_TEST_SUITE_P(Generated, LJFunctorCudaTest,
-                        ::testing::Combine(::testing::Bool(), ::testing::Bool(),
-                                           ::testing::ValuesIn({1, 2, 4, 16, 31, 32, 33, 55, 64, 65}),
-                                           ::testing::ValuesIn({-1, 1, 4, 16, 31, 32, 33, 55, 64, 65})));
+                         ::testing::Combine(::testing::Bool(), ::testing::Bool(),
+                                            ::testing::ValuesIn({1, 2, 4, 16, 31, 32, 33, 55, 64, 65}),
+                                            ::testing::ValuesIn({-1, 1, 4, 16, 31, 32, 33, 55, 64, 65})));
 
 #endif  // AUTOPAS_CUDA

--- a/tests/testAutopas/tests/pairwiseFunctors/LJFunctorCudaTest.cpp
+++ b/tests/testAutopas/tests/pairwiseFunctors/LJFunctorCudaTest.cpp
@@ -221,7 +221,7 @@ TEST_P(LJFunctorCudaTest, testLJFunctorVSLJFunctorCuda) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(Generated, LJFunctorCudaTest,
+INSTANTIATE_TEST_SUITE_P(Generated, LJFunctorCudaTest,
                         ::testing::Combine(::testing::Bool(), ::testing::Bool(),
                                            ::testing::ValuesIn({1, 2, 4, 16, 31, 32, 33, 55, 64, 65}),
                                            ::testing::ValuesIn({-1, 1, 4, 16, 31, 32, 33, 55, 64, 65})));


### PR DESCRIPTION
# Description

Make clang compiler work with nvcc, 

* by adding missing
```
$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=>
```
* and by passing the host compiler to nvcc via -ccbin



## Resolved Issues

- [x] Fixes #366 
- [x] Host compiler was not passed to nvcc

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] New Jenkins test

# Notes
- There exist compatibility restrictions between nvcc and clang! nvcc 10.1 is not compatible with clang >=9.