### PR TITLE
unaligned loads and stores for LJFunctorAVX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,11 +88,12 @@ include(logging)
 include(other-compileroptions)
 include(vectorization)
 include(cuda)
-include(doxygen) # does not really need a target but the variable AUTOPAS_BUILD_EXAMPLES
 
 # tests and examples
 add_subdirectory(examples)
 add_subdirectory(tests)
+
+include(doxygen) # does not really need a target but the variable AUTOPAS_BUILD_EXAMPLES, which is defined in examples.
 
 # write version information
 include(CMakePackageConfigHelpers)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,10 +82,6 @@ add_subdirectory(src)
 # autopasTools
 add_subdirectory(tools)
 
-# tests and examples
-add_subdirectory(examples)
-add_subdirectory(tests)
-
 # modules needing targets:
 include(coloring)
 include(logging)
@@ -93,6 +89,10 @@ include(other-compileroptions)
 include(vectorization)
 include(cuda)
 include(doxygen) # does not really need a target but the variable AUTOPAS_BUILD_EXAMPLES
+
+# tests and examples
+add_subdirectory(examples)
+add_subdirectory(tests)
 
 # write version information
 include(CMakePackageConfigHelpers)

--- a/cmake/tests/has_avx_test.cpp
+++ b/cmake/tests/has_avx_test.cpp
@@ -1,3 +1,5 @@
+// This test is here to check if AVX is enabled.
+// It is used by the md-flex example.
 int main() {
 #ifdef __AVX__
 }

--- a/cmake/tests/has_avx_test.cpp
+++ b/cmake/tests/has_avx_test.cpp
@@ -1,0 +1,4 @@
+int main() {
+#ifdef __AVX__
+}
+#endif

--- a/examples/md-flexible/CMakeLists.txt
+++ b/examples/md-flexible/CMakeLists.txt
@@ -5,15 +5,18 @@ file(
         "src/*.h"
 )
 
-message(STATUS "searching for mpi...")
-find_package(MPI)
+if(AUTOPAS_MPI)
+    message(STATUS "AUTOPAS_MPI set, searching for mpi to link against md-flexible ...")
+    find_package(MPI)
 
-if (NOT ${MPI_CXX_FOUND})
-    message(STATUS "cxx mpi not found, not building sph-main-mpi")
-    return()
-else ()
-    message(STATUS "cxx mpi found: ${MPI_CXX_COMPILER}")
-endif ()
+    if (NOT ${MPI_CXX_FOUND})
+        message(FATAL_ERROR "cxx mpi could not be found, even though AUTOPAS_MPI was set.")
+    else ()
+        message(STATUS "cxx mpi found: ${MPI_CXX_COMPILER}")
+    endif ()
+else()
+    message(STATUS "AUTOPAS_MPI not set, not linking MPI to md-flexible.")
+endif(AUTOPAS_MPI)
 
 include_directories(SYSTEM ${MPI_INCLUDE_PATH})
 
