### PR TITLE
ContainerSelector use owned state instead of try-catch

### DIFF
--- a/src/autopas/selectors/ContainerSelector.h
+++ b/src/autopas/selectors/ContainerSelector.h
@@ -131,10 +131,10 @@ ContainerSelector<Particle, ParticleCell>::generateContainer(ContainerOption con
   if (_currentContainer != nullptr) {
     for (auto particleIter = _currentContainer->begin(IteratorBehavior::haloAndOwned); particleIter.isValid();
          ++particleIter) {
-      // try to add every particle as inner. If it fails try as a halo.
-      try {
+      // add particle as inner if it is owned
+      if (particleIter->isOwned()) {
         container->addParticle(*particleIter);
-      } catch (const autopas::utils::ExceptionHandler::AutoPasException &) {
+      } else {
         container->addHaloParticle(*particleIter);
       }
     }


### PR DESCRIPTION
# Description

ContainerSelector: when changing a container use the owned state to specify whether to add a particle as owned or halo particle instead of using try-catch exception workflow.
