### PR TITLE
Removes static namespace members

### DIFF
--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -11,6 +11,7 @@
 #include <set>
 #include <type_traits>
 
+#include "autopas/InstanceCounter.h"
 #include "autopas/LogicHandler.h"
 #include "autopas/Version.h"
 #include "autopas/options//ExtrapolationMethodOption.h"
@@ -63,7 +64,7 @@ class AutoPas {
   explicit AutoPas(std::ostream &logOutputStream = std::cout) {
     // count the number of autopas instances. This is needed to ensure that the autopas
     // logger is not unregistered while other instances are still using it.
-    _instanceCounter++;
+    InstanceCounter::count++;
     // remove potentially existing logger
     autopas::Logger::unregister();
     // initialize the Logger
@@ -76,8 +77,8 @@ class AutoPas {
   }
 
   ~AutoPas() {
-    _instanceCounter--;
-    if (_instanceCounter == 0) {
+    InstanceCounter::count--;
+    if (InstanceCounter::count == 0) {
       // remove the Logger from the registry. Do this only if we have no other autopas instances running.
       autopas::Logger::unregister();
     }
@@ -789,9 +790,5 @@ class AutoPas {
    */
   bool _externalMPICommunicator{false};
 
-  /**
-   * Instance counter to help track the number of autopas instances. Needed for correct management of the logger.
-   */
-  static inline unsigned int _instanceCounter = 0;
 };  // class AutoPas
 }  // namespace autopas

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -26,11 +26,6 @@
 namespace autopas {
 
 /**
- * Instance counter to help track the number of autopas instances. Needed for correct management of the logger.
- */
-static unsigned int _instanceCounter = 0;
-
-/**
  * The AutoPas class is intended to be the main point of Interaction for the user.
  * It acts as an interface from where all features of the library can be triggered and configured.
  * @tparam Particle Class for particles
@@ -793,5 +788,10 @@ class AutoPas {
    * Stores whether the mpi communicator was provided externally or not
    */
   bool _externalMPICommunicator{false};
+
+  /**
+   * Instance counter to help track the number of autopas instances. Needed for correct management of the logger.
+   */
+  static inline unsigned int _instanceCounter = 0;
 };  // class AutoPas
 }  // namespace autopas

--- a/src/autopas/InstanceCounter.h
+++ b/src/autopas/InstanceCounter.h
@@ -1,0 +1,17 @@
+/**
+ * @file InstanceCounter.h
+ * @author seckler
+ * @date 06.11.20
+ */
+
+#pragma once
+
+namespace autopas {
+
+struct InstanceCounter {
+  /**
+   * Instance counter to help track the number of autopas instances. Needed for correct management of the logger.
+   */
+  static inline unsigned int count{0};
+};
+}  // namespace autopas

--- a/src/autopas/InstanceCounter.h
+++ b/src/autopas/InstanceCounter.h
@@ -8,6 +8,9 @@
 
 namespace autopas {
 
+/**
+ * Class to count autopas instances.
+ */
 struct InstanceCounter {
   /**
    * Instance counter to help track the number of autopas instances. Needed for correct management of the logger.

--- a/src/autopas/containers/UnknowingCellBorderAndFlagManager.h
+++ b/src/autopas/containers/UnknowingCellBorderAndFlagManager.h
@@ -18,9 +18,16 @@ class UnknowingCellBorderAndFlagManager : public CellBorderAndFlagManager {
  public:
   bool cellCanContainHaloParticles(index_t index1d) const override { return true; }
   bool cellCanContainOwnedParticles(index_t index1d) const override { return true; }
+
+  /**
+   * Get the static instance of this class.
+   * @return one instance.
+   */
+  static auto& get() {
+    const static UnknowingCellBorderAndFlagManager unknowingCellBorderAndFlagManager;
+    return unknowingCellBorderAndFlagManager;
+  }
 };
 
-/// An instance of this UnknowingCellBorderAndFlagManager.
-static UnknowingCellBorderAndFlagManager unknowingCellBorderAndFlagManager;
 
 }  // namespace autopas::internal

--- a/src/autopas/containers/UnknowingCellBorderAndFlagManager.h
+++ b/src/autopas/containers/UnknowingCellBorderAndFlagManager.h
@@ -24,7 +24,7 @@ class UnknowingCellBorderAndFlagManager : public CellBorderAndFlagManager {
    * @return one instance.
    */
   static auto &get() {
-    const static UnknowingCellBorderAndFlagManager unknowingCellBorderAndFlagManager;
+    const static UnknowingCellBorderAndFlagManager unknowingCellBorderAndFlagManager{};
     return unknowingCellBorderAndFlagManager;
   }
 };

--- a/src/autopas/containers/UnknowingCellBorderAndFlagManager.h
+++ b/src/autopas/containers/UnknowingCellBorderAndFlagManager.h
@@ -23,11 +23,10 @@ class UnknowingCellBorderAndFlagManager : public CellBorderAndFlagManager {
    * Get the static instance of this class.
    * @return one instance.
    */
-  static auto& get() {
+  static auto &get() {
     const static UnknowingCellBorderAndFlagManager unknowingCellBorderAndFlagManager;
     return unknowingCellBorderAndFlagManager;
   }
 };
-
 
 }  // namespace autopas::internal

--- a/src/autopas/containers/cellPairTraversals/CBasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/CBasedTraversal.h
@@ -139,7 +139,14 @@ inline void CBasedTraversal<ParticleCell, PairwiseFunctor, dataLayout, useNewton
   {
     const unsigned long numColors = stride[0] * stride[1] * stride[2];
     for (unsigned long col = 0; col < numColors; ++col) {
-      notifyColorChange(col);
+#if defined(AUTOPAS_OPENMP)
+#pragma omp single
+#endif
+      {
+        // barrier at omp for of previous loop iteration, so fine to change it for everyone!
+        notifyColorChange(col);
+        // implicit barrier at end of function.
+      }
       std::array<unsigned long, 3> startWithoutOffset(utils::ThreeDimensionalMapping::oneToThreeD(col, stride));
       std::array<unsigned long, 3> start(utils::ArrayMath::add(startWithoutOffset, offset));
 

--- a/src/autopas/containers/verletClusterCells/VerletClusterCells.h
+++ b/src/autopas/containers/verletClusterCells/VerletClusterCells.h
@@ -337,7 +337,7 @@ class VerletClusterCells : public CellBasedParticleContainer<FullParticleCell<Pa
       return ParticleIteratorWrapper<Particle, false>(
           new internal::RegionParticleIterator<Particle, FullParticleCell<Particle>, false>(
               &this->_cells, lowerCornerInBounds, upperCornerInBounds, cellsOfInterest,
-              &internal::unknowingCellBorderAndFlagManager, behavior));
+              &internal::UnknowingCellBorderAndFlagManager::get(), behavior));
     }
   }
 

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -283,7 +283,7 @@ class VerletClusterLists : public ParticleContainerInterface<FullParticleCell<Pa
     return ParticleIteratorWrapper<Particle, true>(
         new internal::RegionParticleIterator<Particle, internal::ClusterTower<Particle>, true>(
             &this->_towers, lowerCornerInBounds, upperCornerInBounds, cellsOfInterest,
-            &internal::unknowingCellBorderAndFlagManager, behavior));
+            &internal::UnknowingCellBorderAndFlagManager::get(), behavior));
   }
 
   /**
@@ -305,7 +305,7 @@ class VerletClusterLists : public ParticleContainerInterface<FullParticleCell<Pa
     return ParticleIteratorWrapper<Particle, false>(
         new internal::RegionParticleIterator<Particle, internal::ClusterTower<Particle>, false>(
             &this->_towers, lowerCornerInBounds, upperCornerInBounds, cellsOfInterest,
-            &internal::unknowingCellBorderAndFlagManager, behavior,
+            &internal::UnknowingCellBorderAndFlagManager::get(), behavior,
             _isValid != ValidityState::invalid ? nullptr : &_particlesToAdd));
   }
 

--- a/src/autopas/containers/verletListsCellBased/varVerletLists/neighborLists/asBuild/VerletNeighborListAsBuild.h
+++ b/src/autopas/containers/verletListsCellBased/varVerletLists/neighborLists/asBuild/VerletNeighborListAsBuild.h
@@ -335,18 +335,12 @@ class VerletNeighborListAsBuild : public VerletNeighborListInterface<Particle>, 
   /**
    * The current color in the traversal during the build of the neighbor list.
    */
