### PR TITLE
Bunch of minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,18 @@
+# cmake stuff
 cmake-build-*/
+CMakeLists.txt.user
+cmake.check_cache
 build*/
+*compile_commands.json
+
+# editor stuff
 *.swp
 .idea/
 venv/
 *.timestamp
-CMakeLists.txt.user
-cmake.check_cache
 *.synctex.gz
+
+# benchmark output folder
 *testTuning_*/
-*compile_commands.json
+*measurePerf_*/
 

--- a/examples/md-flexible/Simulation.h
+++ b/examples/md-flexible/Simulation.h
@@ -139,7 +139,7 @@ class Simulation {
    * Getter for ParticlePropertiesLibrary of Simulation.
    * @return unique_prt(ParticlePropertiesLibrary)
    */
-  const std::unique_ptr<ParticlePropertiesLibrary<double, size_t>> &getPpl() const;
+  [[nodiscard]] const std::unique_ptr<ParticlePropertiesLibrary<double, size_t>> &getPpl() const;
 
  private:
   using AutoPasType = autopas::AutoPas<Particle, ParticleCell>;

--- a/examples/md-flexible/Simulation.h
+++ b/examples/md-flexible/Simulation.h
@@ -48,61 +48,7 @@ class Simulation {
    * @param numParticles
    * @param autopas
    */
-  void writeVTKFile(unsigned int iteration) {
-    _timers.vtk.start();
-
-    std::string fileBaseName = _config->vtkFileName;
-    // only count number of owned particles here
-    const auto numParticles = this->_autopas.getNumberOfParticles(autopas::IteratorBehavior::ownedOnly);
-    std::ostringstream strstr;
-    auto maxNumDigits = std::to_string(_config->iterations).length();
-    strstr << fileBaseName << "_" << std::setfill('0') << std::setw(maxNumDigits) << iteration << ".vtk";
-    std::ofstream vtkFile;
-    vtkFile.open(strstr.str());
-
-    vtkFile << "# vtk DataFile Version 2.0" << std::endl;
-    vtkFile << "Timestep" << std::endl;
-    vtkFile << "ASCII" << std::endl;
-
-    // print positions
-    vtkFile << "DATASET STRUCTURED_GRID" << std::endl;
-    vtkFile << "DIMENSIONS 1 1 1" << std::endl;
-    vtkFile << "POINTS " << numParticles << " double" << std::endl;
-    for (auto iter = _autopas.begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
-      auto pos = iter->getR();
-      vtkFile << pos[0] << " " << pos[1] << " " << pos[2] << std::endl;
-    }
-    vtkFile << std::endl;
-
-    vtkFile << "POINT_DATA " << numParticles << std::endl;
-    // print velocities
-    vtkFile << "VECTORS velocities double" << std::endl;
-    for (auto iter = _autopas.begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
-      auto v = iter->getV();
-      vtkFile << v[0] << " " << v[1] << " " << v[2] << std::endl;
-    }
-    vtkFile << std::endl;
-
-    // print Forces
-    vtkFile << "VECTORS forces double" << std::endl;
-    for (auto iter = _autopas.begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
-      auto f = iter->getF();
-      vtkFile << f[0] << " " << f[1] << " " << f[2] << std::endl;
-    }
-    vtkFile << std::endl;
-
-    // print TypeIDs
-    vtkFile << "SCALARS typeIds int" << std::endl;
-    vtkFile << "LOOKUP_TABLE default" << std::endl;
-    for (auto iter = _autopas.begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
-      vtkFile << iter->getTypeId() << std::endl;
-    }
-    vtkFile << std::endl;
-
-    vtkFile.close();
-
-    _timers.vtk.stop();
-  }
+  void writeVTKFile(unsigned int iteration, autopas::AutoPas<Particle, ParticleCell> &autopas);
 
   /**
    * Initializes the ParticlePropertiesLibrary with properties from _config.
@@ -113,27 +59,30 @@ class Simulation {
    * Initializes the AutoPas Object with the given config and initializes the simulation domain with the Object
    * Generators.
    */
-  void initialize(const MDFlexConfig &mdFlexConfig);
+  void initialize(const MDFlexConfig &mdFlexConfig, autopas::AutoPas<Particle, ParticleCell> &autopas);
 
   /**
    * Calculates the pairwise forces in the system and measures the runtime.
    * @tparam Force Calculation Functor
+   * @param autopas
    */
   template <class FunctorType>
-  void calculateForces();
+  void calculateForces(autopas::AutoPas<Particle, ParticleCell> &autopas);
 
   /**
    * This function processes the main simulation loop
    * -calls the time discretization class(calculate fores, etc ...)
    * -do the output each timestep
    * -collects the duration of every Calculation(Position,Force,Velocity)
+   * @param autopas
    */
-  void simulate();
+  void simulate(autopas::AutoPas<Particle, ParticleCell> &autopas);
 
   /**
    * Prints statistics like duration of calculation etc of the Simulation.
+   * @param autopas
    */
-  void printStatistics();
+  void printStatistics(autopas::AutoPas<Particle, ParticleCell> &autopas);
 
   /**
    * Getter for ParticlePropertiesLibrary of Simulation.
@@ -142,14 +91,11 @@ class Simulation {
   [[nodiscard]] const std::unique_ptr<ParticlePropertiesLibrary<double, size_t>> &getPpl() const;
 
  private:
-  using AutoPasType = autopas::AutoPas<Particle, ParticleCell>;
   using ParticlePropertiesLibraryType = ParticlePropertiesLibrary<double, size_t>;
   constexpr static bool _shifting = true;
   constexpr static bool _mixing = true;
 
-  AutoPasType _autopas;
   std::shared_ptr<MDFlexConfig> _config;
-  std::ofstream _logFile;
   std::unique_ptr<ParticlePropertiesLibraryType> _particlePropertiesLibrary;
 
   struct timers {
@@ -193,67 +139,57 @@ void Simulation<Particle, ParticleCell>::initializeParticlePropertiesLibrary() {
 }
 
 template <class Particle, class ParticleCell>
-void Simulation<Particle, ParticleCell>::initialize(const MDFlexConfig &mdFlexConfig) {
+void Simulation<Particle, ParticleCell>::initialize(const MDFlexConfig &mdFlexConfig,
+                                                    autopas::AutoPas<Particle, ParticleCell> &autopas) {
   _timers.init.start();
 
   _config = std::make_shared<MDFlexConfig>(mdFlexConfig);
   initializeParticlePropertiesLibrary();
-  auto logFileName(_config->logFileName);
 
-  // select either std::out or a logfile for autopas log output.
-  // This does not affect md-flex output.
-  std::streambuf *streamBuf;
-  if (logFileName.empty()) {
-    streamBuf = std::cout.rdbuf();
-  } else {
-    _logFile.open(logFileName);
-    streamBuf = _logFile.rdbuf();
-  }
-  std::ostream outputStream(streamBuf);
-  _autopas.setAllowedCellSizeFactors(*_config->cellSizeFactors);
-  _autopas.setAllowedContainers(_config->containerOptions);
-  _autopas.setAllowedDataLayouts(_config->dataLayoutOptions);
-  _autopas.setAllowedNewton3Options(_config->newton3Options);
-  _autopas.setAllowedTraversals(_config->traversalOptions);
-  _autopas.setBoxMax(_config->boxMax);
-  _autopas.setBoxMin(_config->boxMin);
-  _autopas.setCutoff(_config->cutoff);
-  _autopas.setNumSamples(_config->tuningSamples);
-  _autopas.setSelectorStrategy(_config->selectorStrategy);
-  _autopas.setTuningInterval(_config->tuningInterval);
-  _autopas.setTuningStrategyOption(_config->tuningStrategyOption);
-  _autopas.setVerletClusterSize(_config->verletClusterSize);
-  _autopas.setVerletRebuildFrequency(_config->verletRebuildFrequency);
-  _autopas.setVerletSkin(_config->verletSkinRadius);
+  autopas.setAllowedCellSizeFactors(*_config->cellSizeFactors);
+  autopas.setAllowedContainers(_config->containerOptions);
+  autopas.setAllowedDataLayouts(_config->dataLayoutOptions);
+  autopas.setAllowedNewton3Options(_config->newton3Options);
+  autopas.setAllowedTraversals(_config->traversalOptions);
+  autopas.setBoxMax(_config->boxMax);
+  autopas.setBoxMin(_config->boxMin);
+  autopas.setCutoff(_config->cutoff);
+  autopas.setNumSamples(_config->tuningSamples);
+  autopas.setSelectorStrategy(_config->selectorStrategy);
+  autopas.setTuningInterval(_config->tuningInterval);
+  autopas.setTuningStrategyOption(_config->tuningStrategyOption);
+  autopas.setVerletClusterSize(_config->verletClusterSize);
+  autopas.setVerletRebuildFrequency(_config->verletRebuildFrequency);
+  autopas.setVerletSkin(_config->verletSkinRadius);
   autopas::Logger::get()->set_level(_config->logLevel);
-  _autopas.init();
+  autopas.init();
 
   // load checkpoint
   if (not _config->checkpointfile.empty()) {
-    Checkpoint::loadParticles(_autopas, _config->checkpointfile);
+    Checkpoint::loadParticles(autopas, _config->checkpointfile);
   }
 
   // initializing Objects
   for (const auto &grid : _config->cubeGridObjects) {
-    Generator::cubeGrid<Particle, ParticleCell>(_autopas, grid);
+    Generator::cubeGrid<Particle, ParticleCell>(autopas, grid);
   }
   for (const auto &cube : _config->cubeGaussObjects) {
-    Generator::cubeGauss<Particle, ParticleCell>(_autopas, cube);
+    Generator::cubeGauss<Particle, ParticleCell>(autopas, cube);
   }
   for (const auto &cube : _config->cubeUniformObjects) {
-    Generator::cubeRandom<Particle, ParticleCell>(_autopas, cube);
+    Generator::cubeRandom<Particle, ParticleCell>(autopas, cube);
   }
   for (const auto &sphere : _config->sphereObjects) {
-    Generator::sphere<Particle, ParticleCell>(_autopas, sphere);
+    Generator::sphere<Particle, ParticleCell>(autopas, sphere);
   }
 
   // initializing system to initial temperature and Brownian motion
   if (_config->useThermostat and _config->deltaT != 0) {
     if (_config->addBrownianMotion) {
-      Thermostat::addBrownianMotion(_autopas, *_particlePropertiesLibrary, _config->initTemperature);
+      Thermostat::addBrownianMotion(autopas, *_particlePropertiesLibrary, _config->initTemperature);
     }
     // set system to initial temperature
-    Thermostat::apply(_autopas, *_particlePropertiesLibrary, _config->initTemperature,
+    Thermostat::apply(autopas, *_particlePropertiesLibrary, _config->initTemperature,
                       std::numeric_limits<double>::max());
   }
 
@@ -262,11 +198,11 @@ void Simulation<Particle, ParticleCell>::initialize(const MDFlexConfig &mdFlexCo
 
 template <class Particle, class ParticleCell>
 template <class FunctorType>
-void Simulation<Particle, ParticleCell>::calculateForces() {
+void Simulation<Particle, ParticleCell>::calculateForces(autopas::AutoPas<Particle, ParticleCell> &autopas) {
   _timers.forceUpdateTotal.start();
 
-  FunctorType functor{_autopas.getCutoff(), *_particlePropertiesLibrary};
-  bool tuningIteration = _autopas.iteratePairwise(&functor);
+  FunctorType functor{autopas.getCutoff(), *_particlePropertiesLibrary};
+  bool tuningIteration = autopas.iteratePairwise(&functor);
   // only generate this output if the logger is set to debug
   if (autopas::Logger::get()->level() <= autopas::Logger::LogLevel::debug) {
     std::cout << "Tuning: " << std::boolalpha << tuningIteration << std::endl;
@@ -282,7 +218,7 @@ void Simulation<Particle, ParticleCell>::calculateForces() {
 }
 
 template <class Particle, class ParticleCell>
-void Simulation<Particle, ParticleCell>::simulate() {
+void Simulation<Particle, ParticleCell>::simulate(autopas::AutoPas<Particle, ParticleCell> &autopas) {
   _timers.simulate.start();
 
   // main simulation loop
@@ -294,18 +230,18 @@ void Simulation<Particle, ParticleCell>::simulate() {
     if (_config->deltaT != 0) {
       // only write vtk files periodically and if a filename is given.
       if ((not _config->vtkFileName.empty()) and iteration % _config->vtkWriteFrequency == 0) {
-        this->writeVTKFile(iteration);
+        this->writeVTKFile(iteration, autopas);
       }
 
       // calculate new positions
       _timers.positionUpdate.start();
-      TimeDiscretization::calculatePositions(_autopas, *_particlePropertiesLibrary, _config->deltaT);
+      TimeDiscretization::calculatePositions(autopas, *_particlePropertiesLibrary, _config->deltaT);
       _timers.positionUpdate.stop();
 
       // apply boundary conditions AFTER the position update!
       if (_config->periodic) {
         _timers.boundaries.start();
-        BoundaryConditions<ParticleCell>::applyPeriodic(_autopas);
+        BoundaryConditions<ParticleCell>::applyPeriodic(autopas);
         _timers.boundaries.stop();
       } else {
         throw std::runtime_error(
@@ -315,16 +251,16 @@ void Simulation<Particle, ParticleCell>::simulate() {
     }
     switch (this->_config->functorOption) {
       case MDFlexConfig::FunctorOption::lj12_6: {
-        this->calculateForces<autopas::LJFunctor<Particle, ParticleCell, _shifting, _mixing>>();
+        this->calculateForces<autopas::LJFunctor<Particle, ParticleCell, _shifting, _mixing>>(autopas);
         break;
       }
       case MDFlexConfig::FunctorOption::lj12_6_Globals: {
         this->calculateForces<autopas::LJFunctor<Particle, ParticleCell, _shifting, _mixing,
-                                                 autopas::FunctorN3Modes::Both, /* globals */ true>>();
+                                                 autopas::FunctorN3Modes::Both, /* globals */ true>>(autopas);
         break;
       }
       case MDFlexConfig::FunctorOption::lj12_6_AVX: {
-        this->calculateForces<autopas::LJFunctorAVX<Particle, ParticleCell, _shifting, _mixing>>();
+        this->calculateForces<autopas::LJFunctorAVX<Particle, ParticleCell, _shifting, _mixing>>(autopas);
         break;
       }
     }
