### PR TITLE
Fixes Jenkins not aborting when doxygen fails

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline{
             }
         }
         stage("style check") {
-            parallel(
+            parallel {
                 stage("build documentation") {
                     steps {
                         container('autopas-cmake-doxygen-make') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,6 @@ pipeline{
                     }
                     post {
                         failure {
-                            echo "failure"
                             error "warnings in doxygen documentation"
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,20 +28,9 @@ pipeline{
                         recordIssues filters: [excludeFile('.*README.*')], tools: [doxygen(pattern: 'build-doxygen/DoxygenWarningLog.txt')], failedTotalAll: 1
                     }
                     post {
-                        changed {
-                            echo "change"
-                        }
-                        unstable {
-                            echo "unstable"
-                        }
-                        success {
-                            echo "success"
-                        }
                         failure {
                             echo "failure"
-                        }
-                        aborted {
-                            echo "aborted"
+                            error "warnings in doxygen documentation"
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ pipeline{
                         }
                     }
                 }
-            )
+            }
         }
         stage('build and test'){
             options {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,9 +13,9 @@ pipeline{
         }
         stage("style check") {
             parallel(
-                stage("build documentation) {
+                stage("build documentation") {
                     steps {
-                        container('autopas-cmake-doxygen-make'){
+                        container('autopas-cmake-doxygen-make') {
                             dir("build-doxygen") {
                                 sh 'entrypoint.sh ccache -s'
                                 sh 'cmake ..'
@@ -31,7 +31,7 @@ pipeline{
                 stage ("clang and cmake format") {
                     steps {
                         dir("format"){
-                            container('autopas-clang6-cmake-ninja-make'){
+                            container('autopas-clang6-cmake-ninja-make') {
                                 sh "CC=clang CXX=clang++ cmake -G Ninja -DAUTOPAS_OPENMP=ON .."
                                 sh "ninja clangformat"
                                 sh "ninja cmakeformat"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,23 @@ pipeline{
                         // get doxygen warnings
                         recordIssues filters: [excludeFile('.*README.*')], tools: [doxygen(pattern: 'build-doxygen/DoxygenWarningLog.txt')], failedTotalAll: 1
                     }
+                    post {
+                        changed {
+                            echo "change"
+                        }
+                        unstable {
+                            echo "unstable"
+                        }
+                        success {
+                            echo "success"
+                        }
+                        failure {
+                            echo "failure"
+                        }
+                        aborted {
+                            echo "aborted"
+                        }
+                    }
                 }
                 stage ("clang and cmake format") {
                     steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,9 +12,9 @@ pipeline{
             }
         }
         stage("style check") {
-            steps{
-                parallel(
-                    "build documentation": {
+            parallel(
+                stage("build documentation) {
+                    steps {
                         container('autopas-cmake-doxygen-make'){
                             dir("build-doxygen") {
                                 sh 'entrypoint.sh ccache -s'
@@ -26,8 +26,10 @@ pipeline{
 
                         // get doxygen warnings
                         recordIssues filters: [excludeFile('.*README.*')], tools: [doxygen(pattern: 'build-doxygen/DoxygenWarningLog.txt')], failedTotalAll: 1
-                    },
-                    "clang and cmake format": {
+                    }
+                }
+                stage ("clang and cmake format") {
+                    steps {
                         dir("format"){
                             container('autopas-clang6-cmake-ninja-make'){
                                 sh "CC=clang CXX=clang++ cmake -G Ninja -DAUTOPAS_OPENMP=ON .."
@@ -47,8 +49,10 @@ pipeline{
                                 }
                             }
                         }
-                    },
-                    "custom checks": {
+                    }
+                }
+                stage ("custom checks") {
+                    steps {
                         echo 'Testing src folder'
                         dir("src"){
                             checkCustom()
@@ -62,8 +66,8 @@ pipeline{
                             checkCustom()
                         }
                     }
-                )
-            }
+                }
+            )
         }
         stage('build and test'){
             options {

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -38,6 +38,7 @@ static unsigned int _instanceCounter = 0;
 template <class Particle, class ParticleCell>
 class AutoPas {
  public:
+
   using Particle_t = Particle;
 
   /**

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -38,7 +38,9 @@ static unsigned int _instanceCounter = 0;
 template <class Particle, class ParticleCell>
 class AutoPas {
  public:
-
+  /**
+   * Particle type to be accessible after initialization.
+   */
   using Particle_t = Particle;
 
   /**

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -38,9 +38,7 @@ static unsigned int _instanceCounter = 0;
 template <class Particle, class ParticleCell>
 class AutoPas {
  public:
-  /**
-   * Particle type to be accessible after initialization.
-   */
+
   using Particle_t = Particle;
 
   /**

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -38,7 +38,6 @@ static unsigned int _instanceCounter = 0;
 template <class Particle, class ParticleCell>
 class AutoPas {
  public:
-
   using Particle_t = Particle;
 
   /**


### PR DESCRIPTION
# Description

Jenkins is currently not aborting when doxygen fails.
This PR fixes this by adding a post section to the doxygen step:
```
post {
    failure {
        echo "failure"
        error "warnings in doxygen documentation"
    }
}
```

## Resolved Issues

- [x] fixes Jenkins not aborting when doxygen fails

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Jenkins, check with missing doc: http://vmbungartz10.informatik.tu-muenchen.de/mardyn/blue/organizations/jenkins/AutoPas-Multibranch/detail/PR-408/9
