### PR TITLE
Uses target_compile_features to set cxx_std_17 and cuda_std_14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,16 @@ cmake_policy(SET CMP0079 NEW)
 set(AUTOPAS_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(AUTOPAS_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CUDA_STANDARD 14)
+# starting with cmake 3.17 this is set using target_compile_features.
+if (CMAKE_VERSION VERSION_LESS 3.17)
+    message(
+        STATUS
+            "Setting CMAKE_CXX_STANDARD and CMAKE_CUDA_STANDARD globally because cmake < 3.17 is used."
+    )
+    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CUDA_STANDARD 14)
+endif ()
+
 if (NOT CYGWIN)
     set(CMAKE_CXX_EXTENSIONS OFF)
 endif ()

--- a/cmake/modules/cuda.cmake
+++ b/cmake/modules/cuda.cmake
@@ -42,7 +42,6 @@ if (AUTOPAS_ENABLE_CUDA)
     # cuda as of 10.2 does not support c++17, so set this to 14 here. If cmake < 3.17 is used this
     # is set globally in the top level CMakeLists.txt
     if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
-        message(STATUS "Setting cuda_std_14 via compile features because cmake >= 3.17 is used.")
         target_compile_features(autopas PRIVATE cuda_std_14)
     endif ()
 

--- a/cmake/modules/cuda.cmake
+++ b/cmake/modules/cuda.cmake
@@ -39,6 +39,13 @@ if (AUTOPAS_ENABLE_CUDA)
         file(REMOVE ${CUDAPROGRAM})
     endif ()
 
+    # cuda as of 10.2 does not support c++17, so set this to 14 here. If cmake < 3.17 is used this
+    # is set globally in the top level CMakeLists.txt
+    if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
+        message(STATUS "Setting cuda_std_14 via compile features because cmake >= 3.17 is used.")
+        target_compile_features(autopas PRIVATE cuda_std_14)
+    endif ()
+
     target_compile_options(
         autopas
         PUBLIC

--- a/cmake/modules/other-compileroptions.cmake
+++ b/cmake/modules/other-compileroptions.cmake
@@ -9,6 +9,13 @@ if (AUTOPAS_ENABLE_FAST_MATH)
     )
 endif ()
 
+# autopas requires c++17. If cmake < 3.17 is used this is set globally in the top level
+# CMakeLists.txt
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
+    message(STATUS "Setting cxx_std_17 via compile features because cmake >= 3.17 is used.")
+    target_compile_features(autopas PUBLIC cxx_std_17)
+endif ()
+
 target_compile_options(
     autopas
     PUBLIC

--- a/cmake/modules/other-compileroptions.cmake
+++ b/cmake/modules/other-compileroptions.cmake
@@ -12,7 +12,6 @@ endif ()
 # autopas requires c++17. If cmake < 3.17 is used this is set globally in the top level
 # CMakeLists.txt
 if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
-    message(STATUS "Setting cxx_std_17 via compile features because cmake >= 3.17 is used.")
     target_compile_features(autopas PUBLIC cxx_std_17)
 endif ()
 


### PR DESCRIPTION
# Description
uses target_compile_features to set cxx_std_17 and cuda_std_14.
This affects cmake >= 3.17.

## Resolved Issues

- [x] fixes #276 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] tested locally with cmake 3.17 RC