### PR TITLE
fix errors in StaticSelectors.h

### DIFF
--- a/src/autopas/utils/StaticSelectors.h
+++ b/src/autopas/utils/StaticSelectors.h
@@ -10,7 +10,7 @@
 
 #include "autopas/containers/directSum/DirectSum.h"
 #include "autopas/containers/linkedCells/LinkedCells.h"
-#include "autopas/containers/verletClusterLists/VerletClusterCells.h"
+#include "autopas/containers/verletClusterCells/VerletClusterCells.h"
 #include "autopas/containers/verletClusterLists/VerletClusterLists.h"
 #include "autopas/containers/verletListsCellBased/verletLists/VerletLists.h"
 #include "autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h"
@@ -33,7 +33,7 @@ void withStaticContainerType(std::shared_ptr<ParticleContainer<Particle, Particl
   auto container_ptr = container.get();
   switch (container->getContainerType()) {
     case ContainerOption::directSum:
-      function(dynamic_cast<autopas::DirectSum<Particle, ParticleCell> *>(container_ptr));
+      function(dynamic_cast<autopas::DirectSum<ParticleCell> *>(container_ptr));
       return;
     case ContainerOption::linkedCells:
       function(dynamic_cast<autopas::LinkedCells<Particle, ParticleCell> *>(container_ptr));


### PR DESCRIPTION
# Description
The StaticSelectors.h class had one wrong path to VerletCell and one DirectSum was given two templates but takes only one. 

## Related Pull Requests

- none

## Resolved Issues

- none

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] IDE warnings gone
- [x] Not used for build anyways