@@ -23,7 +26,7 @@ target_include_directories(md-flexible PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 include(autopas_yaml-cpp)
 
-target_link_libraries(md-flexible PUBLIC autopas autopasTools yaml-cpp MPI::MPI_CXX)
+target_link_libraries(md-flexible PUBLIC autopas autopasTools yaml-cpp $<$<BOOL:${AUTOPAS_MPI}>:MPI::MPI_CXX>)
 
 # --- copy script files to build dir ---
 file(

--- a/examples/md-flexible/CMakeLists.txt
+++ b/examples/md-flexible/CMakeLists.txt
@@ -80,6 +80,22 @@ add_test(
         CONFIGURATIONS checkExamples
 )
 
+#dangerous, as lc_c04_combined_SoA uses unaligned values.
+add_test(
+        NAME md-flexible-avx.test-unaligned
+        COMMAND
+        md-flexible
+        --no-end-config
+        --no-flops
+        --functor lennard-jones-AVX2
+        --deltaT 0
+        --particle-generator uniform
+        --log-level debug
+        --traversal lc_c04_combined_SoA
+        --particles-total 71
+        CONFIGURATIONS checkExamples
+)
+
 add_test(
     NAME md-flexMeasurePerf
     COMMAND measurePerf.sh md-flexible -silent

--- a/examples/md-flexible/CMakeLists.txt
+++ b/examples/md-flexible/CMakeLists.txt
@@ -115,7 +115,7 @@ elseif (AUTOPAS_VECTOR_INSTRUCTIONS MATCHES "NATIVE")
             # We are abusing COMPILE_DEFINITIONS here. There is no other sane way of passing "-march=native" ...
             COMPILE_DEFINITIONS "-march=native"
             OUTPUT_VARIABLE HAS_AVX_ERROR
-            )
+    )
 else ()
     message(STATUS "Adding AVX example to test, as proper vectorization is manually specified.")
 endif ()

--- a/examples/md-flexible/CMakeLists.txt
+++ b/examples/md-flexible/CMakeLists.txt
@@ -1,8 +1,8 @@
 file(
-    GLOB_RECURSE
-    MDFlex_SRC
-    "src/*.cpp"
-    "src/*.h"
+        GLOB_RECURSE
+        MDFlex_SRC
+        "src/*.cpp"
+        "src/*.h"
 )
 
 message(STATUS "searching for mpi...")
@@ -27,12 +27,12 @@ target_link_libraries(md-flexible PUBLIC autopas autopasTools yaml-cpp MPI::MPI_
 
 # --- copy script files to build dir ---
 file(
-    GLOB_RECURSE SCRIPTS
-    RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
-    "*.sh"
-    "*.gp"
-    "*.py"
-    "*.yaml"
+        GLOB_RECURSE SCRIPTS
+        RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+        "*.sh"
+        "*.gp"
+        "*.py"
+        "*.yaml"
 )
 
 foreach (script ${SCRIPTS})
@@ -49,8 +49,8 @@ add_subdirectory(tests)
 # randomly generated imbalanced scenario tested with LC only
 # also tests the flop functor
 add_test(
-    NAME md-flexible.test-static
-    COMMAND
+        NAME md-flexible.test-static
+        COMMAND
         md-flexible
         --container linked
         --cutoff 1.
@@ -67,7 +67,7 @@ add_test(
         --periodic false
         --deltaT 0.
         --no-end-config
-    CONFIGURATIONS checkExamples
+        CONFIGURATIONS checkExamples
 )
 
 #stable, periodic particle grid tested with all configurations
@@ -92,26 +92,53 @@ add_test(
         CONFIGURATIONS checkExamples
 )
 
-#dangerous, as lc_c04_combined_SoA uses unaligned values.
-add_test(
-        NAME md-flexible-avx.test-unaligned
-        COMMAND
-        md-flexible
-        --no-end-config
-        --no-flops
-        --functor lennard-jones-AVX2
-        --deltaT 0
-        --particle-generator uniform
-        --log-level debug
-        --traversal lc_c04_combined_SoA
-        --particles-total 71
-        CONFIGURATIONS checkExamples
-)
+set(HAS_AVX true)
+if (NOT AUTOPAS_USE_VECTORIZATION)
+    message(STATUS "No vectorization used, not adding md-flexible-avx.test-unaligned to ctest.")
+    set(HAS_AVX false)
+elseif(AUTOPAS_VECTOR_INSTRUCTIONS MATCHES "SSE")
+    message(STATUS "Only SSE specified, not adding md-flexible-avx.test-unaligned to ctest.")
+    set(HAS_AVX false)
+elseif(AUTOPAS_VECTOR_INSTRUCTIONS MATCHES "NATIVE")
+    message(STATUS "Native vectorization level, trying to detect AVX capability.")
+    if(UNIX)
+        message(STATUS "Unix")
+        EXEC_PROGRAM(cat ARGS "/proc/cpuinfo" OUTPUT_VARIABLE CPUINFO)
+        STRING(REGEX REPLACE "^.*(avx).*$" "\\1" AVX_THERE ${CPUINFO})
+        STRING(COMPARE EQUAL "avx" "${AVX_THERE}" HAS_AVX)
+        message(STATUS "detected avx on Unix? ${HAS_AVX}")
+    else()
+        message(STATUS "no Unix")
+        # set to false, as we don't know...
+        set(HAS_AVX false)
+    endif()
+else()
+    message(STATUS "Adding AVX example to test, as proper vectorization is manually specified.")
+endif ()
+
+if (HAS_AVX)
+    message(STATUS "AVX detected. Adding AVX test.")
+    #dangerous, as lc_c04_combined_SoA uses unaligned values.
+    add_test(
+            NAME md-flexible-avx.test-unaligned
+            COMMAND
+            md-flexible
+            --no-end-config
+            --no-flops
+            --functor lennard-jones-AVX2
+            --deltaT 0
+            --particle-generator uniform
+            --log-level debug
+            --traversal lc_c04_combined_SoA
+            --particles-total 71
+            CONFIGURATIONS checkExamples
+    )
+endif ()
 
 add_test(
-    NAME md-flexMeasurePerf
-    COMMAND measurePerf.sh md-flexible -silent
-    CONFIGURATIONS checkExamples
+        NAME md-flexMeasurePerf
+        COMMAND measurePerf.sh md-flexible -silent
+        CONFIGURATIONS checkExamples
 )
 # cmake-format: on
 

--- a/examples/md-flexible/CMakeLists.txt
+++ b/examples/md-flexible/CMakeLists.txt
@@ -5,7 +5,7 @@ file(
         "src/*.h"
 )
 
-if(AUTOPAS_MPI)
+if (AUTOPAS_MPI)
     message(STATUS "AUTOPAS_MPI set, searching for mpi to link against md-flexible ...")
     find_package(MPI)
 
@@ -14,9 +14,9 @@ if(AUTOPAS_MPI)
     else ()
         message(STATUS "cxx mpi found: ${MPI_CXX_COMPILER}")
     endif ()
-else()
+else ()
     message(STATUS "AUTOPAS_MPI not set, not linking MPI to md-flexible.")
-endif(AUTOPAS_MPI)
+endif (AUTOPAS_MPI)
 
 include_directories(SYSTEM ${MPI_INCLUDE_PATH})
 
@@ -95,27 +95,28 @@ add_test(
         CONFIGURATIONS checkExamples
 )
 
+# The AVX example should only be tested if AVX is available.
 set(HAS_AVX true)
 if (NOT AUTOPAS_USE_VECTORIZATION)
+    # If no vectorization is used, don't enable the example.
     message(STATUS "No vectorization used, not adding md-flexible-avx.test-unaligned to ctest.")
     set(HAS_AVX false)
-elseif(AUTOPAS_VECTOR_INSTRUCTIONS MATCHES "SSE")
+elseif (AUTOPAS_VECTOR_INSTRUCTIONS MATCHES "SSE")
+    # If vectorization is set to SSE: don't enable the example
     message(STATUS "Only SSE specified, not adding md-flexible-avx.test-unaligned to ctest.")
     set(HAS_AVX false)
-elseif(AUTOPAS_VECTOR_INSTRUCTIONS MATCHES "NATIVE")
+elseif (AUTOPAS_VECTOR_INSTRUCTIONS MATCHES "NATIVE")
+    # If Vectorization is set to native: we try to figure out the vectorization level.
     message(STATUS "Native vectorization level, trying to detect AVX capability.")
-    if(UNIX)
-        message(STATUS "Unix")
-        EXEC_PROGRAM(cat ARGS "/proc/cpuinfo" OUTPUT_VARIABLE CPUINFO)
-        STRING(REGEX REPLACE "^.*(avx).*$" "\\1" AVX_THERE ${CPUINFO})
-        STRING(COMPARE EQUAL "avx" "${AVX_THERE}" HAS_AVX)
-        message(STATUS "detected avx on Unix? ${HAS_AVX}")
-    else()
-        message(STATUS "no Unix")
-        # set to false, as we don't know...
-        set(HAS_AVX false)
-    endif()
-else()
+    try_compile(
+            HAS_AVX
+            ${CMAKE_BINARY_DIR}
+            ${AUTOPAS_SOURCE_DIR}/cmake/tests/has_avx_test.cpp
+            # We are abusing COMPILE_DEFINITIONS here. There is no other sane way of passing "-march=native" ...
+            COMPILE_DEFINITIONS "-march=native"
+            OUTPUT_VARIABLE HAS_AVX_ERROR
+            )
+else ()
     message(STATUS "Adding AVX example to test, as proper vectorization is manually specified.")
 endif ()
 
@@ -136,7 +137,7 @@ if (HAS_AVX)
             --particles-total 71
             CONFIGURATIONS checkExamples
     )
-else()
+else ()
     message(STATUS "AVX could not be detected. Not adding AVX test.")
 endif ()
 

--- a/examples/md-flexible/CMakeLists.txt
+++ b/examples/md-flexible/CMakeLists.txt
@@ -133,6 +133,8 @@ if (HAS_AVX)
             --particles-total 71
             CONFIGURATIONS checkExamples
     )
+else()
+    message(STATUS "AVX could not be detected. Not adding AVX test.")
 endif ()
 
 add_test(

--- a/src/autopas/molecularDynamics/LJFunctorAVX.h
+++ b/src/autopas/molecularDynamics/LJFunctorAVX.h
@@ -504,9 +504,9 @@ class LJFunctorAVX : public Functor<Particle, ParticleCell, typename Particle::S
       }
     }
 