@@ -334,13 +270,13 @@ void Simulation<Particle, ParticleCell>::simulate() {
 
     if (_config->deltaT != 0) {
       _timers.velocityUpdate.start();
-      TimeDiscretization::calculateVelocities(_autopas, *_particlePropertiesLibrary, _config->deltaT);
+      TimeDiscretization::calculateVelocities(autopas, *_particlePropertiesLibrary, _config->deltaT);
       _timers.velocityUpdate.stop();
 
       // applying Velocity scaling with Thermostat:
       if (_config->useThermostat and (iteration % _config->thermostatInterval) == 0) {
         _timers.thermostat.start();
-        Thermostat::apply(_autopas, *_particlePropertiesLibrary, _config->targetTemperature, _config->deltaTemp);
+        Thermostat::apply(autopas, *_particlePropertiesLibrary, _config->targetTemperature, _config->deltaTemp);
         _timers.thermostat.stop();
       }
     }
@@ -349,22 +285,22 @@ void Simulation<Particle, ParticleCell>::simulate() {
   // update temperature for generated config output
   if (_config->useThermostat) {
     _timers.thermostat.start();
-    _config->initTemperature = Thermostat::calcTemperature(_autopas, *_particlePropertiesLibrary);
+    _config->initTemperature = Thermostat::calcTemperature(autopas, *_particlePropertiesLibrary);
     _timers.thermostat.stop();
   }
 
   // writes final state of the simulation
   if ((not _config->vtkFileName.empty())) {
-    this->writeVTKFile(_config->iterations);
+    this->writeVTKFile(_config->iterations, autopas);
   }
 
   _timers.simulate.stop();
 }
 
 template <class Particle, class ParticleCell>
-void Simulation<Particle, ParticleCell>::printStatistics() {
+void Simulation<Particle, ParticleCell>::printStatistics(autopas::AutoPas<Particle, ParticleCell> &autopas) {
   using namespace std;
-  size_t flopsPerKernelCall;
+  size_t flopsPerKernelCall = 0;
 
   switch (_config->functorOption) {
     case MDFlexConfig::FunctorOption ::lj12_6: {
@@ -393,8 +329,13 @@ void Simulation<Particle, ParticleCell>::printStatistics() {
   auto digitsTimeTotalNS = std::to_string(durationTotal).length();
 
   // Statistics
+  cout << endl;
+  cout << "Total number of particles at end of Simulation: "
+       << autopas.getNumberOfParticles(autopas::IteratorBehavior::haloAndOwned) << endl;
+  cout << "  Owned: " << autopas.getNumberOfParticles(autopas::IteratorBehavior::ownedOnly) << endl;
+  cout << "  Halo : " << autopas.getNumberOfParticles(autopas::IteratorBehavior::haloOnly) << endl;
   cout << fixed << setprecision(_floatStringPrecision);
-  cout << endl << "Measurements:" << endl;
+  cout << "Measurements:" << endl;
   cout << timerToString("Time total      ", durationTotal, digitsTimeTotalNS);
   cout << timerToString("  Initialization", _timers.init.getTotalTime(), digitsTimeTotalNS, durationTotal);
   cout << timerToString("  Simulation    ", durationSimulate, digitsTimeTotalNS, durationTotal);
@@ -414,7 +355,7 @@ void Simulation<Particle, ParticleCell>::printStatistics() {
 
   cout << timerToString("One iteration   ", _timers.simulate.getTotalTime() / numIterations, digitsTimeTotalNS,
                         durationTotal);
-  auto mfups = _autopas.getNumberOfParticles(autopas::IteratorBehavior::ownedOnly) * numIterations /
+  auto mfups = autopas.getNumberOfParticles(autopas::IteratorBehavior::ownedOnly) * numIterations /
                _timers.forceUpdateTotal.getTotalTime() * 1e-9;
   cout << "Tuning iterations: " << numTuningIterations << " / " << numIterations << " = "
        << ((double)numTuningIterations / numIterations * 100) << "%" << endl;
@@ -422,12 +363,12 @@ void Simulation<Particle, ParticleCell>::printStatistics() {
 
   if (_config->dontMeasureFlops) {
     autopas::FlopCounterFunctor<PrintableMolecule, autopas::FullParticleCell<PrintableMolecule>> flopCounterFunctor(
-        _autopas.getCutoff());
-    _autopas.iteratePairwise(&flopCounterFunctor);
+        autopas.getCutoff());
+    autopas.iteratePairwise(&flopCounterFunctor);
 
     auto flops = flopCounterFunctor.getFlops(flopsPerKernelCall) * numIterations;
     // approximation for flops of verlet list generation
-    if (_autopas.getContainerType() == autopas::ContainerOption::verletLists)
+    if (autopas.getContainerType() == autopas::ContainerOption::verletLists)
       flops +=
           flopCounterFunctor.getDistanceCalculations() *
           autopas::FlopCounterFunctor<PrintableMolecule,
@@ -462,4 +403,62 @@ std::string Simulation<Particle, ParticleCell>::timerToString(const std::string 
   }
   ss << std::endl;
   return ss.str();
+}
+
+template <class Particle, class ParticleCell>
+void Simulation<Particle, ParticleCell>::writeVTKFile(unsigned int iteration,
+                                                      autopas::AutoPas<Particle, ParticleCell> &autopas) {
+  _timers.vtk.start();
+
+  std::string fileBaseName = _config->vtkFileName;
+  // only count number of owned particles here
+  const auto numParticles = autopas.getNumberOfParticles(autopas::IteratorBehavior::ownedOnly);
+  std::ostringstream strstr;
+  auto maxNumDigits = std::to_string(_config->iterations).length();
+  strstr << fileBaseName << "_" << std::setfill('0') << std::setw(maxNumDigits) << iteration << ".vtk";
+  std::ofstream vtkFile;
+  vtkFile.open(strstr.str());
+
+  vtkFile << "# vtk DataFile Version 2.0" << std::endl;
+  vtkFile << "Timestep" << std::endl;
+  vtkFile << "ASCII" << std::endl;
+
+  // print positions
+  vtkFile << "DATASET STRUCTURED_GRID" << std::endl;
+  vtkFile << "DIMENSIONS 1 1 1" << std::endl;
+  vtkFile << "POINTS " << numParticles << " double" << std::endl;
+  for (auto iter = autopas.begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
+    auto pos = iter->getR();
+    vtkFile << pos[0] << " " << pos[1] << " " << pos[2] << std::endl;
+  }
+  vtkFile << std::endl;
+
+  vtkFile << "POINT_DATA " << numParticles << std::endl;
+  // print velocities
+  vtkFile << "VECTORS velocities double" << std::endl;
+  for (auto iter = autopas.begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
+    auto v = iter->getV();
+    vtkFile << v[0] << " " << v[1] << " " << v[2] << std::endl;
+  }
+  vtkFile << std::endl;
+
+  // print Forces
+  vtkFile << "VECTORS forces double" << std::endl;
+  for (auto iter = autopas.begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
+    auto f = iter->getF();
+    vtkFile << f[0] << " " << f[1] << " " << f[2] << std::endl;
+  }
+  vtkFile << std::endl;
+
+  // print TypeIDs
+  vtkFile << "SCALARS typeIds int" << std::endl;
+  vtkFile << "LOOKUP_TABLE default" << std::endl;
+  for (auto iter = autopas.begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
+    vtkFile << iter->getTypeId() << std::endl;
+  }
+  vtkFile << std::endl;
+
+  vtkFile.close();
+
+  _timers.vtk.stop();
 }

--- a/examples/md-flexible/main.cpp
+++ b/examples/md-flexible/main.cpp
@@ -8,8 +8,6 @@
 
 #include "PrintableMolecule.h"
 #include "Simulation.h"
-#include "autopas/molecularDynamics/autopasmd.h"
-#include "autopas/utils/MemoryProfiler.h"
 #include "parsing/MDFlexParser.h"
 
 int main(int argc, char **argv) {

--- a/examples/md-flexible/main.cpp
+++ b/examples/md-flexible/main.cpp
@@ -22,18 +22,34 @@ int main(int argc, char **argv) {
   // make sure sim box is big enough
   config.calcSimulationBox();
 
+  // print config to console
   std::cout << config;
 
+  // select either std::out or a logfile for autopas log output.
+  // This does not affect md-flex output.
+  std::streambuf *streamBuf;
+  std::ofstream logFile;
+  if (config.logFileName.empty()) {
+    streamBuf = std::cout.rdbuf();
+  } else {
+    logFile.open(config.logFileName);
+    streamBuf = logFile.rdbuf();
+  }
+  std::ostream outputStream(streamBuf);
+
   // Initialization
-  simulation.initialize(config);
+  autopas::AutoPas<PrintableMolecule, autopas::FullParticleCell<PrintableMolecule>> autopas(outputStream);
+  simulation.initialize(config, autopas);
+
   std::cout << std::endl << "Using " << autopas::autopas_get_max_threads() << " Threads" << std::endl;
 
   // Simulation
   std::cout << "Starting simulation... " << std::endl;
-  simulation.simulate();
+  simulation.simulate(autopas);
   std::cout << "Simulation done!" << std::endl << std::endl;
 
-  simulation.printStatistics();
+  // Statistics about the simulation
+  simulation.printStatistics(autopas);
 
   // print config.yaml file of current run
   if (config.dontCreateEndConfig) {

--- a/examples/md-flexible/main.cpp
+++ b/examples/md-flexible/main.cpp
@@ -17,7 +17,7 @@ int main(int argc, char **argv) {
   MDFlexConfig config;
 
   if (not MDFlexParser::parseInput(argc, argv, config)) {
-    exit(-1);
+    exit(EXIT_FAILURE);
   }
   // make sure sim box is big enough
   config.calcSimulationBox();

--- a/examples/md-flexible/parsing/CLIParser.cpp
+++ b/examples/md-flexible/parsing/CLIParser.cpp
@@ -502,7 +502,7 @@ bool CLIParser::parseInput(int argc, char **argv, MDFlexConfig &config) {
       }
     }
 
-    // by default sort sorts by first member of pair
+    // By default `std::sort` sorts by first member of pair.
     std::sort(std::begin(options), std::end(options));
 
     // print everything

--- a/examples/md-flexible/parsing/CLIParser.cpp
+++ b/examples/md-flexible/parsing/CLIParser.cpp
@@ -13,7 +13,6 @@
 bool CLIParser::parseInput(int argc, char **argv, MDFlexConfig &config) {
   using namespace std;
   bool displayHelp = false;
-  int option, option_index;
   static struct option long_options[] = {{"help", no_argument, nullptr, 'h'},
                                          {MDFlexConfig::newton3OptionsStr, required_argument, nullptr, '3'},
                                          {MDFlexConfig::checkpointfileStr, required_argument, nullptr, '4'},
@@ -57,10 +56,11 @@ bool CLIParser::parseInput(int argc, char **argv, MDFlexConfig &config) {
   // reset getopt to scan from the start of argv
   optind = 1;
   string strArg;
-  while ((option = getopt_long(argc, argv, "", long_options, &option_index)) != -1) {
+  for (int cliOption = 0, cliOptionIndex = 0;
+       (cliOption = getopt_long(argc, argv, "", long_options, &cliOptionIndex)) != -1;) {
     if (optarg != nullptr) strArg = optarg;
     transform(strArg.begin(), strArg.end(), strArg.begin(), ::tolower);
-    switch (option) {
+    switch (cliOption) {
       case '3': {
         config.newton3Options = autopas::Newton3Option::parseOptions(strArg);
         if (config.newton3Options.empty()) {
@@ -535,7 +535,6 @@ bool checkFileExists(const std::string &filename) {
 }  // namespace
 
 void CLIParser::inputFilesPresent(int argc, char **argv, MDFlexConfig &config) {
-  int option = 0, optionIndex = 0;
   // suppress error messages since we only want to look if the yaml option is there
   auto opterrBefore = opterr;
   opterr = 0;
@@ -546,8 +545,9 @@ void CLIParser::inputFilesPresent(int argc, char **argv, MDFlexConfig &config) {
   optind = 1;
 
   // search all cli parameters for input file options
-  while ((option = getopt_long(argc, argv, "", longOptions, &optionIndex)) != -1) {
-    switch (option) {
+  for (int cliOption = 0, cliOptionIndex = 0;
+       (cliOption = getopt_long(argc, argv, "", longOptions, &cliOptionIndex)) != -1;) {
+    switch (cliOption) {
       case 'C':
         config.checkpointfile = optarg;
         if (not checkFileExists(optarg)) {

--- a/examples/md-flexible/parsing/CLIParser.cpp
+++ b/examples/md-flexible/parsing/CLIParser.cpp
@@ -497,7 +497,7 @@ bool checkFileExists(const std::string &filename) {
 }  // namespace
 
 void CLIParser::inputFilesPresent(int argc, char **argv, MDFlexConfig &config) {
-  int option, optionIndex;
+  int option = 0, optionIndex = 0;
   // suppress error messages since we only want to look if the yaml option is there
   auto opterrBefore = opterr;
   opterr = 0;
@@ -523,6 +523,9 @@ void CLIParser::inputFilesPresent(int argc, char **argv, MDFlexConfig &config) {
           throw std::runtime_error("CLIParser::inputFilesPresent: Yaml-File " + config.yamlFilename + " not found!");
         }
         break;
+      default: {
+        // do nothing
+      }
     }
   }
 

--- a/examples/md-flexible/parsing/CLIParser.cpp
+++ b/examples/md-flexible/parsing/CLIParser.cpp
@@ -12,7 +12,6 @@
 
 bool CLIParser::parseInput(int argc, char **argv, MDFlexConfig &config) {
   using namespace std;
-  bool displayHelp = false;
   static struct option long_options[] = {{"help", no_argument, nullptr, 'h'},
                                          {MDFlexConfig::newton3OptionsStr, required_argument, nullptr, '3'},
                                          {MDFlexConfig::checkpointfileStr, required_argument, nullptr, '4'},
@@ -55,9 +54,10 @@ bool CLIParser::parseInput(int argc, char **argv, MDFlexConfig &config) {
                                          {nullptr, no_argument, nullptr, 0}};  // needed to signal the end of the array
   // reset getopt to scan from the start of argv
   optind = 1;
-  string strArg;
+  bool displayHelp = false;
   for (int cliOption = 0, cliOptionIndex = 0;
        (cliOption = getopt_long(argc, argv, "", long_options, &cliOptionIndex)) != -1;) {
+    string strArg;
     if (optarg != nullptr) strArg = optarg;
     transform(strArg.begin(), strArg.end(), strArg.begin(), ::tolower);
     switch (cliOption) {
@@ -541,12 +541,12 @@ void CLIParser::inputFilesPresent(int argc, char **argv, MDFlexConfig &config) {
   static struct option longOptions[] = {{MDFlexConfig::checkpointfileStr, required_argument, nullptr, 'C'},
                                         {MDFlexConfig::yamlFilenameStr, required_argument, nullptr, 'Y'},
                                         {nullptr, 0, nullptr, 0}};  // needed to signal the end of the array
-  std::string strArg;
   optind = 1;
 
   // search all cli parameters for input file options
   for (int cliOption = 0, cliOptionIndex = 0;
        (cliOption = getopt_long(argc, argv, "", longOptions, &cliOptionIndex)) != -1;) {
+    std::string strArg;
     switch (cliOption) {
       case 'C':
         config.checkpointfile = optarg;

--- a/examples/md-flexible/parsing/CLIParser.cpp
+++ b/examples/md-flexible/parsing/CLIParser.cpp
@@ -456,13 +456,22 @@ bool CLIParser::parseInput(int argc, char **argv, MDFlexConfig &config) {
   }
 
   if (displayHelp) {
-    cout << "Usage: " << argv[0] << endl;
-    for (auto o : long_options) {
-      if (o.name == nullptr) {
-        continue;
+    // filter out null values and copy rest in more sane data structure
+    std::vector<std::pair<std::string, bool>> options;
+    for (auto &o : long_options) {
+      if (o.name != nullptr) {
+        options.emplace_back(std::make_pair(o.name, o.has_arg));
       }
-      cout << "    --" << setw(MDFlexConfig::valueOffset + 2) << left << o.name;
-      if (o.has_arg) {
+    }
+
+    // by default sort sorts by first member of pair
+    std::sort(std::begin(options), std::end(options));
+
+    // print everything
+    cout << "Usage: " << argv[0] << endl;
+    for (auto &o : options) {
+      cout << "    --" << setw(MDFlexConfig::valueOffset + 2) << left << o.first;
+      if (o.second) {
         cout << "option";
       }
       cout << endl;

--- a/examples/md-flexible/parsing/CLIParser.cpp
+++ b/examples/md-flexible/parsing/CLIParser.cpp
@@ -287,15 +287,6 @@ bool CLIParser::parseInput(int argc, char **argv, MDFlexConfig &config) {
         }
         break;
       }
-      case 'P': {
-        try {
-          config.particlesTotal = stoul(strArg);
-        } catch (const exception &) {
-          cerr << "Error parsing total number of particles: " << strArg << endl;
-          displayHelp = true;
-        }
-        break;
-      }
       case 'p': {
         try {
           config.periodic = autopas::utils::StringUtils::parseBoolOption(strArg);

--- a/examples/md-flexible/scripts/measurePerf.sh
+++ b/examples/md-flexible/scripts/measurePerf.sh
@@ -127,22 +127,24 @@ do
                         t=traversals__${container}
 
                         output=$(${EXECUTABLE} \
-                            --container ${container} \
-                            --traversal ${!t} \
-                            --data-layout ${dataLayout} \
-                            --cutoff 1 \
-                            --cell-size ${cellSizeFactor} \
                             --box-length 10 \
+                            --cell-size ${cellSizeFactor} \
+                            --container ${container} \
+                            --cutoff 1 \
+                            --data-layout ${dataLayout} \
+                            --deltaT 0. \
+                            --iterations ${thisReps} \
+                            --newton3 ${newton3Opt} \
+                            --no-end-config \
+                            --no-flops \
                             --particle-generator uniform \
                             --particles-total ${Mols[$i]} \
-                            --iterations ${thisReps} \
+                            --periodic false \
+                            --traversal ${!t} \
                             --tuning-interval $(( ${thisReps} + 1 )) \
                             --verlet-rebuild-frequency ${VLRebuild[$iVL]} \
                             --verlet-skin-radius ${VLSkin[$iVL]} \
-                            --no-flops \
-                            --periodic false \
-                            --newton3 ${newton3Opt} \
-                            --deltaT 0.
+
                         )
 
                         printf '%s\n' "${output}"

--- a/examples/md-flexible/scripts/plotScript.gp
+++ b/examples/md-flexible/scripts/plotScript.gp
@@ -1,16 +1,16 @@
 #!/usr/bin/gnuplot -p
 
 datafiles = "\
-runtimes_DirectSum_AoS.csv                          \
-runtimes_DirectSum_SoA.csv                          \
-runtimes_LinkedCells_AoS.csv                        \
-runtimes_LinkedCells_SoA.csv                        \
-runtimes_VerletLists_AoS_20_0.3.csv                 \
-runtimes_VerletLists_SoA_20_0.3.csv                 \
-runtimes_VerletCells_AoS_20_0.3.csv                 \
-runtimes_VerletCells_SoA_20_0.3.csv                 \
-runtimes_VerletCluster_AoS_20_0.3.csv               \
-runtimes_VerletCluster_SoA_20_0.3.csv               \
+runtimes_DirectSum_AoS_N3on.csv                          \
+runtimes_DirectSum_SoA_N3on.csv                          \
+runtimes_LinkedCells_AoS_N3on.csv                        \
+runtimes_LinkedCells_SoA_N3on.csv                        \
+runtimes_VerletLists_AoS_20_0.3_N3on.csv                 \
+runtimes_VerletLists_SoA_20_0.3_N3on.csv                 \
+runtimes_VerletCells_AoS_20_0.3_N3on.csv                 \
+runtimes_VerletCells_SoA_20_0.3_N3on.csv                 \
+runtimes_VerletCluster_AoS_20_0.3_N3on.csv               \
+runtimes_VerletCluster_SoA_20_0.3_N3on.csv               \
 "
 
 titles = "\

--- a/examples/md-flexible/tests/ParticlePropertiesLibraryTest.cpp
+++ b/examples/md-flexible/tests/ParticlePropertiesLibraryTest.cpp
@@ -6,6 +6,7 @@
 #include "ParticlePropertiesLibraryTest.h"
 
 #include "Simulation.h"
+#include "autopas/AutoPas.h"
 #include "autopas/molecularDynamics/LJFunctor.h"
 #include "parsing/YamlParser.h"
 #include "testingHelpers/commonTypedefs.h"
@@ -78,10 +79,11 @@ TEST_F(ParticlePropertiesLibraryTest, ParticlePropertiesInitialization) {
   Simulation<Molecule, FMCell> simulation;
   // this test need to be adapted if the input file changes
   MDFlexConfig config;
+  autopas::AutoPas<Molecule, FMCell> autopas;
   config.yamlFilename = std::string(YAMLDIRECTORY) + "multipleObjectsWithMultipleTypesTest.yaml";
   YamlParser::parseYamlFile(config);
   config.calcSimulationBox();
-  simulation.initialize(config);
+  simulation.initialize(config, autopas);
   simulation.initializeParticlePropertiesLibrary();
   EXPECT_EQ(simulation.getPpl()->getMass(0), 1.0);
   EXPECT_EQ(simulation.getPpl()->get24Epsilon(0), 24.0);
@@ -105,7 +107,8 @@ TEST_F(ParticlePropertiesLibraryTest, ParticlePropertiesInitializationDefault) {
   Simulation<Molecule, FMCell> simulation;
   MDFlexConfig config;
   config.calcSimulationBox();
-  simulation.initialize(config);
+  autopas::AutoPas<Molecule, FMCell> autopas;
+  simulation.initialize(config, autopas);
   simulation.initializeParticlePropertiesLibrary();
   // default values: epsilon=sigma=mass=1.0
   EXPECT_EQ(simulation.getPpl()->getMass(0), 1.0);

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -26,10 +26,8 @@ namespace autopas {
 static unsigned int _instanceCounter = 0;
 
 /**
- * The AutoPas class is intended to be the main point of Interaction for the
- * user. It puts a layer of abstraction over the container and handles the
- * autotuning.
- * @todo autotuning
+ * The AutoPas class is intended to be the main point of Interaction for the user.
+ * It acts as an interface from where all features of the library can be triggered and configured.
  * @tparam Particle Class for particles
  * @tparam ParticleCell Class for the particle cells
  */

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -141,7 +141,9 @@ class AutoPas {
    * returned bool evaluates to true, the vector can both be empty or non-empty, depending on whether particles have
    * left the container or not.
    */
-  [[nodiscard]] std::pair<std::vector<Particle>, bool> updateContainer() { return _logicHandler->updateContainer(false); }
+  [[nodiscard]] std::pair<std::vector<Particle>, bool> updateContainer() {
+    return _logicHandler->updateContainer(false);
+  }
 
   /**
    * Forces a container update.
@@ -149,7 +151,9 @@ class AutoPas {
    * into the container.
    * @return A vector of invalid particles that do no belong in the current container.
    */
-  [[nodiscard]] std::vector<Particle> updateContainerForced() { return std::get<0>(_logicHandler->updateContainer(true)); }
+  [[nodiscard]] std::vector<Particle> updateContainerForced() {
+    return std::get<0>(_logicHandler->updateContainer(true));
+  }
 
   /**
    * Adds a particle to the container.

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -60,24 +60,7 @@ class AutoPas {
    * Constructor for the autopas class.
    * @param logOutputStream Stream where log output should go to. Default is std::out.
    */
-  explicit AutoPas(std::ostream &logOutputStream = std::cout)
-      : _boxMin{0, 0, 0},
-        _boxMax{0, 0, 0},
-        _cutoff(1.),
-        _verletSkin(0.2),
-        _verletRebuildFrequency(20),
-        _verletClusterSize(64),
-        _tuningInterval(5000),
-        _numSamples(3),
-        _maxEvidence(10),
-        _acquisitionFunctionOption(AcquisitionFunctionOption::lowerConfidenceBound),
-        _tuningStrategyOption(TuningStrategyOption::fullSearch),
-        _selectorStrategy(SelectorStrategyOption::fastestAbs),
-        _allowedContainers(ContainerOption::getAllOptions()),
-        _allowedTraversals(TraversalOption::getAllOptions()),
-        _allowedDataLayouts(DataLayoutOption::getAllOptions()),
-        _allowedNewton3Options(Newton3Option::getAllOptions()),
-        _allowedCellSizeFactors(std::make_unique<NumberSetFinite<double>>(std::set<double>({1.}))) {
+  explicit AutoPas(std::ostream &logOutputStream = std::cout) {
     // count the number of autopas instances. This is needed to ensure that the autopas
     // logger is not unregistered while other instances are still using it.
     _instanceCounter++;
@@ -544,79 +527,80 @@ class AutoPas {
   /**
    * Lower corner of the container.
    */
-  std::array<double, 3> _boxMin;
+  std::array<double, 3> _boxMin{0, 0, 0};
   /**
    * Upper corner of the container.
    */
-  std::array<double, 3> _boxMax;
+  std::array<double, 3> _boxMax{0, 0, 0};
   /**
    * Cutoff radius to be used in this container.
    */
-  double _cutoff;
+  double _cutoff{1.0};
   /**
    * Length added to the cutoff for the verlet lists' skin.
    */
-  double _verletSkin;
+  double _verletSkin{0.2};
   /**
    * Specifies after how many pair-wise traversals the neighbor lists are to be rebuild.
    */
-  unsigned int _verletRebuildFrequency;
+  unsigned int _verletRebuildFrequency{20};
   /**
    * Specifies the size of clusters for verlet lists.
    */
-  unsigned int _verletClusterSize;
+  unsigned int _verletClusterSize{64};
   /**
    * Number of timesteps after which the auto-tuner shall reevaluate all selections.
    */
-  unsigned int _tuningInterval;
+  unsigned int _tuningInterval{5000};
   /**
    * Number of samples the tuner should collect for each combination.
    */
-  unsigned int _numSamples;
+  unsigned int _numSamples{3};
   /**
    * Tuning Strategies which work on a fixed number of evidence should use this value.
    */
-  unsigned int _maxEvidence;
+  unsigned int _maxEvidence{10};
   /**
    * Acquisition function used for tuning.
    * For possible acquisition function choices see AutoPas::AcquisitionFunction.
    */
-  AcquisitionFunctionOption _acquisitionFunctionOption;
+  AcquisitionFunctionOption _acquisitionFunctionOption{AcquisitionFunctionOption::lowerConfidenceBound};
 
   /**
    * Strategy option for the auto tuner.
    * For possible tuning strategy choices see AutoPas::TuningStrategy.
    */
-  TuningStrategyOption _tuningStrategyOption;
+  TuningStrategyOption _tuningStrategyOption{TuningStrategyOption::fullSearch};
 
   /**
    * Strategy for the configuration selector.
    * For possible container choices see AutoPas::SelectorStrategy.
    */
-  SelectorStrategyOption _selectorStrategy;
+  SelectorStrategyOption _selectorStrategy{SelectorStrategyOption::fastestAbs};
   /**
    * List of container types AutoPas can choose from.
    * For possible container choices see AutoPas::ContainerOption.
    */
-  std::set<ContainerOption> _allowedContainers;
+  std::set<ContainerOption> _allowedContainers{ContainerOption::getAllOptions()};
   /**
    * List of traversals AutoPas can choose from.
    * For possible container choices see AutoPas::TraversalOption.
    */
-  std::set<TraversalOption> _allowedTraversals;
+  std::set<TraversalOption> _allowedTraversals{TraversalOption::getAllOptions()};
   /**
    * List of data layouts AutoPas can choose from.
    * For possible container choices see AutoPas::DataLayoutOption.
    */
-  std::set<DataLayoutOption> _allowedDataLayouts;
+  std::set<DataLayoutOption> _allowedDataLayouts{DataLayoutOption::getAllOptions()};
   /**
    * Whether AutoPas is allowed to exploit Newton's third law of motion.
    */
-  std::set<Newton3Option> _allowedNewton3Options;
+  std::set<Newton3Option> _allowedNewton3Options{Newton3Option::getAllOptions()};
   /**
    * Cell size factor to be used in this container (only relevant for LinkedCells, VerletLists and VerletListsCells).
    */
-  std::unique_ptr<NumberSet<double>> _allowedCellSizeFactors;
+  std::unique_ptr<NumberSet<double>> _allowedCellSizeFactors{
+      std::make_unique<NumberSetFinite<double>>(std::set<double>({1.}))};
 
   /**
    * LogicHandler of autopas.

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -141,8 +141,7 @@ class AutoPas {
    * returned bool evaluates to true, the vector can both be empty or non-empty, depending on whether particles have
    * left the container or not.
    */
-  AUTOPAS_WARN_UNUSED_RESULT
-  std::pair<std::vector<Particle>, bool> updateContainer() { return _logicHandler->updateContainer(false); }
+  [[nodiscard]] std::pair<std::vector<Particle>, bool> updateContainer() { return _logicHandler->updateContainer(false); }
 
   /**
    * Forces a container update.
@@ -150,8 +149,7 @@ class AutoPas {
    * into the container.
    * @return A vector of invalid particles that do no belong in the current container.
    */
-  AUTOPAS_WARN_UNUSED_RESULT
-  std::vector<Particle> updateContainerForced() { return std::get<0>(_logicHandler->updateContainer(true)); }
+  [[nodiscard]] std::vector<Particle> updateContainerForced() { return std::get<0>(_logicHandler->updateContainer(true)); }
 
   /**
    * Adds a particle to the container.
@@ -268,7 +266,7 @@ class AutoPas {
    * @param behavior Tells this function to report the number of halo, owned or all particles.
    * @return the number of particles in this container.
    */
-  unsigned long getNumberOfParticles(IteratorBehavior behavior = IteratorBehavior::ownedOnly) const {
+  [[nodiscard]] unsigned long getNumberOfParticles(IteratorBehavior behavior = IteratorBehavior::ownedOnly) const {
     switch (behavior) {
       case IteratorBehavior::ownedOnly: {
         return _logicHandler->getNumParticlesOwned();
@@ -287,19 +285,19 @@ class AutoPas {
    * Returns the type of the currently used container.
    * @return The type of the used container is returned.
    */
-  unsigned long getContainerType() const { return _autoTuner->getContainer()->getContainerType(); }
+  [[nodiscard]] unsigned long getContainerType() const { return _autoTuner->getContainer()->getContainerType(); }
 
   /**
    * Get the lower corner of the container.
    * @return lower corner of the container.
    */
-  std::array<double, 3> getBoxMin() const { return _autoTuner->getContainer()->getBoxMin(); }
+  [[nodiscard]] std::array<double, 3> getBoxMin() const { return _autoTuner->getContainer()->getBoxMin(); }
 
   /**
    * Get the upper corner of the container.
    * @return upper corner of the container.
    */
-  std::array<double, 3> getBoxMax() const { return _autoTuner->getContainer()->getBoxMax(); }
+  [[nodiscard]] std::array<double, 3> getBoxMax() const { return _autoTuner->getContainer()->getBoxMax(); }
 
   /**
    * Set coordinates of the lower corner of the domain.
@@ -317,7 +315,7 @@ class AutoPas {
    * Get cutoff radius.
    * @return
    */
-  double getCutoff() const { return _cutoff; }
+  [[nodiscard]] double getCutoff() const { return _cutoff; }
 
   /**
    * Set cutoff radius.
@@ -335,7 +333,7 @@ class AutoPas {
    * Get allowed cell size factors (only relevant for LinkedCells, VerletLists and VerletListsCells).
    * @return
    */
-  const NumberSet<double> &getAllowedCellSizeFactors() const { return *_allowedCellSizeFactors; }
+  [[nodiscard]] const NumberSet<double> &getAllowedCellSizeFactors() const { return *_allowedCellSizeFactors; }
 
   /**
    * Set allowed cell size factors (only relevant for LinkedCells, VerletLists and VerletListsCells).
@@ -365,7 +363,7 @@ class AutoPas {
    * Get length added to the cutoff for the Verlet lists' skin.
    * @return
    */
-  double getVerletSkin() const { return _verletSkin; }
+  [[nodiscard]] double getVerletSkin() const { return _verletSkin; }
 
   /**
    * Set length added to the cutoff for the Verlet lists' skin.
@@ -377,7 +375,7 @@ class AutoPas {
    * Get Verlet rebuild frequency.
    * @return
    */
-  unsigned int getVerletRebuildFrequency() const { return _verletRebuildFrequency; }
+  [[nodiscard]] unsigned int getVerletRebuildFrequency() const { return _verletRebuildFrequency; }
 
   /**
    * Set Verlet rebuild frequency.
@@ -391,7 +389,7 @@ class AutoPas {
    * Get Verlet cluster size.
    * @return
    */
-  unsigned int getVerletClusterSize() const { return _verletClusterSize; }
+  [[nodiscard]] unsigned int getVerletClusterSize() const { return _verletClusterSize; }
 
   /**
    * Set Verlet cluster size.
@@ -403,7 +401,7 @@ class AutoPas {
    * Get tuning interval.
    * @return
    */
-  unsigned int getTuningInterval() const { return _tuningInterval; }
+  [[nodiscard]] unsigned int getTuningInterval() const { return _tuningInterval; }
 
   /**
    * Set tuning interval.
@@ -415,7 +413,7 @@ class AutoPas {
    * Get number of samples taken per configuration during the tuning.
    * @return
    */
-  unsigned int getNumSamples() const { return _numSamples; }
+  [[nodiscard]] unsigned int getNumSamples() const { return _numSamples; }
 
   /**
    * Set number of samples taken per configuration during the tuning.
@@ -427,7 +425,7 @@ class AutoPas {
    * Get maximum number of evidence for tuning
    * @return
    */
-  unsigned int getMaxEvidence() const { return _maxEvidence; }
+  [[nodiscard]] unsigned int getMaxEvidence() const { return _maxEvidence; }
 
   /**
    * Set maximum number of evidence for tuning
@@ -439,7 +437,7 @@ class AutoPas {
    * Get acquisition function used for tuning
    * @return
    */
-  AcquisitionFunctionOption getAcquisitionFunction() const { return _acquisitionFunctionOption; }
+  [[nodiscard]] AcquisitionFunctionOption getAcquisitionFunction() const { return _acquisitionFunctionOption; }
 
   /**
    * Set acquisition function for tuning
@@ -451,7 +449,7 @@ class AutoPas {
    * Get the selector configuration strategy.
    * @return
    */
-  SelectorStrategyOption getSelectorStrategy() const { return _selectorStrategy; }
+  [[nodiscard]] SelectorStrategyOption getSelectorStrategy() const { return _selectorStrategy; }
 
   /**
    * Set the selector configuration strategy.
@@ -464,7 +462,7 @@ class AutoPas {
    * Get the list of allowed containers.
    * @return
    */
-  const std::set<ContainerOption> &getAllowedContainers() const { return _allowedContainers; }
+  [[nodiscard]] const std::set<ContainerOption> &getAllowedContainers() const { return _allowedContainers; }
 
   /**
    * Set the list of allowed containers.
@@ -479,7 +477,7 @@ class AutoPas {
    * Get the list of allowed traversals.
    * @return
    */
-  const std::set<TraversalOption> &getAllowedTraversals() const { return _allowedTraversals; }
+  [[nodiscard]] const std::set<TraversalOption> &getAllowedTraversals() const { return _allowedTraversals; }
 
   /**
    * Set the list of allowed traversals.
@@ -494,7 +492,7 @@ class AutoPas {
    * Get the list of allowed data layouts.
    * @return
    */
-  const std::set<DataLayoutOption> &getAllowedDataLayouts() const { return _allowedDataLayouts; }
+  [[nodiscard]] const std::set<DataLayoutOption> &getAllowedDataLayouts() const { return _allowedDataLayouts; }
 
   /**
    * Set the list of allowed data layouts.
@@ -509,7 +507,7 @@ class AutoPas {
    * Get the list of allowed newton 3 options.
    * @return
    */
-  const std::set<Newton3Option> &getAllowedNewton3Options() const { return _allowedNewton3Options; }
+  [[nodiscard]] const std::set<Newton3Option> &getAllowedNewton3Options() const { return _allowedNewton3Options; }
 
   /**
    * Set the list of allowed newton 3 options.
@@ -524,13 +522,13 @@ class AutoPas {
    * Getter for the currently selected configuration.
    * @return Configuration object currently used.
    */
-  Configuration getCurrentConfig() const { return _autoTuner->getCurrentConfig(); }
+  [[nodiscard]] Configuration getCurrentConfig() const { return _autoTuner->getCurrentConfig(); }
 
   /**
    * Getter for the tuning strategy option.
    * @return
    */
-  TuningStrategyOption getTuningStrategyOption() const { return _tuningStrategyOption; }
+  [[nodiscard]] TuningStrategyOption getTuningStrategyOption() const { return _tuningStrategyOption; }
 
   /**
    * Setter for the tuning strategy option.

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -35,8 +35,7 @@ class LogicHandler {
    * @copydoc AutoPas::updateContainer()
    * @param forced specifies whether an update of the container is enforced.
    */
-  AUTOPAS_WARN_UNUSED_RESULT
-  std::pair<std::vector<Particle>, bool> updateContainer(bool forced) {
+  [[nodiscard]] std::pair<std::vector<Particle>, bool> updateContainer(bool forced) {
     if (not isContainerValid() or forced) {
       AutoPasLog(debug, "Initiating container update.");
       _containerIsValid = false;
@@ -198,13 +197,13 @@ class LogicHandler {
    * Get the number of owned particles.
    * @return
    */
-  unsigned long getNumParticlesOwned() const { return _numParticlesOwned; }
+  [[nodiscard]] unsigned long getNumParticlesOwned() const { return _numParticlesOwned; }
 
   /**
    * Get the number of halo particles.
    * @return
    */
-  unsigned long getNumParticlesHalo() const { return _numParticlesHalo; }
+  [[nodiscard]] unsigned long getNumParticlesHalo() const { return _numParticlesHalo; }
 
  private:
   void checkMinimalSize() {

--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -63,7 +63,7 @@ class CellBlock3D : public CellBorderAndFlagManager {
    */
   CellBlock3D &operator=(const CellBlock3D) = delete;
 
-  bool cellCanContainHaloParticles(index_t index1d) const override {
+  [[nodiscard]] bool cellCanContainHaloParticles(index_t index1d) const override {
     auto index3d = index3D(index1d);
     bool isHaloCell = false;
     for (size_t i = 0; i < 3; i++) {
@@ -76,7 +76,7 @@ class CellBlock3D : public CellBorderAndFlagManager {
     return isHaloCell;
   }
 
-  bool cellCanContainOwnedParticles(index_t index1d) const override { return not cellCanContainHaloParticles(index1d); }
+  [[nodiscard]] bool cellCanContainOwnedParticles(index_t index1d) const override { return not cellCanContainHaloParticles(index1d); }
 
   /**
    * get the ParticleCell of a specified 1d index
@@ -134,20 +134,20 @@ class CellBlock3D : public CellBorderAndFlagManager {
    * @param pos the position
    * @return the 3d index
    */
-  std::array<index_t, 3> get3DIndexOfPosition(const std::array<double, 3> &pos) const;
+  [[nodiscard]] std::array<index_t, 3> get3DIndexOfPosition(const std::array<double, 3> &pos) const;
 
   /**
    * get the 1d index of the cellblock for a given position
    * @param pos the position
    * @return the 1d index
    */
-  index_t get1DIndexOfPosition(const std::array<double, 3> &pos) const;
+  [[nodiscard]] index_t get1DIndexOfPosition(const std::array<double, 3> &pos) const;
 
   /**
    * get the dimension of the cellblock including the haloboxes
    * @return the dimensions of the cellblock
    */
-  const std::array<index_t, 3> &getCellsPerDimensionWithHalo() const { return _cellsPerDimensionWithHalo; }
+  [[nodiscard]] const std::array<index_t, 3> &getCellsPerDimensionWithHalo() const { return _cellsPerDimensionWithHalo; }
 
   /**
    * checks whether a given position is inside the halo region of the managed
@@ -155,7 +155,7 @@ class CellBlock3D : public CellBorderAndFlagManager {
    * @param position the given position
    * @return true if the position is inside the halo region
    */
-  bool checkInHalo(const std::array<double, 3> &position) const;
+  [[nodiscard]] bool checkInHalo(const std::array<double, 3> &position) const;
 
   /**
    * deletes all particles in the halo cells of the managed cell block
@@ -220,29 +220,30 @@ class CellBlock3D : public CellBorderAndFlagManager {
    * Get the lower corner of the halo region.
    * @return Coordinates of the lower corner.
    */
-  std::array<double, 3> getHaloBoxMin() const { return _haloBoxMin; }
+  [[nodiscard]] std::array<double, 3> getHaloBoxMin() const { return _haloBoxMin; }
 
   /**
    * Get the upper corner of the halo region.
    * @return Coordinates of the upper corner.
    */
-  std::array<double, 3> getHaloBoxMax() const { return _haloBoxMax; }
+  [[nodiscard]] std::array<double, 3> getHaloBoxMax() const { return _haloBoxMax; }
 
   /**
    * Get the number of cells per interaction length.
    * @return cells per interaction length.
    */
-  unsigned long getCellsPerInteractionLength() const { return _cellsPerInteractionLength; }
+  [[nodiscard]] unsigned long getCellsPerInteractionLength() const { return _cellsPerInteractionLength; }
 
   /**
    * Get the cell lengths.
    * @return array of cell lengths.
    */
-  const std::array<double, 3> &getCellLength() const { return _cellLength; }
+  [[nodiscard]] const std::array<double, 3> &getCellLength() const { return _cellLength; }
 
  private:
-  std::array<index_t, 3> index3D(index_t index1d) const;
-  index_t index1D(const std::array<index_t, 3> &index3d) const;
+  [[nodiscard]] std::array<index_t, 3> index3D(index_t index1d) const;
+
+  [[nodiscard]] index_t index1D(const std::array<index_t, 3> &index3d) const;
 
   std::array<index_t, 3> _cellsPerDimensionWithHalo;
   index_t _numCells;

--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -76,7 +76,9 @@ class CellBlock3D : public CellBorderAndFlagManager {
     return isHaloCell;
   }
 
-  [[nodiscard]] bool cellCanContainOwnedParticles(index_t index1d) const override { return not cellCanContainHaloParticles(index1d); }
+  [[nodiscard]] bool cellCanContainOwnedParticles(index_t index1d) const override {
+    return not cellCanContainHaloParticles(index1d);
+  }
 
   /**
    * get the ParticleCell of a specified 1d index
@@ -147,7 +149,9 @@ class CellBlock3D : public CellBorderAndFlagManager {
    * get the dimension of the cellblock including the haloboxes
    * @return the dimensions of the cellblock
    */
-  [[nodiscard]] const std::array<index_t, 3> &getCellsPerDimensionWithHalo() const { return _cellsPerDimensionWithHalo; }
+  [[nodiscard]] const std::array<index_t, 3> &getCellsPerDimensionWithHalo() const {
+    return _cellsPerDimensionWithHalo;
+  }
 
   /**
    * checks whether a given position is inside the halo region of the managed

--- a/src/autopas/containers/CellBorderAndFlagManager.h
+++ b/src/autopas/containers/CellBorderAndFlagManager.h
@@ -29,13 +29,13 @@ class CellBorderAndFlagManager {
    * @param index1d the one-dimensional index of the cell that should be checked
    * @return true if the cell can contain halo particles
    */
-  virtual bool cellCanContainHaloParticles(index_t index1d) const = 0;
+  [[nodiscard]] virtual bool cellCanContainHaloParticles(index_t index1d) const = 0;
 
   /**
    * Checks if the cell with the one-dimensional index index1d can contain owned particles.
    * @param index1d the one-dimensional index of the cell that should be checked
    * @return true if the cell can contain owned particles
    */
-  virtual bool cellCanContainOwnedParticles(index_t index1d) const = 0;
+  [[nodiscard]] virtual bool cellCanContainOwnedParticles(index_t index1d) const = 0;
 };
 }  // namespace autopas::internal

--- a/src/autopas/containers/CompatibleTraversals.h
+++ b/src/autopas/containers/CompatibleTraversals.h
@@ -13,8 +13,7 @@
 #include "autopas/utils/ExceptionHandler.h"
 #include "autopas/utils/StringUtils.h"
 
-namespace autopas {
-namespace compatibleTraversals {
+namespace autopas::compatibleTraversals {
 
 /**
  * Lists all traversal options applicable for the Direct Sum container.
@@ -144,5 +143,4 @@ static inline std::set<ContainerOption> allCompatibleContainers(TraversalOption 
   return result;
 }
 
-}  // namespace compatibleTraversals
-}  // namespace autopas
+}  // namespace autopas::compatibleTraversals

--- a/src/autopas/containers/ParticleContainer.h
+++ b/src/autopas/containers/ParticleContainer.h
@@ -61,7 +61,7 @@ class ParticleContainer : public ParticleContainerInterface<ParticleCell> {
   /**
    * @copydoc autopas::ParticleContainerInterface::getBoxMax()
    */
-  const std::array<double, 3> &getBoxMax() const override final { return _boxMax; }
+  [[nodiscard]] const std::array<double, 3> &getBoxMax() const override final { return _boxMax; }
 
   /**
    * @copydoc autopas::ParticleContainerInterface::setBoxMax()
@@ -71,7 +71,7 @@ class ParticleContainer : public ParticleContainerInterface<ParticleCell> {
   /**
    * @copydoc autopas::ParticleContainerInterface::getBoxMin()
    */
-  const std::array<double, 3> &getBoxMin() const override final { return _boxMin; }
+  [[nodiscard]] const std::array<double, 3> &getBoxMin() const override final { return _boxMin; }
 
   /**
    * @copydoc autopas::ParticleContainerInterface::setBoxMin()
@@ -81,7 +81,7 @@ class ParticleContainer : public ParticleContainerInterface<ParticleCell> {
   /**
    * @copydoc autopas::ParticleContainerInterface::getCutoff()
    */
-  double getCutoff() const override final { return _cutoff; }
+  [[nodiscard]] double getCutoff() const override final { return _cutoff; }
 
   /**
    * @copydoc autopas::ParticleContainerInterface::setCutoff()
@@ -91,7 +91,7 @@ class ParticleContainer : public ParticleContainerInterface<ParticleCell> {
   /**
    * @copydoc autopas::ParticleContainerInterface::getSkin()
    */
-  double getSkin() const override final { return _skin; }
+  [[nodiscard]] double getSkin() const override final { return _skin; }
 
   /**
    * @copydoc autopas::ParticleContainerInterface::setSkin()
@@ -101,7 +101,7 @@ class ParticleContainer : public ParticleContainerInterface<ParticleCell> {
   /**
    * @copydoc autopas::ParticleContainerInterface::getInteractionLength()
    */
-  double getInteractionLength() const override final { return _cutoff + _skin; }
+  [[nodiscard]] double getInteractionLength() const override final { return _cutoff + _skin; }
 
   /**
    * Deletes all particles from the container.
@@ -123,7 +123,7 @@ class ParticleContainer : public ParticleContainerInterface<ParticleCell> {
    * Get the number of particles saved in the container.
    * @return Number of particles in the container.
    */
-  unsigned long getNumParticles() const override {
+  [[nodiscard]] unsigned long getNumParticles() const override {
     size_t numParticles = 0ul;
 #ifdef AUTOPAS_OPENMP
     /// @todo: find a sensible value for magic number

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -70,7 +70,7 @@ class ParticleContainerInterface {
    * Return a enum representing the name of the container class.
    * @return Enum representing the container.
    */
-  virtual ContainerOption getContainerType() const = 0;
+  [[nodiscard]] virtual ContainerOption getContainerType() const = 0;
 
   /**
    * Adds a particle to the container.
@@ -160,30 +160,29 @@ class ParticleContainerInterface {
    * Get the number of particles saved in the container.
    * @return Number of particles in the container.
    */
-  virtual unsigned long getNumParticles() const = 0;
+  [[nodiscard]] virtual unsigned long getNumParticles() const = 0;
 
   /**
    * Iterate over all particles using
    * for(auto iter = container.begin(); iter.isValid(); ++iter) .
    * @param behavior Behavior of the iterator, see IteratorBehavior.
    * @return Iterator to the first particle.
-   * @todo implement IteratorBehavior.
    */
-  virtual ParticleIteratorWrapper<ParticleType, true> begin(
+  [[nodiscard]] virtual ParticleIteratorWrapper<ParticleType, true> begin(
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) = 0;
 
   /**
    * @copydoc begin()
    * @note const version
    */
-  virtual ParticleIteratorWrapper<ParticleType, false> begin(
+  [[nodiscard]] virtual ParticleIteratorWrapper<ParticleType, false> begin(
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const = 0;
 
   /**
    * @copydoc begin()
    * @note cbegin will guarantee to return a const_iterator.
    */
-  virtual ParticleIteratorWrapper<ParticleType, false> cbegin(
+  [[nodiscard]] virtual ParticleIteratorWrapper<ParticleType, false> cbegin(
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const final {
     return begin(behavior);
   };
@@ -196,7 +195,7 @@ class ParticleContainerInterface {
    * @param behavior The behavior of the iterator (shall it iterate over halo particles as well?).
    * @return Iterator to iterate over all particles in a specific region.
    */
-  virtual ParticleIteratorWrapper<ParticleType, true> getRegionIterator(
+  [[nodiscard]] virtual ParticleIteratorWrapper<ParticleType, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) = 0;
 
@@ -204,7 +203,7 @@ class ParticleContainerInterface {
    * @copydoc getRegionIterator()
    * @note const version
    */
-  virtual ParticleIteratorWrapper<ParticleType, false> getRegionIterator(
+  [[nodiscard]] virtual ParticleIteratorWrapper<ParticleType, false> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const = 0;
 
@@ -213,7 +212,7 @@ class ParticleContainerInterface {
    * Allows range-based for loops.
    * @return false
    */
-  constexpr bool end() const { return false; }
+  [[nodiscard]] constexpr bool end() const { return false; }
 
   /**
    * Iterates over all particle pairs in the container.
@@ -225,7 +224,7 @@ class ParticleContainerInterface {
    * Get the upper corner of the container.
    * @return Upper corner of the container.
    */
-  virtual const std::array<double, 3> &getBoxMax() const = 0;
+  [[nodiscard]] virtual const std::array<double, 3> &getBoxMax() const = 0;
 
   /**
    * Set the upper corner of the container.
@@ -237,7 +236,7 @@ class ParticleContainerInterface {
    * Get the lower corner of the container.
    * @return Lower corner of the container.
    */
-  virtual const std::array<double, 3> &getBoxMin() const = 0;
+  [[nodiscard]] virtual const std::array<double, 3> &getBoxMin() const = 0;
 
   /**
    * Set the lower corner of the container.
@@ -249,7 +248,7 @@ class ParticleContainerInterface {
    * Return the cutoff of the container.
    * @return Cutoff radius.
    */
-  virtual double getCutoff() const = 0;
+  [[nodiscard]] virtual double getCutoff() const = 0;
 
   /**
    * Set the cutoff of the container.
@@ -261,7 +260,7 @@ class ParticleContainerInterface {
    * Return the skin of the container.
    * @return skin radius.
    */
-  virtual double getSkin() const = 0;
+  [[nodiscard]] virtual double getSkin() const = 0;
 
   /**
    * Set the skin of the container.
@@ -273,7 +272,7 @@ class ParticleContainerInterface {
    * Return the interaction length (cutoff+skin) of the container.
    * @return interaction length
    */
-  virtual double getInteractionLength() const = 0;
+  [[nodiscard]] virtual double getInteractionLength() const = 0;
 
   /**
    * Updates the container.
@@ -281,14 +280,13 @@ class ParticleContainerInterface {
    * container, if necessary.
    * @return A vector of invalid particles that do not belong into the container.
    */
-  AUTOPAS_WARN_UNUSED_RESULT
-  virtual std::vector<ParticleType> updateContainer() = 0;
+  [[nodiscard]] virtual std::vector<ParticleType> updateContainer() = 0;
 
   /**
    * Generates a traversal selector info for this container.
    * @return Traversal selector info for this container.
    */
-  virtual TraversalSelectorInfo getTraversalSelectorInfo() const = 0;
+  [[nodiscard]] virtual TraversalSelectorInfo getTraversalSelectorInfo() const = 0;
 
   /**
    * Generates a list of all traversals that are theoretically applicable to this container.
@@ -297,7 +295,7 @@ class ParticleContainerInterface {
    *
    * @return Vector of traversal options.
    */
-  std::set<TraversalOption> getAllTraversals() const {
+  [[nodiscard]] std::set<TraversalOption> getAllTraversals() const {
     return compatibleTraversals::allCompatibleTraversals(this->getContainerType());
   }
 };

--- a/src/autopas/containers/TraversalInterface.h
+++ b/src/autopas/containers/TraversalInterface.h
@@ -28,25 +28,25 @@ class TraversalInterface {
    * Return a enum representing the name of the traversal class.
    * @return Enum representing traversal.
    */
-  virtual TraversalOption getTraversalType() const = 0;
+  [[nodiscard]] virtual TraversalOption getTraversalType() const = 0;
 
   /**
    * Checks if the traversal is applicable to the current state of the domain.
    * @return true iff the traversal can be applied.
    */
-  virtual bool isApplicable() const = 0;
+  [[nodiscard]] virtual bool isApplicable() const = 0;
 
   /**
    * Return whether the traversal uses newton 3.
    * @return true iff newton 3 is used.
    */
-  virtual bool getUseNewton3() const = 0;
+  [[nodiscard]] virtual bool getUseNewton3() const = 0;
 
   /**
    * Return the data layout option
    * @return the data layout option
    */
-  virtual DataLayoutOption getDataLayout() const = 0;
+  [[nodiscard]] virtual DataLayoutOption getDataLayout() const = 0;
 
   /**
    * Initializes the traversal. Should be called before traverse().

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -51,7 +51,7 @@ class DirectSum : public ParticleContainer<ParticleCell> {
     this->_cells.resize(2);
   }
 
-  ContainerOption getContainerType() const override { return ContainerOption::directSum; }
+  [[nodiscard]] ContainerOption getContainerType() const override { return ContainerOption::directSum; }
 
   /**
    * @copydoc ParticleContainerInterface::addParticleImpl()
@@ -98,8 +98,7 @@ class DirectSum : public ParticleContainer<ParticleCell> {
     traversal->endTraversal();
   }
 
-  AUTOPAS_WARN_UNUSED_RESULT
-  std::vector<ParticleType> updateContainer() override {
+  [[nodiscard]] std::vector<ParticleType> updateContainer() override {
     // first we delete halo particles, as we don't want them here.
     deleteHaloParticles();
     std::vector<ParticleType> invalidParticles{};
@@ -112,7 +111,7 @@ class DirectSum : public ParticleContainer<ParticleCell> {
     return invalidParticles;
   }
 
-  TraversalSelectorInfo getTraversalSelectorInfo() const override {
+  [[nodiscard]] TraversalSelectorInfo getTraversalSelectorInfo() const override {
     // direct sum technically consists of two cells (owned + halo)
     return TraversalSelectorInfo(
         {2, 0, 0},
@@ -120,20 +119,20 @@ class DirectSum : public ParticleContainer<ParticleCell> {
         utils::ArrayMath::sub(this->getBoxMax(), this->getBoxMin()), 0);
   }
 
-  ParticleIteratorWrapper<ParticleType, true> begin(
+  [[nodiscard]] ParticleIteratorWrapper<ParticleType, true> begin(
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
     return ParticleIteratorWrapper<ParticleType, true>(new internal::ParticleIterator<ParticleType, ParticleCell, true>(
         &this->_cells, 0, &_cellBorderFlagManager, behavior));
   }
 
-  ParticleIteratorWrapper<ParticleType, false> begin(
+  [[nodiscard]] ParticleIteratorWrapper<ParticleType, false> begin(
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const override {
     return ParticleIteratorWrapper<ParticleType, false>(
         new internal::ParticleIterator<ParticleType, ParticleCell, false>(&this->_cells, 0, &_cellBorderFlagManager,
                                                                           behavior));
   }
 
-  ParticleIteratorWrapper<ParticleType, true> getRegionIterator(
+  [[nodiscard]] ParticleIteratorWrapper<ParticleType, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
     std::vector<size_t> cellsOfInterest;
@@ -156,7 +155,7 @@ class DirectSum : public ParticleContainer<ParticleCell> {
             &this->_cells, lowerCorner, higherCorner, cellsOfInterest, &_cellBorderFlagManager, behavior));
   }
 
-  ParticleIteratorWrapper<ParticleType, false> getRegionIterator(
+  [[nodiscard]] ParticleIteratorWrapper<ParticleType, false> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const override {
     std::vector<size_t> cellsOfInterest;
@@ -187,9 +186,9 @@ class DirectSum : public ParticleContainer<ParticleCell> {
     using index_t = std::size_t;
 
    public:
-    bool cellCanContainHaloParticles(index_t index1d) const override { return index1d == 1; }
+    [[nodiscard]] bool cellCanContainHaloParticles(index_t index1d) const override { return index1d == 1; }
 
-    bool cellCanContainOwnedParticles(index_t index1d) const override { return index1d == 0; }
+    [[nodiscard]] bool cellCanContainOwnedParticles(index_t index1d) const override { return index1d == 0; }
 
   } _cellBorderFlagManager;
 

--- a/src/autopas/containers/directSum/DirectSumTraversal.h
+++ b/src/autopas/containers/directSum/DirectSumTraversal.h
@@ -40,7 +40,7 @@ class DirectSumTraversal : public CellPairTraversal<ParticleCell>, public Direct
         _cellFunctor(pairwiseFunctor, cutoff /*should use cutoff here, if not used to build verlet-lists*/),
         _dataLayoutConverter(pairwiseFunctor) {}
 
-  TraversalOption getTraversalType() const override { return TraversalOption::directSumTraversal; }
+  [[nodiscard]] TraversalOption getTraversalType() const override { return TraversalOption::directSumTraversal; }
 
   bool isApplicable() const override {
     int nDevices = 0;
@@ -53,9 +53,9 @@ class DirectSumTraversal : public CellPairTraversal<ParticleCell>, public Direct
       return true;
   }
 
-  bool getUseNewton3() const override { return useNewton3; };
+  [[nodiscard]] bool getUseNewton3() const override { return useNewton3; };
 
-  DataLayoutOption getDataLayout() const override { return dataLayout; };
+  [[nodiscard]] DataLayoutOption getDataLayout() const override { return dataLayout; };
 
   void initTraversal() override {
     auto &cells = *(this->_cells);

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -53,7 +53,7 @@ class LinkedCells : public ParticleContainer<ParticleCell, SoAArraysType> {
       : ParticleContainer<ParticleCell, SoAArraysType>(boxMin, boxMax, cutoff, skin),
         _cellBlock(this->_cells, boxMin, boxMax, cutoff + skin, cellSizeFactor) {}
 
-  ContainerOption getContainerType() const override { return ContainerOption::linkedCells; }
+  [[nodiscard]] ContainerOption getContainerType() const override { return ContainerOption::linkedCells; }
 
   /**
    * @copydoc ParticleContainerInterface::addParticleImpl()
@@ -116,8 +116,7 @@ class LinkedCells : public ParticleContainer<ParticleCell, SoAArraysType> {
     traversal->endTraversal();
   }
 
-  AUTOPAS_WARN_UNUSED_RESULT
-  std::vector<ParticleType> updateContainer() override {
+  [[nodiscard]] std::vector<ParticleType> updateContainer() override {
     this->deleteHaloParticles();
     std::vector<ParticleType> invalidParticles;
 #ifdef AUTOPAS_OPENMP
@@ -168,24 +167,24 @@ class LinkedCells : public ParticleContainer<ParticleCell, SoAArraysType> {
     return invalidParticles;
   }
 
-  TraversalSelectorInfo getTraversalSelectorInfo() const override {
+  [[nodiscard]] TraversalSelectorInfo getTraversalSelectorInfo() const override {
     return TraversalSelectorInfo(this->getCellBlock().getCellsPerDimensionWithHalo(), this->getInteractionLength(),
                                  this->getCellBlock().getCellLength(), 0);
   }
 
-  ParticleIteratorWrapper<ParticleType, true> begin(
+  [[nodiscard]] ParticleIteratorWrapper<ParticleType, true> begin(
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
     return ParticleIteratorWrapper<ParticleType, true>(
         new internal::ParticleIterator<ParticleType, ParticleCell, true>(&this->_cells, 0, &_cellBlock, behavior));
   }
 
-  ParticleIteratorWrapper<ParticleType, false> begin(
+  [[nodiscard]] ParticleIteratorWrapper<ParticleType, false> begin(
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const override {
     return ParticleIteratorWrapper<ParticleType, false>(
         new internal::ParticleIterator<ParticleType, ParticleCell, false>(&this->_cells, 0, &_cellBlock, behavior));
   }
 
-  ParticleIteratorWrapper<ParticleType, true> getRegionIterator(
+  [[nodiscard]] ParticleIteratorWrapper<ParticleType, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
     // We increase the search region by skin, as particles can move over cell borders.
@@ -213,7 +212,7 @@ class LinkedCells : public ParticleContainer<ParticleCell, SoAArraysType> {
                                                                                cellsOfInterest, &_cellBlock, behavior));
   }
 
-  ParticleIteratorWrapper<ParticleType, false> getRegionIterator(
+  [[nodiscard]] ParticleIteratorWrapper<ParticleType, false> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const override {
     // We increase the search region by skin, as particles can move over cell borders.

--- a/src/autopas/containers/linkedCells/traversals/C01CudaTraversal.h
+++ b/src/autopas/containers/linkedCells/traversals/C01CudaTraversal.h
@@ -59,13 +59,13 @@ class C01CudaTraversal : public CellPairTraversal<ParticleCell>, public LinkedCe
 
   void endTraversal() override {}
 
-  TraversalOption getTraversalType() const override { return TraversalOption::c01Cuda; }
+  [[nodiscard]] TraversalOption getTraversalType() const override { return TraversalOption::c01Cuda; }
 
   /**
    * Cuda traversal is only usable if using a GPU.
    * @return
    */
-  bool isApplicable() const override {
+  [[nodiscard]] bool isApplicable() const override {
 #if defined(AUTOPAS_CUDA)
     int nDevices;
     cudaGetDeviceCount(&nDevices);
@@ -87,9 +87,9 @@ class C01CudaTraversal : public CellPairTraversal<ParticleCell>, public LinkedCe
 #endif
   }
 
-  DataLayoutOption getDataLayout() const override { return dataLayout; }
+  [[nodiscard]] DataLayoutOption getDataLayout() const override { return dataLayout; }
 
-  bool getUseNewton3() const override { return useNewton3; }
+  [[nodiscard]] bool getUseNewton3() const override { return useNewton3; }
 
  private:
   /**

--- a/src/autopas/containers/linkedCells/traversals/C01Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/C01Traversal.h
@@ -109,9 +109,9 @@ class C01Traversal
 
   void traverseParticlePairs() override;
 
-  DataLayoutOption getDataLayout() const override { return dataLayout; }
+  [[nodiscard]] DataLayoutOption getDataLayout() const override { return dataLayout; }
 
-  bool getUseNewton3() const override { return useNewton3; }
+  [[nodiscard]] bool getUseNewton3() const override { return useNewton3; }
 
   /**
    * C01 traversals are only usable if useNewton3 is disabled and combined SoA buffers are only applicable if SoA is set
@@ -122,12 +122,12 @@ class C01Traversal
    *
    * @return
    */
-  bool isApplicable() const override {
+  [[nodiscard]] bool isApplicable() const override {
     return not(dataLayout == DataLayoutOption::cuda) and not useNewton3 and
            not(combineSoA && dataLayout != DataLayoutOption::soa);
   }
 
-  TraversalOption getTraversalType() const override {
+  [[nodiscard]] TraversalOption getTraversalType() const override {
     return (combineSoA) ? TraversalOption::c01CombinedSoA : TraversalOption::c01;
   }
 

--- a/src/autopas/containers/linkedCells/traversals/C04HCP.h
+++ b/src/autopas/containers/linkedCells/traversals/C04HCP.h
@@ -48,13 +48,13 @@ class C04HCP : public C08BasedTraversal<ParticleCell, PairwiseFunctor, dataLayou
 
   void traverseParticlePairs() override;
 
-  TraversalOption getTraversalType() const override { return TraversalOption::c04HCP; }
+  [[nodiscard]] TraversalOption getTraversalType() const override { return TraversalOption::c04HCP; }
 
-  DataLayoutOption getDataLayout() const override { return dataLayout; }
+  [[nodiscard]] DataLayoutOption getDataLayout() const override { return dataLayout; }
 
-  bool getUseNewton3() const override { return useNewton3; }
+  [[nodiscard]] bool getUseNewton3() const override { return useNewton3; }
 
-  bool isApplicable() const override {
+  [[nodiscard]] bool isApplicable() const override {
     if (dataLayout == DataLayoutOption::cuda) {
       return false;
     }
@@ -156,6 +156,8 @@ void C04HCP<ParticleCell, PairwiseFunctor, dataLayout, useNewton3>::traverseSing
     case 3:
       startOfThisColor = {-2l, 0l, -1l};
       break;
+    default:
+      autopas::utils::ExceptionHandler::exception("C04HCP::traverseSingleColor: invalid color ({})", color);
   }
 
   // to fix intel64 icpc compiler complaints about perfectly nested loop.

--- a/src/autopas/containers/linkedCells/traversals/C04SoATraversal.h
+++ b/src/autopas/containers/linkedCells/traversals/C04SoATraversal.h
@@ -44,11 +44,11 @@ class C04SoATraversal : public C04BasedTraversal<ParticleCell, PairwiseFunctor, 
 
   void traverseParticlePairs() override;
 
-  TraversalOption getTraversalType() const override { return TraversalOption::c04SoA; }
+  [[nodiscard]] TraversalOption getTraversalType() const override { return TraversalOption::c04SoA; }
 
-  DataLayoutOption getDataLayout() const override { return dataLayout; }
+  [[nodiscard]] DataLayoutOption getDataLayout() const override { return dataLayout; }
 
-  bool getUseNewton3() const override { return useNewton3; }
+  [[nodiscard]] bool getUseNewton3() const override { return useNewton3; }
 
   /**
    * c04SoA traversals are only usable with dataLayout SoA.
@@ -57,7 +57,7 @@ class C04SoATraversal : public C04BasedTraversal<ParticleCell, PairwiseFunctor, 
    * once this bug is fixed, reenable this traversal again for arbitrary `_overlap`s.
    * @return
    */
-  bool isApplicable() const override {
+  [[nodiscard]] bool isApplicable() const override {
     return dataLayout == DataLayoutOption::soa and
            (this->_overlap[0] == 1 and this->_overlap[1] == 1 and this->_overlap[2] == 1);
   }

--- a/src/autopas/containers/linkedCells/traversals/C04Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/C04Traversal.h
@@ -51,17 +51,17 @@ class C04Traversal : public C08BasedTraversal<ParticleCell, PairwiseFunctor, dat
 
   void traverseParticlePairs() override;
 
-  TraversalOption getTraversalType() const override { return TraversalOption::c04; }
+  [[nodiscard]] TraversalOption getTraversalType() const override { return TraversalOption::c04; }
 
-  DataLayoutOption getDataLayout() const override { return dataLayout; }
+  [[nodiscard]] DataLayoutOption getDataLayout() const override { return dataLayout; }
 
-  bool getUseNewton3() const override { return useNewton3; }
+  [[nodiscard]] bool getUseNewton3() const override { return useNewton3; }
 
   /**
    * C04 traversals are usable, if cellSizeFactor >= 1.0 and there are at least 3 cells for each dimension.
    * @return
    */
-  bool isApplicable() const override {
+  [[nodiscard]] bool isApplicable() const override {
     if (dataLayout == DataLayoutOption::cuda) {
       return false;
     }
@@ -78,7 +78,7 @@ class C04Traversal : public C08BasedTraversal<ParticleCell, PairwiseFunctor, dat
 
   constexpr void computeOffsets32Pack();
 
-  constexpr long parity(long x, long y, long z) const { return (x + y + z + 24) % 8; }
+  [[nodiscard]] constexpr long parity(long x, long y, long z) const { return (x + y + z + 24) % 8; }
 
   std::array<std::array<long, 3>, 32> _cellOffsets32Pack;
 

--- a/src/autopas/containers/linkedCells/traversals/C08Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/C08Traversal.h
@@ -46,17 +46,17 @@ class C08Traversal : public C08BasedTraversal<ParticleCell, PairwiseFunctor, dat
 
   void traverseParticlePairs() override;
 
-  TraversalOption getTraversalType() const override { return TraversalOption::c08; }
+  [[nodiscard]] TraversalOption getTraversalType() const override { return TraversalOption::c08; }
 
-  DataLayoutOption getDataLayout() const override { return dataLayout; }
+  [[nodiscard]] DataLayoutOption getDataLayout() const override { return dataLayout; }
 
-  bool getUseNewton3() const override { return useNewton3; }
+  [[nodiscard]] bool getUseNewton3() const override { return useNewton3; }
 
   /**
    * C08 traversals are always usable.
    * @return
    */
-  bool isApplicable() const override { return not(dataLayout == DataLayoutOption::cuda); }
+  [[nodiscard]] bool isApplicable() const override { return not(dataLayout == DataLayoutOption::cuda); }
 
  private:
   C08CellHandler<ParticleCell, PairwiseFunctor, dataLayout, useNewton3> _cellHandler;

--- a/src/autopas/containers/linkedCells/traversals/C18Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/C18Traversal.h
@@ -63,17 +63,17 @@ class C18Traversal : public C18BasedTraversal<ParticleCell, PairwiseFunctor, dat
    */
   void processBaseCell(std::vector<ParticleCell> &cells, unsigned long x, unsigned long y, unsigned long z);
 
-  TraversalOption getTraversalType() const override { return TraversalOption::c18; }
+  [[nodiscard]] TraversalOption getTraversalType() const override { return TraversalOption::c18; }
 
   /**
    * C18 traversal is always usable.
    * @return
    */
-  bool isApplicable() const override { return not(dataLayout == DataLayoutOption::cuda); }
+  [[nodiscard]] bool isApplicable() const override { return not(dataLayout == DataLayoutOption::cuda); }
 
-  DataLayoutOption getDataLayout() const override { return dataLayout; }
+  [[nodiscard]] DataLayoutOption getDataLayout() const override { return dataLayout; }
 
-  bool getUseNewton3() const override { return useNewton3; }
+  [[nodiscard]] bool getUseNewton3() const override { return useNewton3; }
 
  private:
   /**

--- a/src/autopas/containers/linkedCells/traversals/SlicedTraversal.h
+++ b/src/autopas/containers/linkedCells/traversals/SlicedTraversal.h
@@ -52,11 +52,11 @@ class SlicedTraversal : public SlicedBasedTraversal<ParticleCell, PairwiseFuncto
 
   void traverseParticlePairs() override;
 
-  DataLayoutOption getDataLayout() const override { return dataLayout; }
+  [[nodiscard]] DataLayoutOption getDataLayout() const override { return dataLayout; }
 
-  bool getUseNewton3() const override { return useNewton3; }
+  [[nodiscard]] bool getUseNewton3() const override { return useNewton3; }
 
-  TraversalOption getTraversalType() const override { return TraversalOption::sliced; }
+  [[nodiscard]] TraversalOption getTraversalType() const override { return TraversalOption::sliced; }
 
  private:
   C08CellHandler<ParticleCell, PairwiseFunctor, dataLayout, useNewton3> _cellHandler;

--- a/src/autopas/containers/verletClusterCells/traversals/VerletClusterCellsTraversal.h
+++ b/src/autopas/containers/verletClusterCells/traversals/VerletClusterCellsTraversal.h
@@ -46,9 +46,9 @@ class VerletClusterCellsTraversal : public CellPairTraversal<ParticleCell>,
         _neighborMatrixDim(nullptr),
         _clusterSize(clusterSize) {}
 
-  TraversalOption getTraversalType() const override { return TraversalOption::verletClusterCells; }
+  [[nodiscard]] TraversalOption getTraversalType() const override { return TraversalOption::verletClusterCells; }
 
-  bool isApplicable() const override {
+  [[nodiscard]] bool isApplicable() const override {
     if (dataLayout == DataLayoutOption::cuda) {
       int nDevices = 0;
 #if defined(AUTOPAS_CUDA)
@@ -61,9 +61,9 @@ class VerletClusterCellsTraversal : public CellPairTraversal<ParticleCell>,
     }
   }
 
-  bool getUseNewton3() const override { return useNewton3; }
+  [[nodiscard]] bool getUseNewton3() const override { return useNewton3; }
 
-  DataLayoutOption getDataLayout() const override { return dataLayout; }
+  [[nodiscard]] DataLayoutOption getDataLayout() const override { return dataLayout; }
 
   std::tuple<TraversalOption, DataLayoutOption, bool> getSignature() override {
     return std::make_tuple(TraversalOption::verletClusterCells, dataLayout, useNewton3);
@@ -361,7 +361,7 @@ class VerletClusterCellsTraversal : public CellPairTraversal<ParticleCell>,
    * @param box2
    * @return distance
    */
-  inline double getMinDist(const std::array<double, 6> &box1, const std::array<double, 6> &box2) const {
+  [[nodiscard]] inline double getMinDist(const std::array<double, 6> &box1, const std::array<double, 6> &box2) const {
     double sqrDist = 0;
     for (int i = 0; i < 3; ++i) {
       if (box2[i + 3] < box1[i]) {

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -203,7 +203,8 @@ class VerletClusterLists : public ParticleContainerInterface<FullParticleCell<Pa
    * @copydoc ParticleContainerInterface::begin()
    * @note This function additionally rebuilds the towers if the tower-structure isn't valid.
    */
-  [[nodiscard]] ParticleIteratorWrapper<Particle, true> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
+  [[nodiscard]] ParticleIteratorWrapper<Particle, true> begin(
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
     // For good openmp scalability we want the particles to be sorted into the clusters, so we do this!
 #ifdef AUTOPAS_OPENMP
 #pragma omp single

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -80,7 +80,7 @@ class VerletClusterLists : public ParticleContainerInterface<FullParticleCell<Pa
         _cutoff{cutoff},
         _skin{skin} {}
 
-  ContainerOption getContainerType() const override { return ContainerOption::verletClusterLists; }
+  [[nodiscard]] ContainerOption getContainerType() const override { return ContainerOption::verletClusterLists; }
 
   void iteratePairwise(TraversalInterface *traversal) override {
     if (_isValid == ValidityState::cellsAndListsValid) {
@@ -163,8 +163,7 @@ class VerletClusterLists : public ParticleContainerInterface<FullParticleCell<Pa
   /**
    * @copydoc VerletLists::updateContainer()
    */
-  AUTOPAS_WARN_UNUSED_RESULT
-  std::vector<Particle> updateContainer() override {
+  [[nodiscard]] std::vector<Particle> updateContainer() override {
     // first delete all halo particles.
     this->deleteHaloParticles();
 
@@ -193,7 +192,7 @@ class VerletClusterLists : public ParticleContainerInterface<FullParticleCell<Pa
     return invalidParticles;
   }
 
-  TraversalSelectorInfo getTraversalSelectorInfo() const override {
+  [[nodiscard]] TraversalSelectorInfo getTraversalSelectorInfo() const override {
     std::array<double, 3> towerSize = {_towerSideLength, _towerSideLength,
                                        this->getHaloBoxMax()[2] - this->getHaloBoxMin()[2]};
     std::array<unsigned long, 3> towerDimensions = {_towersPerDim[0], _towersPerDim[1], 1};
@@ -204,7 +203,7 @@ class VerletClusterLists : public ParticleContainerInterface<FullParticleCell<Pa
    * @copydoc ParticleContainerInterface::begin()
    * @note This function additionally rebuilds the towers if the tower-structure isn't valid.
    */
-  ParticleIteratorWrapper<Particle, true> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
+  [[nodiscard]] ParticleIteratorWrapper<Particle, true> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
     // For good openmp scalability we want the particles to be sorted into the clusters, so we do this!
 #ifdef AUTOPAS_OPENMP
 #pragma omp single
@@ -223,7 +222,7 @@ class VerletClusterLists : public ParticleContainerInterface<FullParticleCell<Pa
    * @note const version.
    * @note This function additionally iterates over the _particlesToAdd vector if the tower-structure isn't valid.
    */
-  ParticleIteratorWrapper<Particle, false> begin(
+  [[nodiscard]] ParticleIteratorWrapper<Particle, false> begin(
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const override {
     /// @todo use proper cellBorderAndFlagManager instead of the unknowing.
     if (_isValid != ValidityState::invalid) {
@@ -247,7 +246,7 @@ class VerletClusterLists : public ParticleContainerInterface<FullParticleCell<Pa
    * @copydoc ParticleContainerInterface::getRegionIterator()
    * @note This function additionally rebuilds the towers if the tower-structure isn't valid.
    */
-  ParticleIteratorWrapper<Particle, true> getRegionIterator(
+  [[nodiscard]] ParticleIteratorWrapper<Particle, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
     // Special iterator requires sorted cells.
@@ -281,7 +280,7 @@ class VerletClusterLists : public ParticleContainerInterface<FullParticleCell<Pa
    * @note const version.
    * @note This function additionally iterates over _particlesToAdd if the container structure isn't valid.
    */
-  ParticleIteratorWrapper<Particle, false> getRegionIterator(
+  [[nodiscard]] ParticleIteratorWrapper<Particle, false> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const override {
     if (_isValid != ValidityState::invalid && not _particlesToAdd.empty()) {
@@ -340,7 +339,7 @@ class VerletClusterLists : public ParticleContainerInterface<FullParticleCell<Pa
     }
   }
 
-  unsigned long getNumParticles() const override {
+  [[nodiscard]] unsigned long getNumParticles() const override {
     unsigned long sum = 0;
     for (size_t index = 0; index < _towers.size(); index++) {
       sum += _towers[index].getNumActualParticles();
@@ -450,8 +449,7 @@ class VerletClusterLists : public ParticleContainerInterface<FullParticleCell<Pa
     return towerIndex2DTo1D(x, y, _towersPerDim);
   }
 
-  // boxmax
-  const std::array<double, 3> &getBoxMax() const override { return _boxMax; }
+  [[nodiscard]] const std::array<double, 3> &getBoxMax() const override { return _boxMax; }
 
   void setBoxMax(const std::array<double, 3> &boxMax) override { _boxMax = boxMax; }
 
@@ -459,10 +457,9 @@ class VerletClusterLists : public ParticleContainerInterface<FullParticleCell<Pa
    * Get the upper corner of the halo box.
    * @return the upper corner of the halo box.
    */
-  const std::array<double, 3> &getHaloBoxMax() const { return _haloBoxMax; }
+  [[nodiscard]] const std::array<double, 3> &getHaloBoxMax() const { return _haloBoxMax; }
 
-  // boxmin
-  const std::array<double, 3> &getBoxMin() const override { return _boxMin; }
+  [[nodiscard]] const std::array<double, 3> &getBoxMin() const override { return _boxMin; }
 
   void setBoxMin(const std::array<double, 3> &boxMin) override { _boxMin = boxMin; }
 
@@ -470,17 +467,17 @@ class VerletClusterLists : public ParticleContainerInterface<FullParticleCell<Pa
    * Get the lower corner of the halo box.
    * @return the lower corner of the halo box.
    */
-  const std::array<double, 3> &getHaloBoxMin() const { return _haloBoxMin; }
+  [[nodiscard]] const std::array<double, 3> &getHaloBoxMin() const { return _haloBoxMin; }
 
-  double getCutoff() const override { return _cutoff; }
+  [[nodiscard]] double getCutoff() const override { return _cutoff; }
 
   void setCutoff(double cutoff) override { _cutoff = cutoff; }
 
-  double getSkin() const override { return _skin; }
+  [[nodiscard]] double getSkin() const override { return _skin; }
 
   void setSkin(double skin) override { _skin = skin; }
 
-  double getInteractionLength() const override { return _cutoff + _skin; }
+  [[nodiscard]] double getInteractionLength() const override { return _cutoff + _skin; }
 
   void deleteAllParticles() override {
     _isValid = ValidityState::invalid;

--- a/src/autopas/containers/verletClusterLists/traversals/VerletClustersColoringTraversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VerletClustersColoringTraversal.h
@@ -61,11 +61,13 @@ class VerletClustersColoringTraversal : public CBasedTraversal<ParticleCell, Pai
         _functor(pairwiseFunctor),
         _clusterFunctor(pairwiseFunctor) {}
 
-  TraversalOption getTraversalType() const override { return TraversalOption::verletClustersColoring; }
+  [[nodiscard]] TraversalOption getTraversalType() const override { return TraversalOption::verletClustersColoring; }
 
-  DataLayoutOption getDataLayout() const override { return dataLayout; }
-  bool getUseNewton3() const override { return useNewton3; }
-  bool isApplicable() const override {
+  [[nodiscard]] DataLayoutOption getDataLayout() const override { return dataLayout; }
+
+  [[nodiscard]] bool getUseNewton3() const override { return useNewton3; }
+
+  [[nodiscard]] bool isApplicable() const override {
     return (dataLayout == DataLayoutOption::aos || dataLayout == DataLayoutOption::soa);
   }
 

--- a/src/autopas/containers/verletClusterLists/traversals/VerletClustersStaticTraversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VerletClustersStaticTraversal.h
@@ -80,8 +80,8 @@ class VerletClustersStaticTraversal : public TraversalInterface, public VerletCl
              clusterIndex++, clusterCount++) {
           auto &currentCluster = currentTower.getCluster(clusterIndex);
           _clusterFunctor.traverseCluster(currentCluster);
-          for (auto &neighborCluster : currentCluster.getNeighbors()) {
-            _clusterFunctor.traverseClusterPair(currentCluster, neighborCluster);
+          for (auto *neighborCluster : currentCluster.getNeighbors()) {
+            _clusterFunctor.traverseClusterPair(currentCluster, *neighborCluster);
           }
         }
       }

--- a/src/autopas/containers/verletClusterLists/traversals/VerletClustersStaticTraversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VerletClustersStaticTraversal.h
@@ -79,8 +79,8 @@ class VerletClustersStaticTraversal : public TraversalInterface, public VerletCl
              clusterIndex++, clusterCount++) {
           auto &currentCluster = currentTower.getCluster(clusterIndex);
           _clusterFunctor.traverseCluster(currentCluster);
-          for (auto *neighborCluster : currentCluster.getNeighbors()) {
-            _clusterFunctor.traverseClusterPair(currentCluster, *neighborCluster);
+          for (auto &neighborCluster : currentCluster.getNeighbors()) {
+            _clusterFunctor.traverseClusterPair(currentCluster, neighborCluster);
           }
         }
       }

--- a/src/autopas/containers/verletClusterLists/traversals/VerletClustersStaticTraversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VerletClustersStaticTraversal.h
@@ -34,12 +34,13 @@ class VerletClustersStaticTraversal : public TraversalInterface, public VerletCl
   explicit VerletClustersStaticTraversal(PairwiseFunctor *pairwiseFunctor)
       : _functor(pairwiseFunctor), _clusterFunctor(pairwiseFunctor) {}
 
-  TraversalOption getTraversalType() const override { return TraversalOption::verletClustersStatic; }
+  [[nodiscard]] TraversalOption getTraversalType() const override { return TraversalOption::verletClustersStatic; }
 
-  DataLayoutOption getDataLayout() const override { return dataLayout; }
-  bool getUseNewton3() const override { return useNewton3; }
+  [[nodiscard]] DataLayoutOption getDataLayout() const override { return dataLayout; }
 
-  bool isApplicable() const override {
+  [[nodiscard]] bool getUseNewton3() const override { return useNewton3; }
+
+  [[nodiscard]] bool isApplicable() const override {
     return (dataLayout == DataLayoutOption::aos or dataLayout == DataLayoutOption::soa) and not useNewton3;
   }
 

--- a/src/autopas/containers/verletClusterLists/traversals/VerletClustersTraversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VerletClustersTraversal.h
@@ -34,12 +34,13 @@ class VerletClustersTraversal : public TraversalInterface,
   explicit VerletClustersTraversal(PairwiseFunctor *pairwiseFunctor)
       : _functor(pairwiseFunctor), _clusterFunctor(pairwiseFunctor) {}
 
-  TraversalOption getTraversalType() const override { return TraversalOption::verletClusters; }
+  [[nodiscard]] TraversalOption getTraversalType() const override { return TraversalOption::verletClusters; }
 
-  DataLayoutOption getDataLayout() const override { return dataLayout; }
-  bool getUseNewton3() const override { return useNewton3; }
+  [[nodiscard]] DataLayoutOption getDataLayout() const override { return dataLayout; }
 
-  bool isApplicable() const override {
+  [[nodiscard]] bool getUseNewton3() const override { return useNewton3; }
+
+  [[nodiscard]] bool isApplicable() const override {
     return (dataLayout == DataLayoutOption::aos || dataLayout == DataLayoutOption::soa) and not useNewton3;
   }
 

--- a/src/autopas/containers/verletClusterLists/traversals/VerletClustersTraversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VerletClustersTraversal.h
@@ -61,8 +61,8 @@ class VerletClustersTraversal : public TraversalInterface,
 
     const auto _clusterTraverseFunctor = [this](internal::Cluster<Particle, clusterSize> &cluster) {
       _clusterFunctor.traverseCluster(cluster);
-      for (auto &neighborCluster : cluster.getNeighbors()) {
-        _clusterFunctor.traverseClusterPair(cluster, neighborCluster);
+      for (auto *neighborCluster : cluster.getNeighbors()) {
+        _clusterFunctor.traverseClusterPair(cluster, *neighborCluster);
       }
     };
 

--- a/src/autopas/containers/verletClusterLists/traversals/VerletClustersTraversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VerletClustersTraversal.h
@@ -60,8 +60,8 @@ class VerletClustersTraversal : public TraversalInterface,
 
     const auto _clusterTraverseFunctor = [this](internal::Cluster<Particle, clusterSize> &cluster) {
       _clusterFunctor.traverseCluster(cluster);
-      for (auto *neighborCluster : cluster.getNeighbors()) {
-        _clusterFunctor.traverseClusterPair(cluster, *neighborCluster);
+      for (auto &neighborCluster : cluster.getNeighbors()) {
+        _clusterFunctor.traverseClusterPair(cluster, neighborCluster);
       }
     };
 

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -93,8 +93,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<FullParticleCell
    * @copydoc autopas::ParticleContainerInterface::updateContainer()
    * @note This function invalidates the neighbor lists.
    */
-  AUTOPAS_WARN_UNUSED_RESULT
-  std::vector<Particle> updateContainer() override {
+  [[nodiscard]] std::vector<Particle> updateContainer() override {
     AutoPasLog(debug, "updating container");
     _neighborListIsValid = false;
     return _linkedCells.updateContainer();
@@ -127,14 +126,14 @@ class VerletListsLinkedBase : public ParticleContainerInterface<FullParticleCell
   /**
    * @copydoc autopas::ParticleContainerInterface::begin()
    */
-  ParticleIteratorWrapper<Particle, true> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
+  [[nodiscard]] ParticleIteratorWrapper<Particle, true> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
     return _linkedCells.begin(behavior);
   }
 
   /**
    * @copydoc autopas::ParticleContainerInterface::begin()
    */
-  ParticleIteratorWrapper<Particle, false> begin(
+  [[nodiscard]] ParticleIteratorWrapper<Particle, false> begin(
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const override {
     return _linkedCells.begin(behavior);
   }
@@ -142,7 +141,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<FullParticleCell
   /**
    * @copydoc autopas::ParticleContainerInterface::getRegionIterator()
    */
-  ParticleIteratorWrapper<Particle, true> getRegionIterator(
+  [[nodiscard]] ParticleIteratorWrapper<Particle, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
     return _linkedCells.getRegionIterator(lowerCorner, higherCorner, behavior);
@@ -151,7 +150,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<FullParticleCell
   /**
    * @copydoc autopas::ParticleContainerInterface::getRegionIterator()
    */
-  ParticleIteratorWrapper<Particle, false> getRegionIterator(
+  [[nodiscard]] ParticleIteratorWrapper<Particle, false> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
       IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const override {
     return _linkedCells.getRegionIterator(lowerCorner, higherCorner, behavior);
@@ -161,7 +160,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<FullParticleCell
    * Get the dimension of the used cellblock including the haloboxes.
    * @return the dimensions of the used cellblock
    */
-  const std::array<std::size_t, 3> &getCellsPerDimension() const {
+  [[nodiscard]] const std::array<std::size_t, 3> &getCellsPerDimension() const {
     return _linkedCells.getCellBlock().getCellsPerDimensionWithHalo();
   }
 
@@ -169,7 +168,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<FullParticleCell
    * Generates a traversal selector info for this container.
    * @return Traversal selector info for this container.
    */
-  TraversalSelectorInfo getTraversalSelectorInfo() const override {
+  [[nodiscard]] TraversalSelectorInfo getTraversalSelectorInfo() const override {
     return TraversalSelectorInfo(this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(),
                                  this->getInteractionLength(), this->_linkedCells.getCellBlock().getCellLength(), 0);
   }
@@ -177,7 +176,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<FullParticleCell
   /**
    * @copydoc autopas::ParticleContainerInterface::getBoxMax()
    */
-  const std::array<double, 3> &getBoxMax() const override final { return _linkedCells.getBoxMax(); }
+  [[nodiscard]] const std::array<double, 3> &getBoxMax() const override final { return _linkedCells.getBoxMax(); }
 
   /**
    * @copydoc autopas::ParticleContainerInterface::setBoxMax()
@@ -187,7 +186,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<FullParticleCell
   /**
    * @copydoc autopas::ParticleContainerInterface::getBoxMin()
    */
-  const std::array<double, 3> &getBoxMin() const override final { return _linkedCells.getBoxMin(); }
+  [[nodiscard]] const std::array<double, 3> &getBoxMin() const override final { return _linkedCells.getBoxMin(); }
 
   /**
    * @copydoc autopas::ParticleContainerInterface::setBoxMin()
@@ -197,7 +196,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<FullParticleCell
   /**
    * @copydoc autopas::ParticleContainerInterface::getCutoff()
    */
-  double getCutoff() const override final { return _linkedCells.getCutoff(); }
+  [[nodiscard]] double getCutoff() const override final { return _linkedCells.getCutoff(); }
 
   /**
    * @copydoc autopas::ParticleContainerInterface::setCutoff()
@@ -207,7 +206,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<FullParticleCell
   /**
    * @copydoc autopas::ParticleContainerInterface::getSkin()
    */
-  double getSkin() const override final { return _linkedCells.getSkin(); }
+  [[nodiscard]] double getSkin() const override final { return _linkedCells.getSkin(); }
 
   /**
    * @copydoc autopas::ParticleContainerInterface::setSkin()
@@ -217,7 +216,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<FullParticleCell
   /**
    * @copydoc autopas::ParticleContainerInterface::getInteractionLength()
    */
-  double getInteractionLength() const override final { return _linkedCells.getInteractionLength(); }
+  [[nodiscard]] double getInteractionLength() const override final { return _linkedCells.getInteractionLength(); }
 
  protected:
   /// internal linked cells storage, handles Particle storage and used to build verlet lists

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -126,7 +126,8 @@ class VerletListsLinkedBase : public ParticleContainerInterface<FullParticleCell
   /**
    * @copydoc autopas::ParticleContainerInterface::begin()
    */
-  [[nodiscard]] ParticleIteratorWrapper<Particle, true> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
+  [[nodiscard]] ParticleIteratorWrapper<Particle, true> begin(
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
     return _linkedCells.begin(behavior);
   }
 

--- a/src/autopas/containers/verletListsCellBased/verletLists/traversals/TraversalVerlet.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/traversals/TraversalVerlet.h
@@ -37,13 +37,13 @@ class TraversalVerlet
    */
   explicit TraversalVerlet(PairwiseFunctor *pairwiseFunctor) : _functor(pairwiseFunctor) {}
 
-  TraversalOption getTraversalType() const override { return TraversalOption::verletTraversal; }
+  [[nodiscard]] TraversalOption getTraversalType() const override { return TraversalOption::verletTraversal; }
 
-  DataLayoutOption getDataLayout() const override { return dataLayout; }
+  [[nodiscard]] DataLayoutOption getDataLayout() const override { return dataLayout; }
 
-  bool getUseNewton3() const override { return useNewton3; }
+  [[nodiscard]] bool getUseNewton3() const override { return useNewton3; }
 
-  bool isApplicable() const override {
+  [[nodiscard]] bool isApplicable() const override {
     return dataLayout == DataLayoutOption::aos || dataLayout == DataLayoutOption::soa;
   }
 

--- a/src/autopas/containers/verletListsCellBased/verletLists/traversals/VarVerletTraversalAsBuild.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/traversals/VarVerletTraversalAsBuild.h
@@ -46,9 +46,9 @@ class VarVerletTraversalAsBuild : public VarVerletTraversalInterface<VerletNeigh
    */
   explicit VarVerletTraversalAsBuild(PairwiseFunctor *pairwiseFunctor) : _functor(pairwiseFunctor), _soa{nullptr} {}
 
-  bool getUseNewton3() const override { return useNewton3; }
+  [[nodiscard]] bool getUseNewton3() const override { return useNewton3; }
 
-  DataLayoutOption getDataLayout() const override { return dataLayout; }
+  [[nodiscard]] DataLayoutOption getDataLayout() const override { return dataLayout; }
 
   void initTraversal() override {
     auto &neighborList = *(this->_neighborList);
@@ -79,11 +79,11 @@ class VarVerletTraversalAsBuild : public VarVerletTraversalInterface<VerletNeigh
     }
   }
 
-  bool isApplicable() const override {
+  [[nodiscard]] bool isApplicable() const override {
     return dataLayout == DataLayoutOption::soa || dataLayout == DataLayoutOption::aos;
   }
 
-  TraversalOption getTraversalType() const override { return TraversalOption::varVerletTraversalAsBuild; }
+  [[nodiscard]] TraversalOption getTraversalType() const override { return TraversalOption::varVerletTraversalAsBuild; }
 
  private:
   /**

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/C01TraversalVerlet.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/C01TraversalVerlet.h
@@ -43,13 +43,13 @@ class C01TraversalVerlet : public C01BasedTraversal<ParticleCell, PairwiseFuncto
 
   void traverseParticlePairs() override;
 
-  TraversalOption getTraversalType() const override { return TraversalOption::c01Verlet; }
+  [[nodiscard]] TraversalOption getTraversalType() const override { return TraversalOption::c01Verlet; }
 
-  bool isApplicable() const override { return (not useNewton3) && (dataLayout == DataLayoutOption::aos); }
+  [[nodiscard]] bool isApplicable() const override { return (not useNewton3) && (dataLayout == DataLayoutOption::aos); }
 
-  DataLayoutOption getDataLayout() const override { return dataLayout; }
+  [[nodiscard]] DataLayoutOption getDataLayout() const override { return dataLayout; }
 
-  bool getUseNewton3() const override { return useNewton3; }
+  [[nodiscard]] bool getUseNewton3() const override { return useNewton3; }
 
  private:
   PairwiseFunctor *_functor;

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/C18TraversalVerlet.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/C18TraversalVerlet.h
@@ -43,13 +43,13 @@ class C18TraversalVerlet : public C18BasedTraversal<ParticleCell, PairwiseFuncto
 
   void traverseParticlePairs() override;
 
-  TraversalOption getTraversalType() const override { return TraversalOption::c18Verlet; };
+  [[nodiscard]] TraversalOption getTraversalType() const override { return TraversalOption::c18Verlet; };
 
-  bool isApplicable() const override { return dataLayout == DataLayoutOption::aos; }
+  [[nodiscard]] bool isApplicable() const override { return dataLayout == DataLayoutOption::aos; }
 
-  DataLayoutOption getDataLayout() const override { return dataLayout; }
+  [[nodiscard]] DataLayoutOption getDataLayout() const override { return dataLayout; }
 
-  bool getUseNewton3() const override { return useNewton3; }
+  [[nodiscard]] bool getUseNewton3() const override { return useNewton3; }
 
  private:
   PairwiseFunctor *_functor;

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/SlicedTraversalVerlet.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/SlicedTraversalVerlet.h
@@ -50,13 +50,13 @@ class SlicedTraversalVerlet : public SlicedBasedTraversal<ParticleCell, Pairwise
 
   void traverseParticlePairs() override;
 
-  DataLayoutOption getDataLayout() const override { return dataLayout; }
+  [[nodiscard]] DataLayoutOption getDataLayout() const override { return dataLayout; }
 
-  bool getUseNewton3() const override { return useNewton3; }
+  [[nodiscard]] bool getUseNewton3() const override { return useNewton3; }
 
-  TraversalOption getTraversalType() const override { return TraversalOption::slicedVerlet; }
+  [[nodiscard]] TraversalOption getTraversalType() const override { return TraversalOption::slicedVerlet; }
 
-  bool isApplicable() const override { return dataLayout == DataLayoutOption::aos; }
+  [[nodiscard]] bool isApplicable() const override { return dataLayout == DataLayoutOption::aos; }
 
  private:
   PairwiseFunctor *_functor;

--- a/src/autopas/selectors/Configuration.h
+++ b/src/autopas/selectors/Configuration.h
@@ -46,7 +46,7 @@ class Configuration {
    * Returns string representation in JSON style of the configuration object.
    * @return String representation.
    */
-  std::string toString() const {
+  [[nodiscard]] std::string toString() const {
     return "{Container: " + container.to_string() + " , CellSizeFactor: " + std::to_string(cellSizeFactor) +
            " , Traversal: " + traversal.to_string() + " , Data Layout: " + dataLayout.to_string() +
            " , Newton 3: " + newton3.to_string() + "}";

--- a/src/autopas/selectors/OptimumSelector.h
+++ b/src/autopas/selectors/OptimumSelector.h
@@ -74,4 +74,4 @@ inline unsigned long optimumValue(const std::vector<unsigned long> &values, Sele
   return 0;
 }
 
-}  // namespace autopas
+}  // namespace autopas::OptimumSelector

--- a/src/autopas/selectors/OptimumSelector.h
+++ b/src/autopas/selectors/OptimumSelector.h
@@ -13,12 +13,10 @@
 #include "autopas/options/SelectorStrategyOption.h"
 #include "autopas/utils/ExceptionHandler.h"
 
-namespace autopas {
-
 /**
  * Collection of functions for selecting the optimum value out of a vector of values according to a given strategy
  */
-namespace OptimumSelector {
+namespace autopas::OptimumSelector {
 
 /**
  * Minimal value.
@@ -76,5 +74,4 @@ inline unsigned long optimumValue(const std::vector<unsigned long> &values, Sele
   return 0;
 }
 
-}  // namespace OptimumSelector
 }  // namespace autopas

--- a/src/autopas/selectors/OptimumSelector.h
+++ b/src/autopas/selectors/OptimumSelector.h
@@ -33,7 +33,7 @@ inline unsigned long minValue(const std::vector<unsigned long> &values) {
  * @return Arithmetic mean of the vector.
  */
 inline unsigned long meanValue(const std::vector<unsigned long> &values) {
-  return std::accumulate(values.cbegin(), values.cend(), 0l) / values.size();
+  return std::accumulate(values.cbegin(), values.cend(), 0ul) / values.size();
 }
 
 /**

--- a/src/autopas/utils/AutoPasMacros.h
+++ b/src/autopas/utils/AutoPasMacros.h
@@ -6,8 +6,5 @@
 
 #pragma once
 
-/**
- * Highly encourages the compiler to produce a warning if the return value is ignored.
- * @note: this is c++17
- */
-#define AUTOPAS_WARN_UNUSED_RESULT [[nodiscard]]
+// We try not to use precompiler macros so if you feel like adding something here
+// think if it really can not be done in a different way!


### PR DESCRIPTION
# Description

several small stuff I stumbled upon while reviewing code.
- [x] added lots of `[[nodiscard]]` in the traversals
- [x] merge namespaces for `OptimumSelector`
- [x] c04: convert computeOffsets32Pack() to a stateless function and use it in the initializer list of the constructor
- [x] `AutoPas.h` move default values from constructor to declarations.
- [x] Remove `AUTOPAS_WARN_UNUSED`
- [x] fix #458 
- [x] when invoking `md-flexible` with `--help` sort options

# How Has This Been Tested?

just existing tests.
