### PR TITLE
Remove unneeded includes from Bayesian and FullSearch

### DIFF
--- a/src/autopas/selectors/tuningStrategy/BayesianSearch.h
+++ b/src/autopas/selectors/tuningStrategy/BayesianSearch.h
@@ -13,7 +13,7 @@
 
 #include "GaussianProcess.h"
 #include "TuningStrategyInterface.h"
-#include "autopas/selectors/ContainerSelector.h"
+#include "autopas/containers/CompatibleTraversals.h"
 #include "autopas/selectors/FeatureVector.h"
 #include "autopas/utils/ExceptionHandler.h"
 #include "autopas/utils/NumberSet.h"

--- a/src/autopas/selectors/tuningStrategy/FullSearch.h
+++ b/src/autopas/selectors/tuningStrategy/FullSearch.h
@@ -10,7 +10,7 @@
 #include <sstream>
 
 #include "TuningStrategyInterface.h"
-#include "autopas/selectors/ContainerSelector.h"
+#include "autopas/containers/CompatibleTraversals.h"
 #include "autopas/selectors/OptimumSelector.h"
 #include "autopas/utils/ExceptionHandler.h"
 

--- a/src/autopas/utils/NumberSet.h
+++ b/src/autopas/utils/NumberSet.h
@@ -10,7 +10,6 @@
 #include <sstream>
 #include <vector>
 
-#include "autopas/utils/ArrayUtils.h"
 #include "autopas/utils/ExceptionHandler.h"
 #include "autopas/utils/Random.h"
 

--- a/src/autopas/utils/NumberSetFinite.h
+++ b/src/autopas/utils/NumberSetFinite.h
@@ -8,6 +8,7 @@
 
 #include <set>
 
+#include "ArrayUtils.h"
 #include "NumberSet.h"
 
 namespace autopas {


### PR DESCRIPTION
# Description

I was wondering, why the TuningsStrategyFactory was always rebuilt, this fixes that.

