### PR TITLE
Remove restrictions on Particle constructors 

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -72,7 +72,7 @@ You will not be able to completely compile the unit tests with CUDA without a GP
 
 ### General Notes
 * Try to require as few things from the `Particle` classes and from functors as possible.
-* This includes that we do not make restrictions on the constructors of the Particle class.
+* This includes that we do not make restrictions on the constructors of the Particle class, this is tested with `DifferentParticlesTest`. 
 
 ### Namespaces
 * Code in folder `src` should belong to namespace `autopas`.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -70,7 +70,7 @@ You will not be able to completely compile the unit tests with CUDA without a GP
 
 ## AutoPas
 
-### General Notes
+### Guidelines
 * Try to require as few things from the `Particle` classes and from functors as possible.
 * This includes that we do not make restrictions on the constructors of the Particle class, this is tested with `DifferentParticlesTest`. 
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -69,6 +69,11 @@ docker run -v ${PathToAutoPasRoot}/:/autopas -it autopas/autopas-build-cuda \
 You will not be able to completely compile the unit tests with CUDA without a GPU in your system since CMake will try to run tests during the build process.
 
 ## AutoPas
+
+### General Notes
+* Try to require as few things from the `Particle` classes and from functors as possible.
+* This includes that we do not make restrictions on the constructors of the Particle class.
+
 ### Namespaces
 * Code in folder `src` should belong to namespace `autopas`.
 * Classes which shouldn't be used externally should belong to namespace `internal`.

--- a/src/autopas/cells/FullParticleCell.h
+++ b/src/autopas/cells/FullParticleCell.h
@@ -107,8 +107,9 @@ class FullParticleCell : public ParticleCell<Particle> {
   /**
    * Resizes the container so that it contains n elements.
    * @param n New container size
+   * @param toInsert Particle to insert. This is needed to allow for non-default-constructible particles.
    */
-  void resize(size_t n) { _particles.resize(n); }
+  void resize(size_t n, const Particle &toInsert) { _particles.resize(n, toInsert); }
 
   /**
    * Sort the particles in the cell by a dimension.

--- a/src/autopas/containers/verletClusterLists/ClusterTower.h
+++ b/src/autopas/containers/verletClusterLists/ClusterTower.h
@@ -41,7 +41,7 @@ class ClusterTower : public ParticleCell<Particle> {
   /**
    * A prototype for the dummy particle to use.
    */
-  static const Particle dummy;
+  static inline const Particle dummy{};
 
  public:
   /**
@@ -250,12 +250,5 @@ class ClusterTower : public ParticleCell<Particle> {
    */
   size_t _numDummyParticles{};
 };
-
-// Requires all particle classes to have a constructor that takes position, velocity, and id
-template <class Particle, size_t clusterSize>
-const Particle ClusterTower<Particle, clusterSize>::dummy{
-    {std::numeric_limits<double>::max(), std::numeric_limits<double>::max(), std::numeric_limits<double>::max()},
-    {0, 0, 0},
-    0};
 
 }  // namespace autopas::internal

