### PR TITLE
Change INIT_RADIUS of ActiveHarmony to fix #500

### DIFF
--- a/examples/sph/sph-main.cpp
+++ b/examples/sph/sph-main.cpp
@@ -293,7 +293,7 @@ int main() {
   boxMax[1] = boxMax[2] = boxMax[0] / 8.0;
   double cutoff = 0.03;               // 0.012*2.5=0.03; where 2.5 = kernel support radius
   unsigned int rebuildFrequency = 6;  // has to be multiple of two, as there are two functor calls per iteration.
-  double skinToCutoffRatio = 0.1;
+  double skinToCutoffRatio = 0.15;
 
   AutoPasContainer sphSystem;
   sphSystem.setNumSamples(

--- a/examples/sph/sph-main.cpp
+++ b/examples/sph/sph-main.cpp
@@ -47,8 +47,7 @@ void SetupIC(AutoPasContainer &sphSystem, double *end_time, const std::array<dou
   std::cout << "# of particles is... " << i << std::endl;
 
   // Set the end time
-  /// @TODO revert this again before merge!
-  *end_time = 1.;
+  *end_time = .018;
   // end_time for original example: (expects 50 timesteps)
   // *end_time = .12;
   // Fin.
@@ -304,9 +303,8 @@ int main() {
   sphSystem.setVerletSkin(skinToCutoffRatio * cutoff);
   sphSystem.setVerletRebuildFrequency(rebuildFrequency);
 
-  /// @TODO revert this again before merge!
-  sphSystem.setTuningStrategyOption(autopas::TuningStrategyOption::activeHarmony);
-  autopas::Logger::get()->set_level(autopas::Logger::LogLevel::debug);
+  //sphSystem.setTuningStrategyOption(autopas::TuningStrategyOption::activeHarmony);
+  //autopas::Logger::get()->set_level(autopas::Logger::LogLevel::debug);
 
   std::set<autopas::ContainerOption> allowedContainers{autopas::ContainerOption::linkedCells,
                                                        autopas::ContainerOption::verletLists,

--- a/examples/sph/sph-main.cpp
+++ b/examples/sph/sph-main.cpp
@@ -47,7 +47,8 @@ void SetupIC(AutoPasContainer &sphSystem, double *end_time, const std::array<dou
   std::cout << "# of particles is... " << i << std::endl;
 
   // Set the end time
-  *end_time = .018;
+  /// @TODO revert this again before merge!
+  *end_time = 1.;
   // end_time for original example: (expects 50 timesteps)
   // *end_time = .12;
   // Fin.
@@ -302,6 +303,10 @@ int main() {
   sphSystem.setCutoff(cutoff);
   sphSystem.setVerletSkin(skinToCutoffRatio * cutoff);
   sphSystem.setVerletRebuildFrequency(rebuildFrequency);
+
+  /// @TODO revert this again before merge!
+  sphSystem.setTuningStrategyOption(autopas::TuningStrategyOption::activeHarmony);
+  autopas::Logger::get()->set_level(autopas::Logger::LogLevel::debug);
 
   std::set<autopas::ContainerOption> allowedContainers{autopas::ContainerOption::linkedCells,
                                                        autopas::ContainerOption::verletLists,

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -370,7 +370,8 @@ bool AutoTuner<Particle, ParticleCell>::tune(PairwiseFunctor &pairwiseFunctor) {
   if (_samples.size() < _maxSamples) {
     return stillTuning;
   }
-
+  utils::Timer tuningTimer;
+  tuningTimer.start();
   // first tuning iteration -> reset to first config
   if (_iterationsSinceTuning == _tuningInterval) {
     _tuningStrategy->reset(_iteration);
@@ -405,6 +406,8 @@ bool AutoTuner<Particle, ParticleCell>::tune(PairwiseFunctor &pairwiseFunctor) {
     // samples are no longer needed. Delete them here so willRebuild() works as expected.
     _samples.clear();
   }
+  tuningTimer.stop();
+  AutoPasLog(debug, "Tuning took {} ns.", tuningTimer.getTotalTime());
 
   selectCurrentContainer();
   return stillTuning;

--- a/src/autopas/selectors/tuningStrategy/ActiveHarmony.h
+++ b/src/autopas/selectors/tuningStrategy/ActiveHarmony.h
@@ -367,7 +367,7 @@ void ActiveHarmony::resetHarmony() {
     // use ActiveHarmony's implementation of the Nelder-Mead method
     ah_def_strategy(hdef, "nm.so");
     // set the size of the initial simplex (as portion of the total search space)
-    ah_def_cfg(hdef, "INIT_RADIUS", "0.5");
+    ah_def_cfg(hdef, "INIT_RADIUS", "0.7");
     // task initialization
     htask = ah_start(hdesc, hdef);
     ah_def_free(hdef);

--- a/src/autopas/selectors/tuningStrategy/ActiveHarmony.h
+++ b/src/autopas/selectors/tuningStrategy/ActiveHarmony.h
@@ -216,6 +216,7 @@ void ActiveHarmony::fetchConfiguration() {
 void ActiveHarmony::invalidateConfiguration() {
   auto worstPerf = std::numeric_limits<double>::max();
   addEvidence(worstPerf, 0);
+  AutoPasLog(debug, "ActiveHarmony::invalidateConfiguration: {}", _currentConfig.toString());
 }
 
 bool ActiveHarmony::tune(bool currentInvalid) {

--- a/src/autopas/utils/Timer.h
+++ b/src/autopas/utils/Timer.h
@@ -40,9 +40,9 @@ class Timer {
 
   /**
    * Get total accumulated time.
-   * @return total time in nano seconds.
+   * @return Total time in nano seconds.
    */
-  long getTotalTime() const { return _totalTime; }
+  [[nodiscard]] long getTotalTime() const { return _totalTime; }
 
  private:
   /**

--- a/src/autopas/utils/Timer.h
+++ b/src/autopas/utils/Timer.h
@@ -40,7 +40,7 @@ class Timer {
 
   /**
    * Get total accumulated time.
-   * @return
+   * @return total time in nano seconds.
    */
   long getTotalTime() const { return _totalTime; }
 


### PR DESCRIPTION
# Description

This changes the INIT_RADIUS parameters of ActiveHarmony from 0.5 to 0.7.


## Resolved Issues

- [x] fixes #500

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Locally
