### PR TITLE
remove input that apparently breaks macos

### DIFF
--- a/src/autopas/utils/AlignedAllocator.h
+++ b/src/autopas/utils/AlignedAllocator.h
@@ -10,8 +10,6 @@
 #include <xmmintrin.h>
 #endif
 
-#include <malloc.h>
-
 #include <cstdlib>
 #include <limits>
 #include <new>


### PR DESCRIPTION
# Description

malloc is included in `<cstdlib>` according to:
https://en.cppreference.com/w/cpp/memory/c/malloc

This removes the unneeded include of `"malloc.h"`
