### PR TITLE
Calculation fix for time and performance calculations in md-flexible

### DIFF
--- a/examples/md-flexible/Simulation.h
+++ b/examples/md-flexible/Simulation.h
@@ -390,7 +390,7 @@ void Simulation<Particle, ParticleCell>::printStatistics(autopas::AutoPas<Partic
   cout << timerToString("One iteration   ", _timers.simulate.getTotalTime() / iteration, digitsTimeTotalNS,
                         durationTotal);
   auto mfups = autopas.getNumberOfParticles(autopas::IteratorBehavior::ownedOnly) * iteration * 1e-6 /
-		  (_timers.forceUpdateTotal.getTotalTime() * 1e-9);  // 1e-9 for ns to s, 1e-6 for M in MFUP
+               (_timers.forceUpdateTotal.getTotalTime() * 1e-9);  // 1e-9 for ns to s, 1e-6 for M in MFUP
   cout << "Tuning iterations: " << numTuningIterations << " / " << iteration << " = "
        << ((double)numTuningIterations / iteration * 100) << "%" << endl;
   cout << "MFUPs/sec    : " << mfups << endl;
@@ -430,8 +430,7 @@ std::string Simulation<Particle, ParticleCell>::timerToString(const std::string 
 
   std::ostringstream ss;
   ss << std::fixed << std::setprecision(_floatStringPrecision);
-  ss << name << " : " << std::setw(numberWidth) << std::right << timeNS << " ns (" << ((double)timeNS * 1e-9)
-     << "s)";
+  ss << name << " : " << std::setw(numberWidth) << std::right << timeNS << " ns (" << ((double)timeNS * 1e-9) << "s)";
   if (maxTime != 0) {
     ss << " =" << std::setw(7) << std::right << ((double)timeNS / (double)maxTime * 100) << "%";
   }

--- a/examples/md-flexible/Simulation.h
+++ b/examples/md-flexible/Simulation.h
@@ -359,7 +359,7 @@ void Simulation<Particle, ParticleCell>::printStatistics(autopas::AutoPas<Partic
 
   auto durationTotal = _timers.total.stop();
   auto durationSimulate = _timers.simulate.getTotalTime();
-  auto durationSimulateSec = durationSimulate * 1e-6;
+  auto durationSimulateSec = durationSimulate * 1e-9;
 
   // take total time as base for formatting since this should be the longest
   auto digitsTimeTotalNS = std::to_string(durationTotal).length();
@@ -389,8 +389,8 @@ void Simulation<Particle, ParticleCell>::printStatistics(autopas::AutoPas<Partic
 
   cout << timerToString("One iteration   ", _timers.simulate.getTotalTime() / iteration, digitsTimeTotalNS,
                         durationTotal);
-  auto mfups = autopas.getNumberOfParticles(autopas::IteratorBehavior::ownedOnly) * iteration /
-               _timers.forceUpdateTotal.getTotalTime() * 1e-9;
+  auto mfups = autopas.getNumberOfParticles(autopas::IteratorBehavior::ownedOnly) * iteration * 1e-6 /
+		  (_timers.forceUpdateTotal.getTotalTime() * 1e-9);  // 1e-9 for ns to s, 1e-6 for M in MFUP
   cout << "Tuning iterations: " << numTuningIterations << " / " << iteration << " = "
        << ((double)numTuningIterations / iteration * 100) << "%" << endl;
   cout << "MFUPs/sec    : " << mfups << endl;
@@ -430,7 +430,7 @@ std::string Simulation<Particle, ParticleCell>::timerToString(const std::string 
 
   std::ostringstream ss;
   ss << std::fixed << std::setprecision(_floatStringPrecision);
-  ss << name << " : " << std::setw(numberWidth) << std::right << timeNS << " \u03bcs (" << ((double)timeNS * 1e-9)
+  ss << name << " : " << std::setw(numberWidth) << std::right << timeNS << " ns (" << ((double)timeNS * 1e-9)
      << "s)";
   if (maxTime != 0) {
     ss << " =" << std::setw(7) << std::right << ((double)timeNS / (double)maxTime * 100) << "%";


### PR DESCRIPTION
# Description

Calculation fix for time and performance calculations in md-flexible

## Related Pull Requests

- None

## Resolved Issues

- fixes time calculation from ns to s
