### PR TITLE
dot product: 

### DIFF
--- a/src/autopas/utils/ArrayMath.h
+++ b/src/autopas/utils/ArrayMath.h
@@ -154,23 +154,15 @@ template <class T, std::size_t SIZE>
 namespace {
 /**
  * Helper function to provide a templated dot product that is basically the same as writing it out by hand.
- *
- * @note With Clang recursion produces 1 ASM instruction less than parameter expansion. No difference for ICC and GCC.
- *
- * @tparam I Helper index for the recursion.
- * @tparam T Type of the arrays.
- * @tparam SIZE Size of the arrays.
+ * @tparam T
+ * @tparam I
  * @param a
  * @param b
  * @return
  */
-template <std::size_t I, class T, std::size_t SIZE>
-[[nodiscard]] constexpr T dotAux(const std::array<T, SIZE> &a, const std::array<T, SIZE> &b) {
-  if constexpr (I != 0) {
-    return a[I]*b[I] + dotAux<I-1>(a, b);
-  } else {
-    return a[0] * b[0];
-  }
+template <typename T, size_t... I>
+double dotAux(T a, T b, std::integer_sequence<size_t, I...>) {
+  return ((std::get<I>(a) * std::get<I>(b)) + ...);
 }
 }  // namespace
 
@@ -185,7 +177,7 @@ template <std::size_t I, class T, std::size_t SIZE>
  */
 template <class T, std::size_t SIZE>
 [[nodiscard]] constexpr T dot(const std::array<T, SIZE> &a, const std::array<T, SIZE> &b) {
-  return dotAux<SIZE-1>(a, b);
+  return dotAux(a, b, std::make_index_sequence<SIZE>{});
 }
 
 /**

--- a/src/autopas/utils/ArrayMath.h
+++ b/src/autopas/utils/ArrayMath.h
@@ -150,6 +150,22 @@ template <class T, std::size_t SIZE>
   return result;
 }
 
+// unnamed namespace for private helper functions
+namespace {
+/**
+ * Helper function to provide a templated dot product that is basically the same as writing it out by hand.
+ * @tparam T
+ * @tparam I
+ * @param a
+ * @param b
+ * @return
+ */
+template <typename T, size_t... I>
+double dotAux(T a, T b, std::integer_sequence<size_t, I...>) {
+  return ((std::get<I>(a) * std::get<I>(b)) + ...);
+}
+}  // namespace
+
 /**
  * Generates the dot product of two arrays.
  * Returns the sum of a[i]*b[i] summed over all i, where i is in [0, SIZE)
@@ -161,7 +177,7 @@ template <class T, std::size_t SIZE>
  */
 template <class T, std::size_t SIZE>
 [[nodiscard]] constexpr T dot(const std::array<T, SIZE> &a, const std::array<T, SIZE> &b) {
-  return std::inner_product(a.cbegin(), a.cend(), b.cbegin(), static_cast<T>(0));
+  return dotAux(a, b, std::make_index_sequence<SIZE>{});
 }
 
 /**

--- a/src/autopas/utils/ArrayMath.h
+++ b/src/autopas/utils/ArrayMath.h
@@ -167,7 +167,7 @@ namespace {
 template <std::size_t I, class T, std::size_t SIZE>
 [[nodiscard]] constexpr T dotAux(const std::array<T, SIZE> &a, const std::array<T, SIZE> &b) {
   if constexpr (I != 0) {
-    return a[I] * b[I] + dotAux<I - 1>(a, b);
+    return a[I]*b[I] + dotAux<I-1>(a, b);
   } else {
     return a[0] * b[0];
   }
@@ -185,7 +185,7 @@ template <std::size_t I, class T, std::size_t SIZE>
  */
 template <class T, std::size_t SIZE>
 [[nodiscard]] constexpr T dot(const std::array<T, SIZE> &a, const std::array<T, SIZE> &b) {
-  return dotAux<SIZE - 1>(a, b);
+  return dotAux<SIZE-1>(a, b);
 }
 
 /**

--- a/src/autopas/utils/ArrayMath.h
+++ b/src/autopas/utils/ArrayMath.h
@@ -167,7 +167,7 @@ namespace {
 template <std::size_t I, class T, std::size_t SIZE>
 [[nodiscard]] constexpr T dotAux(const std::array<T, SIZE> &a, const std::array<T, SIZE> &b) {
   if constexpr (I != 0) {
-    return a[I]*b[I] + dotAux<I-1>(a, b);
+    return a[I] * b[I] + dotAux<I - 1>(a, b);
   } else {
     return a[0] * b[0];
   }
@@ -185,7 +185,7 @@ template <std::size_t I, class T, std::size_t SIZE>
  */
 template <class T, std::size_t SIZE>
 [[nodiscard]] constexpr T dot(const std::array<T, SIZE> &a, const std::array<T, SIZE> &b) {
-  return dotAux<SIZE-1>(a, b);
+  return dotAux<SIZE - 1>(a, b);
 }
 
 /**

--- a/src/autopas/utils/ArrayMath.h
+++ b/src/autopas/utils/ArrayMath.h
@@ -154,15 +154,23 @@ template <class T, std::size_t SIZE>
 namespace {
 /**
  * Helper function to provide a templated dot product that is basically the same as writing it out by hand.
- * @tparam T
- * @tparam I
+ *
+ * @note With Clang recursion produces 1 ASM instruction less than parameter expansion. No difference for ICC and GCC.
+ *
+ * @tparam I Helper index for the recursion.
+ * @tparam T Type of the arrays.
+ * @tparam SIZE Size of the arrays.
  * @param a
  * @param b
  * @return
  */
-template <typename T, size_t... I>
-double dotAux(T a, T b, std::integer_sequence<size_t, I...>) {
-  return ((std::get<I>(a) * std::get<I>(b)) + ...);
+template <std::size_t I, class T, std::size_t SIZE>
+[[nodiscard]] constexpr T dotAux(const std::array<T, SIZE> &a, const std::array<T, SIZE> &b) {
+  if constexpr (I != 0) {
+    return a[I]*b[I] + dotAux<I-1>(a, b);
+  } else {
+    return a[0] * b[0];
+  }
 }
 }  // namespace
 
@@ -177,7 +185,7 @@ double dotAux(T a, T b, std::integer_sequence<size_t, I...>) {
  */
 template <class T, std::size_t SIZE>
 [[nodiscard]] constexpr T dot(const std::array<T, SIZE> &a, const std::array<T, SIZE> &b) {
-  return dotAux(a, b, std::make_index_sequence<SIZE>{});
+  return dotAux<SIZE-1>(a, b);
 }
 
 /**


### PR DESCRIPTION
# Description

The previous implementation of the dot product used `stl::inner_product`. Looking at the assembly output this turned out to be inefficient. The new implementation uses template parameter pack expansion for a compile-time unrolled explicit summation.

## ~Related Pull Requests~

## ~Resolved Issues~

# How Has This Been Tested?

- [x] Jenkins
