### PR TITLE
VerletListsCells refactoring

### DIFF
--- a/src/autopas/CMakeLists.txt
+++ b/src/autopas/CMakeLists.txt
@@ -12,7 +12,7 @@ file(
     "*.cuh"
 )
 
-add_library(autopas STATIC $<$<BOOL:${AUTOPAS_ENABLE_CUDA}>:${CU_SRC}> ${MY_SRC} containers/verletListsCellBased/verletListsCells/VerletListsCellsNeighborList.h containers/verletListsCellBased/verletListsCells/VerletListsCellsNeighborListInterface.h)
+add_library(autopas STATIC $<$<BOOL:${AUTOPAS_ENABLE_CUDA}>:${CU_SRC}> ${MY_SRC})
 
 target_link_libraries(
     autopas

--- a/src/autopas/CMakeLists.txt
+++ b/src/autopas/CMakeLists.txt
@@ -12,7 +12,7 @@ file(
     "*.cuh"
 )
 
-add_library(autopas STATIC $<$<BOOL:${AUTOPAS_ENABLE_CUDA}>:${CU_SRC}> ${MY_SRC} containers/verletListsCellBased/verletListsCells/VerletListsCellsNeighborList.h)
+add_library(autopas STATIC $<$<BOOL:${AUTOPAS_ENABLE_CUDA}>:${CU_SRC}> ${MY_SRC} containers/verletListsCellBased/verletListsCells/VerletListsCellsNeighborList.h containers/verletListsCellBased/verletListsCells/VerletListsCellsNeighborListInterface.h)
 
 target_link_libraries(
     autopas

--- a/src/autopas/CMakeLists.txt
+++ b/src/autopas/CMakeLists.txt
@@ -12,7 +12,7 @@ file(
     "*.cuh"
 )
 
-add_library(autopas STATIC $<$<BOOL:${AUTOPAS_ENABLE_CUDA}>:${CU_SRC}> ${MY_SRC})
+add_library(autopas STATIC $<$<BOOL:${AUTOPAS_ENABLE_CUDA}>:${CU_SRC}> ${MY_SRC} containers/verletListsCellBased/verletListsCells/VerletListsCellsNeighborList.h)
 
 target_link_libraries(
     autopas

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
@@ -120,8 +120,7 @@ class VerletListsCells
    * @return the neighbor list of the particle
    */
   const std::vector<Particle *> &getVerletList(const Particle *particle) const {
-    const auto indices = _neighborList.getParticleToCellMapConst().at(const_cast<Particle *>(particle));
-    return _neighborList.getAoSConstAll().at(indices.first).at(indices.second).second;
+    return _neighborList.getVerletList(particle);
   }
 
   void rebuildNeighborLists(TraversalInterface *traversal) override {
@@ -145,14 +144,9 @@ class VerletListsCells
 
  private:
   /**
-   * -----Verlet lists for each particle for each cell.
+   * TODO: Verlet lists for each particle for each cell.
    */
   NeighborList _neighborList;
-
-  /**
-   * Mapping of each particle to its corresponding cell and id within this cell.
-   */
-  //std::unordered_map<Particle *, std::pair<size_t, size_t>> _particleToCellMap;
 
   /**
    * The traversal used to build the verletlists.

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
@@ -13,8 +13,8 @@
 #include "autopas/containers/linkedCells/LinkedCells.h"
 #include "autopas/containers/verletListsCellBased/VerletListsLinkedBase.h"
 #include "autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsHelpers.h"
-#include "autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCTraversalInterface.h"
 #include "autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsNeighborList.h"
+#include "autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCTraversalInterface.h"
 #include "autopas/options/DataLayoutOption.h"
 #include "autopas/options/LoadEstimatorOption.h"
 #include "autopas/options/TraversalOption.h"
@@ -63,7 +63,7 @@ class VerletListsCells
   /**
    * @copydoc ParticleContainerInterface::getContainerType()
    */
-  [[nodiscard]] ContainerOption getContainerType() const override { return ContainerOption::verletListsCells; }
+  [[nodiscard]] ContainerOption getContainerType() const override { return _neighborList.getContainerType(); }
 
   /**
    * Generates the load estimation function depending on _loadEstimator.
@@ -150,7 +150,7 @@ class VerletListsCells
   NeighborList _neighborList;
 
   /**
-   * The traversal used to build the verletlists.
+   * The traversal used to build the verlet lists.
    */
   TraversalOption _buildTraversalOption;
 

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
@@ -32,6 +32,7 @@ namespace autopas {
  * the interaction.
  * Cells are created using a cell size of at least cutoff + skin radius.
  * @tparam Particle
+ * @tparam NeighborList The neighbor list used by this container.
  */
 template <class Particle, class NeighborList = VerletListsCellsNeighborList<Particle>>
 class VerletListsCells
@@ -144,7 +145,7 @@ class VerletListsCells
 
  private:
   /**
-   * TODO: Verlet lists for each particle for each cell.
+   * Neighbor list abstraction for neighbor list used in the container.
    */
   NeighborList _neighborList;
 

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsNeighborList.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsNeighborList.h
@@ -7,31 +7,31 @@
 #pragma once
 
 #include "autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsHelpers.h"
+#include "autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsNeighborListInterface.h"
 #include "autopas/options/TraversalOption.h"
 #include "autopas/selectors/TraversalSelector.h"
 #include "autopas/utils/ArrayMath.h"
 #include "autopas/utils/StaticSelectorMacros.h"
-#include "autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsNeighborListInterface.h"
 
 namespace autopas
 {
+/**
+ * Neighbor list to be used with VerletListsCells container. Classic implementation of verlet lists based on linked cells.
+ * @tparam Particle Type of particle to be used for this neighbor list.
+ * */
 template<class Particle>
 class VerletListsCellsNeighborList : public VerletListsCellsNeighborListInterface<Particle>
 {
-
   using LinkedParticleCell = typename VerletListsCellsHelpers<Particle>::VLCCellType;
 
  public:
+  /**
+   * Constructor for VerletListsCellsNeighborList. Initializes private attributes.
+   * */
   VerletListsCellsNeighborList() : _aosNeighborList{}, _particleToCellMap{} {}
 
   /**
-   * Builds AoS neighbor list from underlying linked cells object.
-   * @param linkedCells Linked Cells object used to build the neighor list.
-   * @param useNewton3 Whether Newton 3 should be used for the neighbor list.
-   * @param cutoff
-   * @param skin
-   * @param interactionLength
-   * @param buildTraversalOption Traversal option necessary for generator functor.
+   * @copy VerletListsCellsNeighborListInterface::buildAoSNeighborList()
    * */
   void buildAoSNeighborList(LinkedCells<typename VerletListsCellsHelpers<Particle>::VLCCellType> &linkedCells, bool useNewton3,
                             double cutoff, double skin, double interactionLength, const TraversalOption buildTraversalOption)
@@ -57,23 +57,34 @@ class VerletListsCellsNeighborList : public VerletListsCellsNeighborListInterfac
     applyBuildFunctor(linkedCells, useNewton3, cutoff, skin, interactionLength, buildTraversalOption);
   }
 
-  /**@copy VerletListsCellsNeighborListInterface::buildAoSNeighborList() */
+  /**
+   * @copy VerletListsCellsNeighborListInterface::getVerletList()
+   * */
   const std::vector<Particle *> &getVerletList(const Particle *particle) const {
     const auto indices = _particleToCellMap.at(const_cast<Particle *>(particle));
     return _aosNeighborList.at(indices.first).at(indices.second).second;
   }
 
+  /**
+   * @copy VerletListsCellsNeighborListInterface::getContainerType()
+   * */
+  [[nodiscard]] ContainerOption getContainerType() const override { return ContainerOption::verletListsCells; }
+
+  /**
+   * Returns the neighbor list in AoS layout.
+   * @return Neighbor list in AoS layout.
+   * */
   typename VerletListsCellsHelpers<Particle>::NeighborListsType &getAoSNeighborList() {return _aosNeighborList;}
 
  private:
 
   /**
    * Creates and applies generator functor for the building of the neighbor list.
-   * @param linkedCells Linked Cells object used to build the neighor list.
+   * @param linkedCells Linked Cells object used to build the neighbor list.
    * @param useNewton3 Whether Newton 3 should be used for the neighbor list.
-   * @param cutoff
-   * @param skin
-   * @param interactionLength
+   * @param cutoff Cutoff radius.
+   * @param skin Skin of the verlet list.
+   * @param interactionLength Interaction length of the underlying linked cells object.
    * @param buildTraversalOption Traversal option necessary for generator functor.
    * */
   void applyBuildFunctor(LinkedCells<typename VerletListsCellsHelpers<Particle>::VLCCellType> &linkedCells, bool useNewton3,

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsNeighborList.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsNeighborList.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsHelpers.h"
+
+namespace autopas
+{
+template<class Particle>
+class VerletListsCellsNeighborList
+{
+ public:
+  VerletListsCellsNeighborList() : _aosNeighborList{}, _particleToCellMap{} {}
+  void buildAoSNeighborList(LinkedCells<typename VerletListsCellsHelpers<Particle>::VLCCellType> &linkedCells, bool useNewton3)
+  {
+    // Initialize a neighbor list for each cell.
+    _aosNeighborList.clear();
+    auto &cells = linkedCells.getCells();
+    size_t cellsSize = cells.size();
+    _aosNeighborList.resize(cellsSize);
+    for (size_t cellIndex = 0; cellIndex < cellsSize; ++cellIndex) {
+      _aosNeighborList[cellIndex].reserve(cells[cellIndex].numParticles());
+      size_t particleIndexWithinCell = 0;
+      for (auto iter = cells[cellIndex].begin(); iter.isValid(); ++iter, ++particleIndexWithinCell) {
+        Particle *particle = &*iter;
+        _aosNeighborList[cellIndex].emplace_back(particle, std::vector<Particle *>());
+        // In a cell with N particles, reserve space for 5N neighbors.
+        // 5 is an empirically determined magic number that provides good speed.
+        _aosNeighborList[cellIndex].back().second.reserve(cells[cellIndex].numParticles() * 5);
+        _particleToCellMap[particle] = std::make_pair(cellIndex, particleIndexWithinCell);
+      }
+    }
+  }
+
+  auto &getParticleToCellMap() {return _particleToCellMap;}
+  auto &getParticleToCellMapConst() const {return _particleToCellMap;}
+
+  typename VerletListsCellsHelpers<Particle>::NeighborListsType &getAoSNeighborList() {return _aosNeighborList;}
+  //typename VerletListsCellsHelpers<Particle>::NeighborListsType &getAoSConst() const {return _aosNeighborList;}
+  //const typename VerletListsCellsHelpers<Particle>::NeighborListsType &getAoSConstRef() {return _aosNeighborList;}
+  const typename VerletListsCellsHelpers<Particle>::NeighborListsType &getAoSConstAll() const {return _aosNeighborList;}
+  //typename VerletListsCellsHelpers<Particle>::NeighborListsType getAoS() {return _aosNeighborList;}
+  //typename VerletListsCellsHelpers<Particle>::NeighborListsType getAoSBlandConst() const {return _aosNeighborList;}
+
+ public:
+  typename VerletListsCellsHelpers<Particle>::NeighborListsType _aosNeighborList;
+  std::unordered_map<Particle *, std::pair<size_t, size_t>> _particleToCellMap;
+
+};
+}

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsNeighborList.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsNeighborList.h
@@ -1,3 +1,9 @@
+/**
+ * @file VerletListsCellsNeighborList.h
+ * @author tirgendetwas
+ * @date 25.10.20
+ */
+
 #pragma once
 
 #include "autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsHelpers.h"
@@ -19,7 +25,13 @@ class VerletListsCellsNeighborList : public VerletListsCellsNeighborListInterfac
   VerletListsCellsNeighborList() : _aosNeighborList{}, _particleToCellMap{} {}
 
   /**
-   * TODO
+   * Builds AoS neighbor list from underlying linked cells object.
+   * @param linkedCells Linked Cells object used to build the neighor list.
+   * @param useNewton3 Whether Newton 3 should be used for the neighbor list.
+   * @param cutoff
+   * @param skin
+   * @param interactionLength
+   * @param buildTraversalOption Traversal option necessary for generator functor.
    * */
   void buildAoSNeighborList(LinkedCells<typename VerletListsCellsHelpers<Particle>::VLCCellType> &linkedCells, bool useNewton3,
                             double cutoff, double skin, double interactionLength, const TraversalOption buildTraversalOption)
@@ -44,22 +56,25 @@ class VerletListsCellsNeighborList : public VerletListsCellsNeighborListInterfac
 
     applyBuildFunctor(linkedCells, useNewton3, cutoff, skin, interactionLength, buildTraversalOption);
   }
-  /**TODO*/
 
+  /**@copy VerletListsCellsNeighborListInterface::buildAoSNeighborList() */
   const std::vector<Particle *> &getVerletList(const Particle *particle) const {
     const auto indices = _particleToCellMap.at(const_cast<Particle *>(particle));
     return _aosNeighborList.at(indices.first).at(indices.second).second;
   }
 
-  /**
-   * TODO
-   * */
   typename VerletListsCellsHelpers<Particle>::NeighborListsType &getAoSNeighborList() {return _aosNeighborList;}
 
  private:
 
   /**
-   * TODO
+   * Creates and applies generator functor for the building of the neighbor list.
+   * @param linkedCells Linked Cells object used to build the neighor list.
+   * @param useNewton3 Whether Newton 3 should be used for the neighbor list.
+   * @param cutoff
+   * @param skin
+   * @param interactionLength
+   * @param buildTraversalOption Traversal option necessary for generator functor.
    * */
   void applyBuildFunctor(LinkedCells<typename VerletListsCellsHelpers<Particle>::VLCCellType> &linkedCells, bool useNewton3,
                          double cutoff, double skin, double interactionLength, const TraversalOption buildTraversalOption)
@@ -80,7 +95,9 @@ class VerletListsCellsNeighborList : public VerletListsCellsNeighborListInterfac
     });
   }
 
-  /**TODO*/
+  /**
+   * Internal neighbor list structure in AoS format - Verlet lists for each particle for each cell.
+   * */
   typename VerletListsCellsHelpers<Particle>::NeighborListsType _aosNeighborList;
 
   /**

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsNeighborList.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsNeighborList.h
@@ -5,17 +5,22 @@
 #include "autopas/selectors/TraversalSelector.h"
 #include "autopas/utils/ArrayMath.h"
 #include "autopas/utils/StaticSelectorMacros.h"
+#include "autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsNeighborListInterface.h"
 
 namespace autopas
 {
 template<class Particle>
-class VerletListsCellsNeighborList
+class VerletListsCellsNeighborList : public VerletListsCellsNeighborListInterface<Particle>
 {
 
   using LinkedParticleCell = typename VerletListsCellsHelpers<Particle>::VLCCellType;
 
  public:
   VerletListsCellsNeighborList() : _aosNeighborList{}, _particleToCellMap{} {}
+
+  /**
+   * TODO
+   * */
   void buildAoSNeighborList(LinkedCells<typename VerletListsCellsHelpers<Particle>::VLCCellType> &linkedCells, bool useNewton3,
                             double cutoff, double skin, double interactionLength, const TraversalOption buildTraversalOption)
   {
@@ -39,14 +44,23 @@ class VerletListsCellsNeighborList
 
     applyBuildFunctor(linkedCells, useNewton3, cutoff, skin, interactionLength, buildTraversalOption);
   }
+  /**TODO*/
 
-  auto &getParticleToCellMapConst() const {return _particleToCellMap;}
+  const std::vector<Particle *> &getVerletList(const Particle *particle) const {
+    const auto indices = _particleToCellMap.at(const_cast<Particle *>(particle));
+    return _aosNeighborList.at(indices.first).at(indices.second).second;
+  }
 
+  /**
+   * TODO
+   * */
   typename VerletListsCellsHelpers<Particle>::NeighborListsType &getAoSNeighborList() {return _aosNeighborList;}
-  const typename VerletListsCellsHelpers<Particle>::NeighborListsType &getAoSConstAll() const {return _aosNeighborList;}
 
  private:
 
+  /**
+   * TODO
+   * */
   void applyBuildFunctor(LinkedCells<typename VerletListsCellsHelpers<Particle>::VLCCellType> &linkedCells, bool useNewton3,
                          double cutoff, double skin, double interactionLength, const TraversalOption buildTraversalOption)
   {
@@ -66,7 +80,12 @@ class VerletListsCellsNeighborList
     });
   }
 
+  /**TODO*/
   typename VerletListsCellsHelpers<Particle>::NeighborListsType _aosNeighborList;
+
+  /**
+   * Mapping of each particle to its corresponding cell and id within this cell.
+   */
   std::unordered_map<Particle *, std::pair<size_t, size_t>> _particleToCellMap;
 
 };

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsNeighborListInterface.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsNeighborListInterface.h
@@ -1,6 +1,8 @@
-//
-// Created by TinaVl on 10/27/2020.
-//
+/**
+ * @file VerletListsCellsNeighborListInterface.h
+ * @author tirgendetwas
+ * @date 27.10.20
+ */
 
 #pragma once
 
