### PR TITLE
Performance improvements for cmake files

### DIFF
--- a/cmake/modules/clang-format.cmake
+++ b/cmake/modules/clang-format.cmake
@@ -5,25 +5,19 @@ set(
     INCLUDE_DIRS
     "${PROJECT_SOURCE_DIR}/src/" "${PROJECT_SOURCE_DIR}/examples/" "${PROJECT_SOURCE_DIR}/tests/"
 )
-file(
-    GLOB_RECURSE
-    ALL_SOURCE_FILES
-    "*.cpp"
-    "*.h"
-    "*.cuh"
-    "*.cu"
-)
-foreach (TMP_PATH ${ALL_SOURCE_FILES})
-    set(_found FALSE)
-    foreach (_incdir ${INCLUDE_DIRS})
-        string(FIND ${TMP_PATH} ${_incdir} INCLUDE_DIR_FOUND)
-        if (${INCLUDE_DIR_FOUND} EQUAL 0)
-            set(_found TRUE)
-        endif ()
-    endforeach (_incdir)
-    if (NOT ${_found})
-        list(REMOVE_ITEM ALL_SOURCE_FILES ${TMP_PATH})
-    endif ()
+# reset CF_ALL_SOURCE_FILES
+set(CF_ALL_SOURCE_FILES)
+foreach (TMP_PATH ${INCLUDE_DIRS})
+    # search for files for each path in INCLUDE_DIRS and append them to CF_ALL_SOURCE_FILES
+    file(
+        GLOB_RECURSE
+        CF_ALL_SOURCE_FILES_TMP
+        "${TMP_PATH}/*.cpp"
+        "${TMP_PATH}/*.h"
+        "${TMP_PATH}/*.cuh"
+        "${TMP_PATH}/*.cu"
+    )
+    list(APPEND CF_ALL_SOURCE_FILES ${CF_ALL_SOURCE_FILES_TMP})
 endforeach (TMP_PATH)
 
 find_program(CLANG_FORMAT NAMES clang-format clang-format-6.0)
@@ -31,7 +25,7 @@ find_program(CLANG_FORMAT NAMES clang-format clang-format-6.0)
 if (CLANG_FORMAT)
     message(STATUS "clang format found, added clangformat target")
     set(dummyfiles)
-    foreach (_file ${ALL_SOURCE_FILES})
+    foreach (_file ${CF_ALL_SOURCE_FILES})
         string(
             REPLACE
                 "."

--- a/cmake/modules/clang-format.cmake
+++ b/cmake/modules/clang-format.cmake
@@ -6,7 +6,6 @@ set(
     "${PROJECT_SOURCE_DIR}/src/" "${PROJECT_SOURCE_DIR}/examples/" "${PROJECT_SOURCE_DIR}/tests/"
 )
 # reset CF_ALL_SOURCE_FILES
-set(CF_ALL_SOURCE_FILES)
 foreach (TMP_PATH ${INCLUDE_DIRS})
     # search for files for each path in INCLUDE_DIRS and append them to CF_ALL_SOURCE_FILES
     file(

--- a/cmake/modules/cmake-format.cmake
+++ b/cmake/modules/cmake-format.cmake
@@ -7,28 +7,21 @@ set(
     "${PROJECT_SOURCE_DIR}/src/"
     "${PROJECT_SOURCE_DIR}/examples/"
     "${PROJECT_SOURCE_DIR}/tests/"
-    "${PROJECT_SOURCE_DIR}/CMakeLists.txt"
-    "${PROJECT_SOURCE_DIR}/version.cmake"
 )
 
-file(
-    GLOB_RECURSE
-    ALL_CMake_FILES
-    "CMakeLists.txt"
-    "*.cmake"
-)
+# set ALL_CMake_FILES to cmake files in PROJECT_SOURCE_DIR, as we cannot do a recurse there.
+set(ALL_CMake_FILES "${PROJECT_SOURCE_DIR}/CMakeLists.txt" "${PROJECT_SOURCE_DIR}/version.cmake")
 
-foreach (TMP_PATH ${ALL_CMake_FILES})
-    set(_found FALSE)
-    foreach (_incdir ${INCLUDE_DIRS})
-        string(FIND ${TMP_PATH} ${_incdir} INCLUDE_DIR_FOUND)
-        if (${INCLUDE_DIR_FOUND} EQUAL 0)
-            set(_found TRUE)
-        endif ()
-    endforeach (_incdir)
-    if (NOT ${_found})
-        list(REMOVE_ITEM ALL_CMake_FILES ${TMP_PATH})
-    endif ()
+foreach (TMP_PATH ${INCLUDE_DIRS})
+    # search for files for each path in INCLUDE_DIRS and append them to ALL_CMake_FILES
+    file(
+        GLOB_RECURSE
+        ALL_CMake_FILES_TMP
+        "${TMP_PATH}/CMakeLists.txt"
+        "${TMP_PATH}/*.cmake"
+    )
+
+    list(APPEND ALL_CMake_FILES ${ALL_CMake_FILES_TMP})
 endforeach (TMP_PATH)
 
 find_program(CMAKE_FORMAT NAMES cmake-format)

--- a/examples/sph-mpi/CMakeLists.txt
+++ b/examples/sph-mpi/CMakeLists.txt
@@ -5,6 +5,7 @@ file(
     "*.h"
 )
 
+message(STATUS "searching for mpi...")
 find_package(MPI)
 
 if (NOT ${MPI_CXX_FOUND})


### PR DESCRIPTION
# Description

Removes lots of list operations in clang-format.cmake and cmake-format.cmake.

Previously also files in build directories were traversed and later on removed, this is now fixed.

Exemplary timing results for the cmake command (with 15 build directories):

old      | new
-------- | -------
85.7 s | 3.5 s

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] variables contain same files -- tested via `message(STATUS "${VARNAME}")`
