### PR TITLE
Update clang-format version in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Please keep in mind the following notes while working.
 * Class names start with a capital letter.
 * Use camelCase over snake_case.
 * Google code style is enforced by the CI server.
-* Clang format version 6.0 is enforced (Other versions might format slightly differently).
+* Clang format version 9 is enforced (Other versions might format slightly differently).
 * Use `make clangformat` before submitting a PR.
 * [cmake format](https://github.com/cheshirekow/cmake_format/tree/master/cmake_format) is enforced.
 * Use `make cmakeformat` before submitting a PR.


### PR DESCRIPTION
# Description

Updates the clang-format version from 6.0 to 9 in CONTRIBUTING.md.