### PR TITLE
BayesianClusterSearch initial sampling + evidence decay

### DIFF
--- a/examples/md-flexible/input/testTuning/MDFlex_Case1.yaml
+++ b/examples/md-flexible/input/testTuning/MDFlex_Case1.yaml
@@ -8,7 +8,7 @@ tuning-max-evidence              :  10
 functor                          :  Lennard-Jones (12-6)
 cutoff                           :  2
 deltaT                           :  0
-# 138 tuning iterations + 50 to observe choses configuration
+# 138 tuning iterations + 50 to observe chosen configuration
 iterations                       :  188
 Objects:                         
   CubeGrid:

--- a/examples/md-flexible/input/testTuning/MDFlex_Case2.yaml
+++ b/examples/md-flexible/input/testTuning/MDFlex_Case2.yaml
@@ -1,11 +1,12 @@
 selector-strategy                :  Fastest-Absolute-Value
 tuning-strategy                  :  full-Search
-tuning-acquisition-function      :  expected-improvement
-tuning-interval                  :  1000
+tuning-acquisition-function      :  upper-confidence-bound
+tuning-interval                  :  100
 tuning-samples                   :  3
-tuning-max-evidence              :  50
+tuning-max-evidence              :  40
 functor                          :  Lennard-Jones (12-6)
 cutoff                           :  2
+verlet-skin-radius               :  0.2
 deltaT                           :  0
 cell-size                        :  [1.0,1.5,2.0]
 # 792 tuning iterations + 50 to observe chosen configuration
@@ -14,7 +15,7 @@ Objects:
   CubeGrid:
     0:  
       particles-per-dimension    :  [10, 10, 10]
-      particle-spacing           :  0.4
+      particle-spacing           :  0.5
       bottomLeftCorner           :  [0, 0, 0]
       velocity                   :  [0, 0, 0]
       particle-type              :  0

--- a/examples/md-flexible/input/testTuning/MDFlex_Case2.yaml
+++ b/examples/md-flexible/input/testTuning/MDFlex_Case2.yaml
@@ -7,6 +7,7 @@ tuning-max-evidence              :  40
 functor                          :  Lennard-Jones (12-6)
 cutoff                           :  2
 verlet-skin-radius               :  0.2
+verlet-rebuild-frequency         :  10
 deltaT                           :  0
 cell-size                        :  [1.0,1.5,2.0]
 # 792 tuning iterations + 50 to observe chosen configuration

--- a/examples/md-flexible/scripts/extractClusterGraphCombine.py
+++ b/examples/md-flexible/scripts/extractClusterGraphCombine.py
@@ -272,6 +272,10 @@ for i,(nodeStart, edgeStart, graphEnd) in enumerate(graphPos):
                 else:
                     values[column] = value
 
+            # let src the node with the lower index
+            if (target < src):
+                src, target = target, src
+
             # create new edge if not already exists
             if not (src,target) in edges:
                 edges[src,target] = GraphEdge(src, target)

--- a/examples/md-flexible/scripts/extractClusterGraphSeparate.py
+++ b/examples/md-flexible/scripts/extractClusterGraphSeparate.py
@@ -252,6 +252,10 @@ for nodeStart, edgeStart, graphEnd in graphPos:
                 else:
                     values[column] = value
 
+            # let src the node with the lower index
+            if (target < src):
+                src, target = target, src
+
             edges[src,target] = GraphEdge(src, target, values)
 
     graphs.append(Graph(nodes,edges))

