### PR TITLE
when a number of tuning-phases is specified finish the simulation whe…

### DIFF
--- a/examples/md-flexible/README.md
+++ b/examples/md-flexible/README.md
@@ -48,3 +48,7 @@ rather strict. The VTK file only contains Information about all
 particles positions, velocities, forces and typeIDs. All other options,
 especially the simulation box size and particle properties (still) need
 to be set through a YAML file.
+
+### Misc
+
+* `tuning-phases` overwrites restrictions set by `iterations`

--- a/examples/md-flexible/Simulation.h
+++ b/examples/md-flexible/Simulation.h
@@ -259,7 +259,8 @@ void Simulation<Particle, ParticleCell>::initialize(const MDFlexConfig &mdFlexCo
 
   // sanitize simulation end condition
   if (_config->tuningPhases > 0) {
-    _config->iterations = std::numeric_limits<size_t>::min();
+    // set iterations to zero because we don't want to consider it
+    _config->iterations = 0ul;
   }
 
   // initializing Objects

--- a/examples/md-flexible/parsing/CLIParser.cpp
+++ b/examples/md-flexible/parsing/CLIParser.cpp
@@ -39,6 +39,7 @@ bool CLIParser::parseInput(int argc, char **argv, MDFlexConfig &config) {
                                          {MDFlexConfig::particlesTotalStr, required_argument, nullptr, 'N'},
                                          {MDFlexConfig::relativeOptimumRangeStr, required_argument, nullptr, 'o'},
                                          {MDFlexConfig::periodicStr, required_argument, nullptr, 'p'},
+                                         {MDFlexConfig::tuningPhasesStr, required_argument, nullptr, 'P'},
                                          {MDFlexConfig::verletClusterSizeStr, required_argument, nullptr, 'q'},
                                          {MDFlexConfig::verletSkinRadiusStr, required_argument, nullptr, 'r'},
                                          {MDFlexConfig::particlesSpacingStr, required_argument, nullptr, 's'},
@@ -317,9 +318,9 @@ bool CLIParser::parseInput(int argc, char **argv, MDFlexConfig &config) {
       }
       case 'P': {
         try {
-          config.particlesTotal = stoul(strArg);
+          config.tuningPhases = stoul(strArg);
         } catch (const exception &) {
-          cerr << "Error parsing total number of particles: " << strArg << endl;
+          cerr << "Error parsing number of tuning phases: " << strArg << endl;
           displayHelp = true;
         }
         break;

--- a/examples/md-flexible/parsing/MDFlexConfig.h
+++ b/examples/md-flexible/parsing/MDFlexConfig.h
@@ -114,6 +114,8 @@ class MDFlexConfig {
   FunctorOption functorOption{FunctorOption::lj12_6};
   static inline const char *iterationsStr{"iterations"};
   size_t iterations{10};
+  static inline const char *tuningPhasesStr{"tuning-phases"};
+  size_t tuningPhases{0};
   static inline const char *periodicStr{"periodic-boundaries"};
   bool periodic{true};
   // this starts with a don't such that it can be used as a flag with a sane default.

--- a/examples/md-flexible/parsing/YamlParser.cpp
+++ b/examples/md-flexible/parsing/YamlParser.cpp
@@ -62,6 +62,9 @@ bool parseYamlFile(MDFlexConfig &config) {
   if (node[MDFlexConfig::iterationsStr]) {
     config.iterations = node[MDFlexConfig::iterationsStr].as<unsigned long>();
   }
+  if (node[MDFlexConfig::tuningPhasesStr]) {
+    config.tuningPhases = node[MDFlexConfig::tuningPhasesStr].as<unsigned long>();
+  }
   if (node[MDFlexConfig::dontMeasureFlopsStr]) {
     // "not" needed because of semantics
     config.dontMeasureFlops = not node[MDFlexConfig::dontMeasureFlopsStr].as<bool>();


### PR DESCRIPTION
# Description

MD-Flex can now be run until a specified number of tuning phases is completed

## Related Pull Requests

- merge after #454 (merge target will be master. Currently points to super-class.... for reviewing reasons)

## Resolved Issues

# How Has This Been Tested?

- [x] playing around with md-flex
