### PR TITLE
fixes #393: handling of boundary conditions for md-flexible

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline{
                         stash includes: 'build-doxygen/doc_doxygen/html/**', name: 'doxydocs'
 
                         // get doxygen warnings
-                        recordIssues filters: [excludeFile('.*README.*')], tools: [doxygen(pattern: 'build-doxygen/DoxygenWarningLog.txt')], unstableTotalAll: 1
+                        recordIssues filters: [excludeFile('.*README.*')], tools: [doxygen(pattern: 'build-doxygen/DoxygenWarningLog.txt')], failedTotalAll: 1
                     },
                     "clang and cmake format": {
                         dir("format"){

--- a/examples/md-flexible/CMakeLists.txt
+++ b/examples/md-flexible/CMakeLists.txt
@@ -93,9 +93,15 @@ add_test(
 )
 
 add_test(
-    NAME md-flex-VerletClusterCells
-    COMMAND md-flexible --container VerletClusterCells
+    NAME md-flex-VerletClusterCells-4
+    COMMAND md-flexible --container VerletClusterCells --verlet-cluster-size 4
     CONFIGURATIONS checkExamples
+)
+
+add_test(
+        NAME md-flex-VerletClusterCells-32
+        COMMAND md-flexible --container VerletClusterCells --verlet-cluster-size 32 --no-flops
+        CONFIGURATIONS checkExamples
 )
 
 # add the executable to checkExamples as dependency

--- a/examples/md-flexible/CMakeLists.txt
+++ b/examples/md-flexible/CMakeLists.txt
@@ -93,9 +93,9 @@ add_test(
 )
 
 add_test(
-        NAME md-flex-VerletClusterCells
-        COMMAND md-flexible --container VerletClusterCells
-        CONFIGURATIONS checkExamples
+    NAME md-flex-VerletClusterCells
+    COMMAND md-flexible --container VerletClusterCells
+    CONFIGURATIONS checkExamples
 )
 
 # add the executable to checkExamples as dependency

--- a/examples/md-flexible/CMakeLists.txt
+++ b/examples/md-flexible/CMakeLists.txt
@@ -69,5 +69,11 @@ add_test(
     CONFIGURATIONS checkExamples
 )
 
+add_test(
+        NAME md-flex-VerletClusterCells
+        COMMAND md-flexible --container VerletClusterCells
+        CONFIGURATIONS checkExamples
+)
+
 # add the executable to checkExamples as dependency
 add_dependencies(checkExamples md-flexible)

--- a/examples/md-flexible/CMakeLists.txt
+++ b/examples/md-flexible/CMakeLists.txt
@@ -42,7 +42,7 @@ add_subdirectory(tests)
 # add check for current target
 # cmake-format: off
 add_test(
-    NAME md-flexible.test
+    NAME md-flexible.test-static
     COMMAND
         md-flexible
         --container linked
@@ -59,7 +59,30 @@ add_test(
         --verlet-rebuild-frequency 5
         --verlet-skin-radius 0
         --periodic false
+        --deltaT 0.
     CONFIGURATIONS checkExamples
+)
+
+add_test(
+        NAME md-flexible.test-sim
+        COMMAND
+        md-flexible
+        --container linked
+        --cutoff 1.
+        --distribution-mean 5.0
+        --distribution-stddeviation 2.0
+        --data-layout soa
+        --functor lj
+        --iterations 10
+        --particle-generator gauss
+        --particles-per-dimension 10
+        --particle-spacing 0.4
+        --traversal c08,sliced
+        --verlet-rebuild-frequency 4
+        --verlet-skin-radius 0.5
+        --periodic true
+        --deltaT 0.000000005
+        CONFIGURATIONS checkExamples
 )
 # cmake-format: on
 

--- a/examples/md-flexible/CMakeLists.txt
+++ b/examples/md-flexible/CMakeLists.txt
@@ -94,14 +94,25 @@ add_test(
 
 add_test(
     NAME md-flex-VerletClusterCells-4
-    COMMAND md-flexible --container VerletClusterCells --verlet-cluster-size 4
+    COMMAND
+        md-flexible
+        --container
+        VerletClusterCells
+        --verlet-cluster-size
+        4
     CONFIGURATIONS checkExamples
 )
 
 add_test(
-        NAME md-flex-VerletClusterCells-32
-        COMMAND md-flexible --container VerletClusterCells --verlet-cluster-size 32 --no-flops
-        CONFIGURATIONS checkExamples
+    NAME md-flex-VerletClusterCells-32
+    COMMAND
+        md-flexible
+        --container
+        VerletClusterCells
+        --verlet-cluster-size
+        32
+        --no-flops
+    CONFIGURATIONS checkExamples
 )
 
 # add the executable to checkExamples as dependency

--- a/examples/md-flexible/Simulation.h
+++ b/examples/md-flexible/Simulation.h
@@ -288,14 +288,21 @@ void Simulation<Particle, ParticleCell>::simulate() {
         this->writeVTKFile(iteration);
       }
 
+      // calculate new positions
+      _timers.positionUpdate.start();
+      TimeDiscretization::calculatePositions(_autopas, *_particlePropertiesLibrary, _config->deltaT);
+      _timers.positionUpdate.stop();
+
+      // apply boundary conditions AFTER the position update!
       if (_config->periodic) {
         _timers.boundaries.start();
         BoundaryConditions<ParticleCell>::applyPeriodic(_autopas);
         _timers.boundaries.stop();
+      } else {
+        throw std::runtime_error(
+            "Simulation::simulate(): at least one boundary condition has to be set. Please enable the periodic "
+            "boundary conditions!");
       }
-      _timers.positionUpdate.start();
-      TimeDiscretization::calculatePositions(_autopas, *_particlePropertiesLibrary, _config->deltaT);
-      _timers.positionUpdate.stop();
     }
     switch (this->_config->functorOption) {
       case MDFlexConfig::FunctorOption::lj12_6: {

--- a/examples/md-flexible/parsing/MDFlexConfig.cpp
+++ b/examples/md-flexible/parsing/MDFlexConfig.cpp
@@ -15,7 +15,7 @@ std::string MDFlexConfig::to_string() const {
   auto passedContainerOptionsStr = autopas::utils::ArrayUtils::to_string(containerOptions);
   os << setw(valueOffset) << left << containerOptionsStr << ":  " << passedContainerOptionsStr << endl;
 
-  // if verlet lists are in the container options print verlet config data
+  // since all containers are rebuilt only periodically print Verlet config always.
   os << setw(valueOffset) << left << verletRebuildFrequencyStr << ":  " << verletRebuildFrequency << endl;
   os << setw(valueOffset) << left << verletSkinRadiusStr << ":  " << verletSkinRadius << endl;
   if (passedContainerOptionsStr.find("luster") != std::string::npos) {

--- a/examples/md-flexible/parsing/MDFlexConfig.cpp
+++ b/examples/md-flexible/parsing/MDFlexConfig.cpp
@@ -16,12 +16,10 @@ std::string MDFlexConfig::to_string() const {
   os << setw(valueOffset) << left << containerOptionsStr << ":  " << passedContainerOptionsStr << endl;
 
   // if verlet lists are in the container options print verlet config data
-  if (passedContainerOptionsStr.find("erlet") != std::string::npos) {
-    os << setw(valueOffset) << left << verletRebuildFrequencyStr << ":  " << verletRebuildFrequency << endl;
-    os << setw(valueOffset) << left << verletSkinRadiusStr << ":  " << verletSkinRadius << endl;
-    if (passedContainerOptionsStr.find("luster") != std::string::npos) {
-      os << setw(valueOffset) << left << verletClusterSizeStr << ":  " << verletClusterSize << endl;
-    }
+  os << setw(valueOffset) << left << verletRebuildFrequencyStr << ":  " << verletRebuildFrequency << endl;
+  os << setw(valueOffset) << left << verletSkinRadiusStr << ":  " << verletSkinRadius << endl;
+  if (passedContainerOptionsStr.find("luster") != std::string::npos) {
+    os << setw(valueOffset) << left << verletClusterSizeStr << ":  " << verletClusterSize << endl;
   }
 
   if (containerOptions.size() > 1 or traversalOptions.size() > 1 or dataLayoutOptions.size() > 1) {

--- a/examples/md-flexible/parsing/MDFlexConfig.h
+++ b/examples/md-flexible/parsing/MDFlexConfig.h
@@ -111,7 +111,7 @@ class MDFlexConfig {
   static inline const char *iterationsStr{"iterations"};
   size_t iterations{10};
   static inline const char *periodicStr{"periodic-boundaries"};
-  bool periodic{false};
+  bool periodic{true};
   static inline const char *measureFlopsStr{"no-flops"};
   bool measureFlops{true};
   static inline const char *deltaTStr{"deltaT"};

--- a/examples/md-flexible/scrips/measurePerf.sh
+++ b/examples/md-flexible/scrips/measurePerf.sh
@@ -9,11 +9,11 @@ then
     echo "Illegal number of parameters"
     echo "Usage: $0 PATH_TO_MD-Flexible <-s>"
     echo " -s Silent: no scaling files are written and number of molecules and repetitions is reduced significantly."
-    exit -1
+    exit 1
 fi
 
 EXECUTABLE=$(readlink -e "${1}")
-[[ $? -ne 0 ]] && echo "Path to md-flexible invalid!" && exit -2
+[[ $? -ne 0 ]] && echo "Path to md-flexible invalid!" && exit 2
 
 SILENT=false
 if [[ "${2}" =~ '-s' ]]
@@ -141,7 +141,8 @@ do
                             --verlet-skin-radius ${VLSkin[$iVL]} \
                             --no-flops \
                             --periodic false \
-                            --newton3 ${newton3Opt}
+                            --newton3 ${newton3Opt} \
+                            --deltaT 0.
                         )
 
                         printf '%s\n' "${output}"

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -100,7 +100,8 @@ class LogicHandler {
             // throw exception, rebuild frequency not high enough / skin too small!
             utils::ExceptionHandler::exception(
                 "LogicHandler::addHaloParticle: wasn't able to update halo particle that is too close to "
-                "domain (more than cutoff + skin/2). Rebuild frequency not high enough / skin too small!");
+                "domain (more than cutoff + skin/2). Rebuild frequency not high enough / skin too small!\nParticle: " +
+                haloParticle.toString());
           }
         }
       } else {

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -140,7 +140,7 @@ class DirectSum : public ParticleContainer<ParticleCell> {
     return TraversalSelectorInfo(
         {2, 0, 0},
         this->getCutoff() /*intentionally use cutoff here, as the directsumtraversal should be using the cutoff.*/,
-        utils::ArrayMath::sub(this->getBoxMax(), this->getBoxMin()));
+        utils::ArrayMath::sub(this->getBoxMax(), this->getBoxMin()), 0);
   }
 
   ParticleIteratorWrapper<ParticleType, true> begin(

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -205,7 +205,7 @@ class LinkedCells : public ParticleContainer<ParticleCell, SoAArraysType> {
 
   TraversalSelectorInfo getTraversalSelectorInfo() const override {
     return TraversalSelectorInfo(this->getCellBlock().getCellsPerDimensionWithHalo(), this->getInteractionLength(),
-                                 this->getCellBlock().getCellLength());
+                                 this->getCellBlock().getCellLength(), 0);
   }
 
   ParticleIteratorWrapper<ParticleType, true> begin(

--- a/src/autopas/containers/verletClusterLists/VerletClusterCells.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterCells.h
@@ -72,7 +72,7 @@ class VerletClusterCells : public ParticleContainer<FullParticleCell<Particle>> 
           "trying to use a traversal of wrong type in VerletClusterCells::iteratePairwise");
     }
 
-    traversalInterface->setVerletListPointer(&_clusterSize, &_neighborCellIds, &_neighborMatrixDim, &_neighborMatrix);
+    traversalInterface->setVerletListPointer(&_neighborCellIds, &_neighborMatrixDim, &_neighborMatrix);
 
     if (traversalInterface->getSignature() != _lastTraversalSig or (not _isValid)) {
       if (!_isValid) {
@@ -161,7 +161,7 @@ class VerletClusterCells : public ParticleContainer<FullParticleCell<Particle>> 
       rebuild();
     }
 
-    traversalInterface->setVerletListPointer(&_clusterSize, &_neighborCellIds, &_neighborMatrixDim, &_neighborMatrix);
+    traversalInterface->setVerletListPointer(&_neighborCellIds, &_neighborMatrixDim, &_neighborMatrix);
 
     traversalInterface->rebuildVerlet(_cellsPerDim, this->_cells, _boundingBoxes,
                                       std::ceil(this->getInteractionLength() * _gridSideLengthReciprocal),
@@ -241,7 +241,8 @@ class VerletClusterCells : public ParticleContainer<FullParticleCell<Particle>> 
 
   TraversalSelectorInfo getTraversalSelectorInfo() const override {
     return TraversalSelectorInfo(_cellsPerDim, this->getInteractionLength(),
-                                 {_gridSideLength, _gridSideLength, this->getBoxMax()[2] - this->getBoxMin()[2]});
+                                 {_gridSideLength, _gridSideLength, this->getBoxMax()[2] - this->getBoxMin()[2]},
+                                 _clusterSize);
   }
 
   ParticleIteratorWrapper<Particle, true> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {

--- a/src/autopas/containers/verletClusterLists/VerletClusterCellsParticleIterator.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterCellsParticleIterator.h
@@ -46,6 +46,12 @@ class VerletClusterCellsParticleIterator : public ParticleIteratorInterfaceImpl<
         _cellId(0),
         _behavior(behavior),
         _offsetToDummy(offsetToDummy) {
+    /// @todo: this is currently a workaround as we did not yet implement openmp support for this iterator.
+    if (autopas_get_thread_num() != 0) {
+      _cellId = _vectorOfCells->size();
+      // the iterator is set to invalid.
+      return;
+    }
     _cellIter = (*_vectorOfCells)[0]._particles.begin();
     _cellEnd = _cellIter + getDummyStartbyIndex(0);
     --_cellIter;
@@ -63,7 +69,7 @@ class VerletClusterCellsParticleIterator : public ParticleIteratorInterfaceImpl<
       while (_cellIter == _cellEnd) {
         ++_cellId;
 
-        if (not(_cellId < _vectorOfCells->size())) {
+        if (_cellId >= _vectorOfCells->size()) {
           return *this;
         }
         _cellIter = (*_vectorOfCells)[_cellId]._particles.begin();

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -142,7 +142,7 @@ class VerletClusterLists : public ParticleContainer<FullParticleCell<Particle>> 
   }
 
   TraversalSelectorInfo getTraversalSelectorInfo() const override {
-    return TraversalSelectorInfo(_cellsPerDim, this->getInteractionLength(), {0., 0., 0.});
+    return TraversalSelectorInfo(_cellsPerDim, this->getInteractionLength(), {0., 0., 0.}, _clusterSize);
   }
 
   ParticleIteratorWrapper<Particle, true> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {

--- a/src/autopas/containers/verletClusterLists/traversals/VerletClusterCellsTraversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VerletClusterCellsTraversal.h
@@ -58,7 +58,7 @@ class VerletClusterCellsTraversal : public CellPairTraversal<ParticleCell>,
       cudaGetDeviceCount(&nDevices);
       if (not _functor->getCudaWrapper()) return false;
 #endif
-      return nDevices > 0;
+      return nDevices > 0 and _functor->isAppropriateClusterSize(*_clusterSize);
     } else
       return true;
   }

--- a/src/autopas/containers/verletClusterLists/traversals/VerletClusterCellsTraversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VerletClusterCellsTraversal.h
@@ -38,29 +38,27 @@ class VerletClusterCellsTraversal : public CellPairTraversal<ParticleCell>,
   /**
    * Constructor for the VerletClusterClusterTraversal.
    * @param pairwiseFunctor The functor that defines the interaction of two particles.
+   * @param clusterSize Size of the clusters.
    */
-  VerletClusterCellsTraversal(PairwiseFunctor *pairwiseFunctor)
+  VerletClusterCellsTraversal(PairwiseFunctor *pairwiseFunctor, const unsigned int clusterSize)
       : CellPairTraversal<ParticleCell>({1, 1, 1}),
         _functor(pairwiseFunctor),
         _neighborMatrixDim(nullptr),
-        _clusterSize(nullptr) {}
+        _clusterSize(clusterSize) {}
 
   TraversalOption getTraversalType() const override { return TraversalOption::verletClusterCells; }
 
   bool isApplicable() const override {
-    // TODO enable when functors use owned pointers correctly for soas and global calculation
-    if (dataLayout == DataLayoutOption::soa) {
-      return false;
-    }
     if (dataLayout == DataLayoutOption::cuda) {
       int nDevices = 0;
 #if defined(AUTOPAS_CUDA)
       cudaGetDeviceCount(&nDevices);
       if (not _functor->getCudaWrapper()) return false;
 #endif
-      return nDevices > 0 and _functor->isAppropriateClusterSize(*_clusterSize);
-    } else
-      return true;
+      return nDevices > 0 and _functor->isAppropriateClusterSize(_clusterSize, dataLayout);
+    } else {
+      return _functor->isAppropriateClusterSize(_clusterSize, dataLayout);
+    }
   }
 
   bool getUseNewton3() const override { return useNewton3; }
@@ -71,10 +69,8 @@ class VerletClusterCellsTraversal : public CellPairTraversal<ParticleCell>,
     return std::make_tuple(TraversalOption::verletClusterCells, dataLayout, useNewton3);
   }
 
-  void setVerletListPointer(unsigned int *clusterSize,
-                            std::vector<std::vector<std::vector<std::pair<size_t, size_t>>>> *neighborCellIds,
+  void setVerletListPointer(std::vector<std::vector<std::vector<std::pair<size_t, size_t>>>> *neighborCellIds,
                             size_t *neighborMatrixDim, utils::CudaDeviceVector<unsigned int> *neighborMatrix) override {
-    _clusterSize = clusterSize;
     _neighborCellIds = neighborCellIds;
     _neighborMatrixDim = neighborMatrixDim;
     _neighborMatrix = neighborMatrix;
@@ -270,7 +266,7 @@ class VerletClusterCellsTraversal : public CellPairTraversal<ParticleCell>,
 
  private:
   void traverseCellPairsAoS(std::vector<ParticleCell> *cells) {
-    const auto clusterSize = *_clusterSize;
+    const auto clusterSize = _clusterSize;
 
     // grid
     for (size_t i = 0; i < cells->size(); ++i) {
@@ -309,7 +305,7 @@ class VerletClusterCellsTraversal : public CellPairTraversal<ParticleCell>,
   }
 
   void traverseCellPairsSoA(std::vector<ParticleCell> *cells) {
-    auto clusterSize = *_clusterSize;
+    auto clusterSize = _clusterSize;
     // grid
     for (size_t i = 0; i < cells->size(); ++i) {
       // clusters
@@ -342,11 +338,11 @@ class VerletClusterCellsTraversal : public CellPairTraversal<ParticleCell>,
 
     if (useNewton3) {
       _functor->getCudaWrapper()->CellVerletTraversalN3Wrapper(
-          cudaSoA.get(), _storageCell._particleSoABuffer.getNumParticles() / *_clusterSize, *_clusterSize,
+          cudaSoA.get(), _storageCell._particleSoABuffer.getNumParticles() / _clusterSize, _clusterSize,
           *_neighborMatrixDim, _neighborMatrix->get(), 0);
     } else {
       _functor->getCudaWrapper()->CellVerletTraversalNoN3Wrapper(
-          cudaSoA.get(), _storageCell._particleSoABuffer.getNumParticles() / *_clusterSize, *_clusterSize,
+          cudaSoA.get(), _storageCell._particleSoABuffer.getNumParticles() / _clusterSize, _clusterSize,
           *_neighborMatrixDim, _neighborMatrix->get(), 0);
     }
     utils::CudaExceptionHandler::checkErrorCode(cudaDeviceSynchronize());
@@ -391,7 +387,7 @@ class VerletClusterCellsTraversal : public CellPairTraversal<ParticleCell>,
   size_t *_neighborMatrixDim;
   utils::CudaDeviceVector<unsigned int> *_neighborMatrix;
 
-  unsigned int *_clusterSize;
+  const unsigned int _clusterSize;
 };
 
 }  // namespace autopas

--- a/src/autopas/containers/verletClusterLists/traversals/VerletClusterTraversalInterface.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VerletClusterTraversalInterface.h
@@ -38,7 +38,6 @@ class VerletClusterTraversalInterface {
 
   /**
    * Sets pointer to the verlet lists stored in the container
-   * @param clusterSize pointer to size of clusters in container
    * @param neighborCellIds pointer to neighbor lists in container
    * @param neighborMatrixDim pointer to cuda neighbor matrix dimension
    * @param neighborMatrix pointer to cuda neighbor matrix dimension

--- a/src/autopas/containers/verletClusterLists/traversals/VerletClusterTraversalInterface.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VerletClusterTraversalInterface.h
@@ -43,8 +43,7 @@ class VerletClusterTraversalInterface {
    * @param neighborMatrixDim pointer to cuda neighbor matrix dimension
    * @param neighborMatrix pointer to cuda neighbor matrix dimension
    */
-  virtual void setVerletListPointer(unsigned int *clusterSize,
-                                    std::vector<std::vector<std::vector<std::pair<size_t, size_t>>>> *neighborCellIds,
+  virtual void setVerletListPointer(std::vector<std::vector<std::vector<std::pair<size_t, size_t>>>> *neighborCellIds,
                                     size_t *neighborMatrixDim,
                                     utils::CudaDeviceVector<unsigned int> *neighborMatrix) = 0;
 

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -205,7 +205,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<FullParticleCell
    */
   TraversalSelectorInfo getTraversalSelectorInfo() const override {
     return TraversalSelectorInfo(this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(),
-                                 this->getInteractionLength(), this->_linkedCells.getCellBlock().getCellLength());
+                                 this->getInteractionLength(), this->_linkedCells.getCellBlock().getCellLength(), 0);
   }
 
   /**

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
@@ -65,6 +65,10 @@ class VerletListHelpers {
       return true;
     }
 
+    bool isAppropriateClusterSize(unsigned int clusterSize, DataLayoutOption::Value dataLayout) const override {
+      return false;  // this functor shouldn't be called with clusters!
+    }
+
     void AoSFunctor(Particle &i, Particle &j, bool /*newton3*/) override {
       auto dist = utils::ArrayMath::sub(i.getR(), j.getR());
 
@@ -249,6 +253,11 @@ class VerletListHelpers {
       utils::ExceptionHandler::exception(
           "VerletListGeneratorFunctor::allowsNonNewton3() is not implemented, because it should not be called.");
       return true;
+    }
+
+    bool isAppropriateClusterSize(unsigned int clusterSize,
+                                  autopas::DataLayoutOption::Value dataLayout) const override {
+      return false;  // this functor shouldn't be used with clusters!
     }
 
     void AoSFunctor(Particle &i, Particle &j, bool newton3) override {

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
@@ -255,8 +255,7 @@ class VerletListHelpers {
       return true;
     }
 
-    bool isAppropriateClusterSize(unsigned int clusterSize,
-                                  autopas::DataLayoutOption::Value dataLayout) const override {
+    bool isAppropriateClusterSize(unsigned int clusterSize, DataLayoutOption::Value dataLayout) const override {
       return false;  // this functor shouldn't be used with clusters!
     }
 

--- a/src/autopas/containers/verletListsCellBased/verletLists/neighborLists/asBuild/AsBuildPairGeneratorFunctor.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/neighborLists/asBuild/AsBuildPairGeneratorFunctor.h
@@ -37,6 +37,10 @@ class AsBuildPairGeneratorFunctor
   bool allowsNewton3() override { return true; }
   bool allowsNonNewton3() override { return true; }
 
+  bool isAppropriateClusterSize(unsigned int clusterSize, DataLayoutOption::Value dataLayout) const override {
+    return false;  // this functor shouldn't be called with clusters!
+  }
+
   /**
    * Constructor of the functor.
    * @param neighborList The neighbor list to fill.

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsHelpers.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsHelpers.h
@@ -60,6 +60,10 @@ class VerletListsCellsHelpers {
       return true;
     }
 
+    bool isAppropriateClusterSize(unsigned int clusterSize, DataLayoutOption::Value dataLayout) const override {
+      return false;  // this functor shouldn't be called with clusters!
+    }
+
     void AoSFunctor(Particle &i, Particle &j, bool newton3) override {
       auto dist = utils::ArrayMath::sub(i.getR(), j.getR());
       double distsquare = utils::ArrayMath::dot(dist, dist);

--- a/src/autopas/molecularDynamics/LJFunctor.h
+++ b/src/autopas/molecularDynamics/LJFunctor.h
@@ -134,15 +134,16 @@ class LJFunctor
   bool isAppropriateClusterSize(unsigned int clusterSize, DataLayoutOption::Value dataLayout) const override {
     if (dataLayout != DataLayoutOption::cuda) {
 #if defined(AUTOPAS_CUDA)
-      auto cudaWrapper =
-          _functor->getCudaWrapper() if (cudaWrapper) return cudaWrapper->isAppropriateClusterSize(clusterSize);
+      auto cudaWrapper = _functor->getCudaWrapper();
+      if (cudaWrapper)
+        return cudaWrapper->isAppropriateClusterSize(clusterSize);
       else {
         return false;
       }
 #endif
       return true;
     } else {
-      return true;
+      return dataLayout == DataLayoutOption::aos;  // LJFunctor does not yet support soa for clusters.
     }
   }
 

--- a/src/autopas/molecularDynamics/LJFunctor.h
+++ b/src/autopas/molecularDynamics/LJFunctor.h
@@ -132,7 +132,7 @@ class LJFunctor
   }
 
   bool isAppropriateClusterSize(unsigned int clusterSize, DataLayoutOption::Value dataLayout) const override {
-    if (dataLayout != DataLayoutOption::cuda) {
+    if (dataLayout == DataLayoutOption::cuda) {
 #if defined(AUTOPAS_CUDA)
       auto cudaWrapper = _functor->getCudaWrapper();
       if (cudaWrapper)
@@ -141,9 +141,10 @@ class LJFunctor
         return false;
       }
 #endif
-      return true;
+      return false;
     } else {
       return dataLayout == DataLayoutOption::aos;  // LJFunctor does not yet support soa for clusters.
+      // The reason for this is that the owned state is not handled correctly, see #396.
     }
   }
 

--- a/src/autopas/molecularDynamics/LJFunctor.h
+++ b/src/autopas/molecularDynamics/LJFunctor.h
@@ -134,11 +134,7 @@ class LJFunctor
   bool isAppropriateClusterSize(unsigned int clusterSize, DataLayoutOption::Value dataLayout) const override {
     if (dataLayout == DataLayoutOption::cuda) {
 #if defined(AUTOPAS_CUDA)
-      if (cudaWrapper)
-        return _cudawrapper.isAppropriateClusterSize(clusterSize);
-      else {
-        return false;
-      }
+      return _cudawrapper.isAppropriateClusterSize(clusterSize);
 #endif
       return false;
     } else {
@@ -1117,8 +1113,10 @@ class LJFunctor
   double _epsilon24, _sigmasquare, _shift6 = 0;
 
   ParticlePropertiesLibrary<SoAFloatPrecision, size_t> *_PPLibrary = nullptr;
+
   // sum of the potential energy, only calculated if calculateGlobals is true
   double _upotSum;
+
   // sum of the virial, only calculated if calculateGlobals is true
   std::array<double, 3> _virialSum;
 

--- a/src/autopas/molecularDynamics/LJFunctor.h
+++ b/src/autopas/molecularDynamics/LJFunctor.h
@@ -131,6 +131,21 @@ class LJFunctor
     return useNewton3 == FunctorN3Modes::Newton3Off or useNewton3 == FunctorN3Modes::Both;
   }
 
+  bool isAppropriateClusterSize(unsigned int clusterSize, DataLayoutOption::Value dataLayout) const override {
+    if (dataLayout != DataLayoutOption::cuda) {
+#if defined(AUTOPAS_CUDA)
+      auto cudaWrapper =
+          _functor->getCudaWrapper() if (cudaWrapper) return cudaWrapper->isAppropriateClusterSize(clusterSize);
+      else {
+        return false;
+      }
+#endif
+      return true;
+    } else {
+      return true;
+    }
+  }
+
   void AoSFunctor(Particle &i, Particle &j, bool newton3) override {
     auto sigmasquare = _sigmasquare;
     auto epsilon24 = _epsilon24;

--- a/src/autopas/molecularDynamics/LJFunctor.h
+++ b/src/autopas/molecularDynamics/LJFunctor.h
@@ -134,9 +134,8 @@ class LJFunctor
   bool isAppropriateClusterSize(unsigned int clusterSize, DataLayoutOption::Value dataLayout) const override {
     if (dataLayout == DataLayoutOption::cuda) {
 #if defined(AUTOPAS_CUDA)
-      auto cudaWrapper = _functor->getCudaWrapper();
       if (cudaWrapper)
-        return cudaWrapper->isAppropriateClusterSize(clusterSize);
+        return _cudawrapper.isAppropriateClusterSize(clusterSize);
       else {
         return false;
       }

--- a/src/autopas/molecularDynamics/LJFunctorAVX.h
+++ b/src/autopas/molecularDynamics/LJFunctorAVX.h
@@ -130,6 +130,10 @@ class LJFunctorAVX : public Functor<Particle, ParticleCell, typename Particle::S
     return useNewton3 == FunctorN3Modes::Newton3Off or useNewton3 == FunctorN3Modes::Both;
   }
 
+  bool isAppropriateClusterSize(unsigned int clusterSize, DataLayoutOption::Value dataLayout) const override {
+    return dataLayout == DataLayoutOption::aos;  // LJFunctorAVX does only support clusters via aos.
+  }
+
   void AoSFunctor(Particle &i, Particle &j, bool newton3) override {
     utils::ExceptionHandler::exception("LJFunctorAVX.AoSFunctor() not implemented!");
   }

--- a/src/autopas/molecularDynamics/LJFunctorCuda.cuh
+++ b/src/autopas/molecularDynamics/LJFunctorCuda.cuh
@@ -117,7 +117,7 @@ class LJFunctorCudaWrapper : public CudaWrapperInterface<floatType> {
   void loadLinkedCellsOffsets(unsigned int offsets_size, int *offsets) override;
 
   bool isAppropriateClusterSize(unsigned int clusterSize) const override {
-    return clusterSize % 32 == 0 and clusterSize >= 32 and clusterSize >= 1024;
+    return clusterSize % 32 == 0 and clusterSize >= 32 and clusterSize <= 1024;
   }
 
  private:

--- a/src/autopas/molecularDynamics/LJFunctorCuda.cuh
+++ b/src/autopas/molecularDynamics/LJFunctorCuda.cuh
@@ -116,6 +116,10 @@ class LJFunctorCudaWrapper : public CudaWrapperInterface<floatType> {
 
   void loadLinkedCellsOffsets(unsigned int offsets_size, int *offsets) override;
 
+  bool isAppropriateClusterSize(unsigned int clusterSize) const override {
+    return clusterSize % 32 == 0 and clusterSize >= 32 and clusterSize >= 1024;
+  }
+
  private:
   int numRequiredBlocks(int n) { return ((n - 1) / _num_threads) + 1; }
 

--- a/src/autopas/molecularDynamics/LJFunctorCudaGlobals.cuh
+++ b/src/autopas/molecularDynamics/LJFunctorCudaGlobals.cuh
@@ -121,6 +121,10 @@ class LJFunctorCudaGlobalsWrapper : public CudaWrapperInterface<floatType> {
 
   void loadLinkedCellsOffsets(unsigned int offsets_size, int *offsets) override;
 
+  bool isAppropriateClusterSize(unsigned int clusterSize) const override {
+    return clusterSize % 32 == 0 and clusterSize >= 32 and clusterSize >= 1024;
+  }
+
  private:
   int numRequiredBlocks(int n) { return ((n - 1) / _num_threads) + 1; }
 

--- a/src/autopas/molecularDynamics/LJFunctorCudaGlobals.cuh
+++ b/src/autopas/molecularDynamics/LJFunctorCudaGlobals.cuh
@@ -122,7 +122,7 @@ class LJFunctorCudaGlobalsWrapper : public CudaWrapperInterface<floatType> {
   void loadLinkedCellsOffsets(unsigned int offsets_size, int *offsets) override;
 
   bool isAppropriateClusterSize(unsigned int clusterSize) const override {
-    return clusterSize % 32 == 0 and clusterSize >= 32 and clusterSize >= 1024;
+    return clusterSize % 32 == 0 and clusterSize >= 32 and clusterSize <= 1024;
   }
 
  private:

--- a/src/autopas/pairwiseFunctors/FlopCounterFunctor.h
+++ b/src/autopas/pairwiseFunctors/FlopCounterFunctor.h
@@ -34,6 +34,10 @@ class FlopCounterFunctor : public Functor<Particle, ParticleCell, typename Parti
 
   bool allowsNonNewton3() override { return true; }
 
+  bool isAppropriateClusterSize(unsigned int clusterSize, DataLayoutOption::Value dataLayout) const override {
+    return dataLayout == DataLayoutOption::aos;  // no support for clusters yet, unless aos.
+  }
+
   /**
    * constructor of FlopCounterFunctor
    * @param cutoffRadius the cutoff radius

--- a/src/autopas/pairwiseFunctors/Functor.h
+++ b/src/autopas/pairwiseFunctors/Functor.h
@@ -10,6 +10,7 @@
 #include <type_traits>
 
 #include "autopas/cells/ParticleCell.h"
+#include "autopas/options/DataLayoutOption.h"
 #include "autopas/utils/AlignedAllocator.h"
 #include "autopas/utils/CudaSoA.h"
 #include "autopas/utils/ExceptionHandler.h"
@@ -285,6 +286,7 @@ class Functor {
    * Check whether the given clusterSize is appropriate and can be used by the functor.
    * @param clusterSize The size of the clusters.
    * @param dataLayout The used data layout.
+   * @return true, iff the cluster size is appropriate.
    */
   virtual bool isAppropriateClusterSize(unsigned int clusterSize, DataLayoutOption::Value dataLayout) const = 0;
 

--- a/src/autopas/pairwiseFunctors/Functor.h
+++ b/src/autopas/pairwiseFunctors/Functor.h
@@ -281,6 +281,13 @@ class Functor {
    */
   virtual bool isRelevantForTuning() = 0;
 
+  /**
+   * Check whether the given clusterSize is appropriate and can be used by the functor.
+   * @param clusterSize The size of the clusters.
+   * @param dataLayout The used data layout.
+   */
+  virtual bool isAppropriateClusterSize(unsigned int clusterSize, DataLayoutOption::Value dataLayout) const = 0;
+
 #if defined(AUTOPAS_CUDA)
   /**
    * Provides an interface for traversals to directly access Cuda Functions

--- a/src/autopas/pairwiseFunctors/FunctorCuda.cuh
+++ b/src/autopas/pairwiseFunctors/FunctorCuda.cuh
@@ -84,6 +84,8 @@ class CudaWrapperInterface {
                                             cudaStream_t stream) = 0;
 
   virtual void loadLinkedCellsOffsets(unsigned int offsets_size, int *offsets) = 0;
+
+  virtual bool isAppropriateClusterSize(unsigned int clusterSize) const = 0;
 };
 
 }  // namespace autopas

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -171,7 +171,7 @@ class AutoTuner {
    * Get the currently selected configuration.
    * @return
    */
-  const autopas::Configuration getCurrentConfig() const;
+  autopas::Configuration getCurrentConfig() const;
 
   /**
    * Get the set of all allowed configurations.
@@ -417,7 +417,8 @@ bool AutoTuner<Particle, ParticleCell>::configApplicable(const Configuration &co
     return false;
   }
 
-  _containerSelector.selectContainer(conf.container, ContainerSelectorInfo(conf.cellSizeFactor, _verletSkin));
+  _containerSelector.selectContainer(conf.container,
+                                     ContainerSelectorInfo(conf.cellSizeFactor, _verletSkin, _verletClusterSize));
   auto traversalInfo = _containerSelector.getCurrentContainer()->getTraversalSelectorInfo();
 
   return TraversalSelector<ParticleCell>::template generateTraversal<PairwiseFunctor>(
@@ -426,7 +427,7 @@ bool AutoTuner<Particle, ParticleCell>::configApplicable(const Configuration &co
 }
 
 template <class Particle, class ParticleCell>
-const autopas::Configuration AutoTuner<Particle, ParticleCell>::getCurrentConfig() const {
+autopas::Configuration AutoTuner<Particle, ParticleCell>::getCurrentConfig() const {
   return _tuningStrategy->getCurrentConfiguration();
 }
 }  // namespace autopas

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -331,11 +331,11 @@ void AutoTuner<Particle, ParticleCell>::iteratePairwiseTemplateHelper(PairwiseFu
     autopas::utils::ExceptionHandler::exception(
         "Error: Trying to execute a traversal that is not applicable. Two common reasons:\n"
         "1. The search space is trivial, but no traversals are applicable. \n"
-        "2. You are using multiple functors and one of the not first is not supporting all configuration options of the first.\n"
+        "2. You are using multiple functors and one of the not first is not supporting all configuration options of "
+        "the first.\n"
         "Config: {}\n"
         "Current functor: {}",
-        _tuningStrategy->getCurrentConfiguration().toString(),
-        typeid(*f).name());
+        _tuningStrategy->getCurrentConfiguration().toString(), typeid(*f).name());
   }
 
   // if tuning execute with time measurements

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -329,9 +329,13 @@ void AutoTuner<Particle, ParticleCell>::iteratePairwiseTemplateHelper(PairwiseFu
 
   if (not traversal->isApplicable()) {
     autopas::utils::ExceptionHandler::exception(
-        "Error: Trying to execute a traversal that is not applicable. This normally happens only if the search space "
-        "is trivial, but no traversals are applicable. Config: {}",
-        _tuningStrategy->getCurrentConfiguration().toString());
+        "Error: Trying to execute a traversal that is not applicable. Two common reasons:\n"
+        "1. The search space is trivial, but no traversals are applicable. \n"
+        "2. You are using multiple functors and one of the not first is not supporting all configuration options of the first.\n"
+        "Config: {}\n"
+        "Current functor: {}",
+        _tuningStrategy->getCurrentConfiguration().toString(),
+        typeid(*f).name());
   }
 
   // if tuning execute with time measurements

--- a/src/autopas/selectors/ContainerSelector.h
+++ b/src/autopas/selectors/ContainerSelector.h
@@ -131,10 +131,10 @@ ContainerSelector<Particle, ParticleCell>::generateContainer(ContainerOption con
   if (_currentContainer != nullptr) {
     for (auto particleIter = _currentContainer->begin(IteratorBehavior::haloAndOwned); particleIter.isValid();
          ++particleIter) {
-      // try to add every particle as inner. If it fails try as a halo.
-      try {
+      // add particle as inner if it is owned
+      if (particleIter->isOwned()) {
         container->addParticle(*particleIter);
-      } catch (const autopas::utils::ExceptionHandler::AutoPasException &) {
+      } else {
         container->addHaloParticle(*particleIter);
       }
     }

--- a/src/autopas/selectors/ContainerSelectorInfo.h
+++ b/src/autopas/selectors/ContainerSelectorInfo.h
@@ -24,15 +24,6 @@ class ContainerSelectorInfo {
    * @param cellSizeFactor Cell size factor to be used in this container (only relevant for LinkedCells, VerletLists and
    * VerletListsCells).
    * @param verletSkin Length added to the cutoff for the verlet lists' skin.
-   */
-  explicit ContainerSelectorInfo(double cellSizeFactor, double verletSkin)
-      : cellSizeFactor(cellSizeFactor), verletSkin(verletSkin), verletClusterSize(64) {}
-
-  /**
-   * Constructor.
-   * @param cellSizeFactor Cell size factor to be used in this container (only relevant for LinkedCells, VerletLists and
-   * VerletListsCells).
-   * @param verletSkin Length added to the cutoff for the verlet lists' skin.
    * @param verletClusterSize Size of verlet Clusters
    */
   explicit ContainerSelectorInfo(double cellSizeFactor, double verletSkin, unsigned int verletClusterSize)

--- a/src/autopas/selectors/TraversalSelector.h
+++ b/src/autopas/selectors/TraversalSelector.h
@@ -147,7 +147,7 @@ std::unique_ptr<TraversalInterface> TraversalSelector<ParticleCell>::generateTra
     }
     case TraversalOption::verletClusterCells: {
       return std::make_unique<VerletClusterCellsTraversal<ParticleCell, PairwiseFunctor, dataLayout, useNewton3>>(
-          &pairwiseFunctor);
+          &pairwiseFunctor, info.clusterSize);
     }
     case TraversalOption::verletClustersColoring: {
       return std::make_unique<VerletClustersColoringTraversal<ParticleCell, PairwiseFunctor, dataLayout, useNewton3>>(

--- a/src/autopas/selectors/TraversalSelectorInfo.h
+++ b/src/autopas/selectors/TraversalSelectorInfo.h
@@ -23,6 +23,7 @@ class TraversalSelectorInfo {
    * @param dims Array with the dimension lengths of the domain
    * @param interactionLength Interaction length (cutoff radius + skin)
    * @param cellLength cell length.
+   * @param clusterSize The size of a cluster (set this to 0 if not applicable).
    */
   explicit TraversalSelectorInfo(const std::array<unsigned long, 3> &dims, const double interactionLength,
                                  const std::array<double, 3> &cellLength, const unsigned int clusterSize)

--- a/src/autopas/selectors/TraversalSelectorInfo.h
+++ b/src/autopas/selectors/TraversalSelectorInfo.h
@@ -16,7 +16,7 @@ class TraversalSelectorInfo {
   /**
    * Dummy constructor such that this class can be used in maps
    */
-  TraversalSelectorInfo() : dims({0, 0, 0}), interactionLength(1.0), cellLength({0.0, 0.0, 0.0}) {}
+  TraversalSelectorInfo() : dims({0, 0, 0}), interactionLength(1.0), cellLength({0.0, 0.0, 0.0}), clusterSize{0} {}
 
   /**
    * Constructor of the TraversalSelector class.
@@ -25,8 +25,8 @@ class TraversalSelectorInfo {
    * @param cellLength cell length.
    */
   explicit TraversalSelectorInfo(const std::array<unsigned long, 3> &dims, const double interactionLength,
-                                 const std::array<double, 3> &cellLength)
-      : dims(dims), interactionLength(interactionLength), cellLength(cellLength) {}
+                                 const std::array<double, 3> &cellLength, const unsigned int clusterSize)
+      : dims(dims), interactionLength(interactionLength), cellLength(cellLength), clusterSize{clusterSize} {}
 
   /**
    * Array with the dimension lengths of the domain
@@ -43,5 +43,10 @@ class TraversalSelectorInfo {
    * cell length
    */
   const std::array<double, 3> cellLength;
+
+  /**
+   * This specifies the size of verlet clusters.
+   */
+  const unsigned int clusterSize;
 };
 }  // namespace autopas

--- a/src/autopas/sph/SPHCalcDensityFunctor.h
+++ b/src/autopas/sph/SPHCalcDensityFunctor.h
@@ -34,6 +34,10 @@ class SPHCalcDensityFunctor
 
   bool allowsNonNewton3() override { return true; }
 
+  bool isAppropriateClusterSize(unsigned int clusterSize, DataLayoutOption::Value dataLayout) const override {
+    return dataLayout == DataLayoutOption::aos;  // This functor does only support clusters via aos.
+  }
+
   /**
    * Calculates the density contribution of the interaction of particle i and j.
    * It is not symmetric, because the smoothing lenghts of the two particles can

--- a/src/autopas/sph/SPHCalcHydroForceFunctor.h
+++ b/src/autopas/sph/SPHCalcHydroForceFunctor.h
@@ -36,6 +36,10 @@ class SPHCalcHydroForceFunctor
 
   bool allowsNonNewton3() override { return true; }
 
+  bool isAppropriateClusterSize(unsigned int clusterSize, DataLayoutOption::Value dataLayout) const override {
+    return dataLayout == DataLayoutOption::aos;  // This functor does only support clusters via aos.
+  }
+
   /**
    * Calculates the contribution of the interaction of particle i and j to the
    * hydrodynamic force.

--- a/tests/testAutopas/mocks/MockFunctor.h
+++ b/tests/testAutopas/mocks/MockFunctor.h
@@ -11,6 +11,7 @@
 #include "autopas/autopasIncludes.h"
 #include "autopas/cells/ParticleCell.h"
 #include "autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h"
+#include "autopas/options/DataLayoutOption.h"
 #if defined(AUTOPAS_CUDA)
 #include "autopas/utils/CudaSoA.h"
 #endif
@@ -88,6 +89,9 @@ class MockFunctor : public autopas::Functor<Particle, ParticleCell_t> {
 
   // virtual bool allowsNonNewton3() { return false; }
   MOCK_METHOD(bool, allowsNonNewton3, (), (override));
+
+  MOCK_METHOD(bool, isAppropriateClusterSize, (unsigned int clusterSize, autopas::DataLayoutOption::Value dataLayout),
+              (const, override));
 
   //  bool isRelevantForTuning() { return true; }
   MOCK_METHOD(bool, isRelevantForTuning, (), (override));

--- a/tests/testAutopas/testingHelpers/TouchableParticle.h
+++ b/tests/testAutopas/testingHelpers/TouchableParticle.h
@@ -7,15 +7,35 @@
 #pragma once
 #include <autopas/particles/Particle.h>
 
+/**
+ * Class that extends the default autopas::Particle with a behavior to check how often the particle was touched.
+ * This class is useful for all kinds of ParticleIterator tests.
+ */
 class TouchableParticle : public autopas::Particle {
  public:
+  /**
+   * Constructor with position and id.
+   * @param pos position
+   * @param id id of the particle
+   */
   TouchableParticle(std::array<double, 3> pos, unsigned long id)
       : autopas::Particle(pos, {0, 0, 0}, id), _numTouched(0){};
 
+  /**
+   * Default constructor
+   */
   TouchableParticle() : TouchableParticle({0., 0., 0.}, 0ul) {}
 
+  /**
+   * Touch the particle.
+   * The number of times a particle was touched is saved.
+   */
   void touch() { _numTouched++; }
 
+  /**
+   * Get the number that indicates how often the particle was touch.
+   * @return returns how often the particle was touched.
+   */
   unsigned int getNumTouched() { return _numTouched; }
 
  private:

--- a/tests/testAutopas/testingHelpers/TouchableParticle.h
+++ b/tests/testAutopas/testingHelpers/TouchableParticle.h
@@ -1,0 +1,23 @@
+/**
+ * @file TouchableParticle.h
+ * @author seckler
+ * @date 13.01.20
+ */
+
+#pragma once
+#include <autopas/particles/Particle.h>
+
+class TouchableParticle : public autopas::Particle {
+ public:
+  TouchableParticle(std::array<double, 3> pos, unsigned long id)
+      : autopas::Particle(pos, {0, 0, 0}, id), _numTouched(0){};
+
+  TouchableParticle() : TouchableParticle({0., 0., 0.}, 0ul) {}
+
+  void touch() { _numTouched++; }
+
+  unsigned int getNumTouched() { return _numTouched; }
+
+ private:
+  unsigned int _numTouched;
+};

--- a/tests/testAutopas/tests/autopasInterface/IteratorTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/IteratorTest.cpp
@@ -260,15 +260,15 @@ TEST_P(IteratorTest, RangeBasedIterator) {
 }
 
 /**
- * The main idea of this test is to compare theiterators using openmp with the iterators not using openmp.
+ * The main idea of this test is to compare the iterators using openmp with the iterators not using openmp.
  */
-TEST_P(IteratorTest, testOpenMPIteratorsOwnedOnly) {
+void IteratorTest::testOpenMPIterators(autopas::ContainerOption containerOption, double cellSizeFactor,
+                                       autopas::IteratorBehavior behavior) {
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {8, 8, 8};
   int clusterSize = 64;
   autopas::AutoPas<TouchableParticle, autopas::FullParticleCell<TouchableParticle>> apContainer;
 
-  auto [containerOption, cellSizeFactor] = GetParam();
   apContainer.setAllowedContainers({containerOption});
   apContainer.setCellSizeFactor(cellSizeFactor);
 
@@ -289,13 +289,47 @@ TEST_P(IteratorTest, testOpenMPIteratorsOwnedOnly) {
 #ifdef AUTOPAS_OPENMP
 #pragma omp parallel
 #endif
-  for (auto iter = apContainer.begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
+  for (auto iter = apContainer.begin(behavior); iter.isValid(); ++iter) {
     iter->touch();
+    if (behavior == autopas::IteratorBehavior::ownedOnly) {
+      EXPECT_TRUE(iter->isOwned());
+    } else if (behavior == autopas::IteratorBehavior::haloOnly) {
+      EXPECT_FALSE(iter->isOwned());
+    }
   }
 
-  for (auto iter = apContainer.begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
+  for (auto iter = apContainer.begin(behavior); iter.isValid(); ++iter) {
     EXPECT_EQ(1, iter->getNumTouched());
+    if (behavior == autopas::IteratorBehavior::ownedOnly) {
+      EXPECT_TRUE(iter->isOwned());
+    } else if (behavior == autopas::IteratorBehavior::haloOnly) {
+      EXPECT_FALSE(iter->isOwned());
+    }
   }
+}
+
+/**
+ * Compare the OpenMP iterator behavior for owned only.
+ */
+TEST_P(IteratorTest, testOpenMPIteratorsOwnedOnly) {
+  auto [containerOption, cellSizeFactor] = GetParam();
+  testOpenMPIterators(containerOption, cellSizeFactor, autopas::IteratorBehavior::ownedOnly);
+}
+
+/**
+ * Compare the OpenMP iterator behavior for halo and owned particles.
+ */
+TEST_P(IteratorTest, testOpenMPIteratorsHaloAndOwned) {
+  auto [containerOption, cellSizeFactor] = GetParam();
+  testOpenMPIterators(containerOption, cellSizeFactor, autopas::IteratorBehavior::haloAndOwned);
+}
+
+/**
+ * Compare the OpenMP iterator behavior for halo only.
+ */
+TEST_P(IteratorTest, testOpenMPIteratorsHaloOnly) {
+  auto [containerOption, cellSizeFactor] = GetParam();
+  testOpenMPIterators(containerOption, cellSizeFactor, autopas::IteratorBehavior::haloOnly);
 }
 
 using ::testing::Combine;

--- a/tests/testAutopas/tests/autopasInterface/IteratorTest.h
+++ b/tests/testAutopas/tests/autopasInterface/IteratorTest.h
@@ -28,4 +28,7 @@ class IteratorTest : public testing::Test, public ::testing::WithParamInterface<
       return str;
     }
   };
+
+  void testOpenMPIterators(autopas::ContainerOption containerOption, double cellSizeFactor,
+                           autopas::IteratorBehavior behavior);
 };

--- a/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
@@ -32,7 +32,7 @@ INSTANTIATE_TEST_SUITE_P(
 
               // container factory
               autopas::ContainerSelector<Particle, FPCell> containerSelector({0., 0., 0.}, {10., 10., 10.}, 1.);
-              autopas::ContainerSelectorInfo containerInfo(1., 0.);
+              autopas::ContainerSelectorInfo containerInfo(1., 0., 64);
 
               // generate for all containers, even those to come
               for (auto containerOption : autopas::ContainerOption::getAllOptions()) {
@@ -81,7 +81,7 @@ void Newton3OnOffTest::countFunctorCalls(autopas::ContainerOption containerOptio
   }
 
   autopas::ContainerSelector<Particle, FPCell> containerSelector(getBoxMin(), getBoxMax(), getCutoff());
-  autopas::ContainerSelectorInfo containerInfo(getCellSizeFactor(), getVerletSkin());
+  autopas::ContainerSelectorInfo containerInfo(getCellSizeFactor(), getVerletSkin(), 64);
 
   containerSelector.selectContainer(containerOption, containerInfo);
 

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalRaceConditionTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalRaceConditionTest.h
@@ -43,6 +43,11 @@ class TraversalRaceConditionTest : public AutoPasTestBase {
 
     bool allowsNonNewton3() override { return false; }
 
+    bool isAppropriateClusterSize(unsigned int clusterSize,
+                                  autopas::DataLayoutOption::Value dataLayout) const override {
+      return dataLayout == autopas::DataLayoutOption::aos;  // this functor supports clusters only for aos!
+    }
+
     void AoSFunctor(Particle &i, Particle &j, bool newton3) override {
       auto coordsI = i.getR();
       auto coordsJ = j.getR();

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.cpp
@@ -23,8 +23,10 @@ void testTraversal(autopas::TraversalOption traversalOption, bool useN3, const s
   autopasTools::generators::GridGenerator::fillWithParticles(cells, edgeLength, edgeLength);
 
   NumThreadGuard numThreadGuard(4);
+  // clustersize is 32 if traversal has something like cluster in it, otherwise 0.
+  unsigned int clusterSize = traversalOption.to_string().find("luster") != std::string::npos ? 32 : 0;
   // this test assumes a cell size of 1. in each direction
-  autopas::TraversalSelectorInfo tsi(edgeLength, cutoff, {1., 1., 1.});
+  autopas::TraversalSelectorInfo tsi(edgeLength, cutoff, {1., 1., 1.}, clusterSize);
   std::unique_ptr<autopas::TraversalInterface> traversal;
   if (useN3 and traversalOption != autopas::TraversalOption::c01) {
     traversal = autopas::TraversalSelector<FPCell>::template generateTraversal<TraversalTest::CountFunctor,

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.h
@@ -51,6 +51,11 @@ class TraversalTest : public AutoPasTestBase,
 
     bool allowsNonNewton3() override { return true; }
 
+    bool isAppropriateClusterSize(unsigned int clusterSize,
+                                  autopas::DataLayoutOption::Value dataLayout) const override {
+      return dataLayout == autopas::DataLayoutOption::aos;  // this functor supports clusters only for aos!
+    }
+
     void AoSFunctor(Particle &i, Particle &j, bool newton3) override {
       const auto coordsI = i.getR();
       const auto coordsJ = j.getR();

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterCellsTest.cpp
@@ -523,28 +523,3 @@ TEST_F(VerletClusterCellsTest, testVerletListRegionIterator) {
           << iter->getR()[2] << ")" << std::endl;
   }
 }
-
-TEST_F(VerletClusterCellsTest, testVerletListIteratorsOpenMP) {
-  std::array<double, 3> min = {1, 1, 1};
-  std::array<double, 3> max = {8, 8, 8};
-  double cutoff = 1.;
-  double skin = 0.2;
-  int clusterSize = 64;
-  autopas::VerletClusterCells<TouchableParticle> verletLists(min, max, cutoff, skin, clusterSize);
-
-  autopasTools::generators::RandomGenerator::fillWithParticles(verletLists, TouchableParticle({0., 0., 0.}, 0),
-                                                               verletLists.getBoxMin(), verletLists.getBoxMax(), 500);
-  autopasTools::generators::RandomGenerator::fillWithHaloParticles(verletLists, TouchableParticle({0., 0., 0.}, 0),
-                                                                   cutoff, 50);
-
-#ifdef AUTOPAS_OPENMP
-#pragma omp parallel
-#endif
-  for (auto iter = verletLists.begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
-    iter->touch();
-  }
-
-  for (auto iter = verletLists.begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
-    EXPECT_EQ(1, iter->getNumTouched());
-  }
-}

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterCellsTest.cpp
@@ -46,7 +46,7 @@ TEST_F(VerletClusterCellsTest, testNeighborListBuild) {
 
   MockFunctor<Particle, FPCell> emptyFunctor;
   autopas::VerletClusterCellsTraversal<FPCell, MFunctor, autopas::DataLayoutOption::aos, false> dummyTraversal(
-      &emptyFunctor);
+      &emptyFunctor, verletLists.getTraversalSelectorInfo().clusterSize);
   verletLists.rebuildNeighborLists(&dummyTraversal);
 }
 
@@ -67,7 +67,7 @@ TEST_F(VerletClusterCellsTest, testVerletListIterator) {
 
   MockFunctor<Particle, FPCell> emptyFunctor;
   autopas::VerletClusterCellsTraversal<FPCell, MFunctor, autopas::DataLayoutOption::aos, false>
-      verletClusterCellsTraversal(&emptyFunctor);
+      verletClusterCellsTraversal(&emptyFunctor, verletLists.getTraversalSelectorInfo().clusterSize);
   verletLists.rebuildNeighborLists(&verletClusterCellsTraversal);
 
   int numOwn = 0;
@@ -151,7 +151,7 @@ TEST_F(VerletClusterCellsTest, testVerletListIteratorDelete) {
 
   MockFunctor<Particle, FPCell> emptyFunctor;
   autopas::VerletClusterCellsTraversal<FPCell, MFunctor, autopas::DataLayoutOption::aos, false>
-      verletClusterCellsTraversal(&emptyFunctor);
+      verletClusterCellsTraversal(&emptyFunctor, verletLists.getTraversalSelectorInfo().clusterSize);
   verletLists.rebuildNeighborLists(&verletClusterCellsTraversal);
 
   for (auto iter = verletLists.begin(autopas::IteratorBehavior::haloAndOwned); iter.isValid(); ++iter) {
@@ -195,7 +195,7 @@ TEST_F(VerletClusterCellsTest, testVerletParticleLoss) {
   MockFunctor<Particle, FPCell> emptyFunctor;
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, false)).Times(AtLeast(1));
   autopas::VerletClusterCellsTraversal<FPCell, MFunctor, autopas::DataLayoutOption::aos, false>
-      verletClusterCellsTraversal(&emptyFunctor);
+      verletClusterCellsTraversal(&emptyFunctor, verletLists.getTraversalSelectorInfo().clusterSize);
   verletLists.iteratePairwise(&verletClusterCellsTraversal);
 
   int numOwn = 0;
@@ -391,10 +391,11 @@ TEST_F(VerletClusterCellsTest, testDeleteAllParticles) {
 
 TEST_F(VerletClusterCellsTest, testCheckUpdateContainerNeededNoMove) {
   MockFunctor<Particle, FPCell> emptyFunctor;
+  constexpr unsigned int clusterSize = 32;
   autopas::VerletClusterCellsTraversal<FPCell, MFunctor, autopas::DataLayoutOption::aos, false> dummyTraversal(
-      &emptyFunctor);
+      &emptyFunctor, clusterSize);
   {
-    autopas::VerletClusterCells<Particle> verletClusterCells({0., 0., 0.}, {10., 10., 10.}, 1., 0.5, 32);
+    autopas::VerletClusterCells<Particle> verletClusterCells({0., 0., 0.}, {10., 10., 10.}, 1., 0.5, clusterSize);
     int id = 1;
     for (double x : {-.5, 0., 5., 9.999, 10., 10.5}) {
       for (double y : {-.5, 0., 5., 9.999, 10., 10.5}) {
@@ -462,7 +463,7 @@ TEST_F(VerletClusterCellsTest, testIsContainerUpdateNeeded) {
   // trigger rebuild
   MockFunctor<Particle, FPCell> emptyFunctor;
   autopas::VerletClusterCellsTraversal<FPCell, MFunctor, autopas::DataLayoutOption::aos, false> dummyTraversal(
-      &emptyFunctor);
+      &emptyFunctor, container.getTraversalSelectorInfo().clusterSize);
   container.rebuildNeighborLists(&dummyTraversal);
 
   EXPECT_FALSE(container.isContainerUpdateNeeded());

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterCellsTraversalVersusDirectSumTest.cpp
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterCellsTraversalVersusDirectSumTest.cpp
@@ -10,7 +10,7 @@
 
 VerletClusterCellsTraversalVersusDirectSumTest::VerletClusterCellsTraversalVersusDirectSumTest()
     : _directSum(getBoxMin(), getBoxMax(), getCutoff(), 0.2),
-      _verletCluster(getBoxMin(), getBoxMax(), getCutoff(), 0.2, 64) {}
+      _verletCluster(getBoxMin(), getBoxMax(), getCutoff(), 0.2, _clusterSize) {}
 
 double VerletClusterCellsTraversalVersusDirectSumTest::fRand(double fMin, double fMax) const {
   double f = static_cast<double>(rand()) / RAND_MAX;
@@ -62,7 +62,7 @@ void VerletClusterCellsTraversalVersusDirectSumTest::test(unsigned long numMolec
   autopas::DirectSumTraversal<FMCell, decltype(funcDS), autopas::DataLayoutOption::aos, useNewton3> traversalDS(
       &funcDS, getCutoff());
   autopas::VerletClusterCellsTraversal<FMCell, decltype(funcVC), dataLayout, useNewton3> traversalVerletCluster(
-      &funcVC);
+      &funcVC, _clusterSize);
 
   funcDS.initTraversal();
   _directSum.iteratePairwise(&traversalDS);

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterCellsTraversalVersusDirectSumTest.h
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterCellsTraversalVersusDirectSumTest.h
@@ -40,4 +40,5 @@ class VerletClusterCellsTraversalVersusDirectSumTest : public AutoPasTestBase {
 
   autopas::DirectSum<FMCell> _directSum;
   autopas::VerletClusterCells<Molecule> _verletCluster;
+  static constexpr unsigned int _clusterSize = 64;
 };

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.h
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.h
@@ -49,6 +49,10 @@ class CollectParticlesPerThreadFunctor
   bool allowsNewton3() override { return true; }
   bool allowsNonNewton3() override { return true; }
 
+  bool isAppropriateClusterSize(unsigned int clusterSize, autopas::DataLayoutOption::Value dataLayout) const override {
+    return dataLayout == autopas::DataLayoutOption::aos;  // this functor supports clusters only for aos!
+  }
+
   static void nextColor(int newColor) { _currentColor = newColor; }
 };
 

--- a/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.h
+++ b/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.h
@@ -11,17 +11,7 @@
 #include "AutoPasTestBase.h"
 #include "autopas/autopasIncludes.h"
 #include "autopasTools/generators/RandomGenerator.h"
-
-class TouchableParticle : public autopas::Particle {
- public:
-  TouchableParticle(std::array<double, 3> pos, unsigned long id)
-      : autopas::Particle(pos, {0, 0, 0}, id), _numTouched(0){};
-  void touch() { _numTouched++; }
-  unsigned int getNumTouched() { return _numTouched; }
-
- private:
-  unsigned int _numTouched;
-};
+#include "testingHelpers/TouchableParticle.h"
 
 class RegionParticleIteratorTest : public AutoPasTestBase {
  public:

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
@@ -18,7 +18,7 @@ TEST_F(ContainerSelectorTest, testSelectAndGetCurrentContainer) {
   const double verletSkin = 0;
 
   autopas::ContainerSelector<Particle, FPCell> containerSelector(bBoxMin, bBoxMax, cutoff);
-  autopas::ContainerSelectorInfo containerInfo(cellSizeFactor, verletSkin);
+  autopas::ContainerSelectorInfo containerInfo(cellSizeFactor, verletSkin, 64);
 
   // expect an exception if nothing is selected yet
   EXPECT_THROW((containerSelector.getCurrentContainer()), autopas::utils::ExceptionHandler::AutoPasException);
@@ -70,7 +70,7 @@ TEST_P(ContainerSelectorTest, testContainerConversion) {
   const double verletSkin = 0.1;
 
   autopas::ContainerSelector<Particle, FPCell> containerSelector(bBoxMin, bBoxMax, cutoff);
-  autopas::ContainerSelectorInfo containerInfo(cellSizeFactor, verletSkin);
+  autopas::ContainerSelectorInfo containerInfo(cellSizeFactor, verletSkin, 64);
 
   // select container from which we want to convert from
   containerSelector.selectContainer(from, containerInfo);

--- a/tests/testAutopas/tests/selectors/TraversalSelectorTest.cpp
+++ b/tests/testAutopas/tests/selectors/TraversalSelectorTest.cpp
@@ -16,7 +16,7 @@ TEST_F(TraversalSelectorTest, testSelectAndGetCurrentTraversal) {
 
   // this should be high enough so that sliced is still valid for the current processors thread count.
   constexpr size_t domainSize = 900;
-  autopas::TraversalSelectorInfo traversalSelectorInfo({domainSize, domainSize, domainSize}, 1., {1., 1., 1.});
+  autopas::TraversalSelectorInfo traversalSelectorInfo({domainSize, domainSize, domainSize}, 1., {1., 1., 1.}, 32);
 
   for (auto &traversalOption : autopas::TraversalOption::getAllOptions()) {
     auto traversal =

--- a/tools/autopasTools/generators/RandomGenerator.h
+++ b/tools/autopasTools/generators/RandomGenerator.h
@@ -65,7 +65,8 @@ class RandomGenerator {
                                 unsigned long numParticles = 100ul, unsigned int seed = 42);
 
   /**
-   * Fills only a given part of a container (also AutoPas object) with randomly uniformly distributed particles.
+   * Fills the halo of a container (also AutoPas object) with randomly uniformly distributed particles.
+   * Use haloAddFunction to specify how to add particles to the container!
    * @tparam Container Arbitrary container class that needs to support getBoxMax() and addParticle().
    * @tparam Particle Type of the default particle.
    * @tparam HaloAddFunction function with signature void(Container&, Particle)
@@ -76,11 +77,28 @@ class RandomGenerator {
    * @param haloAddFunction the function of type HaloAddfunction that adds a halo particle to the container.
    * @param seed
    */
-  template <class Container, class Particle,
-            class HaloAddFunction = decltype(detail<Container, Particle>::addHaloParticleF)>
-  static void fillWithHaloParticles(
-      Container &container, const Particle &defaultParticle, double haloWidth, unsigned long numParticles = 100ul,
-      const HaloAddFunction &haloAddFunction = detail<Container, Particle>::addHaloParticleF, unsigned int seed = 42);
+  template <class Container, class Particle, class HaloAddFunction>
+  static void fillWithHaloParticles(Container &container, const Particle &defaultParticle, double haloWidth,
+                                    unsigned long numParticles, const HaloAddFunction &haloAddFunction,
+                                    unsigned int seed = 42);
+
+  /**
+   * Fills the halo of a container with randomly uniformly distributed particles.
+   * Container needs to support addHaloParticle(). If it does not support this, please use the version above.
+   * @tparam Container Arbitrary container class that needs to support getBoxMax() and addParticle().
+   * @tparam Particle Type of the default particle.
+   * @param container
+   * @param defaultParticle
+   * @param haloWidth
+   * @param numParticles
+   * @param seed
+   */
+  template <class Container, class Particle>
+  static void fillWithHaloParticles(Container &container, const Particle &defaultParticle, double haloWidth,
+                                    unsigned long numParticles, unsigned int seed = 42) {
+    fillWithHaloParticles(container, defaultParticle, haloWidth, numParticles,
+                          detail<Container, Particle>::addHaloParticleF, seed);
+  }
 };
 
 template <class Container, class Particle>


### PR DESCRIPTION
# Description

- enables periodic boundary conditions by default for MDFlexConfig.
- fixes: calculate position update first, then boundary update.
- enables an error message if no boundary condition is set.
- ContainerSelector: changing a container now uses the owned state to specify whether to add a particle as owned or halo particle instead of using try-catch exception workflow.
- introduce isAppropriateClusterSize() and use them in VerletClusterCells.

## Resolved Issues

- [x] fixes #393 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Adds an additional test for md-flex to checkExamples for VerletClusterCells.
- [x] Adds new unit test in IteratorTest.cpp that compares the iterators with and without openmp for all containers.