--- a/src/autopas/selectors/FeatureVector.h
+++ b/src/autopas/selectors/FeatureVector.h
@@ -77,38 +77,6 @@ class FeatureVector : public Configuration {
   }
 
   /**
-   * Get cluster-encoded neighbours of given target.
-   * Neighbours are all configurations which differ in at most one configuration from target
-   * @param target
-   * @param dimRestrictions restriction on each dimension
-   * @return all neighbours
-   */
-  static std::vector<Eigen::VectorXi> neighboursManhattan1(const Eigen::VectorXi &target,
-                                                           const std::vector<int> &dimRestrictions) {
-    std::vector<Eigen::VectorXi> result;
-    // neighbours should contain #(possible values for each dimension) - #dimensions (initial vector is skipped once per
-    // dimension)
-    result.reserve(std::accumulate(dimRestrictions.begin(), dimRestrictions.end(), -dimRestrictions.size()));
-
-    // for each dimension
-    for (int i = 0; i < target.size(); ++i) {
-      // initial value
-      auto init = target[i];
-
-      // for each possible value of that dimension
-      for (int x = 0; x < dimRestrictions[i]; ++x) {
-        // skip initial value
-        if (x != init) {
-          auto neighbour = target;
-          neighbour[i] = x;
-          result.push_back(std::move(neighbour));
-        }
-      }
-    }
-    return result;
-  }
-
-  /**
    * Create n latin-hypercube-samples from given featureSpace.
    * @param n number of samples
    * @param rng
@@ -166,12 +134,12 @@ class FeatureVector : public Configuration {
   }
 
   /**
-   * Create n latin-hypercube-samples from given featureSpace only considering continuous values and append a value
-   * representing the current iteration.
+   * From a given continuous featureSpace, create n pairs of latin-hypercube-samples and a value representing the
+   * current iteration.
    * @param n number of samples
    * @param rng
    * @param cellSizeFactors
-   * @param iteration current iteration which may be scaled by some factor
+   * @param iteration Current iteration which may be scaled by some factor.
    * @return vector of sample featureVectors
    */
   static std::vector<Eigen::VectorXd> lhsSampleFeatureContinuousWithIteration(size_t n, Random &rng,

--- a/src/autopas/selectors/FeatureVector.h
+++ b/src/autopas/selectors/FeatureVector.h
@@ -166,17 +166,17 @@ class FeatureVector : public Configuration {
   }
 
   /**
-   * Create n latin-hypercube-samples from given featureSpace only considering continuous values and append the current
-   * iteration to the vector.
+   * Create n latin-hypercube-samples from given featureSpace only considering continuous values and append a value
+   * representing the current iteration.
    * @param n number of samples
    * @param rng
    * @param cellSizeFactors
-   * @param iteration current iteration
+   * @param iteration current iteration which may be scaled by some factor
    * @return vector of sample featureVectors
    */
   static std::vector<Eigen::VectorXd> lhsSampleFeatureContinuousWithIteration(size_t n, Random &rng,
                                                                               const NumberSet<double> &cellSizeFactors,
-                                                                              size_t iteration) {
+                                                                              double iteration) {
     // create n samples from each set
     auto csf = cellSizeFactors.uniformSample(n, rng);
 

--- a/src/autopas/selectors/FeatureVector.h
+++ b/src/autopas/selectors/FeatureVector.h
@@ -164,6 +164,32 @@ class FeatureVector : public Configuration {
 
     return result;
   }
+
+  /**
+   * Create n latin-hypercube-samples from given featureSpace only considering continuous values and append the current
+   * iteration to the vector.
+   * @param n number of samples
+   * @param rng
+   * @param cellSizeFactors
+   * @param iteration current iteration
+   * @return vector of sample featureVectors
+   */
+  static std::vector<Eigen::VectorXd> lhsSampleFeatureContinuousWithIteration(size_t n, Random &rng,
+                                                                              const NumberSet<double> &cellSizeFactors,
+                                                                              size_t iteration) {
+    // create n samples from each set
+    auto csf = cellSizeFactors.uniformSample(n, rng);
+
+    std::vector<Eigen::VectorXd> result;
+    result.reserve(n);
+    for (size_t i = 0; i < n; ++i) {
+      Eigen::VectorXd vec(featureSpaceContinuousDims + 1);
+      vec << csf[i], iteration;
+      result.emplace_back(vec);
+    }
+
+    return result;
+  }
 };
 
 /**

--- a/src/autopas/selectors/FeatureVectorEncoder.h
+++ b/src/autopas/selectors/FeatureVectorEncoder.h
@@ -18,6 +18,27 @@ namespace autopas {
  * Encoder to convert FeatureVector from and to Eigen::Vector.
  */
 class FeatureVectorEncoder {
+  /**
+   * Number of discrete values in a cluster encoded vector
+   */
+  static constexpr size_t clusterDiscreteSize = 3;
+  /**
+   * Index containing information about ContainerTraversalEstimator in continuous part of a cluster encoded vector
+   */
+  static constexpr size_t containerTraversalEstimatorClusterIndex = 0;
+  /**
+   * Index containing information about DataLayout in continuous part of a cluster encoded vector
+   */
+  static constexpr size_t dataLayoutClusterIndex = 1;
+  /**
+   * Index containing information about Newton3 in continuous part of a cluster encoded vector
+   */
+  static constexpr size_t newtonClusterIndex = 2;
+  /**
+   * Index containing information about CellSizeFactor in discrete part of a cluster encoded vector
+   */
+  static constexpr size_t cellSizeFactorClusterIndex = 0.;
+
  public:
   /**
    * Default Constructor
@@ -51,6 +72,12 @@ class FeatureVectorEncoder {
 
     _oneHotDims = FeatureVector::featureSpaceContinuousDims + _containerTraversalEstimatorOptions.size() +
                   _dataLayoutOptions.size() + _newton3Options.size();
+
+    _dimRestrictions.clear();
+    _dimRestrictions.reserve(clusterDiscreteSize);
+    _dimRestrictions.push_back(_containerTraversalEstimatorOptions.size());
+    _dimRestrictions.push_back(_dataLayoutOptions.size());
+    _dimRestrictions.push_back(_newton3Options.size());
   }
 
   /**
@@ -185,10 +212,12 @@ class FeatureVectorEncoder {
    */
   FeatureVector convertFromCluster(const std::pair<Eigen::VectorXi, Eigen::VectorXd> &vec) {
     const auto &[vecDiscrete, vecContinuous] = vec;
-    auto [container, traversal, estimator] = _containerTraversalEstimatorOptions[vecDiscrete[0]];
+    auto [container, traversal, estimator] =
+        _containerTraversalEstimatorOptions[vecDiscrete[containerTraversalEstimatorClusterIndex]];
 
-    return FeatureVector(container, vecContinuous[0], traversal, estimator, _dataLayoutOptions[vecDiscrete[1]],
-                         _newton3Options[vecDiscrete[2]]);
+    return FeatureVector(container, vecContinuous[cellSizeFactorClusterIndex], traversal, estimator,
+                         _dataLayoutOptions[vecDiscrete[dataLayoutClusterIndex]],
+                         _newton3Options[vecDiscrete[newtonClusterIndex]]);
   }
 
   /**
@@ -224,10 +253,86 @@ class FeatureVectorEncoder {
    */
   FeatureVector convertFromClusterWithIteration(const std::pair<Eigen::VectorXi, Eigen::VectorXd> &vec) {
     const auto &[vecDiscrete, vecContinuous] = vec;
-    auto [container, traversal, estimator] = _containerTraversalEstimatorOptions[vecDiscrete[0]];
+    auto [container, traversal, estimator] =
+        _containerTraversalEstimatorOptions[vecDiscrete[containerTraversalEstimatorClusterIndex]];
 
-    return FeatureVector(container, vecContinuous[0], traversal, estimator, _dataLayoutOptions[vecDiscrete[1]],
-                         _newton3Options[vecDiscrete[2]]);
+    return FeatureVector(container, vecContinuous[cellSizeFactorClusterIndex], traversal, estimator,
+                         _dataLayoutOptions[vecDiscrete[dataLayoutClusterIndex]],
+                         _newton3Options[vecDiscrete[newtonClusterIndex]]);
+  }
+
+  /**
+   * Get cluster-encoded neighbours of given target with fixed weight.
+   * Neighbours are all configurations which differ in at most one configuration from target.
+   * @param target
+   * @return
+   */
+  std::vector<std::pair<Eigen::VectorXi, double>> clusterNeighboursManhattan1(const Eigen::VectorXi &target) {
+    std::vector<std::pair<Eigen::VectorXi, double>> result;
+    // neighbours should contain #(possible values for each dimension) - #dimensions (initial vector is skipped once per
+    // dimension)
+    result.reserve(std::accumulate(_dimRestrictions.begin(), _dimRestrictions.end(), -_dimRestrictions.size()));
+
+    // for each dimension
+    for (int i = 0; i < target.size(); ++i) {
+      // initial value
+      auto init = target[i];
+
+      // for each possible value of that dimension
+      for (int x = 0; x < _dimRestrictions[i]; ++x) {
+        // skip initial value
+        if (x != init) {
+          auto neighbour = target;
+          neighbour[i] = x;
+          result.push_back(std::make_pair(std::move(neighbour), 1.));
+        }
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Get cluster-encoded neighbours of given target.
+   * Neighbours are all configurations which differ in at most one configuration from target.
+   * The weight is lowered if ContainerTraversalEstimator dimension is changed but the container stays the same.
+   * @param target
+   * @return
+   */
+  std::vector<std::pair<Eigen::VectorXi, double>> clusterNeighboursManhattan1Container(const Eigen::VectorXi &target) {
+    std::vector<std::pair<Eigen::VectorXi, double>> result;
+    // neighbours should contain #(possible values for each dimension) - #dimensions (initial vector is skipped once per
+    // dimension)
+    result.reserve(std::accumulate(_dimRestrictions.begin(), _dimRestrictions.end(), -_dimRestrictions.size()));
+
+    auto targetContainer =
+        std::get<0>(_containerTraversalEstimatorOptions[target[containerTraversalEstimatorClusterIndex]]);
+
+    // for each dimension
+    for (int i = 0; i < target.size(); ++i) {
+      // initial value
+      auto init = target[i];
+
+      // for each possible value of that dimension
+      for (int x = 0; x < _dimRestrictions[i]; ++x) {
+        // skip initial value
+        if (x != init) {
+          auto neighbour = target;
+          neighbour[i] = x;
+          double weight = 1.;
+          // check if containerTraversalEstimator changed but not container
+          if (i == containerTraversalEstimatorClusterIndex) {
+            auto xContainer = std::get<0>(_containerTraversalEstimatorOptions[x]);
+            if (targetContainer == xContainer) {
+              // assign lower weight
+              weight = 0.5;
+            }
+          }
+
+          result.push_back(std::make_pair(std::move(neighbour), weight));
+        }
+      }
+    }
+    return result;
   }
 
  private:
@@ -236,7 +341,12 @@ class FeatureVectorEncoder {
   std::vector<Newton3Option> _newton3Options;
 
   /**
-   * Dimensions of a one-hot-encoded vector
+   * Restriction of a cluster-encoded vector in each dimension.
+   */
+  std::vector<size_t> _dimRestrictions;
+
+  /**
+   * Dimensions of a one-hot-encoded vector.
    */
   size_t _oneHotDims{0};
 };

--- a/src/autopas/selectors/FeatureVectorEncoder.h
+++ b/src/autopas/selectors/FeatureVectorEncoder.h
@@ -292,9 +292,8 @@ class FeatureVectorEncoder {
   }
 
   /**
-   * Get cluster-encoded neighbours of given target.
-   * Neighbours are all configurations which differ in at most one configuration from target.
-   * The weight is lowered if ContainerTraversalEstimator dimension is changed but the container stays the same.
+   * Get cluster-encoded neighbours of given target. Neighbours are all configurations which differ
+   * in at most one configuration from target. The weight is lowered if container is changed.
    * @param target
    * @return
    */
@@ -319,10 +318,10 @@ class FeatureVectorEncoder {
           auto neighbour = target;
           neighbour[i] = x;
           double weight = 1.;
-          // check if containerTraversalEstimator changed but not container
+          // check if container changed
           if (i == containerTraversalEstimatorClusterIndex) {
             auto xContainer = std::get<0>(_containerTraversalEstimatorOptions[x]);
-            if (targetContainer == xContainer) {
+            if (targetContainer != xContainer) {
               // assign lower weight
               weight = 0.5;
             }
@@ -343,7 +342,7 @@ class FeatureVectorEncoder {
   /**
    * Restriction of a cluster-encoded vector in each dimension.
    */
-  std::vector<size_t> _dimRestrictions;
+  std::vector<int> _dimRestrictions;
 
   /**
    * Dimensions of a one-hot-encoded vector.

--- a/src/autopas/selectors/FeatureVectorEncoder.h
+++ b/src/autopas/selectors/FeatureVectorEncoder.h
@@ -196,11 +196,11 @@ class FeatureVectorEncoder {
    * Discrete values are encoded using their index in given std::vector.
    * Additionaly append current iteration to the continuous tuple.
    * @param vec vector to encode
-   * @param iteration current iteration
+   * @param iteration current iteration which may be scaled by some factor
    * @return cluster encoded vector
    */
   [[nodiscard]] std::pair<Eigen::VectorXi, Eigen::VectorXd> convertToClusterWithIteration(const FeatureVector &vec,
-                                                                                          size_t iteration) const {
+                                                                                          double iteration) const {
     int containerTraversalEstimatorIndex = static_cast<int>(
         std::distance(_containerTraversalEstimatorOptions.begin(),
                       std::find(_containerTraversalEstimatorOptions.begin(), _containerTraversalEstimatorOptions.end(),

--- a/src/autopas/selectors/tuningStrategy/BayesianClusterSearch.h
+++ b/src/autopas/selectors/tuningStrategy/BayesianClusterSearch.h
@@ -215,10 +215,14 @@ class BayesianClusterSearch : public TuningStrategyInterface {
       numSamples = std::min(numSamples, cellSizeFactors.size());
     }
 
-    Random rng(seed);
-    auto samples = cellSizeFactors.uniformSample(cellSizeFactorSampleSize, rng);
+    if (numSamples == 0) {
+      return std::set<double>();
+    }
 
-    return std::set(samples.begin(), samples.end());
+    Random rng(seed);
+    auto samples = cellSizeFactors.uniformSample(numSamples, rng);
+
+    return std::set<double>(samples.begin(), samples.end());
   }
 
   std::set<ContainerOption> _containerOptionsSet;
@@ -277,7 +281,7 @@ class BayesianClusterSearch : public TuningStrategyInterface {
   /**
    * Configuration with lowest time in current tuning phase.
    */
-  Configuration _currentOptimalConfig;
+  FeatureVector _currentOptimalConfig;
 
   /**
    * FullSearch used in the first tuning phase.

--- a/src/autopas/selectors/tuningStrategy/BayesianClusterSearch.h
+++ b/src/autopas/selectors/tuningStrategy/BayesianClusterSearch.h
@@ -99,7 +99,8 @@ class BayesianClusterSearch : public TuningStrategyInterface {
         _currentConfig(),
         _invalidConfigs(),
         _rng(seed),
-        _gaussianCluster({}, continuousDims, GaussianCluster::WeightFunction::wasserstein2, sigma, _rng),
+        _gaussianCluster({}, continuousDims, GaussianCluster::WeightFunction::evidenceMatchingScaledProbabilityGM,
+                         sigma, _rng),
         _neighbourFun([this](const Eigen::VectorXi &target) -> std::vector<std::pair<Eigen::VectorXi, double>> {
           return _encoder.clusterNeighboursManhattan1Container(target);
         }),

--- a/src/autopas/selectors/tuningStrategy/GaussianModel/GaussianClusterLogger.h
+++ b/src/autopas/selectors/tuningStrategy/GaussianModel/GaussianClusterLogger.h
@@ -69,7 +69,7 @@ class GaussianClusterLogger {
 
     // log edges
     for (size_t i = 0; i < clusters.size(); ++i) {
-      for (const auto &[n, weight] : neighbourWeights[i]) {
+      for (const auto &[n, _, weight] : neighbourWeights[i]) {
         if (weight > 0) {
           std::string source = _vecToStringFun(std::make_pair(discreteVectorMap[i], currentContinous));
           std::string target = _vecToStringFun(std::make_pair(discreteVectorMap[n], currentContinous));

--- a/src/autopas/selectors/tuningStrategy/GaussianModel/GaussianModelTypes.h
+++ b/src/autopas/selectors/tuningStrategy/GaussianModel/GaussianModelTypes.h
@@ -30,14 +30,14 @@ using VectorContinuous = Eigen::VectorXd;
 using VectorAcquisition = std::pair<std::pair<VectorDiscrete, VectorContinuous>, double>;
 
 /**
- * function that generate all neighbouring vectors of given vector
+ * function that generate all neighbouring vectors of given vector with weights
  */
-using NeighbourFunction = std::function<std::vector<VectorDiscrete>(VectorDiscrete)>;
+using NeighbourFunction = std::function<std::vector<std::pair<VectorDiscrete, double>>(VectorDiscrete)>;
 
 /**
- * for each vector store a vector of all neighbours and their corresponding weight
+ * for each vector store a vector of all neighbours, their corresponding prior weight and final weight
  */
-using NeighboursWeights = std::vector<std::vector<std::pair<size_t, double>>>;
+using NeighboursWeights = std::vector<std::vector<std::tuple<size_t, double, double>>>;
 
 /**
  * Vector described by a discrete and a continuous part

--- a/src/autopas/utils/NumberInterval.h
+++ b/src/autopas/utils/NumberInterval.h
@@ -94,5 +94,28 @@ class NumberInterval : public NumberSet<Number> {
 
     return result;
   }
+
+  std::set<Number> uniformSampleSet(size_t n, Random &rng) const override {
+    std::set<Number> result;
+    if (n == 0) {
+      return result;
+    } else if (isFinite()) {
+      result.insert(_min);
+      return result;
+    } else if (n == 1) {
+      // if only one sample choose middle
+      result.insert((_max + _min) / 2);
+      return result;
+    }
+
+    Number distance = (_max - _min) / (n - 1);
+    for (size_t i = 0; i < (n - 1); ++i) {
+      result.insert(_min + distance * i);
+    }
+    // add max separatly, avoiding possible rounding errors
+    result.insert(_max);
+
+    return result;
+  }
 };
 }  // namespace autopas

--- a/src/autopas/utils/NumberInterval.h
+++ b/src/autopas/utils/NumberInterval.h
@@ -73,6 +73,11 @@ class NumberInterval : public NumberSet<Number> {
     std::vector<Number> result;
     if (n == 0) {
       return result;
+    } else if (n == 1) {
+      // if only one sample choose middle
+      result.reserve(1);
+      result.push_back((_max + _min) / 2);
+      return result;
     }
 
     result.reserve(n);

--- a/src/autopas/utils/NumberSet.h
+++ b/src/autopas/utils/NumberSet.h
@@ -94,9 +94,18 @@ class NumberSet {
    * spaced evenly across the space.
    * @param n max samples
    * @param rng random number generator
-   * @return samples
+   * @return samples randomly ordered vector of points
    */
   virtual std::vector<Number> uniformSample(size_t n, Random &rng) const = 0;
+
+  /**
+   * Sample up to n points from the set. These points are
+   * spaced evenly across the space.
+   * @param n max samples
+   * @param rng random number generator
+   * @return samples ordered set of points
+   */
+  virtual std::set<Number> uniformSampleSet(size_t n, Random &rng) const = 0;
 };
 
 }  // namespace autopas

--- a/src/autopas/utils/NumberSetFinite.h
+++ b/src/autopas/utils/NumberSetFinite.h
@@ -53,5 +53,6 @@ class NumberSetFinite : public NumberSet<Number> {
   std::vector<Number> uniformSample(size_t n, Random &rng) const override {
     return rng.uniformSample(_set.begin(), _set.end(), n);
   }
+  std::set<Number> uniformSampleSet(size_t n, Random &rng) const override { return rng.randomSubset(_set, n); }
 };
 }  // namespace autopas

--- a/src/autopas/utils/Random.h
+++ b/src/autopas/utils/Random.h
@@ -11,6 +11,8 @@
 #include <random>
 #include <set>
 
+#include "autopas/utils/ExceptionHandler.h"
+
 namespace autopas {
 
 /**
@@ -48,6 +50,10 @@ class Random : public std::mt19937 {
    */
   template <class Iter>
   std::vector<typename std::iterator_traits<Iter>::value_type> uniformSample(Iter poolBegin, Iter poolEnd, size_t n) {
+    if (poolBegin == poolEnd) {
+      autopas::utils::ExceptionHandler::exception("Random.uniformSample: Cannot sample from empty set.");
+    }
+
     std::vector<typename std::iterator_traits<Iter>::value_type> result;
     result.reserve(n);
 

--- a/src/autopas/utils/Random.h
+++ b/src/autopas/utils/Random.h
@@ -89,9 +89,37 @@ class Random : public std::mt19937 {
     size_t pos = distr(*this);
 
     auto it = pool.begin();
-    for (size_t i = 0; i < pos; ++i) ++it;
+    std::advance(it, pos);
 
     return *it;
+  }
+
+  /**
+   * Pick up to n random elements from the set.
+   * Each elements has the same probability to be chosen
+   * @param pool set
+   * @param n number of elements
+   * @return n random elements
+   */
+  template <class T>
+  std::set<T> randomSubset(std::set<T> pool, size_t n) {
+    size_t size = std::min(n, pool.size());
+
+    // create randomly shuffled vector of points to all elements in the pool
+    std::vector<const T *> pointerVec;
+    pointerVec.reserve(pool.size());
+    for (const T &element : pool) {
+      pointerVec.push_back(&element);
+    }
+    std::shuffle(pointerVec.begin(), pointerVec.end(), *this);
+
+    // return first elements of the shuffled vector
+    std::set<T> result;
+    for (size_t i = 0; i < size; ++i) {
+      result.insert(*pointerVec[i]);
+    }
+
+    return result;
   }
 };
 

--- a/tests/testAutopas/tests/selectors/FeatureVectorTest.cpp
+++ b/tests/testAutopas/tests/selectors/FeatureVectorTest.cpp
@@ -150,7 +150,7 @@ TEST_F(FeatureVectorTest, clusterEncode) {
 }
 
 /**
- * Check neighboursManhattan1 generates unique and correct number of neighbours.
+ * Check clusterNeighboursManhattan1 generates unique and correct number of neighbours.
  */
 TEST_F(FeatureVectorTest, clusterNeighboursManhattan1) {
   auto cellSizeFactor = 1.0;
@@ -178,7 +178,7 @@ TEST_F(FeatureVectorTest, clusterNeighboursManhattan1) {
   for (auto fv : vecList) {
     // get neighbours of encoded vector
     auto [encodedDiscrete, encodedContinuous] = encoder.convertToCluster(fv);
-    auto neighbours = autopas::FeatureVector::neighboursManhattan1(encodedDiscrete, dimRestriction);
+    auto neighbours = encoder.clusterNeighboursManhattan1(encodedDiscrete);
 
     // neighbours should contain all container-traversals-estimator + all datalayouts + all newtons - 3 (initial vector
     // is counted trice)
@@ -188,7 +188,52 @@ TEST_F(FeatureVectorTest, clusterNeighboursManhattan1) {
     // neighbours should be unique
     for (size_t i = 0; i < neighbours.size(); ++i) {
       for (size_t j = i + 1; j < neighbours.size(); ++j) {
-        EXPECT_NE(neighbours[i], neighbours[j]);
+        EXPECT_NE(neighbours[i].first, neighbours[j].first);
+      }
+    }
+  }
+}
+
+/**
+ * Check clusterNeighboursManhattan1Container generates unique and correct number of neighbours.
+ */
+TEST_F(FeatureVectorTest, clusterNeighboursManhattan1Container) {
+  auto cellSizeFactor = 1.0;
+  auto dataLayouts = autopas::DataLayoutOption::getAllOptions();
+  auto newtons = autopas::Newton3Option::getAllOptions();
+
+  std::vector<DataLayoutOption> dataLayoutsVec(dataLayouts.begin(), dataLayouts.end());
+  std::vector<Newton3Option> newtonsVec(newtons.begin(), newtons.end());
+
+  FeatureVectorEncoder encoder(allCompatibleContainerTraversalEstimators, dataLayoutsVec, newtonsVec);
+
+  std::vector<int> dimRestriction = {static_cast<int>(allCompatibleContainerTraversalEstimators.size()),
+                                     static_cast<int>(dataLayouts.size()), static_cast<int>(newtons.size())};
+
+  // generate all possible combinations
+  std::vector<FeatureVector> vecList;
+  for (auto [container, traversal, estimator] : allCompatibleContainerTraversalEstimators) {
+    for (auto dataLayout : dataLayouts) {
+      for (auto newton3 : newtons) {
+        vecList.emplace_back(container, cellSizeFactor, traversal, estimator, dataLayout, newton3);
+      }
+    }
+  }
+
+  for (auto fv : vecList) {
+    // get neighbours of encoded vector
+    auto [encodedDiscrete, encodedContinuous] = encoder.convertToCluster(fv);
+    auto neighbours = encoder.clusterNeighboursManhattan1Container(encodedDiscrete);
+
+    // neighbours should contain all container-traversals-estimator + all datalayouts + all newtons - 3 (initial vector
+    // is counted trice)
+    EXPECT_EQ(neighbours.size(),
+              allCompatibleContainerTraversalEstimators.size() + dataLayouts.size() + newtons.size() - 3);
+
+    // neighbours should be unique
+    for (size_t i = 0; i < neighbours.size(); ++i) {
+      for (size_t j = i + 1; j < neighbours.size(); ++j) {
+        EXPECT_NE(neighbours[i].first, neighbours[j].first);
       }
     }
   }

--- a/tests/testAutopas/tests/selectors/tuningStrategy/BayesianClusterSearchTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/BayesianClusterSearchTest.cpp
@@ -45,7 +45,7 @@ TEST_F(BayesianClusterSearchTest, testMaxEvidence) {
  * Find best configuration if configuration are similar through tuning phases.
  */
 TEST_F(BayesianClusterSearchTest, testFindBestSimilar) {
-  constexpr size_t maxEvidence = 3;
+  constexpr size_t maxEvidence = 10;
   constexpr unsigned long seed = 21;
   // we use a dummy time function which increases linearly with the squared distance to the chosen optimal solution
   constexpr double timePerDistanceSquared = 654321;
@@ -78,7 +78,7 @@ TEST_F(BayesianClusterSearchTest, testFindBestSimilar) {
   } while (bayesClusterSearch.tune());
 
   // artificial time skip
-  iteration += 100;
+  iteration += 50;
   bayesClusterSearch.reset(iteration);
 
   // second tuning phase
@@ -98,7 +98,7 @@ TEST_F(BayesianClusterSearchTest, testFindBestSimilar) {
  * Find best configuration if optimal configuration changes over time.
  */
 TEST_F(BayesianClusterSearchTest, testFindBestDifferent) {
-  const size_t maxEvidence = 7;
+  const size_t maxEvidence = 15;
   const unsigned long seed = 21;
   // we use a dummy time function which increases linearly with the squared distance to the chosen optimal solution
   constexpr double timePerDistanceSquared = 654321;
@@ -142,7 +142,7 @@ TEST_F(BayesianClusterSearchTest, testFindBestDifferent) {
   } while (bayesClusterSearch.tune());
 
   // artificial time skip
-  iteration += 100;
+  iteration += 50;
   bayesClusterSearch.reset(iteration);
 
   // second tuning phase
@@ -162,7 +162,7 @@ TEST_F(BayesianClusterSearchTest, testFindBestDifferent) {
  * Find best configuration if optimal configuration changes drastically over time.
  */
 TEST_F(BayesianClusterSearchTest, testFindBestVeryDifferent) {
-  const size_t maxEvidence = 16;
+  const size_t maxEvidence = 20;
   const unsigned long seed = 21;
   // we use a dummy time function which increases linearly with the squared distance to the chosen optimal solution
   constexpr double timePerDistanceSquared = 654321;
@@ -206,7 +206,7 @@ TEST_F(BayesianClusterSearchTest, testFindBestVeryDifferent) {
   } while (bayesClusterSearch.tune());
 
   // artificial time skip
-  iteration += 100;
+  iteration += 50;
   bayesClusterSearch.reset(iteration);
 
   // second tuning phase
@@ -219,5 +219,5 @@ TEST_F(BayesianClusterSearchTest, testFindBestVeryDifferent) {
   autopas::FeatureVector prediction(bayesClusterSearch.getCurrentConfiguration());
   long predictionTime = dummyTimeFun2(prediction);
   long bestTime = dummyTimeFun2(best2);
-  EXPECT_NEAR(predictionTime, bestTime, timePerDistanceSquared * 0.8);
+  EXPECT_NEAR(predictionTime, bestTime, timePerDistanceSquared * 0.25);
 }

--- a/tests/testAutopas/tests/selectors/tuningStrategy/BayesianClusterSearchTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/BayesianClusterSearchTest.cpp
@@ -17,20 +17,39 @@ TEST_F(BayesianClusterSearchTest, testMaxEvidence) {
       {autopas::LoadEstimatorOption::none}, {autopas::DataLayoutOption::soa}, {autopas::Newton3Option::disabled},
       maxEvidence);
 
+  size_t iteration = 0;
+
+  // fullSearch phase
+  do {
+    autopas::FeatureVector current(bayesClusterSearch.getCurrentConfiguration());
+    bayesClusterSearch.addEvidence(0, iteration);
+    ++iteration;
+  } while (bayesClusterSearch.tune());
+
+  // artificial time skip
+  iteration += 100;
+  bayesClusterSearch.reset(iteration);
+
   // while #evidence < maxEvidence. tuning -> True
-  for (size_t i = 1; i < maxEvidence; ++i) {
-    bayesClusterSearch.addEvidence(i, 0);
+  for (size_t i = 1; i < maxEvidence; ++i, ++iteration) {
+    bayesClusterSearch.addEvidence(i, iteration);
     EXPECT_TRUE(bayesClusterSearch.tune());
   }
 
   // #evidence == maxEvidence. tuning -> False
-  bayesClusterSearch.addEvidence(-1, 0);
+  bayesClusterSearch.addEvidence(-1, maxEvidence);
   EXPECT_FALSE(bayesClusterSearch.tune());
 }
 
-TEST_F(BayesianClusterSearchTest, testFindBest) {
-  size_t maxEvidence = 7;
-  unsigned long seed = 21;
+/**
+ * Find best configuration if configuration are similar through tuning phases.
+ */
+TEST_F(BayesianClusterSearchTest, testFindBestSimilar) {
+  constexpr size_t maxEvidence = 3;
+  constexpr unsigned long seed = 21;
+  // we use a dummy time function which increases linearly with the squared distance to the chosen optimal solution
+  constexpr double timePerDistanceSquared = 654321;
+
   autopas::BayesianClusterSearch bayesClusterSearch(
       {autopas::ContainerOption::linkedCells}, autopas::NumberInterval<double>(1, 2),
       {autopas::TraversalOption::c08, autopas::TraversalOption::c01}, {autopas::LoadEstimatorOption::none},
@@ -46,16 +65,159 @@ TEST_F(BayesianClusterSearchTest, testFindBest) {
   auto dummyTimeFun = [&best](autopas::FeatureVector target) -> long {
     Eigen::VectorXd diff = best - target;
     double distanceSquared = diff.squaredNorm();
-    return static_cast<long>(654321 * distanceSquared);
+    return static_cast<long>(timePerDistanceSquared * distanceSquared);
   };
 
-  while (bayesClusterSearch.tune()) {
+  size_t iteration = 0;
+
+  // first tuning phase
+  do {
     autopas::FeatureVector current(bayesClusterSearch.getCurrentConfiguration());
-    bayesClusterSearch.addEvidence(dummyTimeFun(current), 0);
-  }
+    bayesClusterSearch.addEvidence(dummyTimeFun(current), iteration);
+    ++iteration;
+  } while (bayesClusterSearch.tune());
+
+  // artificial time skip
+  iteration += 100;
+  bayesClusterSearch.reset(iteration);
+
+  // second tuning phase
+  do {
+    autopas::FeatureVector current(bayesClusterSearch.getCurrentConfiguration());
+    bayesClusterSearch.addEvidence(dummyTimeFun(current), iteration);
+    ++iteration;
+  } while (bayesClusterSearch.tune());
 
   autopas::FeatureVector prediction(bayesClusterSearch.getCurrentConfiguration());
   long predictionTime = dummyTimeFun(prediction);
   long bestTime = dummyTimeFun(best);
-  EXPECT_NEAR(predictionTime, bestTime, 1);
+  EXPECT_NEAR(predictionTime, bestTime, timePerDistanceSquared * 0.1);
+}
+
+/**
+ * Find best configuration if optimal configuration changes over time.
+ */
+TEST_F(BayesianClusterSearchTest, testFindBestDifferent) {
+  const size_t maxEvidence = 7;
+  const unsigned long seed = 21;
+  // we use a dummy time function which increases linearly with the squared distance to the chosen optimal solution
+  constexpr double timePerDistanceSquared = 654321;
+
+  autopas::BayesianClusterSearch bayesClusterSearch(
+      {autopas::ContainerOption::linkedCells}, autopas::NumberInterval<double>(1, 2),
+      {autopas::TraversalOption::c08, autopas::TraversalOption::c01}, {autopas::LoadEstimatorOption::none},
+      {autopas::DataLayoutOption::soa, autopas::DataLayoutOption::aos},
+      {autopas::Newton3Option::disabled, autopas::Newton3Option::enabled}, maxEvidence,
+      autopas::AcquisitionFunctionOption::upperConfidenceBound, 50, seed);
+
+  // optimal configuration in first tuning phase
+  autopas::FeatureVector best1(autopas::ContainerOption::linkedCells, 1., autopas::TraversalOption::c08,
+                               autopas::LoadEstimatorOption::none, autopas::DataLayoutOption::soa,
+                               autopas::Newton3Option::enabled);
+
+  auto dummyTimeFun1 = [&best1](autopas::FeatureVector target) -> long {
+    Eigen::VectorXd diff = best1 - target;
+    double distanceSquared = diff.squaredNorm();
+    return static_cast<long>(timePerDistanceSquared * distanceSquared);
+  };
+
+  // optimal configuration in second tuning phase (only traversal changed)
+  autopas::FeatureVector best2(autopas::ContainerOption::linkedCells, 1., autopas::TraversalOption::c01,
+                               autopas::LoadEstimatorOption::none, autopas::DataLayoutOption::soa,
+                               autopas::Newton3Option::enabled);
+
+  auto dummyTimeFun2 = [&best2](autopas::FeatureVector target) -> long {
+    Eigen::VectorXd diff = best2 - target;
+    double distanceSquared = diff.squaredNorm();
+    return static_cast<long>(timePerDistanceSquared * distanceSquared);
+  };
+
+  size_t iteration = 0;
+
+  // first tuning phase
+  do {
+    autopas::FeatureVector current(bayesClusterSearch.getCurrentConfiguration());
+    bayesClusterSearch.addEvidence(dummyTimeFun1(current), iteration);
+    ++iteration;
+  } while (bayesClusterSearch.tune());
+
+  // artificial time skip
+  iteration += 100;
+  bayesClusterSearch.reset(iteration);
+
+  // second tuning phase
+  do {
+    autopas::FeatureVector current(bayesClusterSearch.getCurrentConfiguration());
+    bayesClusterSearch.addEvidence(dummyTimeFun2(current), iteration);
+    ++iteration;
+  } while (bayesClusterSearch.tune());
+
+  autopas::FeatureVector prediction(bayesClusterSearch.getCurrentConfiguration());
+  long predictionTime = dummyTimeFun2(prediction);
+  long bestTime = dummyTimeFun2(best2);
+  EXPECT_NEAR(predictionTime, bestTime, timePerDistanceSquared * 0.25);
+}
+
+/**
+ * Find best configuration if optimal configuration changes drastically over time.
+ */
+TEST_F(BayesianClusterSearchTest, testFindBestVeryDifferent) {
+  const size_t maxEvidence = 16;
+  const unsigned long seed = 21;
+  // we use a dummy time function which increases linearly with the squared distance to the chosen optimal solution
+  constexpr double timePerDistanceSquared = 654321;
+
+  autopas::BayesianClusterSearch bayesClusterSearch(
+      {autopas::ContainerOption::linkedCells}, autopas::NumberInterval<double>(1, 2),
+      {autopas::TraversalOption::c08, autopas::TraversalOption::c01}, {autopas::LoadEstimatorOption::none},
+      {autopas::DataLayoutOption::soa, autopas::DataLayoutOption::aos},
+      {autopas::Newton3Option::disabled, autopas::Newton3Option::enabled}, maxEvidence,
+      autopas::AcquisitionFunctionOption::upperConfidenceBound, 50, seed);
+
+  // optimal configuration in first tuning phase
+  autopas::FeatureVector best1(autopas::ContainerOption::linkedCells, 1., autopas::TraversalOption::c08,
+                               autopas::LoadEstimatorOption::none, autopas::DataLayoutOption::soa,
+                               autopas::Newton3Option::enabled);
+
+  auto dummyTimeFun1 = [&best1](autopas::FeatureVector target) -> long {
+    Eigen::VectorXd diff = best1 - target;
+    double distanceSquared = diff.squaredNorm();
+    return static_cast<long>(timePerDistanceSquared * distanceSquared);
+  };
+
+  // optimal configuration in second tuning phase (every option changed)
+  autopas::FeatureVector best2(autopas::ContainerOption::linkedCells, 2., autopas::TraversalOption::c01,
+                               autopas::LoadEstimatorOption::none, autopas::DataLayoutOption::aos,
+                               autopas::Newton3Option::disabled);
+
+  auto dummyTimeFun2 = [&best2](autopas::FeatureVector target) -> long {
+    Eigen::VectorXd diff = best2 - target;
+    double distanceSquared = diff.squaredNorm();
+    return static_cast<long>(timePerDistanceSquared * distanceSquared);
+  };
+
+  size_t iteration = 0;
+
+  // first tuning phase
+  do {
+    autopas::FeatureVector current(bayesClusterSearch.getCurrentConfiguration());
+    bayesClusterSearch.addEvidence(dummyTimeFun1(current), iteration);
+    ++iteration;
+  } while (bayesClusterSearch.tune());
+
+  // artificial time skip
+  iteration += 100;
+  bayesClusterSearch.reset(iteration);
+
+  // second tuning phase
+  do {
+    autopas::FeatureVector current(bayesClusterSearch.getCurrentConfiguration());
+    bayesClusterSearch.addEvidence(dummyTimeFun2(current), iteration);
+    ++iteration;
+  } while (bayesClusterSearch.tune());
+
+  autopas::FeatureVector prediction(bayesClusterSearch.getCurrentConfiguration());
+  long predictionTime = dummyTimeFun2(prediction);
+  long bestTime = dummyTimeFun2(best2);
+  EXPECT_NEAR(predictionTime, bestTime, timePerDistanceSquared * 0.8);
 }

--- a/tests/testAutopas/tests/selectors/tuningStrategy/GaussianModel/GaussianClusterTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/GaussianModel/GaussianClusterTest.cpp
@@ -31,7 +31,7 @@ TEST_F(GaussianClusterTest, maxNoNeighbours) {
   auto functor2 = [](double i1, double i2) { return -std::pow(i1 + 0, 2) - std::pow(i2 - 1, 2) - 2; };
   auto functor3 = [](double i1, double i2) { return -std::pow(i1 + 1, 2) - std::pow(i2 - 1, 2); };
 
-  auto neighboursFun = [](const Eigen::VectorXi &) -> std::vector<Eigen::VectorXi> { return {}; };
+  auto neighboursFun = [](const Eigen::VectorXi &) -> std::vector<std::pair<Eigen::VectorXi, double>> { return {}; };
 
   std::pair domain{NumberInterval<double>(-2, 2), NumberInterval<double>(-2, 2)};
   constexpr double maxError = 1.;
@@ -56,11 +56,12 @@ TEST_F(GaussianClusterTest, maxAllNeighbours) {
   }
 
   // return all but target as neighbours
-  auto neighboursFun = [&allDiscrete](const Eigen::VectorXi &target) -> std::vector<Eigen::VectorXi> {
-    std::vector<Eigen::VectorXi> result;
+  auto neighboursFun =
+      [&allDiscrete](const Eigen::VectorXi &target) -> std::vector<std::pair<Eigen::VectorXi, double>> {
+    std::vector<std::pair<Eigen::VectorXi, double>> result;
     for (const auto &vec : allDiscrete) {
       if (vec != target) {
-        result.emplace_back(vec);
+        result.emplace_back(std::make_pair(vec, 1.));
       }
     }
     return result;
@@ -79,7 +80,7 @@ TEST_F(GaussianClusterTest, maxAllNeighbours) {
 
 void GaussianClusterTest::printMaps(int xChunks, int yChunks, const autopas::NumberSet<double> &domainX,
                                     const autopas::NumberSet<double> &domainY, const autopas::GaussianCluster &gc,
-                                    std::function<std::vector<Eigen::VectorXi>(const Eigen::VectorXi &)> neighboursFun,
+                                    GaussianModelTypes::NeighbourFunction neighboursFun,
                                     autopas::AcquisitionFunctionOption af) {
   // get distance between chunks
   double xSpace = (domainX.getMax() - domainX.getMin()) / (xChunks - 1);

--- a/tests/testAutopas/tests/selectors/tuningStrategy/GaussianModel/GaussianClusterTest.h
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/GaussianModel/GaussianClusterTest.h
@@ -31,8 +31,8 @@ class GaussianClusterTest : public AutoPasTestBase {
    */
   template <class NumberSetType>
   void test2DFunctions(const std::vector<std::function<double(double, double)>> &functions,
-                       std::function<std::vector<Eigen::VectorXi>(const Eigen::VectorXi &)> neighboursFun,
-                       int targetDiscrete, const Eigen::VectorXd &targetContinuous, double precision,
+                       autopas::GaussianModelTypes::NeighbourFunction neighboursFun, int targetDiscrete,
+                       const Eigen::VectorXd &targetContinuous, double precision,
                        const std::pair<NumberSetType, NumberSetType> &domain,
                        autopas::AcquisitionFunctionOption acquisitionFunctionOption, bool visualize) {
     autopas::Random rng(42);  // random generator
@@ -99,7 +99,7 @@ class GaussianClusterTest : public AutoPasTestBase {
    */
   static void printMaps(int xChunks, int yChunks, const autopas::NumberSet<double> &domainX,
                         const autopas::NumberSet<double> &domainY, const autopas::GaussianCluster &gc,
-                        std::function<std::vector<Eigen::VectorXi>(const Eigen::VectorXi &)> neighboursFun,
+                        autopas::GaussianModelTypes::NeighbourFunction neighboursFun,
                         autopas::AcquisitionFunctionOption af);
 
   /**


### PR DESCRIPTION
# Description

BayesianClusterSearch:
- Sample for each cluster in the first tuning phase
- Added iteration as a continuous dimension in order to reduce the consideration of evidence over time.

# How Has This Been Tested?

- [ ] BayesianClusterSearchTest
