### PR TITLE
Make VerletListsLinkedBase directly inherit from ParticleContainerInterface

### DIFF
--- a/src/autopas/containers/ParticleContainer.h
+++ b/src/autopas/containers/ParticleContainer.h
@@ -103,17 +103,6 @@ class ParticleContainer : public ParticleContainerInterface<ParticleCell> {
   double getInteractionLength() const override final { return _cutoff + _skin; }
 
   /**
-   * Checks if the given traversals are applicable to this container.
-   * @param traversalOptions
-   * @return True iff traversalOptions is a subset of _applicableTraversals
-   */
-  bool checkIfTraversalsAreApplicable(const std::set<TraversalOption> &traversalOptions) const {
-    auto applicableTraversals = compatibleTraversals::allCompatibleTraversals(this->getContainerType());
-    return std::includes(applicableTraversals.begin(), applicableTraversals.end(), traversalOptions.begin(),
-                         traversalOptions.end());
-  }
-
-  /**
    * Deletes all particles from the container.
    */
   void deleteAllParticles() override {

--- a/src/autopas/containers/ParticleContainer.h
+++ b/src/autopas/containers/ParticleContainer.h
@@ -38,7 +38,7 @@ class ParticleContainer : public ParticleContainerInterface<ParticleCell> {
       : _cells(), _boxMin(boxMin), _boxMax(boxMax), _cutoff(cutoff), _skin(skin) {}
 
   /**
-   * destructor of ParticleContainer
+   * Destructor of ParticleContainer
    */
   ~ParticleContainer() override = default;
 

--- a/src/autopas/containers/ParticleContainer.h
+++ b/src/autopas/containers/ParticleContainer.h
@@ -38,7 +38,7 @@ class ParticleContainer : public ParticleContainerInterface<ParticleCell> {
       : _cells(), _boxMin(boxMin), _boxMax(boxMax), _cutoff(cutoff), _skin(skin) {}
 
   /**
-   * Destructor of ParticleContainer
+   * Destructor of ParticleContainer.
    */
   ~ParticleContainer() override = default;
 

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -706,7 +706,7 @@ class VerletClusterLists : public ParticleContainer<FullParticleCell<Particle>> 
   int _clusterSize;
 
   /**
-   * The number of clusters. This is not equal to _cells.size(), as every grid might contain multiple clusters.
+   * The number of clusters. This is not equal to _cells.size(), as every grid (=cell) might contain multiple clusters.
    */
   index_t _numClusters;
 

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -85,7 +85,7 @@ class VerletClusterLists : public ParticleContainer<FullParticleCell<Particle>> 
    */
   void addParticle(Particle &p) override {
     // add particle somewhere, because lists will be rebuild anyways
-    _clusters[0].addParticle(p);
+    this->_cells[0].addParticle(p);
   }
 
   /**
@@ -146,13 +146,13 @@ class VerletClusterLists : public ParticleContainer<FullParticleCell<Particle>> 
 
   ParticleIteratorWrapper<Particle, true> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
     return ParticleIteratorWrapper<Particle, true>(
-        new internal::ParticleIterator<Particle, FullParticleCell<Particle>, true>(&this->_clusters));
+        new internal::ParticleIterator<Particle, FullParticleCell<Particle>, true>(&this->_cells));
   }
 
   ParticleIteratorWrapper<Particle, false> begin(
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const override {
     return ParticleIteratorWrapper<Particle, false>(
-        new internal::ParticleIterator<Particle, FullParticleCell<Particle>, false>(&this->_clusters));
+        new internal::ParticleIterator<Particle, FullParticleCell<Particle>, false>(&this->_cells));
   }
 
   ParticleIteratorWrapper<Particle, true> getRegionIterator(
@@ -190,14 +190,6 @@ class VerletClusterLists : public ParticleContainer<FullParticleCell<Particle>> 
     }
   }
 
-  unsigned long getNumParticles() const override {
-    unsigned long sum = 0;
-    for (size_t index = 0; index < _clusters.size(); index++) {
-      sum += _clusters[index].numParticles();
-    }
-    return sum;
-  }
-
   /**
    * Returns the ClusterIndexMap for usage in the traversals of this container.
    * @return the ClusterIndexMap.
@@ -232,7 +224,7 @@ class VerletClusterLists : public ParticleContainer<FullParticleCell<Particle>> 
    * Returns the 2D grid for the XY-plane of this container that defines the cluster towers.
    * @return the grids of this container for usage in traversals.
    */
-  auto &getGrids() { return _clusters; }
+  auto &getGrids() { return this->_cells; }
 
   /**
    * Returns the number of particles in each cluster.
@@ -252,7 +244,7 @@ class VerletClusterLists : public ParticleContainer<FullParticleCell<Particle>> 
     for (index_t x = 0; x < _cellsPerDim[0]; x++) {
       for (index_t y = 0; y < _cellsPerDim[1]; y++) {
         index_t index = VerletClusterMaths::index1D(x, y, _cellsPerDim);
-        auto &grid = _clusters[index];
+        auto &grid = this->_cells[index];
         auto &gridNeighborList = _neighborLists[index];
 
         const index_t numClustersInGrid = grid.numParticles() / _clusterSize;
@@ -286,7 +278,7 @@ class VerletClusterLists : public ParticleContainer<FullParticleCell<Particle>> 
     for (index_t x = 0; x < endX; x++) {
       for (index_t y = 0; y < endY; y++) {
         index_t index = VerletClusterMaths::index1D(x, y, _cellsPerDim);
-        auto &grid = _clusters[index];
+        auto &grid = this->_cells[index];
         auto &gridNeighborList = _neighborLists[index];
 
         const index_t numClustersInGrid = grid.numParticles() / _clusterSize;
@@ -316,13 +308,13 @@ class VerletClusterLists : public ParticleContainer<FullParticleCell<Particle>> 
     index_t numCells = _cellsPerDim[0] * _cellsPerDim[1];
 
     // resize to number of grids
-    _clusters.resize(numCells);
+    this->_cells.resize(numCells);
     _neighborLists.resize(numCells);
 
     sortParticlesIntoClusters(invalidParticles);
 
     // sort by last dimension and reserve space for dummy particles
-    for (auto &cluster : _clusters) {
+    for (auto &cluster : this->_cells) {
       cluster.sortByDim(2);
 
       size_t size = cluster.numParticles();
@@ -345,7 +337,7 @@ class VerletClusterLists : public ParticleContainer<FullParticleCell<Particle>> 
    */
   std::vector<Particle> collectParticlesAndClearClusters() {
     std::vector<Particle> invalidParticles;
-    for (auto &cluster : _clusters) {
+    for (auto &cluster : this->_cells) {
       for (auto it = cluster.begin(); it.isValid(); ++it) {
         invalidParticles.push_back(*it);
       }
@@ -396,7 +388,7 @@ class VerletClusterLists : public ParticleContainer<FullParticleCell<Particle>> 
     for (auto &particle : particles) {
       if (utils::inBox(particle.getR(), _boxMin, _boxMax)) {
         auto index = get1DIndexOfPosition(particle.getR());
-        _clusters[index].addParticle(particle);
+        this->_cells[index].addParticle(particle);
       }
     }
   }
@@ -426,7 +418,7 @@ class VerletClusterLists : public ParticleContainer<FullParticleCell<Particle>> 
     // for all grids
     for (int yi = 0; yi <= gridMaxY; yi++) {
       for (int xi = 0; xi <= gridMaxX; xi++) {
-        auto &iGrid = _clusters[VerletClusterMaths::index1D(xi, yi, _cellsPerDim)];
+        auto &iGrid = this->_cells[VerletClusterMaths::index1D(xi, yi, _cellsPerDim)];
         // calculate number of full clusters and rest
         index_t iSize = iGrid.numParticles() / _clusterSize;
         int iRest = iGrid.numParticles() % _clusterSize;
@@ -475,7 +467,7 @@ class VerletClusterLists : public ParticleContainer<FullParticleCell<Particle>> 
         // calculate distance in xy-plane and skip if already longer than cutoff
         double distXYsqr = distX * distX + distY * distY;
         if (distXYsqr <= _interactionLengthSqr) {
-          auto &jGrid = _clusters[VerletClusterMaths::index1D(xj, yj, _cellsPerDim)];
+          auto &jGrid = this->_cells[VerletClusterMaths::index1D(xj, yj, _cellsPerDim)];
           // calculate number of  full clusters and rest
           const index_t jSize = jGrid.numParticles() / _clusterSize;
           const int jRest = jGrid.numParticles() % _clusterSize;
@@ -568,7 +560,7 @@ class VerletClusterLists : public ParticleContainer<FullParticleCell<Particle>> 
   void padClusters() {
     for (index_t x = 0; x < _cellsPerDim[0]; x++) {
       for (index_t y = 0; y < _cellsPerDim[1]; y++) {
-        auto &grid = _clusters[VerletClusterMaths::index1D(x, y, _cellsPerDim)];
+        auto &grid = this->_cells[VerletClusterMaths::index1D(x, y, _cellsPerDim)];
         index_t rest = grid.numParticles() % _clusterSize;
         if (rest > 0) {
           for (int i = rest; i < _clusterSize; i++) {
@@ -625,7 +617,7 @@ class VerletClusterLists : public ParticleContainer<FullParticleCell<Particle>> 
   }
 
   /**
-   * Builds the _clusterIndexMap to be up to date with _clusters.
+   * Builds the _clusterIndexMap to be up to date with _cells.
    *
    * Every cluster gets an index assigned. The indices are given in a way so that the VerletClustersColoringTraversal
    * works as easy as possible with newton 3. The newton 3 neighbor list just has to only save neighbors with a higher
@@ -686,7 +678,7 @@ class VerletClusterLists : public ParticleContainer<FullParticleCell<Particle>> 
         }
 
         unsigned long gridIndex1D = VerletClusterMaths::index1D(x, y, _cellsPerDim);
-        auto &currentGrid = _clusters[gridIndex1D];
+        auto &currentGrid = this->_cells[gridIndex1D];
 
         auto numClusters = currentGrid.numParticles() / _clusterSize;
         int rest = currentGrid.numParticles() % _clusterSize;
@@ -709,17 +701,12 @@ class VerletClusterLists : public ParticleContainer<FullParticleCell<Particle>> 
   std::vector<std::vector<std::vector<Particle *>>> _neighborLists;
 
   /**
-   * internal storage, particles are split into a grid in xy-dimension
-   */
-  std::vector<FullParticleCell<Particle>> _clusters;
-
-  /**
    * The number of particles in a full cluster.
    */
   int _clusterSize;
 
   /**
-   * The number of clusters. This is not equal to _clusters.size(), as every grid might contain multiple clusters.
+   * The number of clusters. This is not equal to _cells.size(), as every grid might contain multiple clusters.
    */
   index_t _numClusters;
 

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -216,7 +216,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<FullParticleCell
   /**
    * @copydoc autopas::ParticleContainerInterface::setBoxMax()
    */
-  void setBoxMax(const std::array<double, 3> &boxMax) override final { _linkedCells.setBoxMax(boxMax);}
+  void setBoxMax(const std::array<double, 3> &boxMax) override final { _linkedCells.setBoxMax(boxMax); }
 
   /**
    * @copydoc autopas::ParticleContainerInterface::getBoxMin()

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -22,7 +22,7 @@ namespace autopas {
  * @tparam LinkedSoAArraysType SoAArraysType used by the linked cells container
  */
 template <class Particle, class LinkedParticleCell, class LinkedSoAArraysType = typename Particle::SoAArraysType>
-class VerletListsLinkedBase : public ParticleContainer<FullParticleCell<Particle>> {
+class VerletListsLinkedBase : public ParticleContainerInterface<FullParticleCell<Particle>> {
   using ParticleCell = FullParticleCell<Particle>;
 
  public:
@@ -40,8 +40,7 @@ class VerletListsLinkedBase : public ParticleContainer<FullParticleCell<Particle
   VerletListsLinkedBase(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
                         const double skin, const std::set<TraversalOption> &applicableTraversals,
                         const double cellSizeFactor)
-      : ParticleContainer<FullParticleCell<Particle>>(boxMin, boxMax, cutoff, skin),
-        _linkedCells(boxMin, boxMax, cutoff, skin, std::max(1.0, cellSizeFactor)) {
+      : _linkedCells(boxMin, boxMax, cutoff, skin, std::max(1.0, cellSizeFactor)) {
     if (cellSizeFactor < 1.0) {
       AutoPasLog(debug, "VerletListsLinkedBase: CellSizeFactor smaller 1 detected. Set to 1.");
     }
@@ -208,6 +207,51 @@ class VerletListsLinkedBase : public ParticleContainer<FullParticleCell<Particle
     return TraversalSelectorInfo(this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(),
                                  this->getInteractionLength(), this->_linkedCells.getCellBlock().getCellLength());
   }
+
+  /**
+   * @copydoc autopas::ParticleContainerInterface::getBoxMax()
+   */
+  const std::array<double, 3> &getBoxMax() const override final { return _linkedCells.getBoxMax(); }
+
+  /**
+   * @copydoc autopas::ParticleContainerInterface::setBoxMax()
+   */
+  void setBoxMax(const std::array<double, 3> &boxMax) override final { _linkedCells.setBoxMax(boxMax);}
+
+  /**
+   * @copydoc autopas::ParticleContainerInterface::getBoxMin()
+   */
+  const std::array<double, 3> &getBoxMin() const override final { return _linkedCells.getBoxMin(); }
+
+  /**
+   * @copydoc autopas::ParticleContainerInterface::setBoxMin()
+   */
+  void setBoxMin(const std::array<double, 3> &boxMin) override final { _linkedCells.setBoxMin(boxMin); }
+
+  /**
+   * @copydoc autopas::ParticleContainerInterface::getCutoff()
+   */
+  double getCutoff() const override final { return _linkedCells.getCutoff(); }
+
+  /**
+   * @copydoc autopas::ParticleContainerInterface::setCutoff()
+   */
+  void setCutoff(double cutoff) override final { _linkedCells.setCutoff(cutoff); }
+
+  /**
+   * @copydoc autopas::ParticleContainerInterface::getSkin()
+   */
+  double getSkin() const override final { return _linkedCells.getSkin(); }
+
+  /**
+   * @copydoc autopas::ParticleContainerInterface::setSkin()
+   */
+  void setSkin(double skin) override final { _linkedCells.setSkin(skin); }
+
+  /**
+   * @copydoc autopas::ParticleContainerInterface::getInteractionLength()
+   */
+  double getInteractionLength() const override final { return _linkedCells.getInteractionLength(); }
 
  protected:
   /// internal linked cells storage, handles Particle storage and used to build verlet lists

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -80,7 +80,7 @@ class AutoTuner {
    * Getter for the current container.
    * @return Smart pointer to the current container.
    */
-  std::shared_ptr<autopas::ParticleContainer<ParticleCell>> getContainer() {
+  std::shared_ptr<autopas::ParticleContainerInterface<ParticleCell>> getContainer() {
     return _containerSelector.getCurrentContainer();
   }
 
@@ -88,7 +88,7 @@ class AutoTuner {
    * Getter for the current container.
    * @return Smart pointer to the current container.
    */
-  std::shared_ptr<const autopas::ParticleContainer<ParticleCell>> getContainer() const {
+  std::shared_ptr<const autopas::ParticleContainerInterface<ParticleCell>> getContainer() const {
     return _containerSelector.getCurrentContainer();
   }
 

--- a/src/autopas/selectors/ContainerSelector.h
+++ b/src/autopas/selectors/ContainerSelector.h
@@ -70,8 +70,8 @@ class ContainerSelector {
    * @param containerInfo additional parameter for the container
    * @return smartpointer to new container
    */
-  std::unique_ptr<autopas::ParticleContainerInterface<ParticleCell>> generateContainer(ContainerOption containerChoice,
-                                                                              ContainerSelectorInfo containerInfo);
+  std::unique_ptr<autopas::ParticleContainerInterface<ParticleCell>> generateContainer(
+      ContainerOption containerChoice, ContainerSelectorInfo containerInfo);
 
   const std::array<double, 3> _boxMin, _boxMax;
   const double _cutoff;
@@ -80,8 +80,9 @@ class ContainerSelector {
 };
 
 template <class Particle, class ParticleCell>
-std::unique_ptr<autopas::ParticleContainerInterface<ParticleCell>> ContainerSelector<Particle, ParticleCell>::generateContainer(
-    ContainerOption containerChoice, ContainerSelectorInfo containerInfo) {
+std::unique_ptr<autopas::ParticleContainerInterface<ParticleCell>>
+ContainerSelector<Particle, ParticleCell>::generateContainer(ContainerOption containerChoice,
+                                                             ContainerSelectorInfo containerInfo) {
   std::unique_ptr<autopas::ParticleContainerInterface<ParticleCell>> container;
 
   switch (containerChoice) {

--- a/src/autopas/selectors/ContainerSelector.h
+++ b/src/autopas/selectors/ContainerSelector.h
@@ -55,13 +55,13 @@ class ContainerSelector {
    * Getter for the optimal container. If no container is chosen yet the first allowed is selected.
    * @return Smartpointer to the optimal container.
    */
-  std::shared_ptr<autopas::ParticleContainer<ParticleCell>> getCurrentContainer();
+  std::shared_ptr<autopas::ParticleContainerInterface<ParticleCell>> getCurrentContainer();
 
   /**
    * Getter for the optimal container. If no container is chosen yet the first allowed is selected.
    * @return Smartpointer to the optimal container.
    */
-  std::shared_ptr<const autopas::ParticleContainer<ParticleCell>> getCurrentContainer() const;
+  std::shared_ptr<const autopas::ParticleContainerInterface<ParticleCell>> getCurrentContainer() const;
 
  private:
   /**
@@ -70,19 +70,19 @@ class ContainerSelector {
    * @param containerInfo additional parameter for the container
    * @return smartpointer to new container
    */
-  std::unique_ptr<autopas::ParticleContainer<ParticleCell>> generateContainer(ContainerOption containerChoice,
+  std::unique_ptr<autopas::ParticleContainerInterface<ParticleCell>> generateContainer(ContainerOption containerChoice,
                                                                               ContainerSelectorInfo containerInfo);
 
   const std::array<double, 3> _boxMin, _boxMax;
   const double _cutoff;
-  std::shared_ptr<autopas::ParticleContainer<ParticleCell>> _currentContainer;
+  std::shared_ptr<autopas::ParticleContainerInterface<ParticleCell>> _currentContainer;
   ContainerSelectorInfo _currentInfo;
 };
 
 template <class Particle, class ParticleCell>
-std::unique_ptr<autopas::ParticleContainer<ParticleCell>> ContainerSelector<Particle, ParticleCell>::generateContainer(
+std::unique_ptr<autopas::ParticleContainerInterface<ParticleCell>> ContainerSelector<Particle, ParticleCell>::generateContainer(
     ContainerOption containerChoice, ContainerSelectorInfo containerInfo) {
-  std::unique_ptr<autopas::ParticleContainer<ParticleCell>> container;
+  std::unique_ptr<autopas::ParticleContainerInterface<ParticleCell>> container;
 
   switch (containerChoice) {
     case ContainerOption::directSum: {
@@ -142,7 +142,7 @@ std::unique_ptr<autopas::ParticleContainer<ParticleCell>> ContainerSelector<Part
 }
 
 template <class Particle, class ParticleCell>
-std::shared_ptr<autopas::ParticleContainer<ParticleCell>>
+std::shared_ptr<autopas::ParticleContainerInterface<ParticleCell>>
 ContainerSelector<Particle, ParticleCell>::getCurrentContainer() {
   if (_currentContainer == nullptr) {
     autopas::utils::ExceptionHandler::exception(
@@ -152,7 +152,7 @@ ContainerSelector<Particle, ParticleCell>::getCurrentContainer() {
 }
 
 template <class Particle, class ParticleCell>
-std::shared_ptr<const autopas::ParticleContainer<ParticleCell>>
+std::shared_ptr<const autopas::ParticleContainerInterface<ParticleCell>>
 ContainerSelector<Particle, ParticleCell>::getCurrentContainer() const {
   if (_currentContainer == nullptr) {
     autopas::utils::ExceptionHandler::exception(


### PR DESCRIPTION
# Description

Changes VerletListsLinkedBase,s.t., it inherits directly from ParticleContainerInterface instead of ParticleContainer.

The methods provided in ParticleContainer and especially the cells are not needed and sometimes produce completely wrong results if not overwritten.

This prevents stupid errors.

## Resolved Issues

- [x] fixes #94