@@ -15,14 +17,26 @@ template<class Particle>
 class VerletListsCellsNeighborListInterface
 {
  public:
-  /**TODO*/
+  /**default destructor*/
     ~VerletListsCellsNeighborListInterface() = default;
 
-  /**TODO*/
+  /**
+   * Builds AoS neighbor list from underlying linked cells object.
+   * @param linkedCells Linked Cells object used to build the neighor list.
+   * @param useNewton3 Whether Newton 3 should be used for the neighbor list.
+   * @param cutoff
+   * @param skin
+   * @param interactionLength
+   * @param buildTraversalOption Traversal option necessary for generator functor.
+   * */
   virtual void buildAoSNeighborList(LinkedCells<typename VerletListsCellsHelpers<Particle>::VLCCellType> &linkedCells, bool useNewton3,
                             double cutoff, double skin, double interactionLength, const TraversalOption buildTraversalOption) = 0;
 
-  /**TODO*/
+  /**
+   * Get the neighbors list of a particle.
+   * @param particle
+   * @return the neighbor list of the particle
+   */
   virtual const std::vector<Particle *> &getVerletList(const Particle *particle) const = 0;
 };
 

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsNeighborListInterface.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsNeighborListInterface.h
@@ -1,0 +1,29 @@
+//
+// Created by TinaVl on 10/27/2020.
+//
+
+#pragma once
+
+#include "autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsHelpers.h"
+#include "autopas/options/TraversalOption.h"
+#include "autopas/containers/linkedCells/LinkedCells.h"
+
+namespace autopas
+{
+
+template<class Particle>
+class VerletListsCellsNeighborListInterface
+{
+ public:
+  /**TODO*/
+    ~VerletListsCellsNeighborListInterface() = default;
+
+  /**TODO*/
+  virtual void buildAoSNeighborList(LinkedCells<typename VerletListsCellsHelpers<Particle>::VLCCellType> &linkedCells, bool useNewton3,
+                            double cutoff, double skin, double interactionLength, const TraversalOption buildTraversalOption) = 0;
+
+  /**TODO*/
+  virtual const std::vector<Particle *> &getVerletList(const Particle *particle) const = 0;
+};
+
+}

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsNeighborListInterface.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsNeighborListInterface.h
@@ -6,38 +6,49 @@
 
 #pragma once
 
