### PR TITLE
Make all methods adding or updating particles take const Particle&

### DIFF
--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -158,7 +158,7 @@ class AutoPas {
    * This is only allowed if the neighbor lists are not valid.
    * @param p Reference to the particle to be added
    */
-  void addParticle(Particle &p) { _logicHandler->addParticle(p); }
+  void addParticle(const Particle &p) { _logicHandler->addParticle(p); }
 
   /**
    * Adds or updates a particle to/in the container that lies in the halo region of the container.
@@ -175,7 +175,7 @@ class AutoPas {
    *
    * @param haloParticle particle to be added or updated
    */
-  void addOrUpdateHaloParticle(Particle &haloParticle) { _logicHandler->addOrUpdateHaloParticle(haloParticle); }
+  void addOrUpdateHaloParticle(const Particle &haloParticle) { _logicHandler->addOrUpdateHaloParticle(haloParticle); }
 
   /**
    * Deletes all particles.

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -56,7 +56,7 @@ class LogicHandler {
   /**
    * @copydoc AutoPas::addParticle()
    */
-  void addParticle(Particle &p) {
+  void addParticle(const Particle &p) {
     if (not isContainerValid()) {
       _autoTuner.getContainer()->addParticle(p);
       _numParticlesOwned.fetch_add(1, std::memory_order_relaxed);
@@ -71,7 +71,7 @@ class LogicHandler {
   /**
    * @copydoc AutoPas::addOrUpdateHaloParticle()
    */
-  void addOrUpdateHaloParticle(Particle &haloParticle) {
+  void addOrUpdateHaloParticle(const Particle &haloParticle) {
     auto container = _autoTuner.getContainer();
     if (not isContainerValid()) {
       if (not utils::inBox(haloParticle.getR(), _autoTuner.getContainer()->getBoxMin(),

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -75,20 +75,20 @@ class ParticleContainerInterface {
    * Adds a particle to the container.
    * @param p The particle to be added.
    */
-  virtual void addParticle(ParticleType &p) = 0;
+  virtual void addParticle(const ParticleType &p) = 0;
 
   /**
    * Adds a particle to the container that lies in the halo region of the container.
    * @param haloParticle Particle to be added.
    */
-  virtual void addHaloParticle(ParticleType &haloParticle) = 0;
+  virtual void addHaloParticle(const ParticleType &haloParticle) = 0;
 
   /**
    * Update a halo particle of the container with the given haloParticle.
    * @param haloParticle Particle to be updated.
    * @return Returns true if the particle was updated, false if no particle could be found.
    */
-  virtual bool updateHaloParticle(ParticleType &haloParticle) = 0;
+  virtual bool updateHaloParticle(const ParticleType &haloParticle) = 0;
 
   /**
    * Rebuilds the neighbor lists.

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -56,7 +56,7 @@ class DirectSum : public ParticleContainer<ParticleCell> {
   /**
    * @copydoc ParticleContainerInterface::addParticle()
    */
-  void addParticle(ParticleType &p) override {
+  void addParticle(const ParticleType &p) override {
     if (utils::inBox(p.getR(), this->getBoxMin(), this->getBoxMax())) {
       getCell().addParticle(p);
     } else {
@@ -68,7 +68,7 @@ class DirectSum : public ParticleContainer<ParticleCell> {
   /**
    * @copydoc ParticleContainerInterface::addHaloParticle()
    */
-  void addHaloParticle(ParticleType &haloParticle) override {
+  void addHaloParticle(const ParticleType &haloParticle) override {
     ParticleType p_copy = haloParticle;
     p_copy.setOwned(false);
     getHaloCell().addParticle(p_copy);
@@ -77,7 +77,7 @@ class DirectSum : public ParticleContainer<ParticleCell> {
   /**
    * @copydoc ParticleContainerInterface::updateHaloParticle()
    */
-  bool updateHaloParticle(ParticleType &haloParticle) override {
+  bool updateHaloParticle(const ParticleType &haloParticle) override {
     ParticleType pCopy = haloParticle;
     pCopy.setOwned(false);
     return internal::checkParticleInCellAndUpdateByIDAndPosition(getHaloCell(), pCopy, this->getSkin());

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -58,7 +58,7 @@ class LinkedCells : public ParticleContainer<ParticleCell, SoAArraysType> {
   /**
    * @copydoc ParticleContainerInterface::addParticle()
    */
-  void addParticle(ParticleType &p) override {
+  void addParticle(const ParticleType &p) override {
     bool inBox = autopas::utils::inBox(p.getR(), this->getBoxMin(), this->getBoxMax());
     if (inBox) {
       ParticleCell &cell = _cellBlock.getContainingCell(p.getR());
@@ -72,7 +72,7 @@ class LinkedCells : public ParticleContainer<ParticleCell, SoAArraysType> {
   /**
    * @copydoc ParticleContainerInterface::addHaloParticle()
    */
-  void addHaloParticle(ParticleType &haloParticle) override {
+  void addHaloParticle(const ParticleType &haloParticle) override {
     ParticleType pCopy = haloParticle;
     pCopy.setOwned(false);
     ParticleCell &cell = _cellBlock.getContainingCell(pCopy.getR());
@@ -82,7 +82,7 @@ class LinkedCells : public ParticleContainer<ParticleCell, SoAArraysType> {
   /**
    * @copydoc ParticleContainerInterface::updateHaloParticle()
    */
-  bool updateHaloParticle(ParticleType &haloParticle) override {
+  bool updateHaloParticle(const ParticleType &haloParticle) override {
     ParticleType pCopy = haloParticle;
     pCopy.setOwned(false);
     auto cells = _cellBlock.getNearbyHaloCells(pCopy.getR(), this->getSkin());

--- a/src/autopas/containers/verletClusterLists/VerletClusterCells.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterCells.h
@@ -93,7 +93,7 @@ class VerletClusterCells : public ParticleContainer<FullParticleCell<Particle>> 
   /**
    * @copydoc VerletLists::addParticle()
    */
-  void addParticle(Particle &p) override {
+  void addParticle(const Particle &p) override {
     if (autopas::utils::inBox(p.getR(), this->getBoxMin(), this->getBoxMax())) {
       _isValid = false;
       // removes dummy particles in first cell
@@ -110,7 +110,7 @@ class VerletClusterCells : public ParticleContainer<FullParticleCell<Particle>> 
   /**
    * @copydoc VerletLists::addHaloParticle()
    */
-  void addHaloParticle(Particle &haloParticle) override {
+  void addHaloParticle(const Particle &haloParticle) override {
     Particle p_copy = haloParticle;
     if (autopas::utils::notInBox(p_copy.getR(), this->getBoxMin(), this->getBoxMax())) {
       _isValid = false;
@@ -131,7 +131,7 @@ class VerletClusterCells : public ParticleContainer<FullParticleCell<Particle>> 
    * @param haloParticle Particle to be updated.
    * @return Returns true if the particle was updated, false if no particle could be found.
    */
-  bool updateHaloParticle(Particle &haloParticle) override {
+  bool updateHaloParticle(const Particle &haloParticle) override {
     Particle pCopy = haloParticle;
     pCopy.setOwned(false);
 

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -84,7 +84,7 @@ class VerletClusterLists : public ParticleContainer<FullParticleCell<Particle>> 
   /**
    * @copydoc VerletLists::addParticle()
    */
-  void addParticle(Particle &p) override {
+  void addParticle(const Particle &p) override {
     // add particle somewhere, because lists will be rebuild anyways
     this->_cells[0].addParticle(p);
   }
@@ -92,14 +92,14 @@ class VerletClusterLists : public ParticleContainer<FullParticleCell<Particle>> 
   /**
    * @copydoc VerletLists::addHaloParticle()
    */
-  void addHaloParticle(Particle &haloParticle) override {
+  void addHaloParticle(const Particle &haloParticle) override {
     autopas::utils::ExceptionHandler::exception("VerletClusterLists.addHaloParticle not yet implemented.");
   }
 
   /**
    * @copydoc autopas::ParticleContainerInterface::updateHaloParticle()
    */
-  bool updateHaloParticle(Particle &haloParticle) override { throw std::runtime_error("not yet implemented"); }
+  bool updateHaloParticle(const Particle &haloParticle) override { throw std::runtime_error("not yet implemented"); }
 
   /**
    * @copydoc VerletLists::deleteHaloParticles

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -50,7 +50,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<FullParticleCell
    * @copydoc autopas::ParticleContainerInterface::addParticle
    * @note This function invalidates the neighbor lists.
    */
-  void addParticle(Particle &p) override {
+  void addParticle(const Particle &p) override {
     _neighborListIsValid = false;
     _linkedCells.addParticle(p);
   }
@@ -59,7 +59,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<FullParticleCell
    * @copydoc autopas::ParticleContainerInterface::addHaloParticle
    * @note This function invalidates the neighbor lists.
    */
-  void addHaloParticle(Particle &haloParticle) override {
+  void addHaloParticle(const Particle &haloParticle) override {
     _neighborListIsValid = false;
     _linkedCells.addHaloParticle(haloParticle);
   }
@@ -141,7 +141,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<FullParticleCell
    * @param particle
    * @return true if a particle was found and updated, false if it was not found.
    */
-  bool updateHaloParticle(Particle &particle) override {
+  bool updateHaloParticle(const Particle &particle) override {
     Particle pCopy = particle;
     pCopy.setOwned(false);
     auto cells = _linkedCells.getCellBlock().getNearbyHaloCells(pCopy.getR(), this->getSkin());


### PR DESCRIPTION
# Description

AutoPas Interface:
- addParticle(Particle&) is now addParticle(const Particle&)
- addOrUpdateHaloParticle(Particle&) is now addOrUpdateHaloParticle(const Particle&)

Container Interface:
- addParticle(Particle&) is now addParticle(const Particle&)
- addHaloParticle(Particle&) is now addHaloParticle(const Particle&)
- updateHaloParticle(Particle&) is now updateHaloParticle(const Particle&)

## Resolved Issues

- [x] fixes #392 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] locally
- [x] Jenkins