### PR TITLE
SuperClass for tuning strategies and user input for PredicitveTuning

### DIFF
--- a/examples/md-flexible/Simulation.h
+++ b/examples/md-flexible/Simulation.h
@@ -218,6 +218,8 @@ void Simulation<Particle, ParticleCell>::initialize(const MDFlexConfig &mdFlexCo
   _autopas.setBoxMax(_config->boxMax);
   _autopas.setBoxMin(_config->boxMin);
   _autopas.setCutoff(_config->cutoff);
+  _autopas.setRelativeOptimumRange(_config->relativeOptimumRange);
+  _autopas.setMaxTuningPhasesWithoutTest(_config->maxTuningPhasesWithoutTest);
   _autopas.setNumSamples(_config->tuningSamples);
   _autopas.setSelectorStrategy(_config->selectorStrategy);
   _autopas.setTuningInterval(_config->tuningInterval);

--- a/examples/md-flexible/parsing/CLIParser.cpp
+++ b/examples/md-flexible/parsing/CLIParser.cpp
@@ -275,7 +275,7 @@ bool CLIParser::parseInput(int argc, char **argv, MDFlexConfig &config) {
         try {
           config.maxTuningPhasesWithoutTest = (unsigned int)stoul(strArg);
           if (config.maxTuningPhasesWithoutTest < 1) {
-            cerr << "Max tuning phases without est has to be positive!" << endl;
+            cerr << "Max tuning phases without test has to be positive!" << endl;
             displayHelp = true;
           }
         } catch (const exception &) {

--- a/examples/md-flexible/parsing/CLIParser.cpp
+++ b/examples/md-flexible/parsing/CLIParser.cpp
@@ -1,7 +1,7 @@
 /**
  * @file CLIParser.cpp
  * @author F. Gratl
- * @date 10/18/19
+ * @date 18.10.2019
  */
 
 #include "CLIParser.h"
@@ -15,41 +15,43 @@ bool CLIParser::parseInput(int argc, char **argv, MDFlexConfig &config) {
   bool displayHelp = false;
   int option, option_index;
   static struct option long_options[] = {{"help", no_argument, nullptr, 'h'},
-                                         {MDFlexConfig::acquisitionFunctionOptionStr, required_argument, nullptr, 'A'},
-                                         {MDFlexConfig::boxLengthStr, required_argument, nullptr, 'b'},
-                                         {MDFlexConfig::cellSizeFactorsStr, required_argument, nullptr, 'a'},
+                                         {MDFlexConfig::newton3OptionsStr, required_argument, nullptr, '3'},
                                          {MDFlexConfig::checkpointfileStr, required_argument, nullptr, '4'},
+                                         {MDFlexConfig::acquisitionFunctionOptionStr, required_argument, nullptr, 'A'},
+                                         {MDFlexConfig::cellSizeFactorsStr, required_argument, nullptr, 'a'},
+                                         {MDFlexConfig::boxLengthStr, required_argument, nullptr, 'b'},
                                          {MDFlexConfig::containerOptionsStr, required_argument, nullptr, 'c'},
-                                         {MDFlexConfig::dontCreateEndConfigStr, no_argument, nullptr, 'e'},
                                          {MDFlexConfig::cutoffStr, required_argument, nullptr, 'C'},
                                          {MDFlexConfig::dataLayoutOptionsStr, required_argument, nullptr, 'd'},
                                          {MDFlexConfig::deltaTStr, required_argument, nullptr, 'D'},
-                                         {MDFlexConfig::distributionMeanStr, required_argument, nullptr, 'm'},
-                                         {MDFlexConfig::distributionStdDevStr, required_argument, nullptr, 'z'},
+                                         {MDFlexConfig::dontCreateEndConfigStr, no_argument, nullptr, 'e'},
+                                         {MDFlexConfig::tuningMaxEvidenceStr, required_argument, nullptr, 'E'},
                                          {MDFlexConfig::functorOptionStr, required_argument, nullptr, 'f'},
+                                         {MDFlexConfig::dontMeasureFlopsStr, no_argument, nullptr, 'F'},
                                          {MDFlexConfig::generatorOptionStr, required_argument, nullptr, 'g'},
                                          {MDFlexConfig::iterationsStr, required_argument, nullptr, 'i'},
-                                         {MDFlexConfig::logFileNameStr, required_argument, nullptr, 'L'},
-                                         {MDFlexConfig::logLevelStr, required_argument, nullptr, 'l'},
-                                         {MDFlexConfig::dontMeasureFlopsStr, no_argument, nullptr, 'F'},
-                                         {MDFlexConfig::newton3OptionsStr, required_argument, nullptr, '3'},
-                                         {MDFlexConfig::particlesPerDimStr, required_argument, nullptr, 'n'},
-                                         {MDFlexConfig::particlesSpacingStr, required_argument, nullptr, 's'},
-                                         {MDFlexConfig::particlesTotalStr, required_argument, nullptr, 'N'},
-                                         {MDFlexConfig::periodicStr, required_argument, nullptr, 'p'},
-                                         {MDFlexConfig::selectorStrategyStr, required_argument, nullptr, 'y'},
-                                         {MDFlexConfig::thermostatStr, required_argument, nullptr, 'u'},
-                                         {MDFlexConfig::traversalOptionsStr, required_argument, nullptr, 't'},
                                          {MDFlexConfig::tuningIntervalStr, required_argument, nullptr, 'I'},
-                                         {MDFlexConfig::tuningMaxEvidenceStr, required_argument, nullptr, 'E'},
-                                         {MDFlexConfig::tuningSamplesStr, required_argument, nullptr, 'S'},
-                                         {MDFlexConfig::tuningStrategyOptionsStr, required_argument, nullptr, 'T'},
+                                         {MDFlexConfig::logLevelStr, required_argument, nullptr, 'l'},
+                                         {MDFlexConfig::logFileNameStr, required_argument, nullptr, 'L'},
+                                         {MDFlexConfig::distributionMeanStr, required_argument, nullptr, 'm'},
+                                         {MDFlexConfig::maxTuningPhasesWithoutTestStr, required_argument, nullptr, 'M'},
+                                         {MDFlexConfig::particlesPerDimStr, required_argument, nullptr, 'n'},
+                                         {MDFlexConfig::particlesTotalStr, required_argument, nullptr, 'N'},
+                                         {MDFlexConfig::relativeOptimumRangeStr, required_argument, nullptr, 'o'},
+                                         {MDFlexConfig::periodicStr, required_argument, nullptr, 'p'},
                                          {MDFlexConfig::verletClusterSizeStr, required_argument, nullptr, 'q'},
-                                         {MDFlexConfig::verletRebuildFrequencyStr, required_argument, nullptr, 'v'},
                                          {MDFlexConfig::verletSkinRadiusStr, required_argument, nullptr, 'r'},
+                                         {MDFlexConfig::particlesSpacingStr, required_argument, nullptr, 's'},
+                                         {MDFlexConfig::tuningSamplesStr, required_argument, nullptr, 'S'},
+                                         {MDFlexConfig::traversalOptionsStr, required_argument, nullptr, 't'},
+                                         {MDFlexConfig::tuningStrategyOptionsStr, required_argument, nullptr, 'T'},
+                                         {MDFlexConfig::thermostatStr, required_argument, nullptr, 'u'},
+                                         {MDFlexConfig::verletRebuildFrequencyStr, required_argument, nullptr, 'v'},
                                          {MDFlexConfig::vtkFileNameStr, required_argument, nullptr, 'w'},
                                          {MDFlexConfig::vtkWriteFrequencyStr, required_argument, nullptr, 'W'},
+                                         {MDFlexConfig::selectorStrategyStr, required_argument, nullptr, 'y'},
                                          {MDFlexConfig::yamlFilenameStr, required_argument, nullptr, 'Y'},
+                                         {MDFlexConfig::distributionStdDevStr, required_argument, nullptr, 'z'},
                                          {nullptr, no_argument, nullptr, 0}};  // needed to signal the end of the array
   // reset getopt to scan from the start of argv
   optind = 1;
@@ -269,6 +271,19 @@ bool CLIParser::parseInput(int argc, char **argv, MDFlexConfig &config) {
         }
         break;
       }
+      case 'M': {
+        try {
+          config.maxTuningPhasesWithoutTest = (unsigned int)stoul(strArg);
+          if (config.maxTuningPhasesWithoutTest < 1) {
+            cerr << "Max tuning phases without est has to be positive!" << endl;
+            displayHelp = true;
+          }
+        } catch (const exception &) {
+          cerr << "Error parsing max tuning phases without test: " << optarg << endl;
+          displayHelp = true;
+        }
+        break;
+      }
       case 'n': {
         try {
           config.particlesPerDim = stoul(strArg);
@@ -283,6 +298,19 @@ bool CLIParser::parseInput(int argc, char **argv, MDFlexConfig &config) {
           config.particlesTotal = stoul(strArg);
         } catch (const exception &) {
           cerr << "Error parsing total number of particles: " << strArg << endl;
+          displayHelp = true;
+        }
+        break;
+      }
+      case 'o': {
+        try {
+          config.relativeOptimumRange = (double)stoul(strArg);
+          if (config.relativeOptimumRange < 1) {
+            cerr << "Relative optimum range has to be greater or equal one!" << endl;
+            displayHelp = true;
+          }
+        } catch (const exception &) {
+          cerr << "Error parsing relative optimum range: " << optarg << endl;
           displayHelp = true;
         }
         break;

--- a/examples/md-flexible/parsing/CLIParser.h
+++ b/examples/md-flexible/parsing/CLIParser.h
@@ -1,7 +1,7 @@
 /**
  * @file CLIParser.h
  * @author F. Gratl
- * @date 10/18/19
+ * @date 18.10.2019
  */
 
 #pragma once

--- a/examples/md-flexible/parsing/MDFlexConfig.cpp
+++ b/examples/md-flexible/parsing/MDFlexConfig.cpp
@@ -1,7 +1,7 @@
 /**
  * @file MDFlexConfig.cpp
  * @author F. Gratl
- * @date 10/18/19
+ * @date 18.10.2019
  */
 
 #include "MDFlexConfig.h"
@@ -37,6 +37,8 @@ std::string MDFlexConfig::to_string() const {
   os << setw(valueOffset) << left << tuningIntervalStr << ":  " << tuningInterval << endl;
   os << setw(valueOffset) << left << tuningSamplesStr << ":  " << tuningSamples << endl;
   os << setw(valueOffset) << left << tuningMaxEvidenceStr << ":  " << tuningMaxEvidence << endl;
+  os << setw(valueOffset) << left << relativeOptimumRangeStr << ":  " << relativeOptimumRange << endl;
+  os << setw(valueOffset) << left << maxTuningPhasesWithoutTestStr << ":  " << maxTuningPhasesWithoutTest << endl;
   os << setw(valueOffset) << left << functorOptionStr << ":  ";
   switch (functorOption) {
     case FunctorOption::lj12_6: {

--- a/examples/md-flexible/parsing/MDFlexConfig.cpp
+++ b/examples/md-flexible/parsing/MDFlexConfig.cpp
@@ -37,8 +37,10 @@ std::string MDFlexConfig::to_string() const {
   os << setw(valueOffset) << left << tuningIntervalStr << ":  " << tuningInterval << endl;
   os << setw(valueOffset) << left << tuningSamplesStr << ":  " << tuningSamples << endl;
   os << setw(valueOffset) << left << tuningMaxEvidenceStr << ":  " << tuningMaxEvidence << endl;
-  os << setw(valueOffset) << left << relativeOptimumRangeStr << ":  " << relativeOptimumRange << endl;
-  os << setw(valueOffset) << left << maxTuningPhasesWithoutTestStr << ":  " << maxTuningPhasesWithoutTest << endl;
+  if (tuningStrategyOption == autopas::TuningStrategyOption::predictiveTuning) {
+    os << setw(valueOffset) << left << relativeOptimumRangeStr << ":  " << relativeOptimumRange << endl;
+    os << setw(valueOffset) << left << maxTuningPhasesWithoutTestStr << ":  " << maxTuningPhasesWithoutTest << endl;
+  }
   os << setw(valueOffset) << left << functorOptionStr << ":  ";
   switch (functorOption) {
     case FunctorOption::lj12_6: {

--- a/examples/md-flexible/parsing/MDFlexConfig.h
+++ b/examples/md-flexible/parsing/MDFlexConfig.h
@@ -85,21 +85,9 @@ class MDFlexConfig {
   unsigned int tuningSamples{3};
   static inline const char *tuningMaxEvidenceStr{"tuning-max-evidence"};
   unsigned int tuningMaxEvidence{10};
-  /**
-   * Name for the input.
-   */
   static inline const char *relativeOptimumRangeStr{"relative-optimum-range"};
-  /**
-   * Specifies the factor of the range of the optimal configurations in PredicitveTuning.
-   */
   double relativeOptimumRange{1.2};
-  /**
-   * Name for the input.
-   */
   static inline const char *maxTuningPhasesWithoutTestStr{"max-tuning-phases-without-test"};
-  /**
-   * Specifies how many tuning phases a configuration can not be tested in PredicitveTuning.
-   */
   unsigned int maxTuningPhasesWithoutTest{5};
   static inline const char *vtkFileNameStr{"vtk-filename"};
   std::string vtkFileName;

--- a/examples/md-flexible/parsing/MDFlexConfig.h
+++ b/examples/md-flexible/parsing/MDFlexConfig.h
@@ -85,9 +85,21 @@ class MDFlexConfig {
   unsigned int tuningSamples{3};
   static inline const char *tuningMaxEvidenceStr{"tuning-max-evidence"};
   unsigned int tuningMaxEvidence{10};
+  /**
+   * Name for the input.
+   */
   static inline const char *relativeOptimumRangeStr{"relative-optimum-range"};
+  /**
+   * Specifies the factor of the range of the optimal configurations in PredicitveTuning.
+   */
   double relativeOptimumRange{1.2};
+  /**
+   * Name for the input.
+   */
   static inline const char *maxTuningPhasesWithoutTestStr{"max-tuning-phases-without-test"};
+  /**
+   * Specifies how many tuning phases a configuration can not be tested in PredicitveTuning.
+   */
   unsigned int maxTuningPhasesWithoutTest{5};
   static inline const char *vtkFileNameStr{"vtk-filename"};
   std::string vtkFileName;

--- a/examples/md-flexible/parsing/MDFlexConfig.h
+++ b/examples/md-flexible/parsing/MDFlexConfig.h
@@ -1,7 +1,7 @@
 /**
  * @file MDFlexConfig.h
  * @author F. Gratl
- * @date 10/18/19
+ * @date 18.10.2019
  */
 
 #pragma once
@@ -85,6 +85,10 @@ class MDFlexConfig {
   unsigned int tuningSamples{3};
   static inline const char *tuningMaxEvidenceStr{"tuning-max-evidence"};
   unsigned int tuningMaxEvidence{10};
+  static inline const char *relativeOptimumRangeStr{"relative-optimum-range"};
+  double relativeOptimumRange{1.2};
+  static inline const char *maxTuningPhasesWithoutTestStr{"max-tuning-phases-without-test"};
+  unsigned int maxTuningPhasesWithoutTest{5};
   static inline const char *vtkFileNameStr{"vtk-filename"};
   std::string vtkFileName;
   static inline const char *vtkWriteFrequencyStr{"vtk-write-frequency"};

--- a/examples/md-flexible/parsing/MDFlexParser.cpp
+++ b/examples/md-flexible/parsing/MDFlexParser.cpp
@@ -1,7 +1,7 @@
 /**
  * @file MDFlexParser.cpp
  * @author F. Gratl
- * @date 10/18/19
+ * @date 18.10.2019
  */
 
 #include "MDFlexParser.h"

--- a/examples/md-flexible/parsing/MDFlexParser.h
+++ b/examples/md-flexible/parsing/MDFlexParser.h
@@ -1,7 +1,7 @@
 /**
  * @file MDFlexParser.cpp
  * @author F. Gratl
- * @date 10/18/19
+ * @date 18.10.2019
  */
 
 #pragma once

--- a/examples/md-flexible/parsing/YamlParser.cpp
+++ b/examples/md-flexible/parsing/YamlParser.cpp
@@ -1,7 +1,7 @@
 /**
  * @file YamlParser.cpp
  * @author N. Fottner
- * @date 15/7/19
+ * @date 15.07.2019
  */
 
 #include "YamlParser.h"
@@ -89,6 +89,12 @@ bool parseYamlFile(MDFlexConfig &config) {
   }
   if (node[MDFlexConfig::tuningMaxEvidenceStr]) {
     config.tuningMaxEvidence = node[MDFlexConfig::tuningMaxEvidenceStr].as<unsigned int>();
+  }
+  if (node[MDFlexConfig::relativeOptimumRangeStr]) {
+    config.relativeOptimumRange = node[MDFlexConfig::relativeOptimumRangeStr].as<double>();
+  }
+  if (node[MDFlexConfig::maxTuningPhasesWithoutTestStr]) {
+    config.maxTuningPhasesWithoutTest = node[MDFlexConfig::maxTuningPhasesWithoutTestStr].as<unsigned int>();
   }
   if (node[MDFlexConfig::tuningStrategyOptionsStr]) {
     auto parsedOptions =

--- a/examples/md-flexible/parsing/YamlParser.h
+++ b/examples/md-flexible/parsing/YamlParser.h
@@ -1,7 +1,7 @@
 /**
  * @file YamlParser.h
  * @author N. Fottner
- * @date 15/7/19
+ * @date 15.07.2019
  */
 #pragma once
 

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -72,6 +72,8 @@ class AutoPas {
         _tuningInterval(5000),
         _numSamples(3),
         _maxEvidence(10),
+        _relativeOptimumRange(1.2),
+        _maxTuningIterationsWithoutTest(5),
         _acquisitionFunctionOption(AcquisitionFunctionOption::lowerConfidenceBound),
         _tuningStrategyOption(TuningStrategyOption::fullSearch),
         _selectorStrategy(SelectorStrategyOption::fastestAbs),
@@ -124,7 +126,8 @@ class AutoPas {
         _boxMin, _boxMax, _cutoff, _verletSkin, _verletClusterSize,
         std::move(TuningStrategyFactory::generateTuningStrategy(
             _tuningStrategyOption, _allowedContainers, *_allowedCellSizeFactors, _allowedTraversals,
-            _allowedDataLayouts, _allowedNewton3Options, _maxEvidence, _acquisitionFunctionOption)),
+            _allowedDataLayouts, _allowedNewton3Options, _maxEvidence, _relativeOptimumRange,
+            _maxTuningIterationsWithoutTest, _acquisitionFunctionOption)),
         _selectorStrategy, _tuningInterval, _numSamples);
     _logicHandler =
         std::make_unique<autopas::LogicHandler<Particle, ParticleCell>>(*(_autoTuner.get()), _verletRebuildFrequency);
@@ -436,6 +439,34 @@ class AutoPas {
   void setMaxEvidence(unsigned int maxEvidence) { AutoPas::_maxEvidence = maxEvidence; }
 
   /**
+   * Get the range for the optimum in which has to be to be tested
+   * @return
+   */
+  double getRelativeOptimumRange() const { return _relativeOptimumRange; }
+
+  /**
+   * Set the range for the optimum in which has to be to be tested
+   * @param relativeOptimumRange
+   */
+  void setRelativeOptimumRange(unsigned int relativeOptimumRange) {
+    AutoPas::_relativeOptimumRange = relativeOptimumRange;
+  }
+
+  /**
+   * Get the maximum number of tuning phases a configuration can not be tested.
+   * @return
+   */
+  unsigned int getMaxTuningIterationsWithoutTest() const { return _maxTuningIterationsWithoutTest; }
+
+  /**
+   * Set the maximum number of tuning phases a configuration can not be tested.
+   * @param maxTuningIterationsWithoutTest
+   */
+  void setMaxTuningIterationsWithoutTest(unsigned int maxTuningIterationsWithoutTest) {
+    AutoPas::_maxTuningIterationsWithoutTest = maxTuningIterationsWithoutTest;
+  }
+
+  /**
    * Get acquisition function used for tuning
    * @return
    */
@@ -577,6 +608,15 @@ class AutoPas {
    * Tuning Strategies which work on a fixed number of evidence should use this value.
    */
   unsigned int _maxEvidence;
+  /**
+   * Specifies the factor of the range of the optimal configurations in PredicitveTuning.
+   */
+  double _relativeOptimumRange;
+  /**
+   * Specifies how many tuning phases a configuration can not be tested in PredicitveTuning.
+   */
+  unsigned int _maxTuningIterationsWithoutTest;
+
   /**
    * Acquisition function used for tuning.
    * For possible acquisition function choices see AutoPas::AcquisitionFunction.

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -458,7 +458,7 @@ class AutoPas {
 
   /**
    * Set the maximum number of tuning phases a configuration can not be tested.
-   * @param maxTuningIterationsWithoutTest
+   * @param maxTuningPhasesWithoutTest
    */
   void setMaxTuningPhasesWithoutTest(unsigned int maxTuningPhasesWithoutTest) {
     AutoPas::_maxTuningPhasesWithoutTest = maxTuningPhasesWithoutTest;

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -73,7 +73,7 @@ class AutoPas {
         _numSamples(3),
         _maxEvidence(10),
         _relativeOptimumRange(1.2),
-        _maxTuningIterationsWithoutTest(5),
+        _maxTuningPhasesWithoutTest(5),
         _acquisitionFunctionOption(AcquisitionFunctionOption::lowerConfidenceBound),
         _tuningStrategyOption(TuningStrategyOption::fullSearch),
         _selectorStrategy(SelectorStrategyOption::fastestAbs),
@@ -127,7 +127,7 @@ class AutoPas {
         std::move(TuningStrategyFactory::generateTuningStrategy(
             _tuningStrategyOption, _allowedContainers, *_allowedCellSizeFactors, _allowedTraversals,
             _allowedDataLayouts, _allowedNewton3Options, _maxEvidence, _relativeOptimumRange,
-            _maxTuningIterationsWithoutTest, _acquisitionFunctionOption)),
+            _maxTuningPhasesWithoutTest, _acquisitionFunctionOption)),
         _selectorStrategy, _tuningInterval, _numSamples);
     _logicHandler =
         std::make_unique<autopas::LogicHandler<Particle, ParticleCell>>(*(_autoTuner.get()), _verletRebuildFrequency);
@@ -448,22 +448,20 @@ class AutoPas {
    * Set the range for the optimum in which has to be to be tested
    * @param relativeOptimumRange
    */
-  void setRelativeOptimumRange(unsigned int relativeOptimumRange) {
-    AutoPas::_relativeOptimumRange = relativeOptimumRange;
-  }
+  void setRelativeOptimumRange(double relativeOptimumRange) { AutoPas::_relativeOptimumRange = relativeOptimumRange; }
 
   /**
    * Get the maximum number of tuning phases a configuration can not be tested.
    * @return
    */
-  unsigned int getMaxTuningIterationsWithoutTest() const { return _maxTuningIterationsWithoutTest; }
+  unsigned int getMaxTuningPhasesWithoutTest() const { return _maxTuningPhasesWithoutTest; }
 
   /**
    * Set the maximum number of tuning phases a configuration can not be tested.
    * @param maxTuningIterationsWithoutTest
    */
-  void setMaxTuningIterationsWithoutTest(unsigned int maxTuningIterationsWithoutTest) {
-    AutoPas::_maxTuningIterationsWithoutTest = maxTuningIterationsWithoutTest;
+  void setMaxTuningPhasesWithoutTest(unsigned int maxTuningPhasesWithoutTest) {
+    AutoPas::_maxTuningPhasesWithoutTest = maxTuningPhasesWithoutTest;
   }
 
   /**
@@ -615,7 +613,7 @@ class AutoPas {
   /**
    * Specifies how many tuning phases a configuration can not be tested in PredicitveTuning.
    */
-  unsigned int _maxTuningIterationsWithoutTest;
+  unsigned int _maxTuningPhasesWithoutTest;
 
   /**
    * Acquisition function used for tuning.

--- a/src/autopas/options/TuningStrategyOption.h
+++ b/src/autopas/options/TuningStrategyOption.h
@@ -39,7 +39,8 @@ class TuningStrategyOption : public Option<TuningStrategyOption> {
      */
     activeHarmony,
     /**
-     * Predicts all configurations, tests those which are in the optimum range and selects the best.
+     * Predicts performance of all configurations based on previous tuning phases, tests those which are in the optimum
+     * range, and selects the best.
      */
     predictiveTuning,
   };

--- a/src/autopas/options/TuningStrategyOption.h
+++ b/src/autopas/options/TuningStrategyOption.h
@@ -38,6 +38,11 @@ class TuningStrategyOption : public Option<TuningStrategyOption> {
      * ActiveHarmony client / server system
      */
     activeHarmony,
+
+    /**
+     * Predicts all configurations, tests those which are in the optimum range and selects the best.
+     */
+    predictiveTuning,
   };
 
   /**

--- a/src/autopas/options/TuningStrategyOption.h
+++ b/src/autopas/options/TuningStrategyOption.h
@@ -1,7 +1,7 @@
 /**
  * @file TuningStrategyOption.h
  * @author F. Gratl
- * @date 6/3/19
+ * @date 03.06.2019
  */
 
 #pragma once
@@ -38,7 +38,6 @@ class TuningStrategyOption : public Option<TuningStrategyOption> {
      * ActiveHarmony client / server system
      */
     activeHarmony,
-
     /**
      * Predicts all configurations, tests those which are in the optimum range and selects the best.
      */
@@ -72,6 +71,7 @@ class TuningStrategyOption : public Option<TuningStrategyOption> {
         {TuningStrategyOption::fullSearch, "full-Search"},
         {TuningStrategyOption::randomSearch, "random-Search"},
         {TuningStrategyOption::activeHarmony, "active-harmony"},
+        {TuningStrategyOption::predictiveTuning, "predictive-tuning"},
     };
   };
 

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -58,12 +58,12 @@ class AutoTuner {
         _verletSkin(verletSkin),
         _verletClusterSize(verletClusterSize),
         _maxSamples(maxSamples),
-        _samples(maxSamples) {
+        _samples(maxSamples),
+        _iteration(0) {
     if (_tuningStrategy->searchSpaceIsEmpty()) {
       autopas::utils::ExceptionHandler::exception("AutoTuner: Passed tuning strategy has an empty search space.");
     }
 
-    _iteration = 0;
     selectCurrentContainer();
   }
 

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -1,7 +1,7 @@
 /**
  * @file AutoTuner.h
  * @author F. Gratl
- * @date 11.06.18
+ * @date 11.06.2018
  */
 
 #pragma once

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -63,7 +63,7 @@ class AutoTuner {
       autopas::utils::ExceptionHandler::exception("AutoTuner: Passed tuning strategy has an empty search space.");
     }
 
-    _iterations = 0;
+    _iteration = 0;
     selectCurrentContainer();
   }
 
@@ -147,7 +147,7 @@ class AutoTuner {
         // if this was the last sample:
         if (_samples.size() == _maxSamples) {
           auto reducedValue = OptimumSelector::optimumValue(_samples, _selectorStrategy);
-          _tuningStrategy->addEvidence(reducedValue, _iterations);
+          _tuningStrategy->addEvidence(reducedValue, _iteration);
 
           // print config, times and reduced value
           if (autopas::Logger::get()->level() <= autopas::Logger::LogLevel::debug) {
@@ -205,9 +205,9 @@ class AutoTuner {
   std::unique_ptr<TuningStrategyInterface> _tuningStrategy;
 
   /**
-   * _iterations - Counter of the iterations.
+   * _iteration - Counter of the iterations.
    */
-  unsigned int _tuningInterval, _iterationsSinceTuning, _iterations;
+  unsigned int _tuningInterval, _iterationsSinceTuning, _iteration;
   ContainerSelector<Particle, ParticleCell> _containerSelector;
   double _verletSkin;
   unsigned int _verletClusterSize;
@@ -317,7 +317,7 @@ bool AutoTuner<Particle, ParticleCell>::iteratePairwise(PairwiseFunctor *f, bool
 
   if (f->isRelevantForTuning()) {
     ++_iterationsSinceTuning;
-    ++_iterations;
+    ++_iteration;
   }
   return isTuning;
 }
@@ -373,7 +373,7 @@ bool AutoTuner<Particle, ParticleCell>::tune(PairwiseFunctor &pairwiseFunctor) {
 
   // first tuning iteration -> reset to first config
   if (_iterationsSinceTuning == _tuningInterval) {
-    _tuningStrategy->reset();
+    _tuningStrategy->reset(_iteration);
   } else {  // enough samples -> next config
     stillTuning = _tuningStrategy->tune();
   }

--- a/src/autopas/selectors/tuningStrategy/ActiveHarmony.h
+++ b/src/autopas/selectors/tuningStrategy/ActiveHarmony.h
@@ -1,7 +1,7 @@
 /**
  * @file ActiveHarmony.h
  * @author Jakob Englhauser
- * @date 21.10.19
+ * @date 21.10.2019
  */
 
 #pragma once

--- a/src/autopas/selectors/tuningStrategy/ActiveHarmony.h
+++ b/src/autopas/selectors/tuningStrategy/ActiveHarmony.h
@@ -59,7 +59,7 @@ class ActiveHarmony : public TuningStrategyInterface {
       putenv(const_cast<char *>(HARMONY_HOME));
     }
 
-    reset();
+    reset(0);
   }
 
   ~ActiveHarmony() override {
@@ -85,7 +85,7 @@ class ActiveHarmony : public TuningStrategyInterface {
 
   inline const Configuration &getCurrentConfiguration() const override;
 
-  inline void reset() override;
+  inline void reset(size_t iteration) override;
 
   inline std::set<ContainerOption> getAllowedContainerOptions() const override;
 
@@ -279,7 +279,7 @@ void ActiveHarmony::configureTuningParameter(hdef_t *hdef, const char *name, con
   }
 }
 
-void ActiveHarmony::reset() {
+void ActiveHarmony::reset(size_t iteration) {
   _traversalTimes.clear();
   resetHarmony();
 }

--- a/src/autopas/selectors/tuningStrategy/BayesianSearch.h
+++ b/src/autopas/selectors/tuningStrategy/BayesianSearch.h
@@ -103,7 +103,7 @@ class BayesianSearch : public TuningStrategyInterface {
     _gaussianProcess.addEvidence(_currentConfig.oneHotEncode(), time * secondsPerMicroseconds);
   }
 
-  inline void reset() override {
+  inline void reset(size_t iteration) override {
     _gaussianProcess.clear();
     tune();
   }

--- a/src/autopas/selectors/tuningStrategy/BayesianSearch.h
+++ b/src/autopas/selectors/tuningStrategy/BayesianSearch.h
@@ -1,7 +1,7 @@
 /**
  * @file BayesianSearch.h
  * @author Jan Nguyen
- * @date 12.06.19
+ * @date 12.06.2019
  */
 
 #pragma once

--- a/src/autopas/selectors/tuningStrategy/FullSearch.h
+++ b/src/autopas/selectors/tuningStrategy/FullSearch.h
@@ -10,7 +10,7 @@
 #include <sstream>
 #include <utility>
 
-#include "TuningStrategySuperClass.h"
+#include "SetSearchSpaceBasedTuningStrategy.h"
 #include "autopas/selectors/OptimumSelector.h"
 #include "autopas/utils/ExceptionHandler.h"
 
@@ -19,7 +19,7 @@ namespace autopas {
 /**
  * Exhaustive full search of the search space by testing every applicable configuration and then selecting the optimum.
  */
-class FullSearch : public TuningStrategySuperClass {
+class FullSearch : public SetSearchSpaceBasedTuningStrategy {
  public:
   /**
    * Constructor for the FullSearch that generates the search space from the allowed options.
@@ -33,8 +33,8 @@ class FullSearch : public TuningStrategySuperClass {
              const std::set<TraversalOption> &allowedTraversalOptions,
              const std::set<DataLayoutOption> &allowedDataLayoutOptions,
              const std::set<Newton3Option> &allowedNewton3Options)
-      : TuningStrategySuperClass(allowedContainerOptions, allowedCellSizeFactors, allowedTraversalOptions,
-                                 allowedDataLayoutOptions, allowedNewton3Options),
+      : SetSearchSpaceBasedTuningStrategy(allowedContainerOptions, allowedCellSizeFactors, allowedTraversalOptions,
+                                          allowedDataLayoutOptions, allowedNewton3Options),
         _currentConfig(_searchSpace.begin()) {}
 
   /**
@@ -43,7 +43,7 @@ class FullSearch : public TuningStrategySuperClass {
    * @param allowedConfigurations Set of configurations AutoPas can choose from.
    */
   explicit FullSearch(std::set<Configuration> allowedConfigurations)
-      : TuningStrategySuperClass(std::move(allowedConfigurations)), _currentConfig(_searchSpace.begin()) {}
+      : SetSearchSpaceBasedTuningStrategy(std::move(allowedConfigurations)), _currentConfig(_searchSpace.begin()) {}
 
   inline void addEvidence(long time, size_t iteration) override { _traversalTimes[*_currentConfig] = time; }
 

--- a/src/autopas/selectors/tuningStrategy/FullSearch.h
+++ b/src/autopas/selectors/tuningStrategy/FullSearch.h
@@ -49,7 +49,7 @@ class FullSearch : public TuningStrategySuperClass {
 
   inline const Configuration &getCurrentConfiguration() const override { return *_currentConfig; }
 
-  inline void reset() override {
+  inline void reset(size_t iteration) override {
     _traversalTimes.clear();
     _currentConfig = _searchSpace.begin();
   }

--- a/src/autopas/selectors/tuningStrategy/FullSearch.h
+++ b/src/autopas/selectors/tuningStrategy/FullSearch.h
@@ -8,9 +8,9 @@
 
 #include <set>
 #include <sstream>
+#include <utility>
 
-#include "TuningStrategyInterface.h"
-#include "autopas/containers/CompatibleTraversals.h"
+#include "TuningStrategySuperClass.h"
 #include "autopas/selectors/OptimumSelector.h"
 #include "autopas/utils/ExceptionHandler.h"
 
@@ -19,7 +19,7 @@ namespace autopas {
 /**
  * Exhaustive full search of the search space by testing every applicable configuration and then selecting the optimum.
  */
-class FullSearch : public TuningStrategyInterface {
+class FullSearch : public TuningStrategySuperClass {
  public:
   /**
    * Constructor for the FullSearch that generates the search space from the allowed options.
@@ -33,11 +33,9 @@ class FullSearch : public TuningStrategyInterface {
              const std::set<TraversalOption> &allowedTraversalOptions,
              const std::set<DataLayoutOption> &allowedDataLayoutOptions,
              const std::set<Newton3Option> &allowedNewton3Options)
-      : _containerOptions(allowedContainerOptions) {
-    // sets search space and current config
-    populateSearchSpace(allowedContainerOptions, allowedCellSizeFactors, allowedTraversalOptions,
-                        allowedDataLayoutOptions, allowedNewton3Options);
-  }
+      : TuningStrategySuperClass(allowedContainerOptions, allowedCellSizeFactors, allowedTraversalOptions,
+                                 allowedDataLayoutOptions, allowedNewton3Options),
+        _currentConfig(_searchSpace.begin()) {}
 
   /**
    * Constructor for the FullSearch that only contains the given configurations.
@@ -45,17 +43,11 @@ class FullSearch : public TuningStrategyInterface {
    * @param allowedConfigurations Set of configurations AutoPas can choose from.
    */
   explicit FullSearch(std::set<Configuration> allowedConfigurations)
-      : _containerOptions{}, _searchSpace(std::move(allowedConfigurations)), _currentConfig(_searchSpace.begin()) {
-    for (const auto config : _searchSpace) {
-      _containerOptions.insert(config.container);
-    }
-  }
-
-  inline const Configuration &getCurrentConfiguration() const override { return *_currentConfig; }
-
-  inline void removeN3Option(Newton3Option badNewton3Option) override;
+      : TuningStrategySuperClass(std::move(allowedConfigurations)), _currentConfig(_searchSpace.begin()) {}
 
   inline void addEvidence(long time, size_t iteration) override { _traversalTimes[*_currentConfig] = time; }
+
+  inline const Configuration &getCurrentConfiguration() const override { return *_currentConfig; }
 
   inline void reset() override {
     _traversalTimes.clear();
@@ -64,67 +56,14 @@ class FullSearch : public TuningStrategyInterface {
 
   inline bool tune(bool = false) override;
 
-  inline std::set<ContainerOption> getAllowedContainerOptions() const override { return _containerOptions; }
-
-  inline bool searchSpaceIsTrivial() const override { return _searchSpace.size() == 1; }
-
-  inline bool searchSpaceIsEmpty() const override { return _searchSpace.empty(); }
+  inline void removeN3Option(Newton3Option badNewton3Option) override;
 
  private:
-  /**
-   * Fills the search space with the cartesian product of the given options (minus invalid combinations).
-   * @param allowedContainerOptions
-   * @param allowedTraversalOptions
-   * @param allowedDataLayoutOptions
-   * @param allowedNewton3Options
-   */
-  inline void populateSearchSpace(const std::set<ContainerOption> &allowedContainerOptions,
-                                  const std::set<double> &allowedCellSizeFactors,
-                                  const std::set<TraversalOption> &allowedTraversalOptions,
-                                  const std::set<DataLayoutOption> &allowedDataLayoutOptions,
-                                  const std::set<Newton3Option> &allowedNewton3Options);
-
   inline void selectOptimalConfiguration();
 
-  std::set<ContainerOption> _containerOptions;
-  std::set<Configuration> _searchSpace;
   std::set<Configuration>::iterator _currentConfig;
   std::unordered_map<Configuration, size_t, ConfigHash> _traversalTimes;
 };
-
-void FullSearch::populateSearchSpace(const std::set<ContainerOption> &allowedContainerOptions,
-                                     const std::set<double> &allowedCellSizeFactors,
-                                     const std::set<TraversalOption> &allowedTraversalOptions,
-                                     const std::set<DataLayoutOption> &allowedDataLayoutOptions,
-                                     const std::set<Newton3Option> &allowedNewton3Options) {
-  // generate all potential configs
-  for (const auto &containerOption : allowedContainerOptions) {
-    // get all traversals of the container and restrict them to the allowed ones
-    const std::set<TraversalOption> &allContainerTraversals =
-        compatibleTraversals::allCompatibleTraversals(containerOption);
-    std::set<TraversalOption> allowedAndApplicable;
-    std::set_intersection(allowedTraversalOptions.begin(), allowedTraversalOptions.end(),
-                          allContainerTraversals.begin(), allContainerTraversals.end(),
-                          std::inserter(allowedAndApplicable, allowedAndApplicable.begin()));
-
-    for (const auto &cellSizeFactor : allowedCellSizeFactors)
-      for (const auto &traversalOption : allowedAndApplicable) {
-        for (const auto &dataLayoutOption : allowedDataLayoutOptions) {
-          for (const auto &newton3Option : allowedNewton3Options) {
-            _searchSpace.emplace(containerOption, cellSizeFactor, traversalOption, dataLayoutOption, newton3Option);
-          }
-        }
-      }
-  }
-
-  AutoPasLog(debug, "Points in search space: {}", _searchSpace.size());
-
-  if (_searchSpace.empty()) {
-    autopas::utils::ExceptionHandler::exception("FullSearch: No valid configurations could be created.");
-  }
-
-  _currentConfig = _searchSpace.begin();
-}
 
 bool FullSearch::tune(bool) {
   // repeat as long as traversals are not applicable or we run out of configs
@@ -184,5 +123,4 @@ void FullSearch::removeN3Option(Newton3Option badNewton3Option) {
         "Removing all configurations with Newton 3 {} caused the search space to be empty!", badNewton3Option);
   }
 }
-
 }  // namespace autopas

--- a/src/autopas/selectors/tuningStrategy/GaussianProcess.cpp
+++ b/src/autopas/selectors/tuningStrategy/GaussianProcess.cpp
@@ -1,7 +1,7 @@
 /**
  * @file GaussianProcess.cpp
  * @author seckler
- * @date 07.02.20
+ * @date 07.02.2020
  */
 
 #include "GaussianProcess.h"

--- a/src/autopas/selectors/tuningStrategy/GaussianProcess.h
+++ b/src/autopas/selectors/tuningStrategy/GaussianProcess.h
@@ -1,7 +1,7 @@
 /**
  * @file GaussianProcess.h
  * @author Jan Nguyen
- * @date 17.05.19
+ * @date 17.05.2019
  */
 
 #pragma once

--- a/src/autopas/selectors/tuningStrategy/PredictiveTuning.h
+++ b/src/autopas/selectors/tuningStrategy/PredictiveTuning.h
@@ -9,7 +9,7 @@
 #include <set>
 #include <utility>
 
-#include "TuningStrategySuperClass.h"
+#include "SetSearchSpaceBasedTuningStrategy.h"
 #include "autopas/selectors/OptimumSelector.h"
 #include "autopas/utils/ExceptionHandler.h"
 
@@ -20,7 +20,7 @@ namespace autopas {
  * only tests those which are within a certain range of the best prediction. In the end, the configuration
  * that performed best during testing is selected.
  */
-class PredictiveTuning : public TuningStrategySuperClass {
+class PredictiveTuning : public SetSearchSpaceBasedTuningStrategy {
  public:
   /**
    * Constructor for the PredictiveTuning that generates the search space from the allowed options.
@@ -38,8 +38,8 @@ class PredictiveTuning : public TuningStrategySuperClass {
                    const std::set<DataLayoutOption> &allowedDataLayoutOptions,
                    const std::set<Newton3Option> &allowedNewton3Options, double relativeOptimum,
                    unsigned int maxTuningIterationsWithoutTest)
-      : TuningStrategySuperClass(allowedContainerOptions, allowedCellSizeFactors, allowedTraversalOptions,
-                                 allowedDataLayoutOptions, allowedNewton3Options),
+      : SetSearchSpaceBasedTuningStrategy(allowedContainerOptions, allowedCellSizeFactors, allowedTraversalOptions,
+                                          allowedDataLayoutOptions, allowedNewton3Options),
         _currentConfig(_searchSpace.begin()),
         _relativeOptimumRange(relativeOptimum),
         _maxTuningIterationsWithoutTest(maxTuningIterationsWithoutTest) {
@@ -56,7 +56,7 @@ class PredictiveTuning : public TuningStrategySuperClass {
    * @param allowedConfigurations Set of configurations AutoPas can choose from.
    */
   explicit PredictiveTuning(std::set<Configuration> allowedConfigurations)
-      : TuningStrategySuperClass(std::move(allowedConfigurations)),
+      : SetSearchSpaceBasedTuningStrategy(std::move(allowedConfigurations)),
         _currentConfig(_searchSpace.begin()),
         _relativeOptimumRange(1.2),
         _maxTuningIterationsWithoutTest(5) {}

--- a/src/autopas/selectors/tuningStrategy/PredictiveTuning.h
+++ b/src/autopas/selectors/tuningStrategy/PredictiveTuning.h
@@ -100,6 +100,7 @@ class PredictiveTuning : public TuningStrategySuperClass {
   inline void reselectOptimalSearchSpace();
 
   std::set<Configuration>::iterator _currentConfig;
+
   /**
    * Stores the traversal times for each configuration.
    * @param Configuration
@@ -308,18 +309,18 @@ void PredictiveTuning::selectOptimalConfiguration() {
   // In the first couple iterations tune iterates through _searchSpace until predictions are made
   if (_optimalSearchSpace.empty()) {
     for (const auto &configuration : _searchSpace) {
-      if (_traversalTimesStorage[configuration].back().first >= _iterationBeginTuningPhase) {
+      if ((unsigned int) _traversalTimesStorage[configuration].back().first >= _iterationBeginTuningPhase) {
         traversalTimes[configuration] = _traversalTimesStorage[configuration].back().second;
       }
     }
   } else {
     for (const auto &configuration : _optimalSearchSpace) {
-      if (_traversalTimesStorage[configuration].back().first >= _iterationBeginTuningPhase) {
+      if ((unsigned int) _traversalTimesStorage[configuration].back().first >= _iterationBeginTuningPhase) {
         traversalTimes[configuration] = _traversalTimesStorage[configuration].back().second;
       }
     }
     for (const auto &configuration : _tooLongNotTestedSearchSpace) {
-      if (_traversalTimesStorage[configuration].back().first >= _iterationBeginTuningPhase) {
+      if ((unsigned int) _traversalTimesStorage[configuration].back().first >= _iterationBeginTuningPhase) {
         traversalTimes[configuration] = _traversalTimesStorage[configuration].back().second;
       }
     }

--- a/src/autopas/selectors/tuningStrategy/RandomSearch.h
+++ b/src/autopas/selectors/tuningStrategy/RandomSearch.h
@@ -1,7 +1,7 @@
 /**
  * @file RandomSearch.h
  * @author Jan Nguyen
- * @date 10.07.19
+ * @date 10.07.2019
  */
 
 #pragma once

--- a/src/autopas/selectors/tuningStrategy/RandomSearch.h
+++ b/src/autopas/selectors/tuningStrategy/RandomSearch.h
@@ -53,7 +53,7 @@ class RandomSearch : public TuningStrategyInterface {
 
   inline void addEvidence(long time, size_t iteration) override { _traversalTimes[_currentConfig] = time; }
 
-  inline void reset() override {
+  inline void reset(size_t iteration) override {
     _traversalTimes.clear();
     tune();
   }

--- a/src/autopas/selectors/tuningStrategy/TuningStrategyFactory.cpp
+++ b/src/autopas/selectors/tuningStrategy/TuningStrategyFactory.cpp
@@ -16,8 +16,8 @@ std::unique_ptr<autopas::TuningStrategyInterface> autopas::TuningStrategyFactory
     autopas::TuningStrategyOption tuningStrategyOption, const std::set<autopas::ContainerOption> &allowedContainers,
     autopas::NumberSet<double> &allowedCellSizeFactors, const std::set<autopas::TraversalOption> &allowedTraversals,
     const std::set<autopas::DataLayoutOption> &allowedDataLayouts,
-    const std::set<autopas::Newton3Option> &allowedNewton3Options, unsigned int maxEvidence,
-    AcquisitionFunctionOption acquisitionFunctionOption) {
+    const std::set<autopas::Newton3Option> &allowedNewton3Options, unsigned int maxEvidence, double relativeOptimum,
+    unsigned int maxTuningIterationsWithoutTest, AcquisitionFunctionOption acquisitionFunctionOption) {
   // clang compiler bug requires static cast
   switch (static_cast<TuningStrategyOption>(tuningStrategyOption)) {
     case TuningStrategyOption::randomSearch: {
@@ -48,7 +48,8 @@ std::unique_ptr<autopas::TuningStrategyInterface> autopas::TuningStrategyFactory
 
     case TuningStrategyOption::predictiveTuning: {
       return std::make_unique<PredictiveTuning>(allowedContainers, allowedCellSizeFactors.getAll(), allowedTraversals,
-                                                allowedDataLayouts, allowedNewton3Options);
+                                                allowedDataLayouts, allowedNewton3Options, relativeOptimum,
+                                                maxTuningIterationsWithoutTest);
     }
   }
 

--- a/src/autopas/selectors/tuningStrategy/TuningStrategyFactory.cpp
+++ b/src/autopas/selectors/tuningStrategy/TuningStrategyFactory.cpp
@@ -1,7 +1,7 @@
 /**
  * @file TuningStrategyFactory.cpp
  * @author seckler
- * @date 07.02.20
+ * @date 07.02.2020
  */
 
 #include "TuningStrategyFactory.h"
@@ -17,7 +17,7 @@ std::unique_ptr<autopas::TuningStrategyInterface> autopas::TuningStrategyFactory
     autopas::NumberSet<double> &allowedCellSizeFactors, const std::set<autopas::TraversalOption> &allowedTraversals,
     const std::set<autopas::DataLayoutOption> &allowedDataLayouts,
     const std::set<autopas::Newton3Option> &allowedNewton3Options, unsigned int maxEvidence, double relativeOptimum,
-    unsigned int maxTuningIterationsWithoutTest, AcquisitionFunctionOption acquisitionFunctionOption) {
+    unsigned int maxTuningPhasesWithoutTest, AcquisitionFunctionOption acquisitionFunctionOption) {
   // clang compiler bug requires static cast
   switch (static_cast<TuningStrategyOption>(tuningStrategyOption)) {
     case TuningStrategyOption::randomSearch: {
@@ -49,7 +49,7 @@ std::unique_ptr<autopas::TuningStrategyInterface> autopas::TuningStrategyFactory
     case TuningStrategyOption::predictiveTuning: {
       return std::make_unique<PredictiveTuning>(allowedContainers, allowedCellSizeFactors.getAll(), allowedTraversals,
                                                 allowedDataLayouts, allowedNewton3Options, relativeOptimum,
-                                                maxTuningIterationsWithoutTest);
+                                                maxTuningPhasesWithoutTest);
     }
   }
 

--- a/src/autopas/selectors/tuningStrategy/TuningStrategyFactory.cpp
+++ b/src/autopas/selectors/tuningStrategy/TuningStrategyFactory.cpp
@@ -9,6 +9,7 @@
 #include "ActiveHarmony.h"
 #include "BayesianSearch.h"
 #include "FullSearch.h"
+#include "PredictiveTuning.h"
 #include "RandomSearch.h"
 
 std::unique_ptr<autopas::TuningStrategyInterface> autopas::TuningStrategyFactory::generateTuningStrategy(
@@ -43,6 +44,11 @@ std::unique_ptr<autopas::TuningStrategyInterface> autopas::TuningStrategyFactory
     case TuningStrategyOption::activeHarmony: {
       return std::make_unique<ActiveHarmony>(allowedContainers, allowedCellSizeFactors, allowedTraversals,
                                              allowedDataLayouts, allowedNewton3Options);
+    }
+
+    case TuningStrategyOption::predictiveTuning: {
+      return std::make_unique<PredictiveTuning>(allowedContainers, allowedCellSizeFactors.getAll(), allowedTraversals,
+                                                allowedDataLayouts, allowedNewton3Options);
     }
   }
 

--- a/src/autopas/selectors/tuningStrategy/TuningStrategyFactory.h
+++ b/src/autopas/selectors/tuningStrategy/TuningStrategyFactory.h
@@ -20,6 +20,8 @@ namespace autopas::TuningStrategyFactory {
  * @param allowedDataLayouts
  * @param allowedNewton3Options
  * @param maxEvidence
+ * @param relativeOptimum
+ * @param maxTuningIterationsWithoutTest
  * @param acquisitionFunctionOption
  * @return Pointer to the tuning strategy object or the nullpointer if an exception was suppressed.
  */
@@ -27,6 +29,6 @@ std::unique_ptr<autopas::TuningStrategyInterface> generateTuningStrategy(
     autopas::TuningStrategyOption tuningStrategyOption, const std::set<autopas::ContainerOption> &allowedContainers,
     autopas::NumberSet<double> &allowedCellSizeFactors, const std::set<autopas::TraversalOption> &allowedTraversals,
     const std::set<autopas::DataLayoutOption> &allowedDataLayouts,
-    const std::set<autopas::Newton3Option> &allowedNewton3Options, unsigned int maxEvidence,
-    AcquisitionFunctionOption acquisitionFunctionOption);
+    const std::set<autopas::Newton3Option> &allowedNewton3Options, unsigned int maxEvidence, double relativeOptimum,
+    unsigned int maxTuningIterationsWithoutTest, AcquisitionFunctionOption acquisitionFunctionOption);
 }  // namespace autopas::TuningStrategyFactory

--- a/src/autopas/selectors/tuningStrategy/TuningStrategyFactory.h
+++ b/src/autopas/selectors/tuningStrategy/TuningStrategyFactory.h
@@ -1,7 +1,7 @@
 /**
  * @file TuningStrategyFactory.h
  * @author seckler
- * @date 07.02.20
+ * @date 07.02.2020
  */
 
 #pragma once
@@ -21,7 +21,7 @@ namespace autopas::TuningStrategyFactory {
  * @param allowedNewton3Options
  * @param maxEvidence
  * @param relativeOptimum
- * @param maxTuningIterationsWithoutTest
+ * @param maxTuningPhasesWithoutTest
  * @param acquisitionFunctionOption
  * @return Pointer to the tuning strategy object or the nullpointer if an exception was suppressed.
  */
@@ -30,5 +30,5 @@ std::unique_ptr<autopas::TuningStrategyInterface> generateTuningStrategy(
     autopas::NumberSet<double> &allowedCellSizeFactors, const std::set<autopas::TraversalOption> &allowedTraversals,
     const std::set<autopas::DataLayoutOption> &allowedDataLayouts,
     const std::set<autopas::Newton3Option> &allowedNewton3Options, unsigned int maxEvidence, double relativeOptimum,
-    unsigned int maxTuningIterationsWithoutTest, AcquisitionFunctionOption acquisitionFunctionOption);
+    unsigned int maxTuningPhasesWithoutTest, AcquisitionFunctionOption acquisitionFunctionOption);
 }  // namespace autopas::TuningStrategyFactory

--- a/src/autopas/selectors/tuningStrategy/TuningStrategyInterface.h
+++ b/src/autopas/selectors/tuningStrategy/TuningStrategyInterface.h
@@ -1,7 +1,7 @@
 /**
  * @file TuningStrategyInterface.h
  * @author F. Gratl
- * @date 5/29/19
+ * @date 29.05.2019
  */
 
 #pragma once

--- a/src/autopas/selectors/tuningStrategy/TuningStrategyInterface.h
+++ b/src/autopas/selectors/tuningStrategy/TuningStrategyInterface.h
@@ -45,8 +45,9 @@ class TuningStrategyInterface {
 
   /**
    * Reset all internal parameters to the beginning of a new tuning cycle.
+   * @param iteration Gives the current iteration to the tuning strategy.
    */
-  virtual void reset() = 0;
+  virtual void reset(size_t iteration) = 0;
 
   /**
    * Returns all container options the strategy might choose.

--- a/src/autopas/selectors/tuningStrategy/TuningStrategySuperClass.h
+++ b/src/autopas/selectors/tuningStrategy/TuningStrategySuperClass.h
@@ -1,0 +1,123 @@
+/**
+ * @file TuningStrategySuperClass.h
+ * @author Julian Pelloth
+ * @date 29.04.2020
+ */
+
+#pragma once
+
+#include "TuningStrategyInterface.h"
+#include "autopas/containers/CompatibleTraversals.h"
+#include "autopas/utils/ExceptionHandler.h"
+
+namespace autopas {
+
+/**
+ * Super class for tuning strategies
+ */
+class TuningStrategySuperClass : public TuningStrategyInterface {
+ public:
+  /**
+   * Constructor for the TungingStragetySuperClass that generates the search space from the allowed options.
+   * @param allowedContainerOptions
+   * @param allowedTraversalOptions
+   * @param allowedDataLayoutOptions
+   * @param allowedNewton3Options
+   * @param allowedCellSizeFactors
+   */
+  TuningStrategySuperClass(const std::set<ContainerOption> &allowedContainerOptions,
+                           const std::set<double> &allowedCellSizeFactors,
+                           const std::set<TraversalOption> &allowedTraversalOptions,
+                           const std::set<DataLayoutOption> &allowedDataLayoutOptions,
+                           const std::set<Newton3Option> &allowedNewton3Options)
+      : _containerOptions(allowedContainerOptions) {
+    // sets search space and current config
+    populateSearchSpace(allowedContainerOptions, allowedCellSizeFactors, allowedTraversalOptions,
+                        allowedDataLayoutOptions, allowedNewton3Options);
+  }
+
+  /**
+   * Constructor for the TuningStrategySuperClass that only contains the given configurations.
+   * This constructor assumes only valid configurations are passed! Mainly for easier unit testing.
+   * @param allowedConfigurations Set of configurations AutoPas can choose from.
+   */
+  explicit TuningStrategySuperClass(std::set<Configuration> allowedConfigurations)
+      : _containerOptions{}, _searchSpace(std::move(allowedConfigurations)) {
+    for (const auto &config : _searchSpace) {
+      _containerOptions.insert(config.container);
+    }
+  }
+
+  inline std::set<ContainerOption> getAllowedContainerOptions() const override { return _containerOptions; }
+
+  inline bool searchSpaceIsTrivial() const override { return _searchSpace.size() == 1; }
+
+  inline bool searchSpaceIsEmpty() const override { return _searchSpace.empty(); }
+
+ protected:
+  /**
+   * Fills the search space with the cartesian product of the given options (minus invalid combinations).
+   * @param allowedContainerOptions
+   * @param allowedTraversalOptions
+   * @param allowedDataLayoutOptions
+   * @param allowedNewton3Options
+   */
+  inline void populateSearchSpace(const std::set<ContainerOption> &allowedContainerOptions,
+                                  const std::set<double> &allowedCellSizeFactors,
+                                  const std::set<TraversalOption> &allowedTraversalOptions,
+                                  const std::set<DataLayoutOption> &allowedDataLayoutOptions,
+                                  const std::set<Newton3Option> &allowedNewton3Options);
+
+  /**
+   * Finds the optimum in an unordered map
+   * @param findOptimumSearchSpace
+   * @return optimum
+   */
+  static inline std::__detail::_Node_const_iterator<std::pair<const Configuration, unsigned long>, false, true>
+  getOptimum(const std::unordered_map<Configuration, size_t, ConfigHash> &findOptimumSearchSpace);
+
+  std::set<ContainerOption> _containerOptions;
+  std::set<Configuration> _searchSpace;
+};
+
+void TuningStrategySuperClass::populateSearchSpace(const std::set<ContainerOption> &allowedContainerOptions,
+                                                   const std::set<double> &allowedCellSizeFactors,
+                                                   const std::set<TraversalOption> &allowedTraversalOptions,
+                                                   const std::set<DataLayoutOption> &allowedDataLayoutOptions,
+                                                   const std::set<Newton3Option> &allowedNewton3Options) {
+  // generate all potential configs
+  for (const auto &containerOption : allowedContainerOptions) {
+    // get all traversals of the container and restrict them to the allowed ones
+    const std::set<TraversalOption> &allContainerTraversals =
+        compatibleTraversals::allCompatibleTraversals(containerOption);
+    std::set<TraversalOption> allowedAndApplicable;
+    std::set_intersection(allowedTraversalOptions.begin(), allowedTraversalOptions.end(),
+                          allContainerTraversals.begin(), allContainerTraversals.end(),
+                          std::inserter(allowedAndApplicable, allowedAndApplicable.begin()));
+
+    for (const auto &cellSizeFactor : allowedCellSizeFactors)
+      for (const auto &traversalOption : allowedAndApplicable) {
+        for (const auto &dataLayoutOption : allowedDataLayoutOptions) {
+          for (const auto &newton3Option : allowedNewton3Options) {
+            _searchSpace.emplace(containerOption, cellSizeFactor, traversalOption, dataLayoutOption, newton3Option);
+          }
+        }
+      }
+  }
+
+  AutoPasLog(debug, "Points in search space: {}", _searchSpace.size());
+
+  if (_searchSpace.empty()) {
+    autopas::utils::ExceptionHandler::exception("FullSearch: No valid configurations could be created.");
+  }
+}
+
+std::__detail::_Node_const_iterator<std::pair<const Configuration, unsigned long>, false, true>
+TuningStrategySuperClass::getOptimum(
+    const std::unordered_map<Configuration, size_t, ConfigHash> &findOptimumSearchSpace) {
+  return std::min_element(findOptimumSearchSpace.begin(), findOptimumSearchSpace.end(),
+                          [](std::pair<Configuration, size_t> a, std::pair<Configuration, size_t> b) -> bool {
+                            return a.second < b.second;
+                          });
+}
+}  // namespace autopas

--- a/src/autopas/selectors/tuningStrategy/TuningStrategySuperClass.h
+++ b/src/autopas/selectors/tuningStrategy/TuningStrategySuperClass.h
@@ -18,7 +18,7 @@ namespace autopas {
 class TuningStrategySuperClass : public TuningStrategyInterface {
  public:
   /**
-   * Constructor for the TungingStragetySuperClass that generates the search space from the allowed options.
+   * Constructor for the TuningStrategySuperClass that generates the search space from the allowed options.
    * @param allowedContainerOptions
    * @param allowedTraversalOptions
    * @param allowedDataLayoutOptions

--- a/src/autopas/selectors/tuningStrategy/TuningStrategySuperClass.h
+++ b/src/autopas/selectors/tuningStrategy/TuningStrategySuperClass.h
@@ -76,7 +76,13 @@ class TuningStrategySuperClass : public TuningStrategyInterface {
   static inline std::__detail::_Node_const_iterator<std::pair<const Configuration, unsigned long>, false, true>
   getOptimum(const std::unordered_map<Configuration, size_t, ConfigHash> &findOptimumSearchSpace);
 
+  /**
+   * Contains every container option.
+   */
   std::set<ContainerOption> _containerOptions;
+  /**
+   * Contains every configuration.
+   */
   std::set<Configuration> _searchSpace;
 };
 

--- a/src/autopas/selectors/tuningStrategy/TuningStrategySuperClass.h
+++ b/src/autopas/selectors/tuningStrategy/TuningStrategySuperClass.h
@@ -58,6 +58,7 @@ class TuningStrategySuperClass : public TuningStrategyInterface {
   /**
    * Fills the search space with the cartesian product of the given options (minus invalid combinations).
    * @param allowedContainerOptions
+   * @param allowedCellSizeFactors
    * @param allowedTraversalOptions
    * @param allowedDataLayoutOptions
    * @param allowedNewton3Options

--- a/tests/testAutopas/tests/options/OptionTest.cpp
+++ b/tests/testAutopas/tests/options/OptionTest.cpp
@@ -1,7 +1,7 @@
 /**
  * @file OptionTest.cpp
  * @author F. Gratl
- * @date 10/29/19
+ * @date 29.10.2019
  */
 
 #include "OptionTest.h"
@@ -102,6 +102,7 @@ TEST(OptionTest, parseTuningStrategyOptionsTest) {
       {autopas::TuningStrategyOption::fullSearch, "full"},
       {autopas::TuningStrategyOption::randomSearch, "random"},
       {autopas::TuningStrategyOption::activeHarmony, "harmony"},
+      {autopas::TuningStrategyOption::predictiveTuning, "predictive"},
   };
 
   EXPECT_EQ(mapEnumString.size(), autopas::TuningStrategyOption::getOptionNames().size());

--- a/tests/testAutopas/tests/options/OptionTest.h
+++ b/tests/testAutopas/tests/options/OptionTest.h
@@ -1,7 +1,7 @@
 /**
  * @file OptionTest.h
  * @author F. Gratl
- * @date 10/29/19
+ * @date 29.10.2019
  */
 
 #pragma once

--- a/tests/testAutopas/tests/selectors/tuningStrategy/PredictiveTuningTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/PredictiveTuningTest.cpp
@@ -27,9 +27,9 @@ TEST_F(PredictiveTuningTest, testSearchSpaceOneOption) {
 }
 
 TEST_F(PredictiveTuningTest, testSearchSpaceMoreOptions) {
-  autopas::PredictiveTuning predictiveTuning({autopas::ContainerOption::linkedCells}, {1.},
-                                             {autopas::TraversalOption::c08}, {autopas::DataLayoutOption::soa},
-                                             {autopas::Newton3Option::enabled, autopas::Newton3Option::disabled});
+  autopas::PredictiveTuning predictiveTuning(
+      {autopas::ContainerOption::linkedCells}, {1.}, {autopas::TraversalOption::c08}, {autopas::DataLayoutOption::soa},
+      {autopas::Newton3Option::enabled, autopas::Newton3Option::disabled}, 1.2, 5);
   EXPECT_FALSE(predictiveTuning.searchSpaceIsEmpty());
   EXPECT_FALSE(predictiveTuning.searchSpaceIsTrivial());
   EXPECT_THAT(predictiveTuning.getAllowedContainerOptions(),
@@ -39,17 +39,17 @@ TEST_F(PredictiveTuningTest, testSearchSpaceMoreOptions) {
 TEST_F(PredictiveTuningTest, testRemoveN3OptionRemoveAll) {
   autopas::PredictiveTuning predictiveTuning(
       {autopas::ContainerOption::linkedCells}, {1.}, {autopas::TraversalOption::c08, autopas::TraversalOption::sliced},
-      {autopas::DataLayoutOption::soa, autopas::DataLayoutOption::aos}, {autopas::Newton3Option::enabled});
+      {autopas::DataLayoutOption::soa, autopas::DataLayoutOption::aos}, {autopas::Newton3Option::enabled}, 1.2, 5);
 
   EXPECT_THROW(predictiveTuning.removeN3Option(autopas::Newton3Option::enabled),
                autopas::utils::ExceptionHandler::AutoPasException);
 }
 
 TEST_F(PredictiveTuningTest, testRemoveN3OptionRemoveSome) {
-  autopas::PredictiveTuning predictiveTuning({autopas::ContainerOption::linkedCells}, {1.},
-                                             {autopas::TraversalOption::c08, autopas::TraversalOption::sliced},
-                                             {autopas::DataLayoutOption::soa, autopas::DataLayoutOption::aos},
-                                             {autopas::Newton3Option::enabled, autopas::Newton3Option::disabled});
+  autopas::PredictiveTuning predictiveTuning(
+      {autopas::ContainerOption::linkedCells}, {1.}, {autopas::TraversalOption::c08, autopas::TraversalOption::sliced},
+      {autopas::DataLayoutOption::soa, autopas::DataLayoutOption::aos},
+      {autopas::Newton3Option::enabled, autopas::Newton3Option::disabled}, 1.2, 5);
 
   EXPECT_NO_THROW(predictiveTuning.removeN3Option(autopas::Newton3Option::enabled));
   EXPECT_FALSE(predictiveTuning.searchSpaceIsEmpty());
@@ -69,7 +69,7 @@ TEST_F(PredictiveTuningTest, testSelectPossibleConfigurations) {
   autopas::PredictiveTuning predictiveTuning(
       {autopas::ContainerOption::linkedCells}, {1.},
       {autopas::TraversalOption::c08, autopas::TraversalOption::c01, autopas::TraversalOption::sliced},
-      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled});
+      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled}, 1.2, 5);
 
   predictiveTuning.reset(iteration);
 
@@ -123,7 +123,7 @@ TEST_F(PredictiveTuningTest, testTuneFirstIteration) {
   autopas::PredictiveTuning predictiveTuning(
       {autopas::ContainerOption::linkedCells}, {1.},
       {autopas::TraversalOption::c08, autopas::TraversalOption::c01, autopas::TraversalOption::sliced},
-      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled});
+      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled}, 1.2, 5);
 
   predictiveTuning.reset(iteration);
 
@@ -139,7 +139,6 @@ TEST_F(PredictiveTuningTest, testTuneFirstIteration) {
   predictiveTuning.tune();
   EXPECT_EQ(configurationC01, predictiveTuning.getCurrentConfiguration());
   predictiveTuning.addEvidence(20, iteration);
-  ++iteration;
 
   predictiveTuning.tune();
   EXPECT_EQ(configurationSliced, predictiveTuning.getCurrentConfiguration());
@@ -159,7 +158,7 @@ TEST_F(PredictiveTuningTest, testTuningThreeIterations) {
   autopas::PredictiveTuning predictiveTuning(
       {autopas::ContainerOption::linkedCells}, {1.},
       {autopas::TraversalOption::c08, autopas::TraversalOption::c01, autopas::TraversalOption::sliced},
-      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled});
+      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled}, 1.2, 5);
 
   predictiveTuning.reset(iteration);
 
@@ -211,7 +210,6 @@ TEST_F(PredictiveTuningTest, testTuningThreeIterations) {
   predictiveTuning.tune();
   EXPECT_EQ(configurationSliced, predictiveTuning.getCurrentConfiguration());
   predictiveTuning.addEvidence(10, iteration);
-  ++iteration;
 
   // This tests that the right optimum configuration gets selected at the end of a tuning phase.
   predictiveTuning.tune();
@@ -225,15 +223,13 @@ TEST_F(PredictiveTuningTest, testTuningThreeIterations) {
  *      - Sliced is constant the optimum (10).
  * In iteration three to six only sliced should be in _optimalSearchSpace.
  * In the seventh iteration c08 and sliced should be in _optimalSearchSpace.
- *
- * _maxIterationsWithoutTest has to be equal to _maxIterationsWithoutTest in PredictiveTuning.h
  */
 TEST_F(PredictiveTuningTest, testTooLongNotTested) {
   unsigned int iteration = 0;
   unsigned int _maxTuningIterationsWithoutTest = 5;
-  autopas::PredictiveTuning predictiveTuning({autopas::ContainerOption::linkedCells}, {1.},
-                                             {autopas::TraversalOption::c08, autopas::TraversalOption::sliced},
-                                             {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled});
+  autopas::PredictiveTuning predictiveTuning(
+      {autopas::ContainerOption::linkedCells}, {1.}, {autopas::TraversalOption::c08, autopas::TraversalOption::sliced},
+      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled}, 1.2, _maxTuningIterationsWithoutTest);
 
   predictiveTuning.reset(iteration);
 
@@ -289,8 +285,6 @@ TEST_F(PredictiveTuningTest, testTooLongNotTested) {
   EXPECT_EQ(configurationC08, predictiveTuning.getCurrentConfiguration());
   predictiveTuning.addEvidence(20, iteration);
 
-  ++iteration;
-
   predictiveTuning.tune();
   EXPECT_EQ(configurationSliced, predictiveTuning.getCurrentConfiguration());
 }
@@ -308,7 +302,7 @@ TEST_F(PredictiveTuningTest, testInvalidOptimalSearchSpaceOnce) {
   autopas::PredictiveTuning predictiveTuning(
       {autopas::ContainerOption::linkedCells}, {1.},
       {autopas::TraversalOption::c08, autopas::TraversalOption::c01, autopas::TraversalOption::sliced},
-      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled});
+      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled}, 1.2, 5);
 
   predictiveTuning.reset(iteration);
 
@@ -360,7 +354,6 @@ TEST_F(PredictiveTuningTest, testInvalidOptimalSearchSpaceOnce) {
   // Tests if a new _optimalSearchSpace gets selected if the first one is invalid.
   EXPECT_EQ(configurationC08, predictiveTuning.getCurrentConfiguration());
   predictiveTuning.addEvidence(15, iteration);
-  ++iteration;
 
   predictiveTuning.tune();
   EXPECT_EQ(configurationC08, predictiveTuning.getCurrentConfiguration());
@@ -380,7 +373,7 @@ TEST_F(PredictiveTuningTest, testInvalidOptimalSearchSpaceTwice) {
   autopas::PredictiveTuning predictiveTuning(
       {autopas::ContainerOption::linkedCells}, {1.},
       {autopas::TraversalOption::c08, autopas::TraversalOption::c01, autopas::TraversalOption::sliced},
-      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled});
+      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled}, 1.2, 5);
 
   predictiveTuning.reset(iteration);
 
@@ -438,7 +431,6 @@ TEST_F(PredictiveTuningTest, testInvalidOptimalSearchSpaceTwice) {
   // Tests if a new _optimalSearchSpace gets selected if the second one is invalid.
   EXPECT_EQ(configurationC01, predictiveTuning.getCurrentConfiguration());
   predictiveTuning.addEvidence(20, iteration);
-  ++iteration;
 
   predictiveTuning.tune();
   EXPECT_EQ(configurationC01, predictiveTuning.getCurrentConfiguration());

--- a/tests/testAutopas/tests/selectors/tuningStrategy/PredictiveTuningTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/PredictiveTuningTest.cpp
@@ -373,7 +373,7 @@ TEST_F(PredictiveTuningTest, testInvalidOptimalSearchSpaceOnce) {
  *      - Sliced is constant the optimum (10) and invalid in the third iteration.
  *      - C01 is constant out of the optimum range (20).
  * In the third iteration reselectOptimalSearchSpace should be called twice and C01 should be selected after the
- * tuning1.2, 5 phase.
+ * tuning phase.
  */
 TEST_F(PredictiveTuningTest, testInvalidOptimalSearchSpaceTwice) {
   unsigned int iteration = 0;

--- a/tests/testAutopas/tests/selectors/tuningStrategy/PredictiveTuningTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/PredictiveTuningTest.cpp
@@ -10,19 +10,16 @@
 #include <gmock/gmock-more-matchers.h>
 
 TEST_F(PredictiveTuningTest, testSearchSpaceEmpty) {
-  unsigned int iteration = 0;
-  autopas::PredictiveTuning predictiveTuning({}, iteration);
+  autopas::PredictiveTuning predictiveTuning({});
   EXPECT_TRUE(predictiveTuning.searchSpaceIsEmpty());
   EXPECT_FALSE(predictiveTuning.searchSpaceIsTrivial());
   EXPECT_THAT(predictiveTuning.getAllowedContainerOptions(), ::testing::IsEmpty());
 }
 
 TEST_F(PredictiveTuningTest, testSearchSpaceOneOption) {
-  unsigned int iteration = 0;
   autopas::PredictiveTuning predictiveTuning(
       {autopas::Configuration(autopas::ContainerOption::directSum, 1., autopas::TraversalOption::directSumTraversal,
-                              autopas::DataLayoutOption::soa, autopas::Newton3Option::enabled)},
-      iteration);
+                              autopas::DataLayoutOption::soa, autopas::Newton3Option::enabled)});
   EXPECT_FALSE(predictiveTuning.searchSpaceIsEmpty());
   EXPECT_TRUE(predictiveTuning.searchSpaceIsTrivial());
   EXPECT_THAT(predictiveTuning.getAllowedContainerOptions(),
@@ -30,10 +27,9 @@ TEST_F(PredictiveTuningTest, testSearchSpaceOneOption) {
 }
 
 TEST_F(PredictiveTuningTest, testSearchSpaceMoreOptions) {
-  unsigned int iteration = 0;
-  autopas::PredictiveTuning predictiveTuning(
-      {autopas::ContainerOption::linkedCells}, {1.}, {autopas::TraversalOption::c08}, {autopas::DataLayoutOption::soa},
-      {autopas::Newton3Option::enabled, autopas::Newton3Option::disabled}, iteration);
+  autopas::PredictiveTuning predictiveTuning({autopas::ContainerOption::linkedCells}, {1.},
+                                             {autopas::TraversalOption::c08}, {autopas::DataLayoutOption::soa},
+                                             {autopas::Newton3Option::enabled, autopas::Newton3Option::disabled});
   EXPECT_FALSE(predictiveTuning.searchSpaceIsEmpty());
   EXPECT_FALSE(predictiveTuning.searchSpaceIsTrivial());
   EXPECT_THAT(predictiveTuning.getAllowedContainerOptions(),
@@ -41,21 +37,19 @@ TEST_F(PredictiveTuningTest, testSearchSpaceMoreOptions) {
 }
 
 TEST_F(PredictiveTuningTest, testRemoveN3OptionRemoveAll) {
-  unsigned int iteration = 0;
   autopas::PredictiveTuning predictiveTuning(
       {autopas::ContainerOption::linkedCells}, {1.}, {autopas::TraversalOption::c08, autopas::TraversalOption::sliced},
-      {autopas::DataLayoutOption::soa, autopas::DataLayoutOption::aos}, {autopas::Newton3Option::enabled}, iteration);
+      {autopas::DataLayoutOption::soa, autopas::DataLayoutOption::aos}, {autopas::Newton3Option::enabled});
 
   EXPECT_THROW(predictiveTuning.removeN3Option(autopas::Newton3Option::enabled),
                autopas::utils::ExceptionHandler::AutoPasException);
 }
 
 TEST_F(PredictiveTuningTest, testRemoveN3OptionRemoveSome) {
-  unsigned int iteration = 0;
-  autopas::PredictiveTuning predictiveTuning(
-      {autopas::ContainerOption::linkedCells}, {1.}, {autopas::TraversalOption::c08, autopas::TraversalOption::sliced},
-      {autopas::DataLayoutOption::soa, autopas::DataLayoutOption::aos},
-      {autopas::Newton3Option::enabled, autopas::Newton3Option::disabled}, iteration);
+  autopas::PredictiveTuning predictiveTuning({autopas::ContainerOption::linkedCells}, {1.},
+                                             {autopas::TraversalOption::c08, autopas::TraversalOption::sliced},
+                                             {autopas::DataLayoutOption::soa, autopas::DataLayoutOption::aos},
+                                             {autopas::Newton3Option::enabled, autopas::Newton3Option::disabled});
 
   EXPECT_NO_THROW(predictiveTuning.removeN3Option(autopas::Newton3Option::enabled));
   EXPECT_FALSE(predictiveTuning.searchSpaceIsEmpty());
@@ -75,9 +69,9 @@ TEST_F(PredictiveTuningTest, testSelectPossibleConfigurations) {
   autopas::PredictiveTuning predictiveTuning(
       {autopas::ContainerOption::linkedCells}, {1.},
       {autopas::TraversalOption::c08, autopas::TraversalOption::c01, autopas::TraversalOption::sliced},
-      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled}, iteration);
+      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled});
 
-  predictiveTuning.reset();
+  predictiveTuning.reset(iteration);
 
   EXPECT_EQ(configurationC08, predictiveTuning.getCurrentConfiguration());
   predictiveTuning.addEvidence(4, iteration);
@@ -97,7 +91,7 @@ TEST_F(PredictiveTuningTest, testSelectPossibleConfigurations) {
   EXPECT_EQ(configurationSliced, predictiveTuning.getCurrentConfiguration());
 
   // End of the first tuning phase.
-  predictiveTuning.reset();
+  predictiveTuning.reset(iteration);
 
   EXPECT_EQ(configurationC08, predictiveTuning.getCurrentConfiguration());
   predictiveTuning.addEvidence(3, iteration);
@@ -117,7 +111,7 @@ TEST_F(PredictiveTuningTest, testSelectPossibleConfigurations) {
   EXPECT_EQ(configurationSliced, predictiveTuning.getCurrentConfiguration());
 
   // End of the second tuning phase.
-  predictiveTuning.reset();
+  predictiveTuning.reset(iteration);
 
   // This tests the actual prediction.
   EXPECT_EQ(configurationC08, predictiveTuning.getCurrentConfiguration());
@@ -129,9 +123,9 @@ TEST_F(PredictiveTuningTest, testTuneFirstIteration) {
   autopas::PredictiveTuning predictiveTuning(
       {autopas::ContainerOption::linkedCells}, {1.},
       {autopas::TraversalOption::c08, autopas::TraversalOption::c01, autopas::TraversalOption::sliced},
-      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled}, iteration);
+      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled});
 
-  predictiveTuning.reset();
+  predictiveTuning.reset(iteration);
 
   EXPECT_EQ(configurationC08, predictiveTuning.getCurrentConfiguration());
   predictiveTuning.addEvidence(10, iteration);
@@ -165,9 +159,9 @@ TEST_F(PredictiveTuningTest, testTuningThreeIterations) {
   autopas::PredictiveTuning predictiveTuning(
       {autopas::ContainerOption::linkedCells}, {1.},
       {autopas::TraversalOption::c08, autopas::TraversalOption::c01, autopas::TraversalOption::sliced},
-      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled}, iteration);
+      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled});
 
-  predictiveTuning.reset();
+  predictiveTuning.reset(iteration);
 
   EXPECT_EQ(configurationC08, predictiveTuning.getCurrentConfiguration());
   predictiveTuning.addEvidence(11, iteration);
@@ -187,7 +181,7 @@ TEST_F(PredictiveTuningTest, testTuningThreeIterations) {
   EXPECT_EQ(configurationSliced, predictiveTuning.getCurrentConfiguration());
 
   // End of the first tuning phase.
-  predictiveTuning.reset();
+  predictiveTuning.reset(iteration);
 
   EXPECT_EQ(configurationC08, predictiveTuning.getCurrentConfiguration());
   predictiveTuning.addEvidence(11, iteration);
@@ -207,7 +201,7 @@ TEST_F(PredictiveTuningTest, testTuningThreeIterations) {
   EXPECT_EQ(configurationSliced, predictiveTuning.getCurrentConfiguration());
 
   // End of the second tuning phase.
-  predictiveTuning.reset();
+  predictiveTuning.reset(iteration);
 
   // This test if a configuration near the optimum gets selected into _optimalSearchSpace.
   EXPECT_EQ(configurationC08, predictiveTuning.getCurrentConfiguration());
@@ -237,11 +231,11 @@ TEST_F(PredictiveTuningTest, testTuningThreeIterations) {
 TEST_F(PredictiveTuningTest, testTooLongNotTested) {
   unsigned int iteration = 0;
   unsigned int _maxTuningIterationsWithoutTest = 5;
-  autopas::PredictiveTuning predictiveTuning(
-      {autopas::ContainerOption::linkedCells}, {1.}, {autopas::TraversalOption::c08, autopas::TraversalOption::sliced},
-      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled}, iteration);
+  autopas::PredictiveTuning predictiveTuning({autopas::ContainerOption::linkedCells}, {1.},
+                                             {autopas::TraversalOption::c08, autopas::TraversalOption::sliced},
+                                             {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled});
 
-  predictiveTuning.reset();
+  predictiveTuning.reset(iteration);
 
   EXPECT_EQ(configurationC08, predictiveTuning.getCurrentConfiguration());
   predictiveTuning.addEvidence(20, iteration);
@@ -256,7 +250,7 @@ TEST_F(PredictiveTuningTest, testTooLongNotTested) {
   EXPECT_EQ(configurationSliced, predictiveTuning.getCurrentConfiguration());
 
   // End of the first tuning phase.
-  predictiveTuning.reset();
+  predictiveTuning.reset(iteration);
 
   EXPECT_EQ(configurationC08, predictiveTuning.getCurrentConfiguration());
   predictiveTuning.addEvidence(20, iteration);
@@ -273,7 +267,7 @@ TEST_F(PredictiveTuningTest, testTooLongNotTested) {
   // Iterating through the _maxNumberOfIterationsWithoutTest iterations where C08 should not be tested.
   for (int i = 0; i < _maxTuningIterationsWithoutTest; i++) {
     // End of the (i + 2)-th tuning phase.
-    predictiveTuning.reset();
+    predictiveTuning.reset(iteration);
 
     EXPECT_EQ(configurationSliced, predictiveTuning.getCurrentConfiguration());
     predictiveTuning.addEvidence(10, iteration);
@@ -284,7 +278,7 @@ TEST_F(PredictiveTuningTest, testTooLongNotTested) {
   }
 
   // End of the (_maxTuningIterationsWithoutTest + 2)-th tuning phase.
-  predictiveTuning.reset();
+  predictiveTuning.reset(iteration);
 
   EXPECT_EQ(configurationSliced, predictiveTuning.getCurrentConfiguration());
   predictiveTuning.addEvidence(10, iteration);
@@ -314,9 +308,9 @@ TEST_F(PredictiveTuningTest, testInvalidOptimalSearchSpaceOnce) {
   autopas::PredictiveTuning predictiveTuning(
       {autopas::ContainerOption::linkedCells}, {1.},
       {autopas::TraversalOption::c08, autopas::TraversalOption::c01, autopas::TraversalOption::sliced},
-      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled}, iteration);
+      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled});
 
-  predictiveTuning.reset();
+  predictiveTuning.reset(iteration);
 
   EXPECT_EQ(configurationC08, predictiveTuning.getCurrentConfiguration());
   predictiveTuning.addEvidence(15, iteration);
@@ -336,7 +330,7 @@ TEST_F(PredictiveTuningTest, testInvalidOptimalSearchSpaceOnce) {
   EXPECT_EQ(configurationSliced, predictiveTuning.getCurrentConfiguration());
 
   // End of the first tuning phase.
-  predictiveTuning.reset();
+  predictiveTuning.reset(iteration);
 
   EXPECT_EQ(configurationC08, predictiveTuning.getCurrentConfiguration());
   predictiveTuning.addEvidence(15, iteration);
@@ -356,7 +350,7 @@ TEST_F(PredictiveTuningTest, testInvalidOptimalSearchSpaceOnce) {
   EXPECT_EQ(configurationSliced, predictiveTuning.getCurrentConfiguration());
 
   // End of the second tuning phase.
-  predictiveTuning.reset();
+  predictiveTuning.reset(iteration);
 
   EXPECT_EQ(configurationSliced, predictiveTuning.getCurrentConfiguration());
   ++iteration;
@@ -386,9 +380,9 @@ TEST_F(PredictiveTuningTest, testInvalidOptimalSearchSpaceTwice) {
   autopas::PredictiveTuning predictiveTuning(
       {autopas::ContainerOption::linkedCells}, {1.},
       {autopas::TraversalOption::c08, autopas::TraversalOption::c01, autopas::TraversalOption::sliced},
-      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled}, iteration);
+      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled});
 
-  predictiveTuning.reset();
+  predictiveTuning.reset(iteration);
 
   EXPECT_EQ(configurationC08, predictiveTuning.getCurrentConfiguration());
   predictiveTuning.addEvidence(15, iteration);
@@ -408,7 +402,7 @@ TEST_F(PredictiveTuningTest, testInvalidOptimalSearchSpaceTwice) {
   EXPECT_EQ(configurationSliced, predictiveTuning.getCurrentConfiguration());
 
   // End of the first tuning phase.
-  predictiveTuning.reset();
+  predictiveTuning.reset(iteration);
 
   EXPECT_EQ(configurationC08, predictiveTuning.getCurrentConfiguration());
   predictiveTuning.addEvidence(15, iteration);
@@ -428,7 +422,7 @@ TEST_F(PredictiveTuningTest, testInvalidOptimalSearchSpaceTwice) {
   EXPECT_EQ(configurationSliced, predictiveTuning.getCurrentConfiguration());
 
   // End of the second tuning phase.
-  predictiveTuning.reset();
+  predictiveTuning.reset(iteration);
 
   EXPECT_EQ(configurationSliced, predictiveTuning.getCurrentConfiguration());
   ++iteration;

--- a/tests/testAutopas/tests/selectors/tuningStrategy/PredictiveTuningTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/PredictiveTuningTest.cpp
@@ -27,9 +27,10 @@ TEST_F(PredictiveTuningTest, testSearchSpaceOneOption) {
 }
 
 TEST_F(PredictiveTuningTest, testSearchSpaceMoreOptions) {
-  autopas::PredictiveTuning predictiveTuning(
-      {autopas::ContainerOption::linkedCells}, {1.}, {autopas::TraversalOption::c08}, {autopas::DataLayoutOption::soa},
-      {autopas::Newton3Option::enabled, autopas::Newton3Option::disabled}, 1.2, 5);
+  autopas::PredictiveTuning predictiveTuning({autopas::ContainerOption::linkedCells}, {1.},
+                                             {autopas::TraversalOption::c08}, {autopas::DataLayoutOption::soa},
+                                             {autopas::Newton3Option::enabled, autopas::Newton3Option::disabled},
+                                             relativeOptimumRange, maxTuningIterationsWithoutTest);
   EXPECT_FALSE(predictiveTuning.searchSpaceIsEmpty());
   EXPECT_FALSE(predictiveTuning.searchSpaceIsTrivial());
   EXPECT_THAT(predictiveTuning.getAllowedContainerOptions(),
@@ -39,17 +40,19 @@ TEST_F(PredictiveTuningTest, testSearchSpaceMoreOptions) {
 TEST_F(PredictiveTuningTest, testRemoveN3OptionRemoveAll) {
   autopas::PredictiveTuning predictiveTuning(
       {autopas::ContainerOption::linkedCells}, {1.}, {autopas::TraversalOption::c08, autopas::TraversalOption::sliced},
-      {autopas::DataLayoutOption::soa, autopas::DataLayoutOption::aos}, {autopas::Newton3Option::enabled}, 1.2, 5);
+      {autopas::DataLayoutOption::soa, autopas::DataLayoutOption::aos}, {autopas::Newton3Option::enabled},
+      relativeOptimumRange, maxTuningIterationsWithoutTest);
 
   EXPECT_THROW(predictiveTuning.removeN3Option(autopas::Newton3Option::enabled),
                autopas::utils::ExceptionHandler::AutoPasException);
 }
 
 TEST_F(PredictiveTuningTest, testRemoveN3OptionRemoveSome) {
-  autopas::PredictiveTuning predictiveTuning(
-      {autopas::ContainerOption::linkedCells}, {1.}, {autopas::TraversalOption::c08, autopas::TraversalOption::sliced},
-      {autopas::DataLayoutOption::soa, autopas::DataLayoutOption::aos},
-      {autopas::Newton3Option::enabled, autopas::Newton3Option::disabled}, 1.2, 5);
+  autopas::PredictiveTuning predictiveTuning({autopas::ContainerOption::linkedCells}, {1.},
+                                             {autopas::TraversalOption::c08, autopas::TraversalOption::sliced},
+                                             {autopas::DataLayoutOption::soa, autopas::DataLayoutOption::aos},
+                                             {autopas::Newton3Option::enabled, autopas::Newton3Option::disabled},
+                                             relativeOptimumRange, maxTuningIterationsWithoutTest);
 
   EXPECT_NO_THROW(predictiveTuning.removeN3Option(autopas::Newton3Option::enabled));
   EXPECT_FALSE(predictiveTuning.searchSpaceIsEmpty());
@@ -69,7 +72,8 @@ TEST_F(PredictiveTuningTest, testSelectPossibleConfigurations) {
   autopas::PredictiveTuning predictiveTuning(
       {autopas::ContainerOption::linkedCells}, {1.},
       {autopas::TraversalOption::c08, autopas::TraversalOption::c01, autopas::TraversalOption::sliced},
-      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled}, 1.2, 5);
+      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled}, relativeOptimumRange,
+      maxTuningIterationsWithoutTest);
 
   predictiveTuning.reset(iteration);
 
@@ -123,7 +127,8 @@ TEST_F(PredictiveTuningTest, testTuneFirstIteration) {
   autopas::PredictiveTuning predictiveTuning(
       {autopas::ContainerOption::linkedCells}, {1.},
       {autopas::TraversalOption::c08, autopas::TraversalOption::c01, autopas::TraversalOption::sliced},
-      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled}, 1.2, 5);
+      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled}, relativeOptimumRange,
+      maxTuningIterationsWithoutTest);
 
   predictiveTuning.reset(iteration);
 
@@ -158,7 +163,8 @@ TEST_F(PredictiveTuningTest, testTuningThreeIterations) {
   autopas::PredictiveTuning predictiveTuning(
       {autopas::ContainerOption::linkedCells}, {1.},
       {autopas::TraversalOption::c08, autopas::TraversalOption::c01, autopas::TraversalOption::sliced},
-      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled}, 1.2, 5);
+      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled}, relativeOptimumRange,
+      maxTuningIterationsWithoutTest);
 
   predictiveTuning.reset(iteration);
 
@@ -226,10 +232,10 @@ TEST_F(PredictiveTuningTest, testTuningThreeIterations) {
  */
 TEST_F(PredictiveTuningTest, testTooLongNotTested) {
   unsigned int iteration = 0;
-  unsigned int _maxTuningIterationsWithoutTest = 5;
-  autopas::PredictiveTuning predictiveTuning(
-      {autopas::ContainerOption::linkedCells}, {1.}, {autopas::TraversalOption::c08, autopas::TraversalOption::sliced},
-      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled}, 1.2, _maxTuningIterationsWithoutTest);
+  autopas::PredictiveTuning predictiveTuning({autopas::ContainerOption::linkedCells}, {1.},
+                                             {autopas::TraversalOption::c08, autopas::TraversalOption::sliced},
+                                             {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled},
+                                             relativeOptimumRange, maxTuningIterationsWithoutTest);
 
   predictiveTuning.reset(iteration);
 
@@ -260,8 +266,8 @@ TEST_F(PredictiveTuningTest, testTooLongNotTested) {
   predictiveTuning.tune();
   EXPECT_EQ(configurationSliced, predictiveTuning.getCurrentConfiguration());
 
-  // Iterating through the _maxNumberOfIterationsWithoutTest iterations where C08 should not be tested.
-  for (int i = 0; i < _maxTuningIterationsWithoutTest; i++) {
+  // Iterating through the maxNumberOfIterationsWithoutTest iterations where C08 should not be tested.
+  for (int i = 0; i < maxTuningIterationsWithoutTest; i++) {
     // End of the (i + 2)-th tuning phase.
     predictiveTuning.reset(iteration);
 
@@ -273,7 +279,7 @@ TEST_F(PredictiveTuningTest, testTooLongNotTested) {
     EXPECT_EQ(configurationSliced, predictiveTuning.getCurrentConfiguration());
   }
 
-  // End of the (_maxTuningIterationsWithoutTest + 2)-th tuning phase.
+  // End of the (maxTuningIterationsWithoutTest + 2)-th tuning phase.
   predictiveTuning.reset(iteration);
 
   EXPECT_EQ(configurationSliced, predictiveTuning.getCurrentConfiguration());
@@ -302,7 +308,8 @@ TEST_F(PredictiveTuningTest, testInvalidOptimalSearchSpaceOnce) {
   autopas::PredictiveTuning predictiveTuning(
       {autopas::ContainerOption::linkedCells}, {1.},
       {autopas::TraversalOption::c08, autopas::TraversalOption::c01, autopas::TraversalOption::sliced},
-      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled}, 1.2, 5);
+      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled}, relativeOptimumRange,
+      maxTuningIterationsWithoutTest);
 
   predictiveTuning.reset(iteration);
 
@@ -365,15 +372,16 @@ TEST_F(PredictiveTuningTest, testInvalidOptimalSearchSpaceOnce) {
  *      - C08 is constant out of the optimum range (15) and invalid in the third iteration.
  *      - Sliced is constant the optimum (10) and invalid in the third iteration.
  *      - C01 is constant out of the optimum range (20).
- * In the third iteration reselectOptimalSearchSpace should be called twice and C01 should be selected after the tuning
- * phase.
+ * In the third iteration reselectOptimalSearchSpace should be called twice and C01 should be selected after the
+ * tuning1.2, 5 phase.
  */
 TEST_F(PredictiveTuningTest, testInvalidOptimalSearchSpaceTwice) {
   unsigned int iteration = 0;
   autopas::PredictiveTuning predictiveTuning(
       {autopas::ContainerOption::linkedCells}, {1.},
       {autopas::TraversalOption::c08, autopas::TraversalOption::c01, autopas::TraversalOption::sliced},
-      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled}, 1.2, 5);
+      {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled}, relativeOptimumRange,
+      maxTuningIterationsWithoutTest);
 
   predictiveTuning.reset(iteration);
 

--- a/tests/testAutopas/tests/selectors/tuningStrategy/PredictiveTuningTest.h
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/PredictiveTuningTest.h
@@ -22,4 +22,7 @@ class PredictiveTuningTest : public AutoPasTestBase {
   const autopas::Configuration configurationSliced =
       autopas::Configuration(autopas::ContainerOption::linkedCells, 1., autopas::TraversalOption::sliced,
                              autopas::DataLayoutOption::soa, autopas::Newton3Option::disabled);
+  static constexpr double relativeOptimumRange = 1.2;
+
+  static constexpr unsigned int maxTuningIterationsWithoutTest = 5;
 };


### PR DESCRIPTION
# Description

- [x] Create a Super Class for the tuning strategies
- [x] Integrate PredicitveTuning in AutoPas
- [x] Create user input for  _relativeOptimum and _maxTuningIterationsWithoutTest in PredictiveTuning.h.
- [x] Adapt md-flex to new user input

# Other possibility of the super class

If the _currentConfig variable is in the super class instead of the separate tuning strategies, removeN3Option() can be in the super class, but then the super class can only be used for FullSearch and Predicitve Tuning, because right now the other classes use a different data type for _currentConfig.

I would choose the current implementation, but I wanted to mention the other possibility.

## Related Pull Requests

- none

## Resolved Issues

- [x] fixes #452 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] current tests
- [x] run md-flex