### PR TITLE
Indicate tuning

### DIFF
--- a/examples/md-flexible/src/Simulation.h
+++ b/examples/md-flexible/src/Simulation.h
@@ -245,10 +245,6 @@ void Simulation<Particle, ParticleCell>::calculateForces(autopas::AutoPas<Partic
 
   FunctorType functor{autopas.getCutoff(), *_particlePropertiesLibrary};
   bool tuningIteration = autopas.iteratePairwise(&functor);
-  // only generate this output if the logger is set to debug
-  if (autopas::Logger::get()->level() <= autopas::Logger::LogLevel::debug) {
-    std::cout << "Tuning: " << std::boolalpha << tuningIteration << std::endl;
-  }
 
   auto timeIteration = _timers.forceUpdateTotal.stop();
   if (tuningIteration) {

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -326,7 +326,8 @@ template <class Particle, class ParticleCell>
 template <class PairwiseFunctor, DataLayoutOption::Value dataLayout, bool useNewton3, bool inTuningPhase>
 void AutoTuner<Particle, ParticleCell>::iteratePairwiseTemplateHelper(PairwiseFunctor *f, bool doListRebuild) {
   auto containerPtr = getContainer();
-  AutoPasLog(debug, "Iterating with configuration: {}", _tuningStrategy->getCurrentConfiguration().toString());
+  AutoPasLog(debug, "Iterating with configuration: {} tuning: {}",
+             _tuningStrategy->getCurrentConfiguration().toString(), inTuningPhase ? "true" : "false");
 
   auto traversal = TraversalSelector<ParticleCell>::template generateTraversal<PairwiseFunctor, dataLayout, useNewton3>(
       _tuningStrategy->getCurrentConfiguration().traversal, *f, containerPtr->getTraversalSelectorInfo());


### PR DESCRIPTION
# Description

Move tuning indication to AutoPas logger output so that it appears the same way everywhere AutoPas is used.

