### PR TITLE
fix ActiveHarmony LoadEstimator integration.

### DIFF
--- a/src/autopas/selectors/tuningStrategy/ActiveHarmony.h
+++ b/src/autopas/selectors/tuningStrategy/ActiveHarmony.h
@@ -361,6 +361,7 @@ void ActiveHarmony::resetHarmony() {
     configureTuningParameter(hdef, traversalOptionName, _allowedTraversalOptions);
     configureTuningParameter(hdef, dataLayoutOptionName, _allowedDataLayoutOptions);
     configureTuningParameter(hdef, newton3OptionName, _allowedNewton3Options);
+    configureTuningParameter(hdef, loadEstimatorOptionName, _allowedLoadEstimatorOptions);
 
     // use ActiveHarmony's implementation of the Nelder-Mead method
     ah_def_strategy(hdef, "nm.so");


### PR DESCRIPTION
missing call to configureTuningParameter caused program to crash.