-    const __m256d x2 = remainderIsMasked ? _mm256_maskload_pd(&x2ptr[j], _masks[rest - 1]) : _mm256_load_pd(&x2ptr[j]);
-    const __m256d y2 = remainderIsMasked ? _mm256_maskload_pd(&y2ptr[j], _masks[rest - 1]) : _mm256_load_pd(&y2ptr[j]);
-    const __m256d z2 = remainderIsMasked ? _mm256_maskload_pd(&z2ptr[j], _masks[rest - 1]) : _mm256_load_pd(&z2ptr[j]);
+    const __m256d x2 = remainderIsMasked ? _mm256_maskload_pd(&x2ptr[j], _masks[rest - 1]) : _mm256_loadu_pd(&x2ptr[j]);
+    const __m256d y2 = remainderIsMasked ? _mm256_maskload_pd(&y2ptr[j], _masks[rest - 1]) : _mm256_loadu_pd(&y2ptr[j]);
+    const __m256d z2 = remainderIsMasked ? _mm256_maskload_pd(&z2ptr[j], _masks[rest - 1]) : _mm256_loadu_pd(&z2ptr[j]);
 
     const __m256d drx = _mm256_sub_pd(x1, x2);
     const __m256d dry = _mm256_sub_pd(y1, y2);
