### PR TITLE
Fix particle properties init

### DIFF
--- a/examples/md-flexible/parsing/MDFlexConfig.cpp
+++ b/examples/md-flexible/parsing/MDFlexConfig.cpp
@@ -148,7 +148,7 @@ void MDFlexConfig::addParticleType(unsigned long typeId, double epsilon, double 
     if (epsilonMap.at(typeId) == epsilon and sigmaMap.at(typeId) == sigma and massMap.at(typeId) == mass) {
       return;
     } else {  // wrong initialization:
-      throw std::runtime_error("Wrong Particle initializaition: using same typeId for different properties");
+      throw std::runtime_error("Wrong Particle initialization: using same typeId for different properties");
     }
   } else {
     epsilonMap.emplace(typeId, epsilon);

--- a/examples/md-flexible/parsing/YamlParser.cpp
+++ b/examples/md-flexible/parsing/YamlParser.cpp
@@ -153,12 +153,9 @@ bool parseYamlFile(MDFlexConfig &config) {
     config.cubeGaussObjects.clear();
     config.cubeUniformObjects.clear();
     config.sphereObjects.clear();
-    // if no checkpoint will be loaded also clear default particle props.
-    if (!node[MDFlexConfig::checkpointfileStr]) {
-      config.epsilonMap.clear();
-      config.sigmaMap.clear();
-      config.massMap.clear();
-    }
+    config.epsilonMap.clear();
+    config.sigmaMap.clear();
+    config.massMap.clear();
 
     for (YAML::const_iterator objectIterator = node[MDFlexConfig::objectsStr].begin();
          objectIterator != node[MDFlexConfig::objectsStr].end(); ++objectIterator) {

--- a/examples/md-flexible/parsing/YamlParser.cpp
+++ b/examples/md-flexible/parsing/YamlParser.cpp
@@ -153,6 +153,12 @@ bool parseYamlFile(MDFlexConfig &config) {
     config.cubeGaussObjects.clear();
     config.cubeUniformObjects.clear();
     config.sphereObjects.clear();
+    // if no checkpoint will be loaded also clear default particle props.
+    if (!node[MDFlexConfig::checkpointfileStr]) {
+      config.epsilonMap.clear();
+      config.sigmaMap.clear();
+      config.massMap.clear();
+    }
 
     for (YAML::const_iterator objectIterator = node[MDFlexConfig::objectsStr].begin();
          objectIterator != node[MDFlexConfig::objectsStr].end(); ++objectIterator) {


### PR DESCRIPTION
# Description

When defining new particle types through a yaml file defaults need to be cleared.

## ~Related Pull Requests~

## ~Resolved Issues~

# How Has This Been Tested?

- [x] manually