+#include "autopas/containers/linkedCells/LinkedCells.h"
 #include "autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsHelpers.h"
 #include "autopas/options/TraversalOption.h"
-#include "autopas/containers/linkedCells/LinkedCells.h"
 
 namespace autopas
 {
-
+/**
+ * Interface of neighbor lists to be used with VerletListsCells container.
+ * @tparam Particle Type of particle to be used for the neighbor list.
+ * */
 template<class Particle>
 class VerletListsCellsNeighborListInterface
 {
  public:
-  /**default destructor*/
+  /**
+   * Default destructor.
+   * */
     ~VerletListsCellsNeighborListInterface() = default;
 
   /**
    * Builds AoS neighbor list from underlying linked cells object.
-   * @param linkedCells Linked Cells object used to build the neighor list.
+   * @param linkedCells Linked Cells object used to build the neighbor list.
    * @param useNewton3 Whether Newton 3 should be used for the neighbor list.
-   * @param cutoff
-   * @param skin
-   * @param interactionLength
+   * @param cutoff Cutoff radius.
+   * @param skin Skin of the verlet list.
+   * @param interactionLength Interaction length of the underlying linked cells object.
    * @param buildTraversalOption Traversal option necessary for generator functor.
    * */
   virtual void buildAoSNeighborList(LinkedCells<typename VerletListsCellsHelpers<Particle>::VLCCellType> &linkedCells, bool useNewton3,
                             double cutoff, double skin, double interactionLength, const TraversalOption buildTraversalOption) = 0;
 
   /**
-   * Get the neighbors list of a particle.
+   * Get the neighbors list of a particle for this particular neighbor list and container combination.
    * @param particle
    * @return the neighbor list of the particle
    */
   virtual const std::vector<Particle *> &getVerletList(const Particle *particle) const = 0;
+
+  /**
+   * Returns the container type of this neighbor list and the container it belongs to.
+   * @return ContainerOption for this neighbor list and the container it belongs to.
+   */
+  [[nodiscard]] virtual ContainerOption getContainerType() const = 0;
 };
 
 }

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/test.txt
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/test.txt
@@ -1,1 +1,1 @@
-to check if pushing to branch works as intended
+to check if pushing to branch works as intended, now with new user name

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/test.txt
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/test.txt
@@ -1,1 +1,1 @@
-attempt to connect to actual github account
+attempt to connect to actual github account; changed e-mail

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/test.txt
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/test.txt
@@ -1,0 +1,1 @@
+to check if pushing to branch works as intended

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/test.txt
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/test.txt
@@ -1,1 +1,1 @@
-to check if pushing to branch works as intended, now with new user name
+attempt to connect to actual github account


### PR DESCRIPTION
# Description

Neighbor list was added as a template argument to VerletListsCells, everything to do with the neighbor list was abstracted from VerletListsCells into VerletListsCellsNeighborList, a basic interface for the VLC neighbor lists was added (VerletListsCellsNeighborListInterface)

# How Has This Been Tested?

Made sure all of VerletListsCells functionalities worked in the same way after the refactoring (unit tests and md-flexible scenarios with VLC container).