-  static int _currentColor;
-#if defined(AUTOPAS_OPENMP)
-#pragma omp threadprivate(_currentColor)
-#endif
+  int _currentColor{0};
 
   /**
    * Used in checkNeighborListValidity(). Set to false in the pair generating functor.
    */
   std::atomic<bool> _allPairsPresent;
 };
-
-template <class Particle>
-int VerletNeighborListAsBuild<Particle>::_currentColor = 0;
 
 }  // namespace autopas

--- a/src/autopas/iterators/ParticleIterator.h
+++ b/src/autopas/iterators/ParticleIterator.h
@@ -30,8 +30,7 @@ template <class Particle, class ParticleCell, bool modifiable>
 class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle, modifiable> {
   using CellVecType = std::conditional_t<modifiable, std::vector<ParticleCell>, const std::vector<ParticleCell>>;
   using ParticleType = std::conditional_t<modifiable, Particle, const Particle>;
-  using CellBorderAndFlagManagerType =
-      std::conditional_t<modifiable, internal::CellBorderAndFlagManager, const internal::CellBorderAndFlagManager>;
+  using CellBorderAndFlagManagerType = const internal::CellBorderAndFlagManager;
   using ParticleVecType = std::conditional_t<modifiable, std::vector<Particle>, const std::vector<Particle>>;
 
  protected:
@@ -45,7 +44,7 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle, modifiab
    * @param behavior The IteratorBehavior that specifies which type of cells shall be iterated through.
    * @param additionalParticleVectorToIterate Additional Particle Vector to iterate over.
    */
-  ParticleIterator(CellVecType *cont, CellBorderAndFlagManagerType *flagManager, IteratorBehavior behavior,
+  ParticleIterator(CellVecType *cont, const CellBorderAndFlagManagerType *flagManager, IteratorBehavior behavior,
                    ParticleVecType *additionalParticleVectorToIterate)
       : _vectorOfCells(cont),
         _iteratorAcrossCells(cont->begin()),
@@ -305,7 +304,7 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle, modifiab
   /**
    * Manager providing info if cell is in halo.
    */
-  CellBorderAndFlagManagerType *_flagManager;
+  const CellBorderAndFlagManagerType *_flagManager;
 
   /**
    * The behavior of the iterator.

--- a/src/autopas/iterators/RegionParticleIterator.h
+++ b/src/autopas/iterators/RegionParticleIterator.h
@@ -44,7 +44,7 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell, m
    */
   explicit RegionParticleIterator(CellVecType *cont, std::array<double, 3> startRegion, std::array<double, 3> endRegion,
                                   std::vector<size_t> &indicesInRegion,
-                                  CellBorderAndFlagManagerType *flagManager = nullptr,
+                                  const CellBorderAndFlagManagerType *flagManager = nullptr,
                                   IteratorBehavior behavior = haloAndOwned,
                                   ParticleVecType *additionalParticleVectorToIterate = nullptr)
       : ParticleIterator<Particle, ParticleCell, modifiable>(cont, flagManager, behavior,

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
@@ -241,7 +241,7 @@ TEST_F(VerletClusterListsTest, testVerletListColoringTraversalNewton3NoDataRace)
 
   CollectParticlesPerThreadFunctor functor;
   ColoringTraversalWithColorChangeNotify traversal(
-      &functor, clusterSize, [](int currentColor) { CollectParticlesPerThreadFunctor::nextColor(currentColor); });
+      &functor, clusterSize, [&functor](int currentColor) { functor.nextColor(currentColor); });
   functor.initTraversal();
   verletLists.rebuildNeighborLists(&traversal);
   verletLists.iteratePairwise(&traversal);
@@ -252,7 +252,7 @@ TEST_F(VerletClusterListsTest, testVerletListColoringTraversalNewton3NoDataRace)
   for (int color = 0; color < 8; color++) {
     auto &colorList = list[color];
     for (unsigned long i = 0; i < colorList.size(); i++) {
-      for (auto particlePtr : colorList[i]) {
+      for (auto* particlePtr : colorList[i]) {
         for (unsigned long j = i + 1; j < colorList.size(); j++) {
           EXPECT_TRUE(colorList[j].find(particlePtr) == colorList[j].end())
               << particlePtr->toString() << " was accessed by " << i << " and " << j;

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
@@ -240,8 +240,8 @@ TEST_F(VerletClusterListsTest, testVerletListColoringTraversalNewton3NoDataRace)
                                                                numParticles);
 
   CollectParticlesPerThreadFunctor functor;
-  ColoringTraversalWithColorChangeNotify traversal(
-      &functor, clusterSize, [&functor](int currentColor) { functor.nextColor(currentColor); });
+  ColoringTraversalWithColorChangeNotify traversal(&functor, clusterSize,
+                                                   [&functor](int currentColor) { functor.nextColor(currentColor); });
   functor.initTraversal();
   verletLists.rebuildNeighborLists(&traversal);
   verletLists.iteratePairwise(&traversal);
@@ -252,7 +252,7 @@ TEST_F(VerletClusterListsTest, testVerletListColoringTraversalNewton3NoDataRace)
   for (int color = 0; color < 8; color++) {
     auto &colorList = list[color];
     for (unsigned long i = 0; i < colorList.size(); i++) {
-      for (auto* particlePtr : colorList[i]) {
+      for (auto *particlePtr : colorList[i]) {
         for (unsigned long j = i + 1; j < colorList.size(); j++) {
           EXPECT_TRUE(colorList[j].find(particlePtr) == colorList[j].end())
               << particlePtr->toString() << " was accessed by " << i << " and " << j;

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.h
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.h
@@ -63,8 +63,7 @@ class CollectParticlePairsFunctor
 class CollectParticlesPerThreadFunctor
     : public autopas::Functor<autopas::Particle, autopas::FullParticleCell<autopas::Particle>> {
  public:
-  static int _currentColor;
-#pragma omp threadprivate(_currentColor)
+  int _currentColor{};
 
   std::array<std::vector<std::set<Particle *>>, 8> _particlesPerThreadPerColor;
 
@@ -95,10 +94,8 @@ class CollectParticlesPerThreadFunctor
     return dataLayout == autopas::DataLayoutOption::aos;  // this functor supports clusters only for aos!
   }
 
-  static void nextColor(int newColor) { _currentColor = newColor; }
+  void nextColor(int newColor) { _currentColor = newColor; }
 };
-
-int CollectParticlesPerThreadFunctor::_currentColor = 0;
 
 class ColoringTraversalWithColorChangeNotify
     : public autopas::VCLC06Traversal<FPCell, CollectParticlesPerThreadFunctor, autopas::DataLayoutOption::aos, true> {


### PR DESCRIPTION
# Description

- Removes static namespace members, as these have per definition internal linkage and are very bad.
Moves them to class members, which, by default, have external linkage.
- Removes static, thread-private members from VerletNeighborListAsBuild and the VerletClusterLists test.
