### PR TITLE
Fix issue #500

### DIFF
--- a/src/autopas/selectors/tuningStrategy/ActiveHarmony.h
+++ b/src/autopas/selectors/tuningStrategy/ActiveHarmony.h
@@ -230,7 +230,7 @@ bool ActiveHarmony::tune(bool currentInvalid) {
   if (currentInvalid) {
     if (ah_converged(htask)) {
       AutoPasLog(debug, "Active Harmony converged to invalid configuration; resetting active-harmony server.");
-      resetHarmony();
+      reset(0);
     } else {
       invalidateConfiguration();
     }

--- a/src/autopas/selectors/tuningStrategy/ActiveHarmony.h
+++ b/src/autopas/selectors/tuningStrategy/ActiveHarmony.h
@@ -214,7 +214,7 @@ void ActiveHarmony::fetchConfiguration() {
 }
 
 void ActiveHarmony::invalidateConfiguration() {
-  auto worstPerf = std::numeric_limits<double>::max();
+  auto worstPerf = std::numeric_limits<long>::max();
   addEvidence(worstPerf, 0);
   AutoPasLog(debug, "ActiveHarmony::invalidateConfiguration: {}", _currentConfig.toString());
 }
@@ -230,7 +230,7 @@ bool ActiveHarmony::tune(bool currentInvalid) {
   if (currentInvalid) {
     if (ah_converged(htask)) {
       AutoPasLog(debug, "Active Harmony converged to invalid configuration; resetting active-harmony server.");
-      reset(0);
+      resetHarmony();
     } else {
       invalidateConfiguration();
     }


### PR DESCRIPTION
# Description

The in #500 described bug was caused by an implicit conversion from long to double. The invalidateConfiguration method thus reported good times to Active Harmony which in turn learned to return invalid configurations. So the only way for a valid configuration to be chosen would have been to have very short time steps or be lucky and not have to invalidate any configs.

## Resolved Issues

- [X] fixes #500 

# How Has This Been Tested?
- [X] locally, with sph-main-mpi.

# Considerations before merging
* Since the bug described in #500 could not be observed universally, someone else should test this fix on their machine.
