### PR TITLE
More N3 tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -250,7 +250,7 @@ pipeline {
                         container('autopas-llvm-archer') {
                             dir("build-archer") {
                                 sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DAUTOPAS_ENABLE_THREAD_SANITIZER=ON -DAUTOPAS_OPENMP=ON -DCCACHE=ON -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_USE_VECTORIZATION=OFF .."
-                                sh "entrypoint.sh ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
+                                sh 'export TSAN_OPTIONS="ignore_noninstrumented_modules=1" && entrypoint.sh ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)'
                                 sh 'export TSAN_OPTIONS="ignore_noninstrumented_modules=1" && ctest --verbose -j8'
                             }
                             dir("build-archer/examples") {

--- a/src/autopas/utils/WrapOpenMP.h
+++ b/src/autopas/utils/WrapOpenMP.h
@@ -177,4 +177,8 @@ class AutoPasLock {
 
 #endif
 
+// These properties are needed because we use AutoPasLock in vectors on which we call resize().
+static_assert(std::is_default_constructible_v<AutoPasLock>, "AutoPasLock needs to be default constructible!");
+static_assert(std::is_move_constructible_v<AutoPasLock>, "AutoPasLock needs to be move constructible!");
+
 }  // namespace autopas

--- a/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
@@ -95,7 +95,7 @@ void Newton3OnOffTest::countFunctorCalls(autopas::ContainerOption containerOptio
   }
 
   autopas::ContainerSelector<Particle> containerSelector(getBoxMin(), getBoxMax(), getCutoff());
-  autopas::ContainerSelectorInfo containerInfo(getCellSizeFactor(), getVerletSkin(), 64,
+  autopas::ContainerSelectorInfo containerInfo(getCellSizeFactor(), getVerletSkin(), getClusterSize(),
                                                autopas::LoadEstimatorOption::none);
 
   containerSelector.selectContainer(containerOption, containerInfo);

--- a/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
@@ -6,94 +6,80 @@
 
 #include "Newton3OnOffTest.h"
 
+#include "autopas/selectors/ContainerSelector.h"
+#include "autopas/selectors/TraversalSelector.h"
 #include "autopas/utils/Logger.h"
 #include "autopas/utils/StaticCellSelector.h"
 
-using ::testing::_;  // anything is ok
+using ::testing::_;
 using ::testing::Combine;
 using ::testing::Return;
 using ::testing::ValuesIn;
 
 // Parse combination strings and call actual test function
 TEST_P(Newton3OnOffTest, countFunctorCallsTest) {
-  auto [containerTraversalTuple, dataLayoutOption] = GetParam();
-  auto [containerOption, traversalOption] = containerTraversalTuple;
-
-  // skip combinations that are for now not applicable
-  if ((traversalOption == autopas::TraversalOption::vlc_c18 or
-       traversalOption == autopas::TraversalOption::vlc_sliced or
-       traversalOption == autopas::TraversalOption::vlc_sliced_balanced or
-       traversalOption == autopas::TraversalOption::vlc_sliced_c02) and
-      dataLayoutOption == autopas::DataLayoutOption::soa) {
-    auto skipMessage = "Traveral " + traversalOption.to_string() + " is not applicable with SoA";
-    GTEST_SKIP_(skipMessage.c_str());
-  }
+  auto [containerOption, traversalOption, dataLayoutOption] = GetParam();
 
   countFunctorCalls(containerOption, traversalOption, dataLayoutOption);
 }
 
-// Generate Unittests for all Container / Traversal / Datalayout combinations
+// Generate Unittests for all Configurations that support both Newton3 modes
 INSTANTIATE_TEST_SUITE_P(
     Generated, Newton3OnOffTest,
-    Combine(ValuesIn([]() -> std::vector<std::tuple<autopas::ContainerOption, autopas::TraversalOption>> {
-              // needed because CellBlock3D (called when building containers) logs always
-              autopas::Logger::create();
+    ValuesIn(
+        []() -> std::vector<std::tuple<autopas::ContainerOption, autopas::TraversalOption, autopas::DataLayoutOption>> {
+          // needed because CellBlock3D (called when building containers) logs always
+          autopas::Logger::create();
 
-              std::vector<std::tuple<autopas::ContainerOption, autopas::TraversalOption>> ret;
+          std::vector<std::tuple<autopas::ContainerOption, autopas::TraversalOption, autopas::DataLayoutOption>>
+              applicableCombinations;
 
-              // container factory
-              autopas::ContainerSelector<Particle> containerSelector({0., 0., 0.}, {10., 10., 10.}, 1.);
-              autopas::ContainerSelectorInfo containerInfo(1., 0., 64, autopas::LoadEstimatorOption::none);
+          // container factory
+          autopas::ContainerSelector<Particle> containerSelector({0., 0., 0.}, {10., 10., 10.}, 1.);
+          autopas::ContainerSelectorInfo containerInfo(
+              Newton3OnOffTest::getCellSizeFactor(), Newton3OnOffTest::getVerletSkin(),
+              Newton3OnOffTest::getClusterSize(), autopas::LoadEstimatorOption::none);
 
-              // generate for all containers, even those to come
-              for (auto containerOption : autopas::ContainerOption::getAllOptions()) {
-                // skip containers that do not work with both newton modes
-                // @TODO: let verlet lists support Newton 3
-                if (containerOption == autopas::ContainerOption::verletLists or
-                    containerOption == autopas::ContainerOption::varVerletListsAsBuild or
-                    containerOption == autopas::ContainerOption::verletClusterCells) {
-                  continue;
-                }
+          // generate for all containers
+          for (auto containerOption : autopas::ContainerOption::getAllOptions()) {
+            containerSelector.selectContainer(containerOption, containerInfo);
+            auto container = containerSelector.getCurrentContainer();
 
-                containerSelector.selectContainer(containerOption, containerInfo);
+            for (auto traversalOption : container->getAllTraversals()) {
+              for (auto dataLayoutOption : autopas::DataLayoutOption::getAllOptions()) {
+                // this is the functor that will be used in the test.
+                MockFunctor<Particle> f;
+                // generate both newton3 versions of the same traversal and check that both are applicable
+                bool configOk = autopas::utils::withStaticCellType<Particle>(
+                    containerSelector.getCurrentContainer()->getParticleCellTypeEnum(), [&](auto particleCellDummy) {
+                      auto traversalSelector = autopas::TraversalSelector<decltype(particleCellDummy)>();
+                      auto traversalWithN3 = traversalSelector.generateTraversal(
+                          traversalOption, f, containerSelector.getCurrentContainer()->getTraversalSelectorInfo(),
+                          dataLayoutOption, autopas::Newton3Option::enabled);
+                      auto traversalWithoutN3 = traversalSelector.generateTraversal(
+                          traversalOption, f, containerSelector.getCurrentContainer()->getTraversalSelectorInfo(),
+                          dataLayoutOption, autopas::Newton3Option::disabled);
 
-                auto container = containerSelector.getCurrentContainer();
+                      return traversalWithN3->isApplicable() and traversalWithoutN3->isApplicable();
+                    });
 
-                for (auto traversalOption : container->getAllTraversals()) {
-                  // exclude traversals that do not support Newton3
-                  if (traversalOption == autopas::TraversalOption::lc_c01 or
-                      traversalOption ==
-                          autopas::TraversalOption::lc_c01_combined_SoA /*and autopas::autopas_get_max_threads() > 1*/
-                      or traversalOption == autopas::TraversalOption::vlc_c01 or
-                      traversalOption == autopas::TraversalOption::vcl_cluster_iteration or
-                      traversalOption == autopas::TraversalOption::vcl_c01_balanced) {
-                    continue;
-                  }
-                  if (traversalOption == autopas::TraversalOption::lc_c01_cuda) {
-                    // Traversal provides no AoS and SoA Traversal
-                    continue;
-                  }
-
-                  ret.emplace_back(containerOption, traversalOption);
+                if (configOk) {
+                  applicableCombinations.emplace_back(containerOption, traversalOption, dataLayoutOption);
                 }
               }
+            }
+          }
 
-              autopas::Logger::unregister();
+          autopas::Logger::unregister();
 
-              return ret;
-            }()),
-            ValuesIn(autopas::DataLayoutOption::getAllOptions())),
+          return applicableCombinations;
+        }()),
     Newton3OnOffTest::PrintToStringParamName());
 
 // Count number of Functor calls with and without newton 3 and compare
 void Newton3OnOffTest::countFunctorCalls(autopas::ContainerOption containerOption,
                                          autopas::TraversalOption traversalOption,
                                          autopas::DataLayoutOption dataLayout) {
-  if (traversalOption == autopas::TraversalOption::lc_c04_combined_SoA and
-      dataLayout != autopas::DataLayoutOption::soa) {
-    return;
-  }
-
   autopas::ContainerSelector<Particle> containerSelector(getBoxMin(), getBoxMax(), getCutoff());
   autopas::ContainerSelectorInfo containerInfo(getCellSizeFactor(), getVerletSkin(), getClusterSize(),
                                                autopas::LoadEstimatorOption::none);
@@ -145,9 +131,8 @@ void Newton3OnOffTest::countFunctorCalls(autopas::ContainerOption containerOptio
   }
 }
 
-template <class ParticleFunctor, class Container, class Traversal>
-void Newton3OnOffTest::iterate(Container container, Traversal traversal, autopas::DataLayoutOption dataLayout,
-                               autopas::Newton3Option newton3, ParticleFunctor *f) {
+template <class Container, class Traversal>
+void Newton3OnOffTest::iterate(Container container, Traversal traversal) {
   container->rebuildNeighborLists(traversal.get());
   container->iteratePairwise(traversal.get());
 }
@@ -161,30 +146,33 @@ std::pair<size_t, size_t> Newton3OnOffTest::eval(autopas::DataLayoutOption dataL
   EXPECT_CALL(mockFunctor, allowsNonNewton3()).WillRepeatedly(Return(not useNewton3));
 
   auto traversalSelectorInfo = container->getTraversalSelectorInfo();
-  const autopas::Newton3Option n3option =
-      (useNewton3) ? autopas::Newton3Option::enabled : autopas::Newton3Option::disabled;
 
+  // depending on the layout set up expectations on what Functors are called
   switch (dataLayout) {
     case autopas::DataLayoutOption::soa: {
-      // single cell
-      EXPECT_CALL(mockFunctor, SoAFunctorSingle(_, useNewton3))
-          .Times(testing::AtLeast(1))
-          .WillRepeatedly(testing::InvokeWithoutArgs([&]() { callsSC++; }));
+      // some containers actually use different SoA functor calls so expect them instead of the regular ones
+      if (container->getContainerType() == autopas::ContainerOption::varVerletListsAsBuild) {
+        EXPECT_CALL(mockFunctor, SoAFunctorVerlet(_, _, _, useNewton3))
+            .Times(testing::AtLeast(1))
+            .WillRepeatedly(testing::InvokeWithoutArgs([&]() { callsPair++; }));
 
-      // pair of cells
-      EXPECT_CALL(mockFunctor, SoAFunctorPair(_, _, useNewton3))
-          .Times(testing::AtLeast(1))
-          .WillRepeatedly(testing::InvokeWithoutArgs([&]() { callsPair++; }));
+        // non useNewton3 variant should not happen
+        EXPECT_CALL(mockFunctor, SoAFunctorVerlet(_, _, _, not useNewton3)).Times(0);
 
-      // non useNewton3 variant should not happen
-      EXPECT_CALL(mockFunctor, SoAFunctorPair(_, _, not useNewton3)).Times(0);
-      autopas::utils::withStaticCellType<Particle>(container->getParticleCellTypeEnum(), [&](auto particleCellDummy) {
-        iterate(container,
-                autopas::TraversalSelector<decltype(particleCellDummy)>::template generateTraversal<
-                    MockFunctor<Particle>, autopas::DataLayoutOption::soa, useNewton3>(traversalOption, mockFunctor,
-                                                                                       traversalSelectorInfo),
-                dataLayout, n3option, &mockFunctor);
-      });
+      } else {
+        // single cell
+        EXPECT_CALL(mockFunctor, SoAFunctorSingle(_, useNewton3))
+            .Times(testing::AtLeast(1))
+            .WillRepeatedly(testing::InvokeWithoutArgs([&]() { callsSC++; }));
+
+        // pair of cells
+        EXPECT_CALL(mockFunctor, SoAFunctorPair(_, _, useNewton3))
+            .Times(testing::AtLeast(1))
+            .WillRepeatedly(testing::InvokeWithoutArgs([&]() { callsPair++; }));
+
+        // non useNewton3 variant should not happen
+        EXPECT_CALL(mockFunctor, SoAFunctorPair(_, _, not useNewton3)).Times(0);
+      }
       break;
     }
     case autopas::DataLayoutOption::aos: {
@@ -195,13 +183,6 @@ std::pair<size_t, size_t> Newton3OnOffTest::eval(autopas::DataLayoutOption dataL
       // non useNewton3 variant should not happen
       EXPECT_CALL(mockFunctor, AoSFunctor(_, _, not useNewton3)).Times(0);
 
-      autopas::utils::withStaticCellType<Particle>(container->getParticleCellTypeEnum(), [&](auto particleCellDummy) {
-        iterate(container,
-                autopas::TraversalSelector<decltype(particleCellDummy)>::template generateTraversal<
-                    MockFunctor<Particle>, autopas::DataLayoutOption::aos, useNewton3>(traversalOption, mockFunctor,
-                                                                                       traversalSelectorInfo),
-                dataLayout, n3option, &mockFunctor);
-      });
       break;
     }
     case autopas::DataLayoutOption::cuda: {
@@ -215,18 +196,22 @@ std::pair<size_t, size_t> Newton3OnOffTest::eval(autopas::DataLayoutOption dataL
 
       EXPECT_CALL(mockFunctor, CudaFunctor(_, _, not useNewton3)).Times(0);
 #endif
-      autopas::utils::withStaticCellType<Particle>(container->getParticleCellTypeEnum(), [&](auto particleCellDummy) {
-        iterate(container,
-                autopas::TraversalSelector<decltype(particleCellDummy)>::template generateTraversal<
-                    MockFunctor<Particle>, autopas::DataLayoutOption::cuda, useNewton3>(traversalOption, mockFunctor,
-                                                                                        traversalSelectorInfo),
-                dataLayout, n3option, &mockFunctor);
-      });
       break;
     }
-    default:
+    default: {
       ADD_FAILURE() << "This test does not support data layout : " << dataLayout.to_string();
+    }
   }
+
+  const autopas::Newton3Option n3Option =
+      useNewton3 ? autopas::Newton3Option::enabled : autopas::Newton3Option::disabled;
+
+  // simulate iteration
+  autopas::utils::withStaticCellType<Particle>(container->getParticleCellTypeEnum(), [&](auto particleCellDummy) {
+    iterate(container,
+            autopas::TraversalSelector<decltype(particleCellDummy)>::template generateTraversal<MockFunctor<Particle>>(
+                traversalOption, mockFunctor, traversalSelectorInfo, dataLayout, n3Option));
+  });
 
   return std::make_pair(callsSC.load(), callsPair.load());
 }

--- a/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.h
+++ b/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.h
@@ -31,12 +31,12 @@ class Newton3OnOffTest
 
   std::array<double, 3> getBoxMin() const { return {0.0, 0.0, 0.0}; }
 
-  std::array<double, 3> getBoxMax() const { return {3.0, 3.0, 3.0}; }
+  std::array<double, 3> getBoxMax() const { return {10.0, 10.0, 10.0}; }
 
   double getCutoff() const { return 1.0; }
   double getCellSizeFactor() const { return 1.0; }
   double getVerletSkin() const { return 0.0; }
-  unsigned int getClusterSize() const { return 64; }
+  unsigned int getClusterSize() const { return 4; }
 
   void countFunctorCalls(autopas::ContainerOption containerOption, autopas::TraversalOption traversalOption,
                          autopas::DataLayoutOption dataLayout);

--- a/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.h
+++ b/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.h
@@ -9,8 +9,9 @@
 #include <gtest/gtest.h>
 
 #include "AutoPasTestBase.h"
-#include "autopas/AutoPas.h"
-#include "autopas/sph/autopassph.h"
+#include "autopas/options/ContainerOption.h"
+#include "autopas/options/DataLayoutOption.h"
+#include "autopas/options/TraversalOption.h"
 #include "autopasTools/generators/RandomGenerator.h"
 #include "mocks/MockFunctor.h"
 #include "testingHelpers/commonTypedefs.h"
@@ -21,7 +22,7 @@
 class Newton3OnOffTest
     : public AutoPasTestBase,
       public ::testing::WithParamInterface<
-          std::tuple<std::tuple<autopas::ContainerOption, autopas::TraversalOption>, autopas::DataLayoutOption>> {
+          std::tuple<autopas::ContainerOption, autopas::TraversalOption, autopas::DataLayoutOption>> {
  public:
   Newton3OnOffTest() : mockFunctor() {}
 
@@ -33,17 +34,16 @@ class Newton3OnOffTest
 
   std::array<double, 3> getBoxMax() const { return {10.0, 10.0, 10.0}; }
 
-  double getCutoff() const { return 1.0; }
-  double getCellSizeFactor() const { return 1.0; }
-  double getVerletSkin() const { return 0.0; }
-  unsigned int getClusterSize() const { return 4; }
+  static double getCutoff() { return 1.0; }
+  static double getCellSizeFactor() { return 1.0; }
+  static double getVerletSkin() { return 0.0; }
+  static int getClusterSize() { return 4; }
 
   void countFunctorCalls(autopas::ContainerOption containerOption, autopas::TraversalOption traversalOption,
                          autopas::DataLayoutOption dataLayout);
 
-  template <class ParticleFunctor, class Container, class Traversal>
-  void iterate(Container container, Traversal traversal, autopas::DataLayoutOption dataLayout,
-               autopas::Newton3Option newton3, ParticleFunctor *f);
+  template <class Container, class Traversal>
+  void iterate(Container container, Traversal traversal);
 
   MockFunctor<Particle> mockFunctor;
 
@@ -65,8 +65,7 @@ class Newton3OnOffTest
     std::string operator()(const testing::TestParamInfo<ParamType> &info) const {
       auto inputTuple = static_cast<ParamType>(info.param);
 
-      auto [containerTraversalTuple, dataLayoutOption] = inputTuple;
-      auto [containerOption, traversalOption] = containerTraversalTuple;
+      auto [containerOption, traversalOption, dataLayoutOption] = inputTuple;
 
       auto retStr =
           containerOption.to_string() + "_" + traversalOption.to_string() + "_" + dataLayoutOption.to_string();


### PR DESCRIPTION
# Description

- [x] Let the Newton3OnOffTest test more Configuations that actually should be testable here.
- [x] Use `isApplicable()` instead on manually throwing out configurations.
  Non-Applicable configurations do not generate tests now.

For some reason, clang-format decided to change the indent on a large part of the file so review with hiding whitespaces

## ~Related Pull Requests~

## ~Resolved Issues~

# How Has This Been Tested?

Ran the tests and they did not fail :innocent: 