@@ -528,7 +528,7 @@ class LJFunctorAVX : public Functor<Particle, ParticleCell, typename Particle::S
     const __m256i ownedStateJ = remainderIsMasked
                                     ? _mm256_castpd_si256(_mm256_maskload_pd(
                                           reinterpret_cast<double const *>(&ownedStatePtr2[j]), _masks[rest - 1]))
-                                    : _mm256_load_si256(reinterpret_cast<const __m256i *>(&ownedStatePtr2[j]));
+                                    : _mm256_loadu_si256(reinterpret_cast<const __m256i *>(&ownedStatePtr2[j]));
     // This requires that dummy is the first entry in OwnershipState!
     const __m256d dummyMask = _mm256_cmp_pd(_mm256_castsi256_pd(ownedStateJ), _zero, _CMP_NEQ_UQ);
     const __m256d cutoffDummyMask = _mm256_and_pd(cutoffMask, dummyMask);
@@ -563,22 +563,22 @@ class LJFunctorAVX : public Functor<Particle, ParticleCell, typename Particle::S
     // if newton 3 is used subtract fD from particle j
     if (newton3) {
       const __m256d fx2 =
-          remainderIsMasked ? _mm256_maskload_pd(&fx2ptr[j], _masks[rest - 1]) : _mm256_load_pd(&fx2ptr[j]);
+          remainderIsMasked ? _mm256_maskload_pd(&fx2ptr[j], _masks[rest - 1]) : _mm256_loadu_pd(&fx2ptr[j]);
       const __m256d fy2 =
-          remainderIsMasked ? _mm256_maskload_pd(&fy2ptr[j], _masks[rest - 1]) : _mm256_load_pd(&fy2ptr[j]);
+          remainderIsMasked ? _mm256_maskload_pd(&fy2ptr[j], _masks[rest - 1]) : _mm256_loadu_pd(&fy2ptr[j]);
       const __m256d fz2 =
-          remainderIsMasked ? _mm256_maskload_pd(&fz2ptr[j], _masks[rest - 1]) : _mm256_load_pd(&fz2ptr[j]);
+          remainderIsMasked ? _mm256_maskload_pd(&fz2ptr[j], _masks[rest - 1]) : _mm256_loadu_pd(&fz2ptr[j]);
 
       const __m256d fx2new = _mm256_sub_pd(fx2, fx);
       const __m256d fy2new = _mm256_sub_pd(fy2, fy);
       const __m256d fz2new = _mm256_sub_pd(fz2, fz);
 
       remainderIsMasked ? _mm256_maskstore_pd(&fx2ptr[j], _masks[rest - 1], fx2new)
-                        : _mm256_store_pd(&fx2ptr[j], fx2new);
+                        : _mm256_storeu_pd(&fx2ptr[j], fx2new);
       remainderIsMasked ? _mm256_maskstore_pd(&fy2ptr[j], _masks[rest - 1], fy2new)
-                        : _mm256_store_pd(&fy2ptr[j], fy2new);
+                        : _mm256_storeu_pd(&fy2ptr[j], fy2new);
       remainderIsMasked ? _mm256_maskstore_pd(&fz2ptr[j], _masks[rest - 1], fz2new)
-                        : _mm256_store_pd(&fz2ptr[j], fz2new);
+                        : _mm256_storeu_pd(&fz2ptr[j], fz2new);
     }
 
     if (calculateGlobals) {

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorAVXTest.h
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorAVXTest.h
@@ -32,8 +32,9 @@ class LJFunctorAVXTest : public AutoPasTestBase, public ::testing::WithParamInte
    *
    * @param newton3
    * @param doDeleteSomeParticles
+   * @param useUnalignedViews
    */
-  void testLJFunctorVSLJFunctorAVXTwoCells(bool newton3, bool doDeleteSomeParticles);
+  void testLJFunctorVSLJFunctorAVXTwoCells(bool newton3, bool doDeleteSomeParticles, bool useUnalignedViews);
 
   /**
    * Checks equality of SoALoader, SoAFunctorSingle and SoAExtractor.
@@ -44,8 +45,9 @@ class LJFunctorAVXTest : public AutoPasTestBase, public ::testing::WithParamInte
    *
    * @param newton3
    * @param doDeleteSomeParticles
+   * @param useUnalignedViews
    */
-  void testLJFunctorVSLJFunctorAVXOneCell(bool newton3, bool doDeleteSomeParticles);
+  void testLJFunctorVSLJFunctorAVXOneCell(bool newton3, bool doDeleteSomeParticles, bool useUnalignedViews);
 
   /**
    * Creates two cells, generates neighbor lists manually and then compares the SoAFunctorVerlet calls.


### PR DESCRIPTION
# Description

Replaces unaligned loads and stores in LJFunctorAVX to be able to simulate with non-aligned SoAs from SoAViews (combined SoAs)

## Todo

Should probably be implemented using a template parameter to decide whether aligned or unaligned intrinsics should be used.

## Resolved Issues

- fixes md-flexible not being build if mpi is not present.
- [x] fixes #535 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Ran example:
```bash
   ./md-flexible --no-end-config --no-flops --functor lennard-jones-AVX2 --deltaT 0 --particle-generator uniform --log-level debug --traversal lc_c04_combined_SoA --particles-total 71
```
- [x] Added the above example to the ctest tests