### PR TITLE
Introduces TuningStrategyFactory

### DIFF
--- a/cmake/modules/other-compileroptions.cmake
+++ b/cmake/modules/other-compileroptions.cmake
@@ -22,11 +22,11 @@ target_compile_options(
         $<$<AND:$<NOT:$<BOOL:${AUTOPAS_ENABLE_FAST_MATH}>>,$<CXX_COMPILER_ID:Intel>>:$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=>-fp-model
         precise>
         # Warnings:
+    PRIVATE
         # no warnings for intel because it's mainly spam, but we disable one, because of a compiler
         # bug:
         # https://software.intel.com/en-us/forums/intel-c-compiler/topic/814098
         $<$<CXX_COMPILER_ID:Intel>:$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=>-wd13212>
-    PRIVATE
         $<$<CXX_COMPILER_ID:GNU>:
         $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=>-Wsuggest-override
         $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=>-Wall

--- a/src/autopas/CMakeLists.txt
+++ b/src/autopas/CMakeLists.txt
@@ -21,9 +21,8 @@ target_link_libraries(
         ${CMAKE_THREAD_LIBS_INIT} # required for Logger and ExceptionHandler Do not link against
                                   # openmp when using archer
         $<$<AND:$<BOOL:${AUTOPAS_OPENMP}>,$<NOT:$<BOOL:${ARCHER}>>>:OpenMP::OpenMP_CXX>
-        Eigen3
         spdlog::spdlog
-        harmony
+    PRIVATE harmony Eigen3
 )
 
 # Ompstuff needs to be here because OpenMP.cmake needs to run before this file to create to OpenMP

--- a/src/autopas/CMakeLists.txt
+++ b/src/autopas/CMakeLists.txt
@@ -22,7 +22,9 @@ target_link_libraries(
                                   # openmp when using archer
         $<$<AND:$<BOOL:${AUTOPAS_OPENMP}>,$<NOT:$<BOOL:${ARCHER}>>>:OpenMP::OpenMP_CXX>
         spdlog::spdlog
-    PRIVATE harmony Eigen3
+    PRIVATE
+        # harmony and Eigen3 are only needed privately when building AutoPas.
+        harmony Eigen3
 )
 
 # Ompstuff needs to be here because OpenMP.cmake needs to run before this file to create to OpenMP

--- a/src/autopas/selectors/FeatureVector.h
+++ b/src/autopas/selectors/FeatureVector.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <Eigen/Dense>
+#include <Eigen/Core>
 #include <vector>
 
 #include "autopas/selectors/Configuration.h"

--- a/src/autopas/selectors/tuningStrategy/BayesianSearch.h
+++ b/src/autopas/selectors/tuningStrategy/BayesianSearch.h
@@ -139,7 +139,7 @@ class BayesianSearch : public TuningStrategyInterface {
   std::unordered_set<FeatureVector, ConfigHash> _invalidConfigs;
 
   Random _rng;
-  GaussianProcess<Eigen::VectorXd> _gaussianProcess;
+  GaussianProcess _gaussianProcess;
   size_t _maxEvidence;
   AcquisitionFunctionOption _predAcqFunction;
   size_t _predNumLHSamples;

--- a/src/autopas/selectors/tuningStrategy/GaussianProcess.cpp
+++ b/src/autopas/selectors/tuningStrategy/GaussianProcess.cpp
@@ -1,0 +1,41 @@
+/**
+ * @file GaussianProcess.cpp
+ * @author seckler
+ * @date 07.02.20
+ */
+
+#include "GaussianProcess.h"
+
+#include <Eigen/Cholesky>
+
+void autopas::GaussianProcess::Hyperparameters::precalculate(double sigma, const std::vector<Eigen::VectorXd> &inputs,
+                                                             const Eigen::VectorXd &outputs) {
+  size_t size = outputs.size();
+  // mean of output shifted to zero
+  Eigen::VectorXd outputCentered = outputs - mean * Eigen::VectorXd::Ones(size);
+
+  Eigen::MatrixXd covMat(size, size);
+  // calculate covariance matrix
+  for (size_t i = 0; i < size; ++i) {
+    covMat(i, i) = kernel(inputs[i], inputs[i], theta, dimScales) + sigma;
+    for (size_t j = i + 1; j < size; ++j) {
+      covMat(i, j) = covMat(j, i) = kernel(inputs[i], inputs[j], theta, dimScales);
+    }
+  }
+
+  // cholesky decomposition
+  Eigen::LLT<Eigen::MatrixXd> llt = covMat.llt();
+  Eigen::MatrixXd l = llt.matrixL();
+
+  // precalculate inverse of covMat and weights for predictions
+  covMatInv = llt.solve(Eigen::MatrixXd::Identity(size, size));
+  weights = covMatInv * outputCentered;
+
+  // likelihood of evidence given parameters
+  score = std::exp(-0.5 * outputCentered.dot(weights)) / l.diagonal().prod();
+
+  if (std::isnan(score)) {
+    // error score calculation failed
+    utils::ExceptionHandler::exception("GaussianProcess: invalid score ", score);
+  }
+}

--- a/src/autopas/selectors/tuningStrategy/TuningStrategyFactory.cpp
+++ b/src/autopas/selectors/tuningStrategy/TuningStrategyFactory.cpp
@@ -1,0 +1,52 @@
+/**
+ * @file TuningStrategyFactory.cpp
+ * @author seckler
+ * @date 07.02.20
+ */
+
+#include "TuningStrategyFactory.h"
+
+#include "ActiveHarmony.h"
+#include "BayesianSearch.h"
+#include "FullSearch.h"
+#include "RandomSearch.h"
+
+std::unique_ptr<autopas::TuningStrategyInterface> autopas::TuningStrategyFactory::generateTuningStrategy(
+    autopas::TuningStrategyOption tuningStrategyOption, const std::set<autopas::ContainerOption> &allowedContainers,
+    autopas::NumberSet<double> &allowedCellSizeFactors, const std::set<autopas::TraversalOption> &allowedTraversals,
+    const std::set<autopas::DataLayoutOption> &allowedDataLayouts,
+    const std::set<autopas::Newton3Option> &allowedNewton3Options, unsigned int maxEvidence,
+    AcquisitionFunctionOption acquisitionFunctionOption) {
+  // clang compiler bug requires static cast
+  switch (static_cast<TuningStrategyOption>(tuningStrategyOption)) {
+    case TuningStrategyOption::randomSearch: {
+      return std::make_unique<RandomSearch>(allowedContainers, allowedCellSizeFactors, allowedTraversals,
+                                            allowedDataLayouts, allowedNewton3Options, maxEvidence);
+    }
+    case TuningStrategyOption::fullSearch: {
+      if (not allowedCellSizeFactors.isFinite()) {
+        autopas::utils::ExceptionHandler::exception(
+            "AutoPas::generateTuningStrategy: fullSearch can not handle infinite cellSizeFactors!");
+        return nullptr;
+      }
+
+      return std::make_unique<FullSearch>(allowedContainers, allowedCellSizeFactors.getAll(), allowedTraversals,
+                                          allowedDataLayouts, allowedNewton3Options);
+    }
+
+    case TuningStrategyOption::bayesianSearch: {
+      return std::make_unique<BayesianSearch>(allowedContainers, allowedCellSizeFactors, allowedTraversals,
+                                              allowedDataLayouts, allowedNewton3Options, maxEvidence,
+                                              acquisitionFunctionOption);
+    }
+
+    case TuningStrategyOption::activeHarmony: {
+      return std::make_unique<ActiveHarmony>(allowedContainers, allowedCellSizeFactors, allowedTraversals,
+                                             allowedDataLayouts, allowedNewton3Options);
+    }
+  }
+
+  autopas::utils::ExceptionHandler::exception("AutoPas::generateTuningStrategy: Unknown tuning strategy {}!",
+                                              tuningStrategyOption);
+  return nullptr;
+}

--- a/src/autopas/selectors/tuningStrategy/TuningStrategyFactory.h
+++ b/src/autopas/selectors/tuningStrategy/TuningStrategyFactory.h
@@ -24,8 +24,9 @@ namespace autopas::TuningStrategyFactory {
  * @return Pointer to the tuning strategy object or the nullpointer if an exception was suppressed.
  */
 std::unique_ptr<autopas::TuningStrategyInterface> generateTuningStrategy(
-    TuningStrategyOption tuningStrategyOption, const std::set<ContainerOption> &allowedContainers,
-    NumberSet<double> &allowedCellSizeFactors, const std::set<TraversalOption> &allowedTraversals,
-    const std::set<DataLayoutOption> &allowedDataLayouts, const std::set<Newton3Option> &allowedNewton3Options,
-    unsigned int maxEvidence, AcquisitionFunctionOption acquisitionFunctionOption);
+    autopas::TuningStrategyOption tuningStrategyOption, const std::set<autopas::ContainerOption> &allowedContainers,
+    autopas::NumberSet<double> &allowedCellSizeFactors, const std::set<autopas::TraversalOption> &allowedTraversals,
+    const std::set<autopas::DataLayoutOption> &allowedDataLayouts,
+    const std::set<autopas::Newton3Option> &allowedNewton3Options, unsigned int maxEvidence,
+    AcquisitionFunctionOption acquisitionFunctionOption);
 }  // namespace autopas::TuningStrategyFactory

--- a/src/autopas/selectors/tuningStrategy/TuningStrategyFactory.h
+++ b/src/autopas/selectors/tuningStrategy/TuningStrategyFactory.h
@@ -1,0 +1,31 @@
+/**
+ * @file TuningStrategyFactory.h
+ * @author seckler
+ * @date 07.02.20
+ */
+
+#pragma once
+
+#include "TuningStrategyInterface.h"
+#include "autopas/options/AcquisitionFunctionOption.h"
+#include "autopas/options/TuningStrategyOption.h"
+
+namespace autopas::TuningStrategyFactory {
+/**
+ * Generates a new Tuning Strategy object.
+ * @param tuningStrategyOption
+ * @param allowedContainers
+ * @param allowedCellSizeFactors
+ * @param allowedTraversals
+ * @param allowedDataLayouts
+ * @param allowedNewton3Options
+ * @param maxEvidence
+ * @param acquisitionFunctionOption
+ * @return Pointer to the tuning strategy object or the nullpointer if an exception was suppressed.
+ */
+std::unique_ptr<autopas::TuningStrategyInterface> generateTuningStrategy(
+    TuningStrategyOption tuningStrategyOption, const std::set<ContainerOption> &allowedContainers,
+    NumberSet<double> &allowedCellSizeFactors, const std::set<TraversalOption> &allowedTraversals,
+    const std::set<DataLayoutOption> &allowedDataLayouts, const std::set<Newton3Option> &allowedNewton3Options,
+    unsigned int maxEvidence, AcquisitionFunctionOption acquisitionFunctionOption);
+}  // namespace autopas::TuningStrategyFactory

--- a/tests/testAutopas/CMakeLists.txt
+++ b/tests/testAutopas/CMakeLists.txt
@@ -21,10 +21,9 @@ target_link_libraries(
     runTests
     autopas
     autopasTools
-    gmock # gmock includes the gtest target includes of libraries that are normally not needed when
-          # building AutoPas, but are needed for some tests:
-    Eigen3
-    harmony
+    gmock # gmock includes the gtest target, so we don't need it here.
+    Eigen3 # Eigen3 is needed for the tests, but normally not required when using AutoPas.
+    harmony # ActiveHarmony is needed for the tests, but normally not required when using AutoPas.
 )
 
 # this cmake module was only introduced in 3.10

--- a/tests/testAutopas/CMakeLists.txt
+++ b/tests/testAutopas/CMakeLists.txt
@@ -21,7 +21,10 @@ target_link_libraries(
     runTests
     autopas
     autopasTools
-    gmock # gmock includes the gtest target
+    gmock # gmock includes the gtest target includes of libraries that are normally not needed when
+          # building AutoPas, but are needed for some tests:
+    Eigen3
+    harmony
 )
 
 # this cmake module was only introduced in 3.10

--- a/tests/testAutopas/tests/selectors/tuningStrategy/GaussianProcessTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/GaussianProcessTest.cpp
@@ -10,7 +10,7 @@ using namespace autopas;
 
 TEST_F(GaussianProcessTest, wrongDimension) {
   Random rng(32);
-  GaussianProcess<Eigen::VectorXd> gp(2, 0.001, rng);
+  GaussianProcess gp(2, 0.001, rng);
 
   Eigen::VectorXd f1 = Eigen::VectorXd::Ones(1);
   Eigen::VectorXd f2 = Eigen::VectorXd::Zero(3);
@@ -25,7 +25,7 @@ TEST_F(GaussianProcessTest, noEvidence) {
   double epsilon = 0.05;  // allowed error for tests
 
   double sigma = 0.001;  // noise
-  GaussianProcess<Eigen::VectorXd> gp(1, sigma, rng);
+  GaussianProcess gp(1, sigma, rng);
 
   Eigen::VectorXd f1(1);
   f1 << 0.;
@@ -40,7 +40,7 @@ TEST_F(GaussianProcessTest, oneEvidence) {
 
   double epsilon = 0.05;
   double sigma = 0.001;
-  GaussianProcess<Eigen::VectorXd> gp(1, sigma, rng);
+  GaussianProcess gp(1, sigma, rng);
 
   Eigen::VectorXd f1(1);
   f1 << 0.;
@@ -64,7 +64,7 @@ TEST_F(GaussianProcessTest, twoEvidence) {
 
   double epsilon = 0.05;  // allowed error for tests
   double sigma = 0.001;   // noise
-  GaussianProcess<Eigen::VectorXd> gp(1, sigma, rng);
+  GaussianProcess gp(1, sigma, rng);
 
   Eigen::VectorXd f1(1);
   f1 << -100.;
@@ -94,7 +94,7 @@ TEST_F(GaussianProcessTest, clear) {
 
   double epsilon = 0.05;  // allowed error for tests
   double sigma = 0.001;   // noise
-  GaussianProcess<Eigen::VectorXd> gp(1, sigma, rng);
+  GaussianProcess gp(1, sigma, rng);
 
   Eigen::VectorXd f1(1);
   f1 << -100.;
@@ -137,7 +137,7 @@ TEST_F(GaussianProcessTest, sine) {
   constexpr double domainStart = 0.;      // start of tested domain
   constexpr double domainEnd = 2 * M_PI;  // end of tested domain
 
-  GaussianProcess<Eigen::VectorXd> gp(1, 0.001, rng);
+  GaussianProcess gp(1, 0.001, rng);
 
   // create equidistant evidence over the domain
   double evidenceStep = (domainEnd - domainStart) / (numEvidence - 1);
@@ -231,8 +231,7 @@ TEST_F(GaussianProcessTest, 2dMinGridBig) {
 }
 
 void GaussianProcessTest::printMap(int xChunks, int yChunks, const autopas::NumberSet<double> &domainX,
-                                   const autopas::NumberSet<double> &domainY,
-                                   const autopas::GaussianProcess<Eigen::VectorXd> &gp,
+                                   const autopas::NumberSet<double> &domainY, const autopas::GaussianProcess &gp,
                                    autopas::AcquisitionFunctionOption af, double colorFactor) {
   // get distance between chunks
   double xSpace = (domainX.getMax() - domainX.getMin()) / (xChunks - 1);

--- a/tests/testAutopas/tests/selectors/tuningStrategy/GaussianProcessTest.h
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/GaussianProcessTest.h
@@ -42,7 +42,7 @@ class GaussianProcessTest : public AutoPasTestBase {
     constexpr size_t numEvidence = 7;      // number of samples allowed to make
     constexpr size_t lhsNumSamples = 850;  // number of samples to find min of acquisition function
 
-    autopas::GaussianProcess<Eigen::VectorXd> gp(2, 0.001, rng);
+    autopas::GaussianProcess gp(2, 0.001, rng);
 
     // add first evidence
     Eigen::VectorXd firstEvidence(2);
@@ -93,6 +93,6 @@ class GaussianProcessTest : public AutoPasTestBase {
    * @param colorFactor Multiplies the mean by this factor to gain the color
    */
   static void printMap(int xChunks, int yChunks, const autopas::NumberSet<double> &domainX,
-                       const autopas::NumberSet<double> &domainY, const autopas::GaussianProcess<Eigen::VectorXd> &gp,
+                       const autopas::NumberSet<double> &domainY, const autopas::GaussianProcess &gp,
                        autopas::AcquisitionFunctionOption af, double colorFactor);
 };


### PR DESCRIPTION
# Description

This PR introduces TuningStrategyFactory.
This mainly removes public dependencies by removing their inclusion through AutoPas.h.
Instead, they now are them only included within TuningStrategyFactory.cpp.
The following dependencies are removed:
* ActiveHarmony
* Eigen3

## Resolved Issues

- [x] fixes #413 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] locally
- [x] Jenkins
