### PR TITLE
Evidence smoothing

### DIFF
--- a/src/autopas/namespaces.h
+++ b/src/autopas/namespaces.h
@@ -26,6 +26,11 @@ namespace internal {}
 namespace memoryProfiler {}
 
 /**
+ * Algorithms for creating a smooth function through a series of points.
+ */
+namespace smoothing {}
+
+/**
  * In this namespace all functionality of the Smoothed Particle Hydrodynamics module of autopas is present.
  * This mainly includes kernels and particles.
  */

--- a/src/autopas/namespaces.h
+++ b/src/autopas/namespaces.h
@@ -15,25 +15,10 @@
 namespace autopas {
 
 /**
- * Namespace to handle mathematical operations of std::array.
- */
-namespace utils::ArrayMath {}
-
-/**
- * In this namespace some helper functions for std::array can be found.
- */
-namespace utils::ArrayUtils {}
-
-/**
- * In this namespace some helper functions for std::tuple can be found.
- */
-namespace utils::TupleUtils {}
-
-/**
  * This namespace is used for implementation specifics.
  * If you are a developer of AutoPas you might want to take a look inside here.
  */
-namespace internal {}  // namespace internal
+namespace internal {}
 
 /**
  * This namespace is used for memory profiling functions.
@@ -44,7 +29,7 @@ namespace memoryProfiler {}
  * In this namespace all functionality of the Smoothed Particle Hydrodynamics module of autopas is present.
  * This mainly includes kernels and particles.
  */
-namespace sph {}  // namespace sph
+namespace sph {}
 
 /**
  * In this namespace some helper classes and functions can be found used inside of AutoPas.
@@ -54,21 +39,36 @@ namespace sph {}  // namespace sph
 namespace utils {
 
 /**
+ * Namespace to handle mathematical operations of std::array.
+ */
+namespace ArrayMath {}
+
+/**
+ * In this namespace some helper functions for std::array can be found.
+ */
+namespace ArrayUtils {}
+
+/**
  * Some functions to parse enums from (input-) strings.
  */
-namespace StringUtils {}  // namespace StringUtils
+namespace StringUtils {}
 
 /**
  * Namespace to handle the conversion between one dimensional and three dimensional indices.
  * The running index is x.
  */
-namespace ThreeDimensionalMapping {}  // namespace ThreeDimensionalMapping
+namespace ThreeDimensionalMapping {}
+
+/**
+ * In this namespace some helper functions for std::tuple can be found.
+ */
+namespace TupleUtils {}
 
 }  // namespace utils
 
 /**
  * Namespace that contains the explicitly defined options of AutoPas.
  */
-namespace options {}  // namespace options
+namespace options {}
 
 }  // namespace autopas

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -30,11 +30,12 @@ namespace autopas {
  * 1. Measuring time of the iteration.
  * 2. Selecting an appropriate configuration for the pairwise iteration.
  *
- * The tuner can be in one of two states, depending on whether it currently should look for a new optimum,
- * which is called a tuning phase. During a tuning phase,for each Configuration multiple measurements can be taken,
+ * The tuner can be in one of two states. If it currently should look for a new optimum, it is in the 
+ * so-called tuning phase. During a tuning phase, for each Configuration, multiple measurements can be taken,
  * which are called samples. To reduce noise, the samples for one configuration are then condensed to one value for
- * the current tuning phase, called evidence. These evidence are handed on to a tuningStrategy, which selects a) what
+ * the current tuning phase, called evidence. The evidences are handed on to a tuningStrategy, which selects a) what
  * Configuration to test next and b) which configuration is the best in this tuning phase.
