### PR TITLE
Update to use new archer image

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,16 +33,6 @@ if (NOT CMAKE_CXX_COMPILER_ID IN_LIST SUPPORTED_COMPILERS)
     message(WARNING "Compiler " ${CMAKE_CXX_COMPILER_ID} " not supported!")
 endif ()
 
-# ~~~
-# Check if the compiler command is archer.
-# CMAKE_CXX_COMPILER contains the whole path.
-# "archer" must be after the last "/"
-# ~~~
-if (CMAKE_CXX_COMPILER MATCHES ".*archer[^/]*")
-    message(STATUS "Archer detected!")
-    set(ARCHER true)
-endif ()
-
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 # let ccmake and cmake-gui offer the default build type options

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -241,7 +241,7 @@ pipeline{
                     steps{
                         container('autopas-llvm-archer'){
                             dir("build-archer"){
-                                sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DCCACHE=ON -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_USE_VECTORIZATION=OFF .."
+                                sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DAUTOPAS_ENABLE_THREAD_SANITIZER=ON -DAUTOPAS_OPENMP=ON -DCCACHE=ON -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_USE_VECTORIZATION=OFF .."
                                 sh "entrypoint.sh ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
                                 sh 'export TSAN_OPTIONS="ignore_noninstrumented_modules=1" && ctest --verbose'
                             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -239,14 +239,14 @@ pipeline{
                 }
                 stage("archer") {
                     steps{
-                        container('autopas-archer'){
+                        container('autopas-llvm-archer'){
                             dir("build-archer"){
-                                sh "CXXFLAGS=-Wno-pass-failed CC=clang-archer CXX=clang-archer++ cmake -G Ninja -DCCACHE=ON -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_USE_VECTORIZATION=OFF .."
+                                sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DCCACHE=ON -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_USE_VECTORIZATION=OFF .."
                                 sh "entrypoint.sh ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
-                                sh 'export TSAN_OPTIONS="ignore_noninstrumented_modules=1" && export ARCHER_OPTIONS="print_ompt_counters=1" && ctest --verbose'
+                                sh 'export TSAN_OPTIONS="ignore_noninstrumented_modules=1" && ctest --verbose'
                             }
                             dir("build-archer/examples"){
-                                sh 'export TSAN_OPTIONS="ignore_noninstrumented_modules=1" && export ARCHER_OPTIONS="print_ompt_counters=1" && ctest -C checkExamples -j8 --verbose'
+                                sh 'export TSAN_OPTIONS="ignore_noninstrumented_modules=1" && ctest -C checkExamples -j8 --verbose'
                             }
                         }
                     }

--- a/cmake/modules/OpenMP.cmake
+++ b/cmake/modules/OpenMP.cmake
@@ -1,9 +1,6 @@
 option(AUTOPAS_OPENMP "Activates OpenMP shared memory parallelization." OFF)
 
-if (ARCHER)
-    message(STATUS "archer detected, OpenMP enabled by default, so skipping OpenMP package search")
-    set(AUTOPAS_OPENMP ON)
-elseif (AUTOPAS_OPENMP)
+if (AUTOPAS_OPENMP)
     message(STATUS "OpenMP enabled.")
     find_package(OpenMP REQUIRED)
     # OpenMP version 4.5 was specified in 11.2015

--- a/src/autopas/CMakeLists.txt
+++ b/src/autopas/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries(
     PUBLIC
         rt # required for Time.h
         ${CMAKE_THREAD_LIBS_INIT} # required for Logger and ExceptionHandler
-        $<$<AND:$<BOOL:${AUTOPAS_OPENMP}>,$<NOT:$<BOOL:${ARCHER}>>>:OpenMP::OpenMP_CXX>
+        $<$<BOOL:${AUTOPAS_OPENMP}>:OpenMP::OpenMP_CXX>
         spdlog::spdlog
     PRIVATE
         # harmony and Eigen3 are only needed privately when building AutoPas.

--- a/src/autopas/CMakeLists.txt
+++ b/src/autopas/CMakeLists.txt
@@ -18,8 +18,7 @@ target_link_libraries(
     autopas
     PUBLIC
         rt # required for Time.h
-        ${CMAKE_THREAD_LIBS_INIT} # required for Logger and ExceptionHandler Do not link against
-                                  # openmp when using archer
+        ${CMAKE_THREAD_LIBS_INIT} # required for Logger and ExceptionHandler
         $<$<AND:$<BOOL:${AUTOPAS_OPENMP}>,$<NOT:$<BOOL:${ARCHER}>>>:OpenMP::OpenMP_CXX>
         spdlog::spdlog
     PRIVATE


### PR DESCRIPTION
# Description

Update Jenkinsfile to use the new Archer image.
This archer image uses the new llvm-integrated archer version:
https://github.com/llvm/llvm-project/tree/master/openmp/tools/archer/

# Additional Info
This update becomes needed, as the old version provided false errors in #453.
Archer is now fully integrated into the thread-sanitizer, so we more or less only use that now and can remove any Archer specific functions from the cmake files.