### PR TITLE
Adds proper version info.

### DIFF
--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -12,6 +12,7 @@
 #include <type_traits>
 
 #include "autopas/LogicHandler.h"
+#include "autopas/Version.h"
 #include "autopas/options//ExtrapolationMethodOption.h"
 #include "autopas/options/AcquisitionFunctionOption.h"
 #include "autopas/options/LoadEstimatorOption.h"
@@ -75,6 +76,8 @@ class AutoPas {
     // The logger is normally only flushed on successful program termination.
     // This line ensures flushing when log messages of level warning or more severe are created.
     autopas::Logger::get()->flush_on(spdlog::level::warn);
+
+    AutoPasLog(info, "AutoPas Version: {}", AutoPas_VERSION);
   }
 
   ~AutoPas() {

--- a/src/autopas/CMakeLists.txt
+++ b/src/autopas/CMakeLists.txt
@@ -42,4 +42,5 @@ if (AUTOPAS_ENABLE_CUDA)
     target_include_directories(autopas SYSTEM PUBLIC ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
 endif ()
 
-target_include_directories(autopas PUBLIC ../.)
+target_include_directories(autopas PUBLIC ${AUTOPAS_SOURCE_DIR}/src/)
+target_include_directories(autopas PUBLIC ${AUTOPAS_BINARY_DIR}/src/)

--- a/src/autopas/Version.h.in
+++ b/src/autopas/Version.h.in
@@ -1,0 +1,13 @@
+/**
+ * @file Version.h
+ *
+ * @note copy-paste from cmake's configuration.
+ */
+#pragma once
+
+#define AutoPas_VERSION_MAJOR @AutoPas_VERSION_MAJOR@
+#define AutoPas_VERSION_MINOR @AutoPas_VERSION_MINOR@
+#define AutoPas_VERSION_PATCH @AutoPas_VERSION_PATCH@
+#define AutoPas_VERSION_SUFFIX "@AutoPas_VERSION_SUFFIX@"
+#define AutoPas_VERSION_IS_DIRTY @AutoPas_VERSION_IS_DIRTY@
+#define AutoPas_VERSION "@AutoPas_VERSION@"

--- a/version.cmake
+++ b/version.cmake
@@ -1,14 +1,92 @@
-set(AutoPas_VERSION_MAJOR 0 CACHE STRING "AutoPas major version number." FORCE)
-set(AutoPas_VERSION_MINOR 1 CACHE STRING "AutoPas minor version number." FORCE)
-set(AutoPas_VERSION_PATCH 0 CACHE STRING "AutoPas patch version number." FORCE)
-set(
-    AutoPas_VERSION
-    ${AutoPas_VERSION_MAJOR}.${AutoPas_VERSION_MINOR}.${AutoPas_VERSION_PATCH}
-    CACHE STRING "AutoPas version" FORCE
-)
-mark_as_advanced(
-    AutoPas_VERSION
-    AutoPas_VERSION_MAJOR
-    AutoPas_VERSION_MINOR
-    AutoPas_VERSION_PATCH
+# NOTE: copy-paste from cmake's configuration.
+
+# AutoPas version number components.
+set(AutoPas_VERSION_MAJOR 0)
+set(AutoPas_VERSION_MINOR 1)
+set(AutoPas_VERSION_PATCH 0)
+#set(AutoPas_VERSION_RC 0)
+set(AutoPas_VERSION_IS_DIRTY 0)
+
+# Start with the full version number used in tags.  It has no dev info.
+set(AutoPas_VERSION "${AutoPas_VERSION_MAJOR}.${AutoPas_VERSION_MINOR}.${AutoPas_VERSION_PATCH}")
+if(DEFINED AutoPas_VERSION_RC)
+    set(AutoPas_VERSION "${AutoPas_VERSION}-rc${AutoPas_VERSION_RC}")
+endif()
+
+# Releases define a small patch level.
+if("${AutoPas_VERSION_PATCH}" VERSION_LESS 20000000)
+    set(AutoPas_VERSION_IS_RELEASE 1)
+else()
+    set(AutoPas_VERSION_IS_RELEASE 0)
+endif()
+
+if(NOT AutoPas_VERSION_NO_GIT)
+    # If this source was exported by 'git archive', use its commit info.
+    set(git_info [==[$Format:%h %s$]==])
+
+    # Otherwise, try to identify the current development source version.
+    if(NOT git_info MATCHES "^([0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]?[0-9a-f]?)[0-9a-f]* "
+            AND EXISTS ${AutoPas_SOURCE_DIR}/.git)
+        find_package(Git QUIET)
+        if(GIT_FOUND)
+            macro(_git)
+                execute_process(
+                        COMMAND ${GIT_EXECUTABLE} ${ARGN}
+                        WORKING_DIRECTORY ${AutoPas_SOURCE_DIR}
+                        RESULT_VARIABLE _git_res
+                        OUTPUT_VARIABLE _git_out OUTPUT_STRIP_TRAILING_WHITESPACE
+                        ERROR_VARIABLE _git_err ERROR_STRIP_TRAILING_WHITESPACE
+                )
+            endmacro()
+        endif()
+        if(COMMAND _git)
+            # Get the commit checked out in this work tree.
+            _git(log -n 1 HEAD "--pretty=format:%h %s" --)
+            set(git_info "${_git_out}")
+        endif()
+    endif()
+
+    # Extract commit information if available.
+    if(git_info MATCHES "^([0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]?[0-9a-f]?)[0-9a-f]* (.*)$")
+        # Have commit information.
+        set(git_hash "${CMAKE_MATCH_1}")
+        set(git_subject "${CMAKE_MATCH_2}")
+
+        # If this is not the exact commit of a release, add dev info.
+        if(NOT "${git_subject}" MATCHES "^[Cc][Mm]ake ${AutoPas_VERSION}$")
+            set(AutoPas_VERSION "${AutoPas_VERSION}-g${git_hash}")
+        endif()
+
+        # If this is a work tree, check whether it is dirty.
+        if(COMMAND _git)
+            _git(update-index -q --refresh)
+            _git(diff-index --name-only HEAD --)
+            if(_git_out)
+                set(AutoPas_VERSION_IS_DIRTY 1)
+            endif()
+        endif()
+    else()
+        # No commit information.
+        if(NOT AutoPas_VERSION_IS_RELEASE)
+            # Generic development version.
+            set(AutoPas_VERSION "${AutoPas_VERSION}-git")
+        endif()
+    endif()
+endif()
+
+# Extract the version suffix component.
+if(AutoPas_VERSION MATCHES "-(.*)$")
+    set(AutoPas_VERSION_SUFFIX "${CMAKE_MATCH_1}")
+else()
+    set(AutoPas_VERSION_SUFFIX "")
+endif()
+if(AutoPas_VERSION_IS_DIRTY)
+    set(AutoPas_VERSION ${AutoPas_VERSION}-dirty)
+endif()
+
+message(STATUS "AutoPas_Version: ${AutoPas_VERSION}")
+
+configure_file(
+        "${AUTOPAS_SOURCE_DIR}/src/autopas/Version.h.in"
+        "${AUTOPAS_BINARY_DIR}/src/autopas/Version.h"
 )

--- a/version.cmake
+++ b/version.cmake
@@ -54,7 +54,7 @@ if(NOT AutoPas_VERSION_NO_GIT)
 
         # If this is not the exact commit of a release, add dev info.
         if(NOT "${git_subject}" MATCHES "^[Cc][Mm]ake ${AutoPas_VERSION}$")
-            set(AutoPas_VERSION "${AutoPas_VERSION}-g${git_hash}")
+            set(AutoPas_VERSION "${AutoPas_VERSION}-${git_hash}")
         endif()
 
         # If this is a work tree, check whether it is dirty.


### PR DESCRIPTION
# Description

This code has more or less been copy-pasted from cmake's configuration.
* Adds git version to the version string.
* Adds `dirty` to version string, if the git tree is not clean
* Prints AutoPas_Version to info log. E.g.,
```
[2020-10-13 13:08:29.999] [AutoPasLog] [info] AutoPas Version: 0.1.0-cef07c3-dirty
```
## Limitations

Change of the version number will currently only be triggered if cmake is called. This could be changed 


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Ran manually