+ * If it should not look for a new optimum it is not in a tuning phase.
  *
  * @tparam Particle
  * @tparam ParticleCell

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -158,7 +158,7 @@ class AutoTuner {
           auto reducedValue = OptimumSelector::optimumValue(_samples, _selectorStrategy);
 
           _evidences[currentConfig].emplace_back(_iteration, reducedValue);
-          auto smoothedValue = Smoothing::smoothLastPoint(_evidences[currentConfig], .25);
+          auto smoothedValue = smoothing::smoothLastPoint(_evidences[currentConfig], .25);
 
           _tuningStrategy->addEvidence(smoothedValue, _iteration);
 

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -158,7 +158,7 @@ class AutoTuner {
           auto reducedValue = OptimumSelector::optimumValue(_samples, _selectorStrategy);
 
           _evidences[currentConfig].emplace_back(_iteration, reducedValue);
-          auto smoothedValue = smoothing::smoothLastPoint(_evidences[currentConfig], .25);
+          auto smoothedValue = smoothing::smoothLastPoint(_evidences[currentConfig], 5);
 
           _tuningStrategy->addEvidence(smoothedValue, _iteration);
 
@@ -169,7 +169,7 @@ class AutoTuner {
             ss << currentConfig.toString() << " : ";
             // print all timings
             ss << utils::ArrayUtils::to_string(_samples, " ", {"[ ", " ]"});
-            ss << " Reduced value: " << reducedValue;  // TODO: remove this. Should not break performance testing tool.
+            // ss << " Reduced value: " << reducedValue;  // This line is only for plotting purposes
             ss << " Smoothed value: " << smoothedValue;
             AutoPasLog(debug, "Collected times for  {}", ss.str());
           }

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -30,7 +30,7 @@ namespace autopas {
  * 1. Measuring time of the iteration.
  * 2. Selecting an appropriate configuration for the pairwise iteration.
  *
- * The tuner can be in one of two states. If it currently should look for a new optimum, it is in the 
+ * The tuner can be in one of two states. If it currently should look for a new optimum, it is in the
  * so-called tuning phase. During a tuning phase, for each Configuration, multiple measurements can be taken,
  * which are called samples. To reduce noise, the samples for one configuration are then condensed to one value for
  * the current tuning phase, called evidence. The evidences are handed on to a tuningStrategy, which selects a) what

--- a/src/autopas/selectors/Smoothing.cpp
+++ b/src/autopas/selectors/Smoothing.cpp
@@ -122,11 +122,13 @@ double calculateYFitSimple(const std::vector<std::pair<size_t, size_t>> &points,
   return yFittedI;
 }
 
-size_t autopas::smoothing::smoothLastPoint(const std::vector<std::pair<size_t, size_t>> &points, double span) {
-  if (span <= 0 or span > 1.0) {
-    throw std::runtime_error("span should be 0 < span <= 1");
+size_t autopas::smoothing::smoothLastPoint(const std::vector<std::pair<size_t, size_t>> &points,
+                                           size_t pointsPerEstimation) {
+  // if one or no points are used for smoothing do nothing
+  if (pointsPerEstimation <= 2) {
+    return points.back().second;
   }
-
+  // if there are not enough points to smooth do nothing
   if (points.size() < 2) {
     if (points.size() == 1) {
       return points[0].second;
@@ -134,8 +136,8 @@ size_t autopas::smoothing::smoothLastPoint(const std::vector<std::pair<size_t, s
     return 0;
   }
 
-  // pick at least two points and not more than total number of points
-  size_t pointsPerEstimation = std::max(static_cast<size_t>(span * points.size()), 2ul);
+  // do not try to use more points than there are.
+  pointsPerEstimation = std::min(pointsPerEstimation, points.size());
 
   // only fit last point
   size_t i = points.size() - 1;

--- a/src/autopas/selectors/Smoothing.cpp
+++ b/src/autopas/selectors/Smoothing.cpp
@@ -32,7 +32,7 @@ std::tuple<std::vector<double>, bool> calculateWeightsSimple(const std::vector<s
 
   double sumOfWeights = 0.0;
 
-  // compute all weiths that can be assumed to be non-zero
+  // compute all weighs that can be assumed to be non-zero
   for (size_t j = 0; j < weights.size(); ++j) {
     auto xj = points[j + firstIndex].first;
     // residual = |xi - xj|
@@ -116,7 +116,7 @@ double calculateYFitSimple(const std::vector<std::pair<size_t, size_t>> &points,
   return yFittedI;
 }
 
-size_t autopas::Smoothing::smoothLastPoint(const std::vector<std::pair<size_t, size_t>> &points, double span) {
+size_t autopas::smoothing::smoothLastPoint(const std::vector<std::pair<size_t, size_t>> &points, double span) {
   if (span <= 0 or span > 1.0) {
     throw std::runtime_error("span should be 0 < span <= 1");
   }

--- a/src/autopas/selectors/Smoothing.cpp
+++ b/src/autopas/selectors/Smoothing.cpp
@@ -22,6 +22,7 @@
 std::tuple<std::vector<double>, bool> calculateWeightsSimple(const std::vector<std::pair<size_t, size_t>> &points,
                                                              size_t pointsPerEstimation,
                                                              size_t maxDistFromIntervalEdge) {
+  // since we will only smooth the last point there is no outer loop and i shall be fixed
   const size_t i = points.size() - 1;
   const size_t firstIndex = i - pointsPerEstimation + 1;
   // initialize all weights with 0
@@ -85,6 +86,7 @@ std::tuple<std::vector<double>, bool> calculateWeightsSimple(const std::vector<s
  */
 double calculateYFitSimple(const std::vector<std::pair<size_t, size_t>> &points, size_t pointsPerEstimation,
                            const std::vector<double> &weights) {
+  // since we will only smooth the last point there is no outer loop and i shall be fixed
   const size_t i = points.size() - 1;
   const size_t firstIndex = i - pointsPerEstimation + 1;
   std::vector<double> projections = weights;
@@ -139,7 +141,7 @@ size_t autopas::smoothing::smoothLastPoint(const std::vector<std::pair<size_t, s
   // do not try to use more points than there are.
   pointsPerEstimation = std::min(pointsPerEstimation, points.size());
 
-  // only fit last point
+  // since we will only smooth the last point there is no outer loop and i shall be fixed
   size_t i = points.size() - 1;
   // find neighborhood
   const auto firstIndex = i - pointsPerEstimation + 1;

--- a/src/autopas/selectors/Smoothing.cpp
+++ b/src/autopas/selectors/Smoothing.cpp
@@ -29,8 +29,8 @@ std::tuple<std::vector<double>, bool> calculateWeightsSimple(const std::vector<s
 
   const auto &xi = points[i].first;
 
-  // define thresholds for shortcuts: if residuals are beyond these values the
-  // are assumed to be 0 respectively 1
+  // Define thresholds for shortcuts: If residuals are beyond these values, they
+  // are assumed to be 0, respectively 1.
   auto maxDistFromIntervalEdgeHigh = maxDistFromIntervalEdge * .999;
   auto maxDistFromIntervalEdgeLow = maxDistFromIntervalEdge * .001;
 
@@ -75,7 +75,7 @@ std::tuple<std::vector<double>, bool> calculateWeightsSimple(const std::vector<s
 /**
  * Calculates the smoothed y-value of the last point in the vector.
  * The fitted value is the sum of projections of the y-values of the neighbors in the chosen interval.
- * Each porjection is the sum of the respective weight and the residuals proportion of the weighted sum of squared
+ * Each projection is the sum of the respective weight and the proportion of the residuals of the weighted sum of squared
  * residuals.
  *
  * @param points

--- a/src/autopas/selectors/Smoothing.cpp
+++ b/src/autopas/selectors/Smoothing.cpp
@@ -1,0 +1,151 @@
+/**
+ * @file Smoothing.cpp
+ * @author F. Gratl
+ * @date 23/11/2020
+ */
+
+#include "Smoothing.h"
+
+#include "autopas/utils/Math.h"
+
+/**
+ * TODO
+ * @param points
+ * @param pointsPerEstimation
+ * @param maxDistFromIntervalEdge
+ * @return
+ */
+std::tuple<std::vector<double>, bool> calculateWeightsSimple(const std::vector<std::pair<size_t, size_t>> &points,
+                                                             size_t pointsPerEstimation,
+                                                             size_t maxDistFromIntervalEdge) {
+  const size_t i = points.size() - 1;
+  const size_t firstIndex = i - pointsPerEstimation + 1;
+  // initialize all weights with 0
+  std::vector<double> weights(pointsPerEstimation);
+
+  const auto &xi = points[i].first;
+
+  // define thresholds for shortcuts: if residuals are beyond these values the
+  // are assumed to be 0 respectively 1
+  auto maxDistFromIntervalEdgeHigh = maxDistFromIntervalEdge * .999;
+  auto maxDistFromIntervalEdgeLow = maxDistFromIntervalEdge * .001;
+
+  double sumOfWeights = 0.0;
+
+  // compute all weiths that can be assumed to be non-zero
+  for (size_t j = 0; j < weights.size(); ++j) {
+    auto xj = points[j + firstIndex].first;
+    // residual = |xi - xj|
+    size_t residual = xj > xi ? xj - xi : xi - xj;
+
+    // if x are too far apart ...
+    if (residual <= maxDistFromIntervalEdgeHigh) {
+      if (residual > maxDistFromIntervalEdgeLow) {
+        // tri-cube function
+        weights[j] = autopas::utils::Math::pow<3>(
+            1.0 - autopas::utils::Math::pow<3>(static_cast<double>(residual) / maxDistFromIntervalEdge));
+      } else {
+        weights[j] = 1.0;
+      }
+
+      sumOfWeights += weights[j];
+    } else if (xj > xi) {
+      // break because from here on weights will only be more 0
+      break;
+    }
+  }
+
+  bool fitIsOk = true;
+  if (sumOfWeights <= .0) {
+    fitIsOk = false;
+  } else {
+    // normalize weights
+    for (auto &weight : weights) {
+      weight /= sumOfWeights;
+    }
+  }
+  return std::make_tuple(weights, fitIsOk);
+}
+
+/**
+ * TODO
+ * @param points
+ * @param pointsPerEstimation
+ * @param maxDistFromIntervalEdge
+ * @param weights
+ * @return
+ */
+double calculateYFitSimple(const std::vector<std::pair<size_t, size_t>> &points, size_t pointsPerEstimation,
+                           const size_t maxDistFromIntervalEdge, const std::vector<double> &weights) {
+  const size_t i = points.size() - 1;
+  const size_t firstIndex = i - pointsPerEstimation + 1;
+  std::vector<double> projections = weights;
+
+  if (maxDistFromIntervalEdge > 0) {
+    // weighted center of x
+    // TODO: make this a size_t ?
+    double sumWeightedX = 0.;
+    for (size_t j = 0; j < weights.size(); ++j) {
+      sumWeightedX += weights[j] * points[j + firstIndex].first;
+    }
+
+    double weightedDistFromCenterXSquare = 0.;
+    for (size_t j = 0; j < weights.size(); ++j) {
+      auto deviation = points[j + firstIndex].first - sumWeightedX;
+      weightedDistFromCenterXSquare += weights[j] * deviation * deviation;
+    }
+
+    // threshold whether points are not too clumped up
+    size_t pointsRange = points.back().first - points.front().first;
+    if (weightedDistFromCenterXSquare > 1e-6 * pointsRange * pointsRange) {
+      double distIToCenter = points[i].first - sumWeightedX;
+      double distDivSqDev = distIToCenter / weightedDistFromCenterXSquare;
+
+      for (size_t j = 0; j < weights.size(); ++j) {
+        double deviation = points[j + firstIndex].first - sumWeightedX;
+        projections[j] = weights[j] * (1. + distDivSqDev * deviation);
+      }
+    }
+  }
+
+  double yFittedI = 0.;
+  for (size_t j = 0; j < projections.size(); ++j) {
+    yFittedI += projections[j] * points[j + firstIndex].second;
+  }
+
+  return yFittedI;
+}
+
+size_t autopas::Smoothing::smoothLastPoint(const std::vector<std::pair<size_t, size_t>> &points, double span) {
+  if (span <= 0 or span > 1.0) {
+    throw std::runtime_error("span should be 0 < span <= 1");
+  }
+
+  if (points.size() < 2) {
+    if (points.size() == 1) {
+      return points[0].second;
+    }
+    return 0;
+  }
+
+  // pick at least two points and not more than total number of points
+  size_t pointsPerEstimation = std::max(static_cast<size_t>(span * points.size()), 2ul);
+
+  // only fit last point
+  size_t i = points.size() - 1;
+  // find neighborhood
+  const auto firstIndex = i - pointsPerEstimation + 1;
+
+  // maxDistFromIntervalEdge = max(xi - xFirst, xLast - xi)
+  auto maxDistFromIntervalEdge = std::max(points[i].first - points[firstIndex].first, 0ul);
+
+  // Calculate weights
+  auto [weights, fitOk] = calculateWeightsSimple(points, pointsPerEstimation, maxDistFromIntervalEdge);
+
+  // either apply fit or take original datapoint
+  if (fitOk) {
+    return std::round(calculateYFitSimple(points, pointsPerEstimation, maxDistFromIntervalEdge, weights));
+  } else {
+    return points[i].second;
+  }
+}

--- a/src/autopas/selectors/Smoothing.cpp
+++ b/src/autopas/selectors/Smoothing.cpp
@@ -75,8 +75,8 @@ std::tuple<std::vector<double>, bool> calculateWeightsSimple(const std::vector<s
 /**
  * Calculates the smoothed y-value of the last point in the vector.
  * The fitted value is the sum of projections of the y-values of the neighbors in the chosen interval.
- * Each projection is the sum of the respective weight and the proportion of the residuals of the weighted sum of squared
- * residuals.
+ * Each projection is the sum of the respective weight and the proportion of the residuals of the weighted sum of
+ * squared residuals.
  *
  * @param points
  * @param pointsPerEstimation

--- a/src/autopas/selectors/Smoothing.h
+++ b/src/autopas/selectors/Smoothing.h
@@ -9,7 +9,7 @@
 #include <tuple>
 #include <vector>
 
-namespace autopas::Smoothing {
+namespace autopas::smoothing {
 
 /**
  * Calculates the smoothed y value for the last point in the given points according to the LOESS algorithm.
@@ -22,4 +22,4 @@ namespace autopas::Smoothing {
  */
 size_t smoothLastPoint(const std::vector<std::pair<size_t, size_t>> &points, double span);
 
-}  // namespace autopas::Smoothing
+}  // namespace autopas::smoothing

--- a/src/autopas/selectors/Smoothing.h
+++ b/src/autopas/selectors/Smoothing.h
@@ -17,7 +17,7 @@ namespace autopas::smoothing {
  * @note This function operates with unsigned values and does not protect against under-/overflow!
  *
  * @param points
- * @param span Fractions of points that shall be taken into account for the smoothing.
+ * @param pointsPerEstimation Number of points to take into account for smoothing.
  * @return
  */
 size_t smoothLastPoint(const std::vector<std::pair<size_t, size_t>> &points, size_t pointsPerEstimation);

--- a/src/autopas/selectors/Smoothing.h
+++ b/src/autopas/selectors/Smoothing.h
@@ -1,0 +1,25 @@
+/**
+ * @file Smoothing.h
+ * @author F. Gratl
+ * @date 23/11/2020
+ */
+
+#pragma once
+
+#include <tuple>
+#include <vector>
+
+namespace autopas::Smoothing {
+
+/**
+ * Calculates the smoothed y value for the last point in the given points according to the LOESS algorithm.
+ *
+ * @note This function operates with unsigned values and does not protect against under-/overflow!
+ *
+ * @param points
+ * @param span Fractions of points that shall be taken into account for the smoothing.
+ * @return
+ */
+size_t smoothLastPoint(const std::vector<std::pair<size_t, size_t>> &points, double span);
+
+}  // namespace autopas::Smoothing

--- a/src/autopas/selectors/Smoothing.h
+++ b/src/autopas/selectors/Smoothing.h
@@ -20,6 +20,6 @@ namespace autopas::smoothing {
  * @param span Fractions of points that shall be taken into account for the smoothing.
  * @return
  */
-size_t smoothLastPoint(const std::vector<std::pair<size_t, size_t>> &points, double span);
+size_t smoothLastPoint(const std::vector<std::pair<size_t, size_t>> &points, size_t pointsPerEstimation);
 
 }  // namespace autopas::smoothing

--- a/src/autopas/utils/Math.h
+++ b/src/autopas/utils/Math.h
@@ -17,6 +17,25 @@ namespace autopas::utils::Math {
 const double normalScale = 1. / std::sqrt(2 * M_PI);
 
 /**
+ * No-overhead power function with exponent known at compile time.
+ * @tparam exponent
+ * @tparam T
+ * @param base
+ * @return
+ */
+template <size_t exponent, class T>
+T pow(T base) {
+  if (exponent == 0) {
+    return 1;
+  }
+  // the compiler should unroll this loop
+  for (size_t i = 0; i < exponent - 1; ++i) {
+    base *= base;
+  }
+  return base;
+}
+
+/**
  * Probability density function PDF of the standard normal distribution.
  * @param x
  * @return PDF(x)

--- a/src/autopas/utils/Math.h
+++ b/src/autopas/utils/Math.h
@@ -28,11 +28,13 @@ T pow(T base) {
   if (exponent == 0) {
     return 1;
   }
+
+  T res = base;
   // the compiler should unroll this loop
   for (size_t i = 0; i < exponent - 1; ++i) {
-    base *= base;
+    res *= base;
   }
-  return base;
+  return res;
 }
 
 /**

--- a/tests/testAutopas/tests/selectors/SmoothingTest.cpp
+++ b/tests/testAutopas/tests/selectors/SmoothingTest.cpp
@@ -1,0 +1,28 @@
+/**
+ * @file SmoothingTest.cpp
+ * @author F. Gratl
+ * @date 23/11/2020
+ */
+
+#include "SmoothingTest.h"
+
+#include "autopas/selectors/Smoothing.h"
+
+TEST(SmoothingTest, lowessLastPoint) {
+  std::vector<size_t> v_xval{1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 8, 10, 12};
+  std::vector<size_t> v_yval{18, 2, 15, 6, 10, 4, 16, 11, 7, 3, 14, 17, 20, 12, 9, 13, 1, 8};
+
+  std::vector<std::pair<size_t, long>> obs;
+  obs.reserve(v_xval.size());
+  for (size_t i = 0; i < v_xval.size(); ++i) {
+    obs.emplace_back(v_xval[i], v_yval[i]);
+  }
+
+  // YS values with F = .25, NSTEPS = 0, DELTA = 0.0
+  std::cout << "THE TEST" << std::endl;
+  {
+    auto out = autopas::Smoothing::smoothLastPoint(obs, .25);
+    // out should be an integer (or long)
+    EXPECT_EQ(out, 6);
+  }
+}

--- a/tests/testAutopas/tests/selectors/SmoothingTest.cpp
+++ b/tests/testAutopas/tests/selectors/SmoothingTest.cpp
@@ -20,7 +20,7 @@ TEST(SmoothingTest, lowessLastPoint) {
 
   // YS values with F = .25, NSTEPS = 0, DELTA = 0.0
   {
-    auto out = autopas::smoothing::smoothLastPoint(obs, .25);
+    auto out = autopas::smoothing::smoothLastPoint(obs, (.25 * obs.size()));
     // out should be an integer (or long)
     EXPECT_EQ(out, 6);
   }

--- a/tests/testAutopas/tests/selectors/SmoothingTest.cpp
+++ b/tests/testAutopas/tests/selectors/SmoothingTest.cpp
@@ -21,7 +21,6 @@ TEST(SmoothingTest, lowessLastPoint) {
   // YS values with F = .25, NSTEPS = 0, DELTA = 0.0
   {
     auto out = autopas::smoothing::smoothLastPoint(obs, (.25 * obs.size()));
-    // out should be an integer (or long)
     EXPECT_EQ(out, 6);
   }
 }

--- a/tests/testAutopas/tests/selectors/SmoothingTest.cpp
+++ b/tests/testAutopas/tests/selectors/SmoothingTest.cpp
@@ -19,7 +19,6 @@ TEST(SmoothingTest, lowessLastPoint) {
   }
 
   // YS values with F = .25, NSTEPS = 0, DELTA = 0.0
-  std::cout << "THE TEST" << std::endl;
   {
     auto out = autopas::smoothing::smoothLastPoint(obs, .25);
     // out should be an integer (or long)

--- a/tests/testAutopas/tests/selectors/SmoothingTest.cpp
+++ b/tests/testAutopas/tests/selectors/SmoothingTest.cpp
@@ -9,19 +9,19 @@
 #include "autopas/selectors/Smoothing.h"
 
 TEST(SmoothingTest, lowessLastPoint) {
-  std::vector<size_t> v_xval{1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 8, 10, 12};
-  std::vector<size_t> v_yval{18, 2, 15, 6, 10, 4, 16, 11, 7, 3, 14, 17, 20, 12, 9, 13, 1, 8};
+  std::vector<size_t> xvals{1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 8, 10, 12};
+  std::vector<size_t> yvals{18, 2, 15, 6, 10, 4, 16, 11, 7, 3, 14, 17, 20, 12, 9, 13, 1, 8};
 
-  std::vector<std::pair<size_t, long>> obs;
-  obs.reserve(v_xval.size());
-  for (size_t i = 0; i < v_xval.size(); ++i) {
-    obs.emplace_back(v_xval[i], v_yval[i]);
+  std::vector<std::pair<size_t, size_t>> obs;
+  obs.reserve(xvals.size());
+  for (size_t i = 0; i < xvals.size(); ++i) {
+    obs.emplace_back(xvals[i], yvals[i]);
   }
 
   // YS values with F = .25, NSTEPS = 0, DELTA = 0.0
   std::cout << "THE TEST" << std::endl;
   {
-    auto out = autopas::Smoothing::smoothLastPoint(obs, .25);
+    auto out = autopas::smoothing::smoothLastPoint(obs, .25);
     // out should be an integer (or long)
     EXPECT_EQ(out, 6);
   }

--- a/tests/testAutopas/tests/selectors/SmoothingTest.h
+++ b/tests/testAutopas/tests/selectors/SmoothingTest.h
@@ -1,0 +1,11 @@
+/**
+ * @file SmoothingTest.h
+ * @author F. Gratl
+ * @date 23/11/2020
+ */
+
+#pragma once
+
+#include "AutoPasTestBase.h"
+
+class SmoothingTest : public AutoPasTestBase {};


### PR DESCRIPTION
# Description

- [x] implemented a smoothing algorithm (based on loess)
- [x] pass smoothed values to tuning strategies

## ~Related Pull Requests~

## ~Resolved Issues~

# How Has This Been Tested?

- [x] New tests for the smoothing algorithm
- [x] Existing tests (might change expected values for some tuning strategy tests)
- [x] Plotting values:
![Plot_SmoothVSReducedValue](https://user-images.githubusercontent.com/2656700/101520425-c5af5300-3984-11eb-8b88-6c2ade86e741.png)
The dashed line represents the "reduced values" (what we used so far), the normal line the smoothed values. We can see that due to external stress on the system the reduced values spike frantically and sometimes lead to a wrong ordering. The smoothed lines are much more robust and always stay in the same vertical order.
 Simulation parameters: 
`md-flexible --deltaT 0 --particle-generator uniform --cutoff 1 --box-length 10 --particles-total 20000 --traversal vlc_c01,lc_c08 --tuning-interval 10 --tuning-phases 100`