--- a/src/autopas/containers/verletClusterLists/ClusterTower.h
+++ b/src/autopas/containers/verletClusterLists/ClusterTower.h
@@ -136,7 +136,8 @@ class ClusterTower : public ParticleCell<Particle> {
    */
   std::vector<Particle> &&collectAllActualParticles() {
     if (not _particles._particles.empty()) {
-      // workaround to remove requirement of default constructible particles.
+      // Workaround to remove requirement of default constructible particles.
+      // This function will always only shrink the array, particles are not actually inserted.
       _particles._particles.resize(getNumActualParticles(), _particles._particles[0]);
     }
     return std::move(_particles._particles);

--- a/src/autopas/containers/verletClusterLists/ClusterTower.h
+++ b/src/autopas/containers/verletClusterLists/ClusterTower.h
@@ -38,11 +38,6 @@ namespace autopas::internal {
  */
 template <class Particle, size_t clusterSize>
 class ClusterTower : public ParticleCell<Particle> {
-  /**
-   * A prototype for the dummy particle to use.
-   */
-  static inline const Particle dummy{};
-
  public:
   /**
    * Adds a particle to the cluster tower. If generateClusters() has already been called on this ClusterTower, clear()
@@ -103,8 +98,9 @@ class ClusterTower : public ParticleCell<Particle> {
   void fillUpWithDummyParticles(double dummyStartX, double dummyDistZ) {
     auto &lastCluster = getCluster(getNumClusters() - 1);
     for (size_t index = 1; index <= _numDummyParticles; index++) {
-      lastCluster[clusterSize - index] = dummy;
+      lastCluster[clusterSize - index] = lastCluster[0];  // use first Particle in last cluster as dummy particle!
       lastCluster[clusterSize - index].setR({dummyStartX, 0, dummyDistZ * index});
+      lastCluster[clusterSize - index].setID(std::numeric_limits<size_t>::max());
     }
   }
 
@@ -139,7 +135,10 @@ class ClusterTower : public ParticleCell<Particle> {
    * @return
    */
   std::vector<Particle> &&collectAllActualParticles() {
-    _particles._particles.resize(getNumActualParticles());
+    if (not _particles._particles.empty()) {
+      // workaround to remove requirement of default constructible particles.
+      _particles._particles.resize(getNumActualParticles(), _particles._particles[0]);
+    }
     return std::move(_particles._particles);
   }
 

--- a/src/autopas/containers/verletClusterLists/VerletClusterCells.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterCells.h
@@ -97,8 +97,10 @@ class VerletClusterCells : public ParticleContainer<FullParticleCell<Particle>> 
   void addParticleImpl(const Particle &p) override {
     if (autopas::utils::inBox(p.getR(), this->getBoxMin(), this->getBoxMax())) {
       _isValid = false;
-      // removes dummy particles in first cell
-      this->_cells[0].resize(_dummyStarts[0]);
+      // removes dummy particles in first cell, if the cell is not empty!
+      if (this->_cells[0].begin().isValid()) {
+        this->_cells[0].resize(_dummyStarts[0], *(this->_cells[0].begin()));
+      }
       // add particle somewhere, because lists will be rebuild anyways
       this->_cells[0].addParticle(p);
       ++_dummyStarts[0];
@@ -115,8 +117,10 @@ class VerletClusterCells : public ParticleContainer<FullParticleCell<Particle>> 
     Particle p_copy = haloParticle;
     if (autopas::utils::notInBox(p_copy.getR(), this->getBoxMin(), this->getBoxMax())) {
       _isValid = false;
-      // removes dummy particles in first cell
-      this->_cells[0].resize(_dummyStarts[0]);
+      // removes dummy particles in first cell, if the cell is not empty!
+      if (this->_cells[0].begin().isValid()) {
+        this->_cells[0].resize(_dummyStarts[0], *(this->_cells[0].begin()));
+      }
       p_copy.setOwned(false);
       // add particle somewhere, because lists will be rebuild anyways
       this->_cells[0].addParticle(p_copy);
@@ -352,7 +356,10 @@ class VerletClusterCells : public ParticleContainer<FullParticleCell<Particle>> 
    */
   void deleteDummyParticles() {
     for (size_t i = 0; i < this->_cells.size(); ++i) {
-      this->_cells[i].resize(_dummyStarts[i]);
+      // removes dummy particles in first cell, if the cell is not empty!
+      if (this->_cells[i].begin().isValid()) {
+        this->_cells[i].resize(_dummyStarts[i], *(this->_cells[i].begin()));
+      }
     }
     _isValid = false;
   }
@@ -433,19 +440,19 @@ class VerletClusterCells : public ParticleContainer<FullParticleCell<Particle>> 
       const auto numParticles = this->_cells[i].numParticles();
 
       _dummyStarts[i] = numParticles;
-      unsigned int numDummys = _clusterSize;
-      if (numParticles > 0) {
-        numDummys -= (numParticles % (size_t)_clusterSize);
-      }
+      auto sizeLastCluster = (numParticles % _clusterSize);
+      unsigned int numDummys = sizeLastCluster != 0 ? _clusterSize - sizeLastCluster : 0;
 
-      Particle dummyParticle = Particle();
-      for (unsigned int j = 0; j < numDummys; ++j) {
-        dummyParticle.setR({_boxMaxWithHalo[0] + 8 * this->getInteractionLength() + static_cast<double>(i),
-                            _boxMaxWithHalo[1] + 8 * this->getInteractionLength() + static_cast<double>(j),
-                            _boxMaxWithHalo[2] + 8 * this->getInteractionLength()});
-        dummyParticle.setID(std::numeric_limits<size_t>::max());
-        dummyParticle.setOwned(false);
-        this->_cells[i].addParticle(dummyParticle);
+      if (numDummys != 0) {
+        Particle dummyParticle = *(this->_cells[i].begin());
+        for (unsigned int j = 0; j < numDummys; ++j) {
+          dummyParticle.setR({_boxMaxWithHalo[0] + 8 * this->getInteractionLength() + static_cast<double>(i),
+                              _boxMaxWithHalo[1] + 8 * this->getInteractionLength() + static_cast<double>(j),
+                              _boxMaxWithHalo[2] + 8 * this->getInteractionLength()});
+          dummyParticle.setID(std::numeric_limits<size_t>::max());
+          dummyParticle.setOwned(false);
+          this->_cells[i].addParticle(dummyParticle);
+        }
       }
     }
 

--- a/src/autopas/containers/verletClusterLists/VerletClusterCells.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterCells.h
@@ -97,10 +97,7 @@ class VerletClusterCells : public ParticleContainer<FullParticleCell<Particle>> 
   void addParticleImpl(const Particle &p) override {
     if (autopas::utils::inBox(p.getR(), this->getBoxMin(), this->getBoxMax())) {
       _isValid = false;
-      // removes dummy particles in first cell, if the cell is not empty!
-      if (this->_cells[0].begin().isValid()) {
-        this->_cells[0].resize(_dummyStarts[0], *(this->_cells[0].begin()));
-      }
+      removeDummiesFromFirstCell();
       // add particle somewhere, because lists will be rebuild anyways
       this->_cells[0].addParticle(p);
       ++_dummyStarts[0];
@@ -117,10 +114,7 @@ class VerletClusterCells : public ParticleContainer<FullParticleCell<Particle>> 
     Particle p_copy = haloParticle;
     if (autopas::utils::notInBox(p_copy.getR(), this->getBoxMin(), this->getBoxMax())) {
       _isValid = false;
-      // removes dummy particles in first cell, if the cell is not empty!
-      if (this->_cells[0].begin().isValid()) {
-        this->_cells[0].resize(_dummyStarts[0], *(this->_cells[0].begin()));
-      }
+      removeDummiesFromFirstCell();
       p_copy.setOwned(false);
       // add particle somewhere, because lists will be rebuild anyways
       this->_cells[0].addParticle(p_copy);
@@ -500,6 +494,17 @@ class VerletClusterCells : public ParticleContainer<FullParticleCell<Particle>> 
     }
     return true;
   }
+
+  /**
+   * Removes dummy particles from the first cell.
+   */
+  void removeDummiesFromFirstCell() {
+    // removes dummy particles in first cell, if the cell is not empty!
+    if (this->_cells[0].begin().isValid()) {
+      this->_cells[0].resize(_dummyStarts[0], *(this->_cells[0].begin()));
+    }
+  }
+
   std::array<double, 3> _boxMinWithHalo, _boxMaxWithHalo;
 
   /// indices where dummy particles in the cells start

--- a/src/autopas/containers/verletClusterLists/traversals/VerletClusterCellsTraversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VerletClusterCellsTraversal.h
@@ -335,6 +335,7 @@ class VerletClusterCellsTraversal : public CellPairTraversal<ParticleCell>,
     }
 
     auto cudaSoA = _functor->createFunctorCudaSoA(_storageCell._particleSoABufferDevice);
+    // if no particles exist no need to call a traversal
     if (auto numParticlesInSoA = _storageCell._particleSoABuffer.getNumParticles(); numParticlesInSoA != 0) {
       if (useNewton3) {
         _functor->getCudaWrapper()->CellVerletTraversalN3Wrapper(cudaSoA.get(), numParticlesInSoA / _clusterSize,

--- a/src/autopas/containers/verletClusterLists/traversals/VerletClusterCellsTraversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VerletClusterCellsTraversal.h
@@ -335,17 +335,18 @@ class VerletClusterCellsTraversal : public CellPairTraversal<ParticleCell>,
     }
 
     auto cudaSoA = _functor->createFunctorCudaSoA(_storageCell._particleSoABufferDevice);
-
-    if (useNewton3) {
-      _functor->getCudaWrapper()->CellVerletTraversalN3Wrapper(
-          cudaSoA.get(), _storageCell._particleSoABuffer.getNumParticles() / _clusterSize, _clusterSize,
-          *_neighborMatrixDim, _neighborMatrix->get(), 0);
-    } else {
-      _functor->getCudaWrapper()->CellVerletTraversalNoN3Wrapper(
-          cudaSoA.get(), _storageCell._particleSoABuffer.getNumParticles() / _clusterSize, _clusterSize,
-          *_neighborMatrixDim, _neighborMatrix->get(), 0);
+    if (auto numParticlesInSoA = _storageCell._particleSoABuffer.getNumParticles(); numParticlesInSoA != 0) {
+      if (useNewton3) {
+        _functor->getCudaWrapper()->CellVerletTraversalN3Wrapper(cudaSoA.get(), numParticlesInSoA / _clusterSize,
+                                                                 _clusterSize, *_neighborMatrixDim,
+                                                                 _neighborMatrix->get(), 0);
+      } else {
+        _functor->getCudaWrapper()->CellVerletTraversalNoN3Wrapper(cudaSoA.get(), numParticlesInSoA / _clusterSize,
+                                                                   _clusterSize, *_neighborMatrixDim,
+                                                                   _neighborMatrix->get(), 0);
+      }
+      utils::CudaExceptionHandler::checkErrorCode(cudaDeviceSynchronize());
     }
-    utils::CudaExceptionHandler::checkErrorCode(cudaDeviceSynchronize());
 #else
     utils::ExceptionHandler::exception("VerletClusterCellsTraversal was compiled without Cuda support");
 #endif

--- a/tests/testAutopas/tests/autopasInterface/DifferentParticlesTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/DifferentParticlesTest.cpp
@@ -10,48 +10,28 @@
 #include "testingHelpers/commonTypedefs.h"
 
 /**
- * A particle class with only a default constructor.
+ * A particle class without an actual constructor (only copy, etc.).
  */
-class OnlyDefaultConstructibleParticle : public Particle {
+class NonConstructibleParticle : public Particle {
  public:
   /**
    * Default constructor.
    */
-  OnlyDefaultConstructibleParticle() = default;
+  NonConstructibleParticle() = default;
 };
 
 /**
- * Tests if AutoPas still compiles with a Particle that implements the normal interface, BUT implements a different
- * compiler.
+ * Tests if AutoPas still compiles with a Particle that implements the normal interface, BUT no constructor.
  */
-TEST_F(DifferentParticlesTest, testOnlyDefaultConstructibleParticle) {
-  autopas::AutoPas<OnlyDefaultConstructibleParticle, autopas::FullParticleCell<OnlyDefaultConstructibleParticle>>
-      autoPas;
+TEST_F(DifferentParticlesTest, testNonConstructibleParticle) {
+  autopas::AutoPas<NonConstructibleParticle, autopas::FullParticleCell<NonConstructibleParticle>> autoPas;
   autoPas.setBoxMin({0., 0., 0.});
   autoPas.setBoxMax({10., 10., 10.});
   autoPas.setCutoff(1.);
   autoPas.init();
-}
 
-/**
- * A particle class with only a non-default constructor.
- */
-class NonDefaultConstructibleParticle : public Particle {
- public:
-  /**
-   * Non-default constructor.
-   */
-  NonDefaultConstructibleParticle(int, int){};
-};
-
-/**
- * Tests if AutoPas still compiles with a Particle that implements the normal interface, BUT implements a different
- * compiler.
- */
-TEST_F(DifferentParticlesTest, testNonDefaultConstructibleParticle) {
-  autopas::AutoPas<NonDefaultConstructibleParticle, autopas::FullParticleCell<NonDefaultConstructibleParticle>> autoPas;
-  autoPas.setBoxMin({0., 0., 0.});
-  autoPas.setBoxMax({10., 10., 10.});
-  autoPas.setCutoff(1.);
-  autoPas.init();
+  // We also check if iteratePairwise can be instantiated.
+  MockFunctor<NonConstructibleParticle, autopas::FullParticleCell<NonConstructibleParticle>> functor;
+  EXPECT_CALL(functor, isRelevantForTuning()).WillRepeatedly(::testing::Return(false));
+  autoPas.iteratePairwise(&functor);
 }

--- a/tests/testAutopas/tests/autopasInterface/DifferentParticlesTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/DifferentParticlesTest.cpp
@@ -1,0 +1,57 @@
+/**
+ * @file DifferentParticlesTest.cpp
+ * @author seckler
+ * @date 20.02.2020
+ */
+
+#include "DifferentParticlesTest.h"
+
+#include "autopas/AutoPas.h"
+#include "testingHelpers/commonTypedefs.h"
+
+/**
+ * A particle class with only a default constructor.
+ */
+class OnlyDefaultConstructibleParticle : public Particle {
+ public:
+  /**
+   * Default constructor.
+   */
+  OnlyDefaultConstructibleParticle() = default;
+};
+
+/**
+ * Tests if AutoPas still compiles with a Particle that implements the normal interface, BUT implements a different
+ * compiler.
+ */
+TEST_F(DifferentParticlesTest, testOnlyDefaultConstructibleParticle) {
+  autopas::AutoPas<OnlyDefaultConstructibleParticle, autopas::FullParticleCell<OnlyDefaultConstructibleParticle>>
+      autoPas;
+  autoPas.setBoxMin({0., 0., 0.});
+  autoPas.setBoxMax({10., 10., 10.});
+  autoPas.setCutoff(1.);
+  autoPas.init();
+}
+
+/**
+ * A particle class with only a non-default constructor.
+ */
+class NonDefaultConstructibleParticle : public Particle {
+ public:
+  /**
+   * Non-default constructor.
+   */
+  NonDefaultConstructibleParticle(int, int){};
+};
+
+/**
+ * Tests if AutoPas still compiles with a Particle that implements the normal interface, BUT implements a different
+ * compiler.
+ */
+TEST_F(DifferentParticlesTest, testNonDefaultConstructibleParticle) {
+  autopas::AutoPas<NonDefaultConstructibleParticle, autopas::FullParticleCell<NonDefaultConstructibleParticle>> autoPas;
+  autoPas.setBoxMin({0., 0., 0.});
+  autoPas.setBoxMax({10., 10., 10.});
+  autoPas.setCutoff(1.);
+  autoPas.init();
+}

--- a/tests/testAutopas/tests/autopasInterface/DifferentParticlesTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/DifferentParticlesTest.cpp
@@ -25,9 +25,7 @@ class NonConstructibleParticle : public Particle {
  */
 TEST_F(DifferentParticlesTest, testNonConstructibleParticle) {
   autopas::AutoPas<NonConstructibleParticle, autopas::FullParticleCell<NonConstructibleParticle>> autoPas;
-  autoPas.setBoxMin({0., 0., 0.});
   autoPas.setBoxMax({10., 10., 10.});
-  autoPas.setCutoff(1.);
   autoPas.init();
 
   // We also check if iteratePairwise can be instantiated.

--- a/tests/testAutopas/tests/autopasInterface/DifferentParticlesTest.h
+++ b/tests/testAutopas/tests/autopasInterface/DifferentParticlesTest.h
@@ -1,0 +1,11 @@
+/**
+ * @file DifferentParticlesTest.h
+ * @author seckler
+ * @date 20.02.2020
+ */
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+class DifferentParticlesTest : public testing::Test {};

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterTowerTest.cpp
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterTowerTest.cpp
@@ -57,12 +57,12 @@ static void testClusterGenerationAndDummies() {
 
     // Skip generating neighbor lists
 
-    // Check if dummy particles are filled in correctly. (Dummy particles always have ID 0, filled up particles have
-    // ID>0.
+    // Check if dummy particles are filled in correctly. (Dummy particles always have ID
+    // std::numeric_limits<size_t>::max(), filled up particles have ID>0.
     tower.fillUpWithDummyParticles(0, 0);
     const auto &lastCluster = tower.getCluster(tower.getNumClusters() - 1);
     for (size_t i = 1; i <= tower.getNumDummyParticles(); i++) {
-      EXPECT_EQ(lastCluster[clusterSize - i].getID(), 0);
+      EXPECT_EQ(lastCluster[clusterSize - i].getID(), std::numeric_limits<size_t>::max());
     }
   }
 }


### PR DESCRIPTION
# Description

Removes all restrictions on constructors of the Particle classes.
AutoPas now works with non-default constructible particles and thus will never call any real constructor of a particle.
The copy constructor is, however, required!

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Adds a test that checks that AutoPas works with Particles that do not provide any real constructors (except for copy, move, ...)
