### PR TITLE
Build time optimizations

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -90,6 +90,7 @@ More details can be found [here](../libs/fake-dlclose/README.md).
 ### Namespaces
 * Code in folder `src` should belong to namespace `autopas`.
 * Classes which shouldn't be used externally should belong to namespace `internal`.
+* Each test should use its own namespace. This allows the tests to be included in one big `.cpp` file, which reduces compilation time.  
 
 ### Logging
 AutoPas has its own logger based on [spdlog](https://github.com/gabime/spdlog) which can be used after the initialization of an AutoPas object via:

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -9,6 +9,7 @@ extraction:
         - libssl-dev
     after_prepare:    # Customizable step used by all languages.
       # installs cmake!
+      - cmake --version
       - wget -O cmake.tar.gz https://github.com/Kitware/CMake/releases/download/v3.16.4/cmake-3.16.4.tar.gz
       - tar zxf cmake.tar.gz
       - cd cmake-*/
@@ -21,7 +22,7 @@ extraction:
       - cmake --version
     configure:
       command:
-      - mkdir build
-      - cd build
+      - mkdir _lgtm_build_dir
+      - cd _lgtm_build_dir
       # uses AUTOPAS_USE_TEST_GLOB to speed up compilation.
       - cmake -DAUTOPAS_USE_TEST_GLOB=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-fpermissive .. 

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -28,4 +28,5 @@ extraction:
       - cmake -DAUTOPAS_USE_TEST_GLOB=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DBUILD_DOCS=OFF -DCATKIN_ENABLE_TESTING=OFF -DBUILD_DOCUMENTATION=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-fpermissive ..
     index:
       build_command:
+        - cd _lgtm_build_dir
         - make -j2

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -13,7 +13,7 @@ extraction:
       - cd cmake-*/
       - mkdir build
       - cd build
-      - cmake -DCMAKE_INSTALL_PREFIX:PATH=~/.local/ -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_USE_TEST_GLOB=On ..
+      - cmake -DCMAKE_INSTALL_PREFIX:PATH=~/.local/ -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_USE_TEST_GLOB=ON ..
       - make install
       - ls ~/.local/bin
       - export PATH=~/.local/bin:$PATH

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -25,8 +25,8 @@ extraction:
       - mkdir -p _lgtm_build_dir
       - cd _lgtm_build_dir
       # uses AUTOPAS_USE_TEST_GLOB to speed up compilation.
-      - cmake -DAUTOPAS_USE_TEST_GLOB=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DBUILD_DOCS=OFF -DCATKIN_ENABLE_TESTING=OFF -DBUILD_DOCUMENTATION=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-fpermissive ..
+      - cmake -DAUTOPAS_USE_TEST_GLOB=OFF -DCMAKE_VERBOSE_MAKEFILE=ON -DBUILD_DOCS=OFF -DCATKIN_ENABLE_TESTING=OFF -DBUILD_DOCUMENTATION=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-fpermissive ..
     index:
       build_command:
         - cd _lgtm_build_dir
-        - make -j2
+        - make -j4

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -13,7 +13,7 @@ extraction:
       - cd cmake-*/
       - mkdir build
       - cd build
-      - cmake -DCMAKE_INSTALL_PREFIX:PATH=~/.local/ -DCMAKE_BUILD_TYPE=Release ..
+      - cmake -DCMAKE_INSTALL_PREFIX:PATH=~/.local/ -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_USE_TEST_GLOB=On ..
       - make install
       - ls ~/.local/bin
       - export PATH=~/.local/bin:$PATH

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -25,7 +25,7 @@ extraction:
       - mkdir -p _lgtm_build_dir
       - cd _lgtm_build_dir
       # uses AUTOPAS_USE_TEST_GLOB to speed up compilation.
-      - cmake -DAUTOPAS_USE_TEST_GLOB=OFF -DCMAKE_VERBOSE_MAKEFILE=ON -DBUILD_DOCS=OFF -DCATKIN_ENABLE_TESTING=OFF -DBUILD_DOCUMENTATION=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-fpermissive ..
+      - CC=clang CXX=clang++ cmake -DAUTOPAS_USE_TEST_GLOB=OFF -DCMAKE_VERBOSE_MAKEFILE=ON -DBUILD_DOCS=OFF -DCATKIN_ENABLE_TESTING=OFF -DBUILD_DOCUMENTATION=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-fpermissive ..
     index:
       build_command:
         - cd _lgtm_build_dir

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -22,7 +22,7 @@ extraction:
       - cmake --version
     configure:
       command:
-      - mkdir _lgtm_build_dir
+      - mkdir -p _lgtm_build_dir
       - cd _lgtm_build_dir
       # uses AUTOPAS_USE_TEST_GLOB to speed up compilation.
-      - cmake -DAUTOPAS_USE_TEST_GLOB=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-fpermissive .. 
+      - cmake -DAUTOPAS_USE_TEST_GLOB=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DBUILD_DOCS=OFF -DCATKIN_ENABLE_TESTING=OFF -DBUILD_DOCUMENTATION=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-fpermissive ..

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -29,4 +29,4 @@ extraction:
     index:
       build_command:
         - cd _lgtm_build_dir
-        - make -j 1
+        - make -j 4

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -25,8 +25,8 @@ extraction:
       - mkdir -p _lgtm_build_dir
       - cd _lgtm_build_dir
       # uses AUTOPAS_USE_TEST_GLOB to speed up compilation.
-      - CC=clang CXX=clang++ cmake -DAUTOPAS_USE_TEST_GLOB=OFF -DCMAKE_VERBOSE_MAKEFILE=ON -DBUILD_DOCS=OFF -DCATKIN_ENABLE_TESTING=OFF -DBUILD_DOCUMENTATION=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-fpermissive ..
+      - CC=clang CXX=clang++ cmake -DAUTOPAS_BUILD_EXAMPLES=OFF -DAUTOPAS_USE_TEST_GLOB=OFF -DCMAKE_VERBOSE_MAKEFILE=ON -DBUILD_DOCS=OFF -DCATKIN_ENABLE_TESTING=OFF -DBUILD_DOCUMENTATION=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-fpermissive ..
     index:
       build_command:
         - cd _lgtm_build_dir
-        - make -j 4
+        - make -j 2

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -29,4 +29,4 @@ extraction:
     index:
       build_command:
         - cd _lgtm_build_dir
-        - make
+        - make -j 2

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -8,13 +8,20 @@ extraction:
         - cmake
         - libssl-dev
     after_prepare:    # Customizable step used by all languages.
+      # installs cmake!
       - wget -O cmake.tar.gz https://github.com/Kitware/CMake/releases/download/v3.16.4/cmake-3.16.4.tar.gz
       - tar zxf cmake.tar.gz
       - cd cmake-*/
       - mkdir build
       - cd build
-      - cmake -DCMAKE_INSTALL_PREFIX:PATH=~/.local/ -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_USE_TEST_GLOB=ON ..
+      - cmake -DCMAKE_INSTALL_PREFIX:PATH=~/.local/ -DCMAKE_BUILD_TYPE=Release ..
       - make install
       - ls ~/.local/bin
-      - export PATH=~/.local/bin:$PATH
+      - export PATH=~/.local/bin:$PATH   # env variables are propagated, so this is visible in the configure step!
       - cmake --version
+    configure:
+      command:
+      - mkdir build
+      - cd build
+      # uses AUTOPAS_USE_TEST_GLOB to speed up compilation.
+      - cmake -DAUTOPAS_USE_TEST_GLOB=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-fpermissive .. 

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -26,3 +26,6 @@ extraction:
       - cd _lgtm_build_dir
       # uses AUTOPAS_USE_TEST_GLOB to speed up compilation.
       - cmake -DAUTOPAS_USE_TEST_GLOB=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DBUILD_DOCS=OFF -DCATKIN_ENABLE_TESTING=OFF -DBUILD_DOCUMENTATION=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-fpermissive ..
+    index:
+      build_command:
+        - make -j2

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -29,4 +29,4 @@ extraction:
     index:
       build_command:
         - cd _lgtm_build_dir
-        - make -j 2
+        - make -j 1

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -29,4 +29,4 @@ extraction:
     index:
       build_command:
         - cd _lgtm_build_dir
-        - make -j4
+        - make

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -184,29 +184,6 @@ pipeline {
                         }
                     }
                 }
-                stage("address sanitizer") {
-                    steps {
-                        container('autopas-gcc7-cmake-make') {
-                            dir("build-addresssanitizer") {
-                                // -DAUTOPAS_USE_TEST_GLOB=ON fails with internal compiler error...
-                                sh "cmake -DAUTOPAS_USE_TEST_GLOB=OFF -DCCACHE=ON -DCMAKE_BUILD_TYPE=Debug -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
-                                sh "entrypoint.sh make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
-                                sh './tests/testAutopas/runTests'
-                            }
-                        }
-                    }
-                }
-                stage("address sanitizer release") {
-                    steps {
-                        container('autopas-gcc7-cmake-make') {
-                            dir("build-addresssanitizer-release") {
-                                sh "cmake -DAUTOPAS_USE_TEST_GLOB=ON -DCCACHE=ON -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
-                                sh "entrypoint.sh make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
-                                sh './tests/testAutopas/runTests'
-                            }
-                        }
-                    }
-                }
                 stage("clang openmp") {
                     steps {
                         container('autopas-clang6-cmake-ninja-make') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,7 +104,7 @@ pipeline {
                     steps {
                         container('cuda-10') {
                             dir("build-cuda") {
-                                sh "cmake -DAUTOPAS_USE_TEST_GLOB=On -DAUTOPAS_ENABLE_CUDA=ON -DCCACHE=ON .."
+                                sh "cmake -DAUTOPAS_USE_TEST_GLOB=ON -DAUTOPAS_ENABLE_CUDA=ON -DCCACHE=ON .."
                                 sh "entrypoint.sh make -j 4 > buildlog-cuda.txt 2>&1 || (cat buildlog-cuda.txt && exit 1)"
                                 sh "./tests/testAutopas/runTests"
                             }
@@ -124,7 +124,7 @@ pipeline {
                     steps {
                         container('cuda-10') {
                             dir("build-cuda") {
-                                sh "CC=clang CXX=clang++ cmake -DAUTOPAS_USE_TEST_GLOB=On -DCCACHE=ON -DAUTOPAS_ENABLE_CUDA=ON .."
+                                sh "CC=clang CXX=clang++ cmake -DAUTOPAS_USE_TEST_GLOB=ON -DCCACHE=ON -DAUTOPAS_ENABLE_CUDA=ON .."
                                 sh "entrypoint.sh make -j 4 > buildlog-cuda-clang.txt 2>&1 || (cat buildlog-cuda-clang.txt && exit 1)"
                                 sh "./tests/testAutopas/runTests"
                                 // cuda variants of valgrind:
@@ -149,7 +149,7 @@ pipeline {
                     steps {
                         container('autopas-gcc7-cmake-make') {
                             dir("build") {
-                                sh "cmake -DAUTOPAS_USE_TEST_GLOB=On -DCCACHE=ON .."
+                                sh "cmake -DAUTOPAS_USE_TEST_GLOB=ON -DCCACHE=ON .."
                                 sh "entrypoint.sh make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
                                 sh 'env GTEST_OUTPUT="xml:$(pwd)/test.xml" ./tests/testAutopas/runTests'
                             }
@@ -163,7 +163,7 @@ pipeline {
                     steps {
                         container('autopas-gcc7-cmake-make') {
                             dir("build-openmp") {
-                                sh "cmake -DAUTOPAS_USE_TEST_GLOB=On -DCCACHE=ON -DAUTOPAS_OPENMP=ON .."
+                                sh "cmake -DAUTOPAS_USE_TEST_GLOB=ON -DCCACHE=ON -DAUTOPAS_OPENMP=ON .."
                                 sh "entrypoint.sh make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
                                 sh './tests/testAutopas/runTests'
                             }
@@ -177,7 +177,7 @@ pipeline {
                     steps {
                         container('autopas-gcc7-cmake-make') {
                             dir("build-openmp-address-sanitizer") {
-                                sh "cmake -DAUTOPAS_USE_TEST_GLOB=On -DCCACHE=ON -DAUTOPAS_OPENMP=ON -DCMAKE_BUILD_TYPE=Debug -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
+                                sh "cmake -DAUTOPAS_USE_TEST_GLOB=ON -DCCACHE=ON -DAUTOPAS_OPENMP=ON -DCMAKE_BUILD_TYPE=Debug -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
                                 sh "entrypoint.sh make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
                                 sh './tests/testAutopas/runTests'
                             }
@@ -188,7 +188,7 @@ pipeline {
                     steps {
                         container('autopas-gcc7-cmake-make') {
                             dir("build-addresssanitizer") {
-                                sh "cmake -DAUTOPAS_USE_TEST_GLOB=On -DCCACHE=ON -DCMAKE_BUILD_TYPE=Debug -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
+                                sh "cmake -DAUTOPAS_USE_TEST_GLOB=ON -DCCACHE=ON -DCMAKE_BUILD_TYPE=Debug -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
                                 sh "entrypoint.sh make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
                                 sh './tests/testAutopas/runTests'
                             }
@@ -199,7 +199,7 @@ pipeline {
                     steps {
                         container('autopas-gcc7-cmake-make') {
                             dir("build-addresssanitizer-release") {
-                                sh "cmake -DAUTOPAS_USE_TEST_GLOB=On -DCCACHE=ON -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
+                                sh "cmake -DAUTOPAS_USE_TEST_GLOB=ON -DCCACHE=ON -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
                                 sh "entrypoint.sh make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
                                 sh './tests/testAutopas/runTests'
                             }
@@ -210,7 +210,7 @@ pipeline {
                     steps {
                         container('autopas-clang6-cmake-ninja-make') {
                             dir("build-clang-ninja-openmp") {
-                                sh "CC=clang CXX=clang++ cmake -G Ninja -DAUTOPAS_USE_TEST_GLOB=On -DCCACHE=ON -DAUTOPAS_OPENMP=ON .."
+                                sh "CC=clang CXX=clang++ cmake -G Ninja -DAUTOPAS_USE_TEST_GLOB=ON -DCCACHE=ON -DAUTOPAS_OPENMP=ON .."
                                 sh "entrypoint.sh ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
                                 sh './tests/testAutopas/runTests'
                             }
@@ -224,7 +224,7 @@ pipeline {
                     steps {
                         container('autopas-clang6-cmake-ninja-make') {
                             dir("build-clang-ninja-addresssanitizer-debug") {
-                                sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DAUTOPAS_USE_TEST_GLOB=On -DCCACHE=ON -DCMAKE_BUILD_TYPE=Debug -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
+                                sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DAUTOPAS_USE_TEST_GLOB=ON -DCCACHE=ON -DCMAKE_BUILD_TYPE=Debug -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
                                 sh "entrypoint.sh ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
                                 sh './tests/testAutopas/runTests'
                             }
@@ -235,7 +235,7 @@ pipeline {
                     steps {
                         container('autopas-clang6-cmake-ninja-make') {
                             dir("build-clang-ninja-addresssanitizer-release") {
-                                sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DAUTOPAS_USE_TEST_GLOB=On -DCCACHE=ON -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
+                                sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DAUTOPAS_USE_TEST_GLOB=ON -DCCACHE=ON -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
                                 sh "entrypoint.sh ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
                                 sh './tests/testAutopas/runTests'
                             }
@@ -249,7 +249,7 @@ pipeline {
                     steps {
                         container('autopas-llvm-archer') {
                             dir("build-archer") {
-                                sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DAUTOPAS_USE_TEST_GLOB=On -DAUTOPAS_ENABLE_THREAD_SANITIZER=ON -DAUTOPAS_OPENMP=ON -DCCACHE=ON -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_USE_VECTORIZATION=OFF .."
+                                sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DAUTOPAS_USE_TEST_GLOB=ON -DAUTOPAS_ENABLE_THREAD_SANITIZER=ON -DAUTOPAS_OPENMP=ON -DCCACHE=ON -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_USE_VECTORIZATION=OFF .."
                                 sh 'export TSAN_OPTIONS="ignore_noninstrumented_modules=1" && entrypoint.sh ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)'
                                 sh 'export TSAN_OPTIONS="ignore_noninstrumented_modules=1" && ctest --verbose -j8'
                             }
@@ -274,7 +274,7 @@ pipeline {
                 // generate coverage
                 dir("coverage") {
                     container('autopas-build-code-coverage') {
-                        sh "cmake -DAUTOPAS_USE_TEST_GLOB=On -DAUTOPAS_CODE_COVERAGE=ON -DCCACHE=ON -DCMAKE_BUILD_TYPE=Debug .."
+                        sh "cmake -DAUTOPAS_USE_TEST_GLOB=ON -DAUTOPAS_CODE_COVERAGE=ON -DCCACHE=ON -DCMAKE_BUILD_TYPE=Debug .."
                         sh "entrypoint.sh make AutoPas_cobertura -j 4"
                     }
                     cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: 'coverage.xml', conditionalCoverageTargets: '70, 0, 0', failUnhealthy: false, failUnstable: false, lineCoverageTargets: '80, 0, 0', maxNumberOfBuilds: 0, methodCoverageTargets: '80, 0, 0', onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -188,7 +188,8 @@ pipeline {
                     steps {
                         container('autopas-gcc7-cmake-make') {
                             dir("build-addresssanitizer") {
-                                sh "cmake -DAUTOPAS_USE_TEST_GLOB=ON -DCCACHE=ON -DCMAKE_BUILD_TYPE=Debug -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
+                                // -DAUTOPAS_USE_TEST_GLOB=ON fails with internal compiler error...
+                                sh "cmake -DAUTOPAS_USE_TEST_GLOB=OFF -DCCACHE=ON -DCMAKE_BUILD_TYPE=Debug -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
                                 sh "entrypoint.sh make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
                                 sh './tests/testAutopas/runTests'
                             }
@@ -249,7 +250,8 @@ pipeline {
                     steps {
                         container('autopas-llvm-archer') {
                             dir("build-archer") {
-                                sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DAUTOPAS_USE_TEST_GLOB=ON -DAUTOPAS_ENABLE_THREAD_SANITIZER=ON -DAUTOPAS_OPENMP=ON -DCCACHE=ON -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_USE_VECTORIZATION=OFF .."
+                                // -DAUTOPAS_USE_TEST_GLOB=ON fails with internal compiler error...
+                                sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DAUTOPAS_USE_TEST_GLOB=OFF -DAUTOPAS_ENABLE_THREAD_SANITIZER=ON -DAUTOPAS_OPENMP=ON -DCCACHE=ON -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_USE_VECTORIZATION=OFF .."
                                 sh 'export TSAN_OPTIONS="ignore_noninstrumented_modules=1" && entrypoint.sh ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)'
                                 sh 'export TSAN_OPTIONS="ignore_noninstrumented_modules=1" && ctest --verbose -j8'
                             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,7 +104,7 @@ pipeline {
                     steps {
                         container('cuda-10') {
                             dir("build-cuda") {
-                                sh "cmake -DAUTOPAS_ENABLE_CUDA=ON -DCCACHE=ON .."
+                                sh "cmake -DAUTOPAS_USE_TEST_GLOB=On -DAUTOPAS_ENABLE_CUDA=ON -DCCACHE=ON .."
                                 sh "entrypoint.sh make -j 4 > buildlog-cuda.txt 2>&1 || (cat buildlog-cuda.txt && exit 1)"
                                 sh "./tests/testAutopas/runTests"
                             }
@@ -124,7 +124,7 @@ pipeline {
                     steps {
                         container('cuda-10') {
                             dir("build-cuda") {
-                                sh "CC=clang CXX=clang++ cmake -DCCACHE=ON -DAUTOPAS_ENABLE_CUDA=ON .."
+                                sh "CC=clang CXX=clang++ cmake -DAUTOPAS_USE_TEST_GLOB=On -DCCACHE=ON -DAUTOPAS_ENABLE_CUDA=ON .."
                                 sh "entrypoint.sh make -j 4 > buildlog-cuda-clang.txt 2>&1 || (cat buildlog-cuda-clang.txt && exit 1)"
                                 sh "./tests/testAutopas/runTests"
                                 // cuda variants of valgrind:
@@ -149,7 +149,7 @@ pipeline {
                     steps {
                         container('autopas-gcc7-cmake-make') {
                             dir("build") {
-                                sh "cmake -DCCACHE=ON .."
+                                sh "cmake -DAUTOPAS_USE_TEST_GLOB=On -DCCACHE=ON .."
                                 sh "entrypoint.sh make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
                                 sh 'env GTEST_OUTPUT="xml:$(pwd)/test.xml" ./tests/testAutopas/runTests'
                             }
@@ -163,7 +163,7 @@ pipeline {
                     steps {
                         container('autopas-gcc7-cmake-make') {
                             dir("build-openmp") {
-                                sh "cmake -DCCACHE=ON -DAUTOPAS_OPENMP=ON .."
+                                sh "cmake -DAUTOPAS_USE_TEST_GLOB=On -DCCACHE=ON -DAUTOPAS_OPENMP=ON .."
                                 sh "entrypoint.sh make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
                                 sh './tests/testAutopas/runTests'
                             }
@@ -177,7 +177,7 @@ pipeline {
                     steps {
                         container('autopas-gcc7-cmake-make') {
                             dir("build-openmp-address-sanitizer") {
-                                sh "cmake -DCCACHE=ON -DAUTOPAS_OPENMP=ON -DCMAKE_BUILD_TYPE=Debug -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
+                                sh "cmake -DAUTOPAS_USE_TEST_GLOB=On -DCCACHE=ON -DAUTOPAS_OPENMP=ON -DCMAKE_BUILD_TYPE=Debug -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
                                 sh "entrypoint.sh make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
                                 sh './tests/testAutopas/runTests'
                             }
@@ -188,7 +188,7 @@ pipeline {
                     steps {
                         container('autopas-gcc7-cmake-make') {
                             dir("build-addresssanitizer") {
-                                sh "cmake -DCCACHE=ON -DCMAKE_BUILD_TYPE=Debug -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
+                                sh "cmake -DAUTOPAS_USE_TEST_GLOB=On -DCCACHE=ON -DCMAKE_BUILD_TYPE=Debug -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
                                 sh "entrypoint.sh make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
                                 sh './tests/testAutopas/runTests'
                             }
@@ -199,7 +199,7 @@ pipeline {
                     steps {
                         container('autopas-gcc7-cmake-make') {
                             dir("build-addresssanitizer-release") {
-                                sh "cmake -DCCACHE=ON -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
+                                sh "cmake -DAUTOPAS_USE_TEST_GLOB=On -DCCACHE=ON -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
                                 sh "entrypoint.sh make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
                                 sh './tests/testAutopas/runTests'
                             }
@@ -210,7 +210,7 @@ pipeline {
                     steps {
                         container('autopas-clang6-cmake-ninja-make') {
                             dir("build-clang-ninja-openmp") {
-                                sh "CC=clang CXX=clang++ cmake -G Ninja -DCCACHE=ON -DAUTOPAS_OPENMP=ON .."
+                                sh "CC=clang CXX=clang++ cmake -G Ninja -DAUTOPAS_USE_TEST_GLOB=On -DCCACHE=ON -DAUTOPAS_OPENMP=ON .."
                                 sh "entrypoint.sh ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
                                 sh './tests/testAutopas/runTests'
                             }
@@ -224,7 +224,7 @@ pipeline {
                     steps {
                         container('autopas-clang6-cmake-ninja-make') {
                             dir("build-clang-ninja-addresssanitizer-debug") {
-                                sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DCCACHE=ON -DCMAKE_BUILD_TYPE=Debug -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
+                                sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DAUTOPAS_USE_TEST_GLOB=On -DCCACHE=ON -DCMAKE_BUILD_TYPE=Debug -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
                                 sh "entrypoint.sh ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
                                 sh './tests/testAutopas/runTests'
                             }
@@ -235,7 +235,7 @@ pipeline {
                     steps {
                         container('autopas-clang6-cmake-ninja-make') {
                             dir("build-clang-ninja-addresssanitizer-release") {
-                                sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DCCACHE=ON -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
+                                sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DAUTOPAS_USE_TEST_GLOB=On -DCCACHE=ON -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
                                 sh "entrypoint.sh ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
                                 sh './tests/testAutopas/runTests'
                             }
@@ -249,7 +249,7 @@ pipeline {
                     steps {
                         container('autopas-llvm-archer') {
                             dir("build-archer") {
-                                sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DAUTOPAS_ENABLE_THREAD_SANITIZER=ON -DAUTOPAS_OPENMP=ON -DCCACHE=ON -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_USE_VECTORIZATION=OFF .."
+                                sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DAUTOPAS_USE_TEST_GLOB=On -DAUTOPAS_ENABLE_THREAD_SANITIZER=ON -DAUTOPAS_OPENMP=ON -DCCACHE=ON -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_USE_VECTORIZATION=OFF .."
                                 sh 'export TSAN_OPTIONS="ignore_noninstrumented_modules=1" && entrypoint.sh ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)'
                                 sh 'export TSAN_OPTIONS="ignore_noninstrumented_modules=1" && ctest --verbose -j8'
                             }
@@ -274,7 +274,7 @@ pipeline {
                 // generate coverage
                 dir("coverage") {
                     container('autopas-build-code-coverage') {
-                        sh "cmake -DAUTOPAS_CODE_COVERAGE=ON -DCCACHE=ON -DCMAKE_BUILD_TYPE=Debug .."
+                        sh "cmake -DAUTOPAS_USE_TEST_GLOB=On -DAUTOPAS_CODE_COVERAGE=ON -DCCACHE=ON -DCMAKE_BUILD_TYPE=Debug .."
                         sh "entrypoint.sh make AutoPas_cobertura -j 4"
                     }
                     cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: 'coverage.xml', conditionalCoverageTargets: '70, 0, 0', failUnhealthy: false, failUnstable: false, lineCoverageTargets: '80, 0, 0', maxNumberOfBuilds: 0, methodCoverageTargets: '80, 0, 0', onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false

--- a/tests/testAutopas/CMakeLists.txt
+++ b/tests/testAutopas/CMakeLists.txt
@@ -16,12 +16,23 @@ endif ()
 option(AUTOPAS_USE_TEST_GLOB "Testing: Use one cpp file that includes all other cpp files. Reduces the amount of needed template instantiations." OFF)
 
 if(AUTOPAS_USE_TEST_GLOB)
+    # Create new list.
     set(NEW_LIST ${MY_SRC})
+
+    # Prepend each element of the list with '#include "' and append '"\n'.
+    # This will generate an include directive for each file.
     list(TRANSFORM NEW_LIST PREPEND "#include \"")
     list(TRANSFORM NEW_LIST APPEND "\"\n")
+
+    # Create a variable that holds the test file name.
+
     set(AUTOPAS_TEST_FILES ${CMAKE_CURRENT_BINARY_DIR}/test_glob.cpp)
+
+    # Write the content of NEW_LIST to the file.
+    # The content contains includes to each entry of MY_SRC.
     file(WRITE ${AUTOPAS_TEST_FILES} ${NEW_LIST})
 else()
+    # If we do not use one global file, we define AUTOPAS_TEST_FILES as the normal sources.
     set(AUTOPAS_TEST_FILES ${MY_SRC})
 endif()
 

--- a/tests/testAutopas/CMakeLists.txt
+++ b/tests/testAutopas/CMakeLists.txt
@@ -13,7 +13,7 @@ if (AUTOPAS_ENABLE_CUDA)
     )
 endif ()
 
-option(AUTOPAS_USE_TEST_GLOB "Testing: Use one cpp file that includes all other cpp files. Reduces the amount of needed template instantiations." ON)
+option(AUTOPAS_USE_TEST_GLOB "Testing: Use one cpp file that includes all other cpp files. Reduces the amount of needed template instantiations." OFF)
 
 if(AUTOPAS_USE_TEST_GLOB)
     set(NEW_LIST ${MY_SRC})

--- a/tests/testAutopas/CMakeLists.txt
+++ b/tests/testAutopas/CMakeLists.txt
@@ -13,7 +13,19 @@ if (AUTOPAS_ENABLE_CUDA)
     )
 endif ()
 
-add_executable(runTests $<$<BOOL:${AUTOPAS_ENABLE_CUDA}>:${CU_SRC}> ${MY_SRC})
+option(AUTOPAS_USE_TEST_GLOB "Testing: Use one cpp file that includes all other cpp files. Reduces the amount of needed template instantiations." ON)
+
+if(AUTOPAS_USE_TEST_GLOB)
+    set(NEW_LIST ${MY_SRC})
+    list(TRANSFORM NEW_LIST PREPEND "#include \"")
+    list(TRANSFORM NEW_LIST APPEND "\"\n")
+    set(AUTOPAS_TEST_FILES ${CMAKE_CURRENT_BINARY_DIR}/test_glob.cpp)
+    file(WRITE ${AUTOPAS_TEST_FILES} ${NEW_LIST})
+else()
+    set(AUTOPAS_TEST_FILES ${MY_SRC})
+endif()
+
+add_executable(runTests $<$<BOOL:${AUTOPAS_ENABLE_CUDA}>:${CU_SRC}> ${AUTOPAS_TEST_FILES})
 
 target_compile_definitions(runTests PRIVATE)
 

--- a/tests/testAutopas/addNameSpace.sh
+++ b/tests/testAutopas/addNameSpace.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# This script adds a namespace to the specified file. The name of the namespace is the name of the file without the extension.
+# It will add an opening `namespace namespacename {` after the last include.
+# The namespace is closed by adding a line at the end of the file.
+
 f=$1
 
 namespace=$(basename $f)
@@ -10,5 +14,5 @@ echo "namespace $namespace {" >> tempfile
 let line++
 tail --lines=+$line $f >> tempfile
 echo "" >> tempfile
-echo "} // end namespace $namespace" >> tempfile
+echo "}  // end namespace $namespace" >> tempfile
 mv tempfile $f

--- a/tests/testAutopas/addNameSpace.sh
+++ b/tests/testAutopas/addNameSpace.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+f=$1
+
+namespace=$(basename $f)
+namespace="${namespace%.*}"
+line=`grep -n '^#include' $f | tail -1 | cut -f1 -d:`
+head -$line $f > tempfile
+echo "" >> tempfile
+echo "namespace $namespace {" >> tempfile
+let line++
+tail --lines=+$line $f >> tempfile
+echo "" >> tempfile
+echo "} // end namespace $namespace" >> tempfile
+mv tempfile $f

--- a/tests/testAutopas/tests/ArcherShouldReportThis.cpp
+++ b/tests/testAutopas/tests/ArcherShouldReportThis.cpp
@@ -6,7 +6,9 @@
 
 #include <gtest/gtest.h>
 
-#define N 100
+namespace ArcherShouldReportThis {
+
+constexpr size_t N = 100;
 
 // this test is here just to test if archer is working.
 // and is thus currently disabled.
@@ -25,3 +27,4 @@ TEST(DISABLED_ArcherShouldReportThis, test) {
   std::cout << "a[80]" << a[80] << std::endl;
 }
 #endif
+} // end namespace ArcherShouldReportThis

--- a/tests/testAutopas/tests/ArcherShouldReportThis.cpp
+++ b/tests/testAutopas/tests/ArcherShouldReportThis.cpp
@@ -27,4 +27,4 @@ TEST(DISABLED_ArcherShouldReportThis, test) {
   std::cout << "a[80]" << a[80] << std::endl;
 }
 #endif
-} // end namespace ArcherShouldReportThis
+}  // end namespace ArcherShouldReportThis

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
@@ -557,4 +557,4 @@ INSTANTIATE_TEST_SUITE_P(Generated, AutoPasInterface2ContainersTest,
                          Combine(ValuesIn(getTestableContainerOptions()), ValuesIn(getTestableContainerOptions())),
                          AutoPasInterface2ContainersTest::PrintToStringParamName());
 
-} // end namespace AutoPasInterfaceTest
+}  // end namespace AutoPasInterfaceTest

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
@@ -10,6 +10,8 @@
 #include "autopas/molecularDynamics/LJFunctor.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace AutoPasInterfaceTest {
+
 constexpr double cutoff = 1.1;
 constexpr double skin = 0.2;
 constexpr std::array<double, 3> boxMin{0., 0., 0.};
@@ -554,3 +556,5 @@ static inline auto getTestableContainerOptions() {
 INSTANTIATE_TEST_SUITE_P(Generated, AutoPasInterface2ContainersTest,
                          Combine(ValuesIn(getTestableContainerOptions()), ValuesIn(getTestableContainerOptions())),
                          AutoPasInterface2ContainersTest::PrintToStringParamName());
+
+} // end namespace AutoPasInterfaceTest

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.h
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.h
@@ -55,4 +55,4 @@ class AutoPasInterface2ContainersTest
   };
 };
 
-} // end namespace AutoPasInterfaceTest
+}  // end namespace AutoPasInterfaceTest

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.h
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.h
@@ -12,6 +12,8 @@
 
 #include "autopas/AutoPas.h"
 
+namespace AutoPasInterfaceTest {
+
 using testingTuple =
     std::tuple<std::tuple<autopas::ContainerOption, autopas::TraversalOption, autopas::LoadEstimatorOption>,
                autopas::DataLayoutOption, autopas::Newton3Option, double /*cell size factor*/>;
@@ -52,3 +54,5 @@ class AutoPasInterface2ContainersTest
     }
   };
 };
+
+} // end namespace AutoPasInterfaceTest

--- a/tests/testAutopas/tests/autopasInterface/AutoPasTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasTest.cpp
@@ -8,6 +8,8 @@
 
 #include "testingHelpers/commonTypedefs.h"
 
+namespace AutoPasTest {
+
 using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::Return;
@@ -248,3 +250,4 @@ TEST_F(AutoPasTest, getNumParticlesIteratorTest) {
     expectedParticles(numParticles, 0);
   }
 }
+} // end namespace AutoPasTest

--- a/tests/testAutopas/tests/autopasInterface/AutoPasTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasTest.cpp
@@ -250,4 +250,4 @@ TEST_F(AutoPasTest, getNumParticlesIteratorTest) {
     expectedParticles(numParticles, 0);
   }
 }
-} // end namespace AutoPasTest
+}  // end namespace AutoPasTest

--- a/tests/testAutopas/tests/autopasInterface/AutoPasTest.h
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasTest.h
@@ -11,6 +11,8 @@
 #include "autopas/AutoPas.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace AutoPasTest {
+
 class AutoPasTest : public testing::Test {
  public:
   AutoPasTest() {
@@ -25,3 +27,5 @@ class AutoPasTest : public testing::Test {
 
   autopas::AutoPas<Particle> autoPas;
 };
+
+} // end namespace AutoPasTest

--- a/tests/testAutopas/tests/autopasInterface/AutoPasTest.h
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasTest.h
@@ -28,4 +28,4 @@ class AutoPasTest : public testing::Test {
   autopas::AutoPas<Particle> autoPas;
 };
 
-} // end namespace AutoPasTest
+}  // end namespace AutoPasTest

--- a/tests/testAutopas/tests/autopasInterface/DifferentParticlesTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/DifferentParticlesTest.cpp
@@ -25,4 +25,4 @@ TEST_F(DifferentParticlesTest, testNonConstructibleParticle) {
   EXPECT_CALL(functor, isRelevantForTuning()).WillRepeatedly(::testing::Return(false));
   autoPas.iteratePairwise(&functor);
 }
-} // end namespace DifferentParticlesTest
+}  // end namespace DifferentParticlesTest

--- a/tests/testAutopas/tests/autopasInterface/DifferentParticlesTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/DifferentParticlesTest.cpp
@@ -10,6 +10,8 @@
 #include "testingHelpers/NonConstructibleParticle.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace DifferentParticlesTest {
+
 /**
  * Tests if AutoPas still compiles with a Particle that implements the normal interface, BUT no constructor.
  */
@@ -23,3 +25,4 @@ TEST_F(DifferentParticlesTest, testNonConstructibleParticle) {
   EXPECT_CALL(functor, isRelevantForTuning()).WillRepeatedly(::testing::Return(false));
   autoPas.iteratePairwise(&functor);
 }
+} // end namespace DifferentParticlesTest

--- a/tests/testAutopas/tests/autopasInterface/DifferentParticlesTest.h
+++ b/tests/testAutopas/tests/autopasInterface/DifferentParticlesTest.h
@@ -8,4 +8,8 @@
 
 #include <gtest/gtest.h>
 
+namespace DifferentParticlesTest {
+
 class DifferentParticlesTest : public testing::Test {};
+
+} // end namespace DifferentParticlesTest

--- a/tests/testAutopas/tests/autopasInterface/DifferentParticlesTest.h
+++ b/tests/testAutopas/tests/autopasInterface/DifferentParticlesTest.h
@@ -12,4 +12,4 @@ namespace DifferentParticlesTest {
 
 class DifferentParticlesTest : public testing::Test {};
 
-} // end namespace DifferentParticlesTest
+}  // end namespace DifferentParticlesTest

--- a/tests/testAutopas/tests/autopasInterface/IteratorTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/IteratorTest.cpp
@@ -11,6 +11,8 @@
 #include "testingHelpers/TouchableParticle.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace IteratorTest {
+
 constexpr double cutoff = 1.;
 constexpr double skin = 0.2;
 constexpr std::array<double, 3> boxMin{0., 0., 0.};
@@ -572,3 +574,5 @@ INSTANTIATE_TEST_SUITE_P(Generated, IteratorTest,
                          Combine(ValuesIn(getTestableContainerOptions()), Values(0.5, 1., 1.5), Values(true, false),
                                  Values(true, false)),
                          IteratorTest::PrintToStringParamName());
+
+} // end namespace IteratorTest

--- a/tests/testAutopas/tests/autopasInterface/IteratorTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/IteratorTest.cpp
@@ -575,4 +575,4 @@ INSTANTIATE_TEST_SUITE_P(Generated, IteratorTest,
                                  Values(true, false)),
                          IteratorTest::PrintToStringParamName());
 
-} // end namespace IteratorTest
+}  // end namespace IteratorTest

--- a/tests/testAutopas/tests/autopasInterface/IteratorTest.h
+++ b/tests/testAutopas/tests/autopasInterface/IteratorTest.h
@@ -12,6 +12,8 @@
 
 #include "autopas/AutoPas.h"
 
+namespace IteratorTest {
+
 using testingTuple = std::tuple<autopas::ContainerOption, double /*cell size factor*/, bool /*testConstIterators*/,
                                 bool /*priorForceCalc*/>;
 
@@ -36,3 +38,4 @@ class IteratorTest : public testing::Test, public ::testing::WithParamInterface<
   static void testOpenMPIterators(autopas::ContainerOption containerOption, double cellSizeFactor,
                                   autopas::IteratorBehavior behavior, bool testRegionIterators, bool priorForceCalc);
 };
+} // end namespace IteratorTest

--- a/tests/testAutopas/tests/autopasInterface/IteratorTest.h
+++ b/tests/testAutopas/tests/autopasInterface/IteratorTest.h
@@ -38,4 +38,4 @@ class IteratorTest : public testing::Test, public ::testing::WithParamInterface<
   static void testOpenMPIterators(autopas::ContainerOption containerOption, double cellSizeFactor,
                                   autopas::IteratorBehavior behavior, bool testRegionIterators, bool priorForceCalc);
 };
-} // end namespace IteratorTest
+}  // end namespace IteratorTest

--- a/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
@@ -218,4 +218,4 @@ std::pair<size_t, size_t> Newton3OnOffTest::eval(autopas::DataLayoutOption dataL
   return std::make_pair(callsSC.load(), callsPair.load());
 }
 
-} // end namespace Newton3OnOffTest
+}  // end namespace Newton3OnOffTest

--- a/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
@@ -11,6 +11,8 @@
 #include "autopas/utils/Logger.h"
 #include "autopas/utils/StaticCellSelector.h"
 
+namespace Newton3OnOffTest {
+
 using ::testing::_;
 using ::testing::Combine;
 using ::testing::Return;
@@ -215,3 +217,5 @@ std::pair<size_t, size_t> Newton3OnOffTest::eval(autopas::DataLayoutOption dataL
 
   return std::make_pair(callsSC.load(), callsPair.load());
 }
+
+} // end namespace Newton3OnOffTest

--- a/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.h
+++ b/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.h
@@ -78,4 +78,4 @@ class Newton3OnOffTest
   };
 };
 
-} // end namespace Newton3OnOffTest
+}  // end namespace Newton3OnOffTest

--- a/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.h
+++ b/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.h
@@ -16,6 +16,8 @@
 #include "mocks/MockFunctor.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace Newton3OnOffTest {
+
 /**
  * Test to check if newton3 and non-newton3 work as expected
  */
@@ -75,3 +77,5 @@ class Newton3OnOffTest
     }
   };
 };
+
+} // end namespace Newton3OnOffTest

--- a/tests/testAutopas/tests/cells/FullParticleCellTest.cpp
+++ b/tests/testAutopas/tests/cells/FullParticleCellTest.cpp
@@ -8,6 +8,8 @@
 
 #include "testingHelpers/commonTypedefs.h"
 
+namespace FullParticleCellTest {
+
 TEST_F(FullParticleCellTest, testRangeBasedLoop) {
   autopas::FullParticleCell<Particle> cell({1., 1., 1.});
 
@@ -28,3 +30,4 @@ TEST_F(FullParticleCellTest, testRangeBasedLoop) {
     ASSERT_EQ(iter->getF(), comparison);
   }
 }
+} // end namespace FullParticleCellTest

--- a/tests/testAutopas/tests/cells/FullParticleCellTest.cpp
+++ b/tests/testAutopas/tests/cells/FullParticleCellTest.cpp
@@ -30,4 +30,4 @@ TEST_F(FullParticleCellTest, testRangeBasedLoop) {
     ASSERT_EQ(iter->getF(), comparison);
   }
 }
-} // end namespace FullParticleCellTest
+}  // end namespace FullParticleCellTest

--- a/tests/testAutopas/tests/cells/FullParticleCellTest.h
+++ b/tests/testAutopas/tests/cells/FullParticleCellTest.h
@@ -8,4 +8,7 @@
 
 #include <gtest/gtest.h>
 
+namespace FullParticleCellTest {
+
 class FullParticleCellTest : public testing::Test {};
+} // end namespace FullParticleCellTest

--- a/tests/testAutopas/tests/cells/FullParticleCellTest.h
+++ b/tests/testAutopas/tests/cells/FullParticleCellTest.h
@@ -11,4 +11,4 @@
 namespace FullParticleCellTest {
 
 class FullParticleCellTest : public testing::Test {};
-} // end namespace FullParticleCellTest
+}  // end namespace FullParticleCellTest

--- a/tests/testAutopas/tests/cells/SortedCellViewTest.cpp
+++ b/tests/testAutopas/tests/cells/SortedCellViewTest.cpp
@@ -10,6 +10,8 @@
 #include "autopas/cells/SortedCellView.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace SortedCellViewTest {
+
 TEST_F(SortedCellViewTest, testParticleAccess) {
   auto fpc = autopas::FullParticleCell<Particle>();
   Particle p1 = Particle();
@@ -55,3 +57,4 @@ TEST_F(SortedCellViewTest, testParticleSorting) {
     }
   }
 }
+} // end namespace SortedCellViewTest

--- a/tests/testAutopas/tests/cells/SortedCellViewTest.cpp
+++ b/tests/testAutopas/tests/cells/SortedCellViewTest.cpp
@@ -57,4 +57,4 @@ TEST_F(SortedCellViewTest, testParticleSorting) {
     }
   }
 }
-} // end namespace SortedCellViewTest
+}  // end namespace SortedCellViewTest

--- a/tests/testAutopas/tests/cells/SortedCellViewTest.h
+++ b/tests/testAutopas/tests/cells/SortedCellViewTest.h
@@ -14,4 +14,4 @@ namespace SortedCellViewTest {
 
 class SortedCellViewTest : public AutoPasTestBase {};
 
-} // end namespace SortedCellViewTest
+}  // end namespace SortedCellViewTest

--- a/tests/testAutopas/tests/cells/SortedCellViewTest.h
+++ b/tests/testAutopas/tests/cells/SortedCellViewTest.h
@@ -10,4 +10,8 @@
 
 #include "AutoPasTestBase.h"
 
+namespace SortedCellViewTest {
+
 class SortedCellViewTest : public AutoPasTestBase {};
+
+} // end namespace SortedCellViewTest

--- a/tests/testAutopas/tests/containers/AllContainersTests.cpp
+++ b/tests/testAutopas/tests/containers/AllContainersTests.cpp
@@ -1,5 +1,5 @@
 /**
- * @file TestsAllContainers.cpp
+ * @file AllContainersTests.cpp
  * @author humig
  * @date 08.07.2019
  */
@@ -7,6 +7,8 @@
 #include "AllContainersTests.h"
 
 #include <gtest/gtest.h>
+
+namespace AllContainersTests {
 
 INSTANTIATE_TEST_SUITE_P(Generated, AllContainersTests, testing::ValuesIn(autopas::ContainerOption::getAllOptions()),
                          AllContainersTests::getParamToStringFunction());
@@ -161,3 +163,4 @@ void AllContainersTests::testUpdateContainerDeletesDummy(bool previouslyOwned) {
 TEST_P(AllContainersTests, testUpdateContainerDeletesPreviouslyOwnedDummy) { testUpdateContainerDeletesDummy(true); }
 
 TEST_P(AllContainersTests, testUpdateContainerDeletesPreviouslyHaloDummy) { testUpdateContainerDeletesDummy(false); }
+} // end namespace AllContainersTests

--- a/tests/testAutopas/tests/containers/AllContainersTests.cpp
+++ b/tests/testAutopas/tests/containers/AllContainersTests.cpp
@@ -163,4 +163,4 @@ void AllContainersTests::testUpdateContainerDeletesDummy(bool previouslyOwned) {
 TEST_P(AllContainersTests, testUpdateContainerDeletesPreviouslyOwnedDummy) { testUpdateContainerDeletesDummy(true); }
 
 TEST_P(AllContainersTests, testUpdateContainerDeletesPreviouslyHaloDummy) { testUpdateContainerDeletesDummy(false); }
-} // end namespace AllContainersTests
+}  // end namespace AllContainersTests

--- a/tests/testAutopas/tests/containers/AllContainersTests.h
+++ b/tests/testAutopas/tests/containers/AllContainersTests.h
@@ -1,5 +1,5 @@
 /**
- * @file TestsAllContainers.h
+ * @file AllContainersTests.h
  * @author humig
  * @date 08.07.2019
  */
@@ -9,6 +9,8 @@
 #include "AutoPasTestBase.h"
 #include "autopas/selectors/ContainerSelector.h"
 #include "testingHelpers/commonTypedefs.h"
+
+namespace AllContainersTests {
 
 using ParamType = autopas::ContainerOption;
 
@@ -39,3 +41,5 @@ class AllContainersTests : public AutoPasTestBase, public ::testing::WithParamIn
 
   void testUpdateContainerDeletesDummy(bool previouslyOwned);
 };
+
+} // end namespace AllContainersTests

--- a/tests/testAutopas/tests/containers/AllContainersTests.h
+++ b/tests/testAutopas/tests/containers/AllContainersTests.h
@@ -42,4 +42,4 @@ class AllContainersTests : public AutoPasTestBase, public ::testing::WithParamIn
   void testUpdateContainerDeletesDummy(bool previouslyOwned);
 };
 
-} // end namespace AllContainersTests
+}  // end namespace AllContainersTests

--- a/tests/testAutopas/tests/containers/CellBlock3DTest.cpp
+++ b/tests/testAutopas/tests/containers/CellBlock3DTest.cpp
@@ -9,6 +9,8 @@
 #include "autopas/utils/ArrayUtils.h"
 #include "autopasTools/generators/GridGenerator.h"
 
+namespace CellBlock3DTest {
+
 void testIndex(autopas::internal::CellBlock3D<FMCell> &cellBlock, std::array<double, 3> &start,
                std::array<double, 3> &dr, std::array<int, 3> &numParts) {
   auto mesh = CellBlock3DTest::getMesh(start, dr, numParts);
@@ -158,3 +160,5 @@ TEST_F(CellBlock3DTest, testClearHaloParticles) {
   EXPECT_EQ(getNumberOfParticlesInBox(_cells_11x4x4_nonZeroBoxMin, _vec4), 11 * 4 * 4);
   EXPECT_EQ(getNumberOfParticlesInBox(_cells_19x19x19, _vec19), 19 * 19 * 19);
 }
+
+} // end namespace CellBlock3DTest

--- a/tests/testAutopas/tests/containers/CellBlock3DTest.cpp
+++ b/tests/testAutopas/tests/containers/CellBlock3DTest.cpp
@@ -161,4 +161,4 @@ TEST_F(CellBlock3DTest, testClearHaloParticles) {
   EXPECT_EQ(getNumberOfParticlesInBox(_cells_19x19x19, _vec19), 19 * 19 * 19);
 }
 
-} // end namespace CellBlock3DTest
+}  // end namespace CellBlock3DTest

--- a/tests/testAutopas/tests/containers/CellBlock3DTest.h
+++ b/tests/testAutopas/tests/containers/CellBlock3DTest.h
@@ -39,4 +39,4 @@ class CellBlock3DTest : public AutoPasTestBase {
       _cells_11x4x4_nonZeroBoxMin, _cells_19x19x19;
 };
 
-} // end namespace CellBlock3DTest
+}  // end namespace CellBlock3DTest

--- a/tests/testAutopas/tests/containers/CellBlock3DTest.h
+++ b/tests/testAutopas/tests/containers/CellBlock3DTest.h
@@ -12,6 +12,8 @@
 #include "autopas/containers/CellBlock3D.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace CellBlock3DTest {
+
 class CellBlock3DTest : public AutoPasTestBase {
  public:
   CellBlock3DTest()
@@ -36,3 +38,5 @@ class CellBlock3DTest : public AutoPasTestBase {
   autopas::internal::CellBlock3D<FMCell> _cells_1x1x1, _cells_1x1x1_cs2, _cells_2x2x2, _cells_2x2x2_cs05, _cells_3x3x3,
       _cells_11x4x4_nonZeroBoxMin, _cells_19x19x19;
 };
+
+} // end namespace CellBlock3DTest

--- a/tests/testAutopas/tests/containers/TraversalComparison.cpp
+++ b/tests/testAutopas/tests/containers/TraversalComparison.cpp
@@ -14,6 +14,8 @@
 #include "autopas/utils/StringUtils.h"
 #include "autopasTools/generators/RandomGenerator.h"
 
+namespace TraversalComparison {
+
 /**
  * Generates a random 3d shift with the given magnitude. The shift is uniformly distributed on a sphere with radius
  * magnitude.
@@ -306,3 +308,5 @@ auto TraversalComparison::getTestParams() {
 
 INSTANTIATE_TEST_SUITE_P(Generated, TraversalComparison, ::testing::ValuesIn(TraversalComparison::getTestParams()),
                          toString);
+
+} // end namespace TraversalComparison

--- a/tests/testAutopas/tests/containers/TraversalComparison.cpp
+++ b/tests/testAutopas/tests/containers/TraversalComparison.cpp
@@ -309,4 +309,4 @@ auto TraversalComparison::getTestParams() {
 INSTANTIATE_TEST_SUITE_P(Generated, TraversalComparison, ::testing::ValuesIn(TraversalComparison::getTestParams()),
                          toString);
 
-} // end namespace TraversalComparison
+}  // end namespace TraversalComparison

--- a/tests/testAutopas/tests/containers/TraversalComparison.h
+++ b/tests/testAutopas/tests/containers/TraversalComparison.h
@@ -79,4 +79,4 @@ class TraversalComparison : public AutoPasTestBase, public ::testing::WithParamI
   static inline std::map<mykey_t, Globals> _globalValuesReference{};
 };
 
-} // end namespace TraversalComparison
+}  // end namespace TraversalComparison

--- a/tests/testAutopas/tests/containers/TraversalComparison.h
+++ b/tests/testAutopas/tests/containers/TraversalComparison.h
@@ -18,6 +18,8 @@
 #include "autopasTools/generators/RandomGenerator.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace TraversalComparison {
+
 enum DeletionPosition {
   // We have chosen the values explicitly, s.t., this enum can be used using bit manipulation, i.e., beforeAndAfterLists
   // enables both bits for beforeLists and afterLists.
@@ -76,3 +78,5 @@ class TraversalComparison : public AutoPasTestBase, public ::testing::WithParamI
   static inline std::map<mykey_t, std::vector<std::array<double, 3>>> _forcesReference{};
   static inline std::map<mykey_t, Globals> _globalValuesReference{};
 };
+
+} // end namespace TraversalComparison

--- a/tests/testAutopas/tests/containers/directSum/DSSequentialTraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/directSum/DSSequentialTraversalTest.cpp
@@ -9,6 +9,8 @@
 #include "autopas/containers/directSum/traversals/DSSequentialTraversal.h"
 #include "autopasTools/generators/RandomGenerator.h"
 
+namespace DSSequentialTraversalTest {
+
 using ::testing::_;
 using ::testing::AtLeast;
 
@@ -93,3 +95,5 @@ TEST_F(DSSequentialTraversalTest, testTraversalCuda) {
 }
 
 #endif
+
+} // end namespace DSSequentialTraversalTest

--- a/tests/testAutopas/tests/containers/directSum/DSSequentialTraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/directSum/DSSequentialTraversalTest.cpp
@@ -96,4 +96,4 @@ TEST_F(DSSequentialTraversalTest, testTraversalCuda) {
 
 #endif
 
-} // end namespace DSSequentialTraversalTest
+}  // end namespace DSSequentialTraversalTest

--- a/tests/testAutopas/tests/containers/directSum/DSSequentialTraversalTest.h
+++ b/tests/testAutopas/tests/containers/directSum/DSSequentialTraversalTest.h
@@ -9,7 +9,11 @@
 #include "AutoPasTestBase.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace DSSequentialTraversalTest {
+
 class DSSequentialTraversalTest : public AutoPasTestBase {
  public:
   void testTraversal(bool useSoA);
 };
+
+} // end namespace DSSequentialTraversalTest

--- a/tests/testAutopas/tests/containers/directSum/DSSequentialTraversalTest.h
+++ b/tests/testAutopas/tests/containers/directSum/DSSequentialTraversalTest.h
@@ -16,4 +16,4 @@ class DSSequentialTraversalTest : public AutoPasTestBase {
   void testTraversal(bool useSoA);
 };
 
-} // end namespace DSSequentialTraversalTest
+}  // end namespace DSSequentialTraversalTest

--- a/tests/testAutopas/tests/containers/directSum/DirectSumContainerTest.cpp
+++ b/tests/testAutopas/tests/containers/directSum/DirectSumContainerTest.cpp
@@ -53,4 +53,4 @@ TEST_F(DirectSumContainerTest, testUpdateContainerCloseToBoundary) {
     EXPECT_EQ(movedIDs.count(particle.getID()), 1);
   }
 }
-} // end namespace DirectSumContainerTest
+}  // end namespace DirectSumContainerTest

--- a/tests/testAutopas/tests/containers/directSum/DirectSumContainerTest.cpp
+++ b/tests/testAutopas/tests/containers/directSum/DirectSumContainerTest.cpp
@@ -6,6 +6,8 @@
 
 #include "DirectSumContainerTest.h"
 
+namespace DirectSumContainerTest {
+
 TEST_F(DirectSumContainerTest, testUpdateContainerCloseToBoundary) {
   autopas::DirectSum<autopas::Particle> directSum({0., 0., 0.}, {10., 10., 10.}, 1., 0.);
   int id = 1;
@@ -51,3 +53,4 @@ TEST_F(DirectSumContainerTest, testUpdateContainerCloseToBoundary) {
     EXPECT_EQ(movedIDs.count(particle.getID()), 1);
   }
 }
+} // end namespace DirectSumContainerTest

--- a/tests/testAutopas/tests/containers/directSum/DirectSumContainerTest.h
+++ b/tests/testAutopas/tests/containers/directSum/DirectSumContainerTest.h
@@ -12,4 +12,8 @@
 #include "autopas/particles/Particle.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace DirectSumContainerTest {
+
 class DirectSumContainerTest : public AutoPasTestBase {};
+
+} // end namespace DirectSumContainerTest

--- a/tests/testAutopas/tests/containers/directSum/DirectSumContainerTest.h
+++ b/tests/testAutopas/tests/containers/directSum/DirectSumContainerTest.h
@@ -16,4 +16,4 @@ namespace DirectSumContainerTest {
 
 class DirectSumContainerTest : public AutoPasTestBase {};
 
-} // end namespace DirectSumContainerTest
+}  // end namespace DirectSumContainerTest

--- a/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
@@ -129,4 +129,4 @@ REGISTER_TYPED_TEST_SUITE_P(LinkedCellsTest, testUpdateContainer, testUpdateCont
 using MyTypes = ::testing::Types<autopas::LinkedCells<Particle>, autopas::LinkedCellsReferences<Particle>>;
 INSTANTIATE_TYPED_TEST_SUITE_P(GeneratedTyped, LinkedCellsTest, MyTypes);
 
-} // end namespace LinkedCellsTest
+}  // end namespace LinkedCellsTest

--- a/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
@@ -8,6 +8,8 @@
 
 #include <gmock/gmock-generated-matchers.h>
 
+namespace LinkedCellsTest {
+
 TYPED_TEST_SUITE_P(LinkedCellsTest);
 
 TYPED_TEST_P(LinkedCellsTest, testUpdateContainer) {
@@ -126,3 +128,5 @@ REGISTER_TYPED_TEST_SUITE_P(LinkedCellsTest, testUpdateContainer, testUpdateCont
 
 using MyTypes = ::testing::Types<autopas::LinkedCells<Particle>, autopas::LinkedCellsReferences<Particle>>;
 INSTANTIATE_TYPED_TEST_SUITE_P(GeneratedTyped, LinkedCellsTest, MyTypes);
+
+} // end namespace LinkedCellsTest

--- a/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.h
@@ -14,6 +14,8 @@
 #include "autopas/particles/Particle.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace LinkedCellsTest {
+
 template <class LinkedCellsType>
 class LinkedCellsTest : public AutoPasTestBase {
  public:
@@ -22,3 +24,5 @@ class LinkedCellsTest : public AutoPasTestBase {
  protected:
   LinkedCellsType _linkedCells;
 };
+
+} // end namespace LinkedCellsTest

--- a/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.h
@@ -25,4 +25,4 @@ class LinkedCellsTest : public AutoPasTestBase {
   LinkedCellsType _linkedCells;
 };
 
-} // end namespace LinkedCellsTest
+}  // end namespace LinkedCellsTest

--- a/tests/testAutopas/tests/containers/linkedCells/ParticleVectorTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/ParticleVectorTest.cpp
@@ -71,4 +71,4 @@ TEST_F(ParticleVectorTest, testDirtySizeAfterImplicitResize) {
   EXPECT_EQ(particleVector.dirtySize(), 9);
 }
 
-} // end namespace ParticleVectorTest
+}  // end namespace ParticleVectorTest

--- a/tests/testAutopas/tests/containers/linkedCells/ParticleVectorTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/ParticleVectorTest.cpp
@@ -11,6 +11,8 @@
 
 #include "autopas/containers/linkedCells/ParticleVector.h"
 
+namespace ParticleVectorTest {
+
 ParticleVectorTest::ParticleVectorTest() = default;
 
 TEST_F(ParticleVectorTest, testdirtySizeAfterMarkAsClean) {
@@ -68,3 +70,5 @@ TEST_F(ParticleVectorTest, testDirtySizeAfterImplicitResize) {
   EXPECT_EQ(particleVector.totalSize(), 9);
   EXPECT_EQ(particleVector.dirtySize(), 9);
 }
+
+} // end namespace ParticleVectorTest

--- a/tests/testAutopas/tests/containers/linkedCells/ParticleVectorTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/ParticleVectorTest.h
@@ -17,4 +17,4 @@ class ParticleVectorTest : public AutoPasTestBase {
   ParticleVectorTest();
 };
 
-} // end namespace ParticleVectorTest
+}  // end namespace ParticleVectorTest

--- a/tests/testAutopas/tests/containers/linkedCells/ParticleVectorTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/ParticleVectorTest.h
@@ -10,7 +10,11 @@
 #include "AutoPasTestBase.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace ParticleVectorTest {
+
 class ParticleVectorTest : public AutoPasTestBase {
  public:
   ParticleVectorTest();
 };
+
+} // end namespace ParticleVectorTest

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/C01TraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/C01TraversalTest.cpp
@@ -37,4 +37,4 @@ TEST_F(C01TraversalTest, testIsApplicable) {
       dims, &functor, 1., {1., 1., 1.});
   EXPECT_EQ(c01T_N3on_combineSoA.isApplicable(), false);
 }
-} // end namespace C01TraversalTest
+}  // end namespace C01TraversalTest

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/C01TraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/C01TraversalTest.cpp
@@ -9,6 +9,8 @@
 #include "autopas/containers/linkedCells/traversals/LCC01Traversal.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace C01TraversalTest {
+
 // Place to implement special test cases, which only apply to C01 Traversal
 
 TEST_F(C01TraversalTest, testIsApplicable) {
@@ -35,3 +37,4 @@ TEST_F(C01TraversalTest, testIsApplicable) {
       dims, &functor, 1., {1., 1., 1.});
   EXPECT_EQ(c01T_N3on_combineSoA.isApplicable(), false);
 }
+} // end namespace C01TraversalTest

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/C01TraversalTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/C01TraversalTest.h
@@ -8,9 +8,13 @@
 
 #include "AutoPasTestBase.h"
 
+namespace C01TraversalTest {
+
 class C01TraversalTest : public AutoPasTestBase {
  public:
   C01TraversalTest() = default;
 
   ~C01TraversalTest() override = default;
 };
+
+} // end namespace C01TraversalTest

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/C01TraversalTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/C01TraversalTest.h
@@ -17,4 +17,4 @@ class C01TraversalTest : public AutoPasTestBase {
   ~C01TraversalTest() override = default;
 };
 
-} // end namespace C01TraversalTest
+}  // end namespace C01TraversalTest

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/C08TraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/C08TraversalTest.cpp
@@ -10,4 +10,4 @@ namespace C08TraversalTest {
 
 // Place to implement special test cases, which only apply to C08 Traversal
 
-} // end namespace C08TraversalTest
+}  // end namespace C08TraversalTest

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/C08TraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/C08TraversalTest.cpp
@@ -6,4 +6,8 @@
 
 #include "C08TraversalTest.h"
 
+namespace C08TraversalTest {
+
 // Place to implement special test cases, which only apply to C08 Traversal
+
+} // end namespace C08TraversalTest

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/C08TraversalTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/C08TraversalTest.h
@@ -8,9 +8,13 @@
 
 #include "AutoPasTestBase.h"
 
+namespace C08TraversalTest {
+
 class C08TraversalTest : public AutoPasTestBase {
  public:
   C08TraversalTest() = default;
 
   ~C08TraversalTest() override = default;
 };
+
+} // end namespace C08TraversalTest

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/C08TraversalTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/C08TraversalTest.h
@@ -17,4 +17,4 @@ class C08TraversalTest : public AutoPasTestBase {
   ~C08TraversalTest() override = default;
 };
 
-} // end namespace C08TraversalTest
+}  // end namespace C08TraversalTest

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/C18TraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/C18TraversalTest.cpp
@@ -10,4 +10,4 @@ namespace C18TraversalTest {
 
 // Place to implement special test cases, which only apply to C18 Traversal
 
-} // end namespace C18TraversalTest
+}  // end namespace C18TraversalTest

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/C18TraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/C18TraversalTest.cpp
@@ -6,4 +6,8 @@
 
 #include "C18TraversalTest.h"
 
+namespace C18TraversalTest {
+
 // Place to implement special test cases, which only apply to C18 Traversal
+
+} // end namespace C18TraversalTest

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/C18TraversalTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/C18TraversalTest.h
@@ -8,9 +8,13 @@
 
 #include "AutoPasTestBase.h"
 
+namespace C18TraversalTest {
+
 class C18TraversalTest : public AutoPasTestBase {
  public:
   C18TraversalTest() = default;
 
   ~C18TraversalTest() override = default;
 };
+
+} // end namespace C18TraversalTest

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/C18TraversalTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/C18TraversalTest.h
@@ -17,4 +17,4 @@ class C18TraversalTest : public AutoPasTestBase {
   ~C18TraversalTest() override = default;
 };
 
-} // end namespace C18TraversalTest
+}  // end namespace C18TraversalTest

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/SlicedTraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/SlicedTraversalTest.cpp
@@ -82,4 +82,4 @@ TEST_F(SlicedTraversalTest, testIsApplicableOkOnlyOneDim) {
   EXPECT_TRUE(slicedTraversal.isApplicable());
 }
 
-} // end namespace SlicedTraversalTest
+}  // end namespace SlicedTraversalTest

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/SlicedTraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/SlicedTraversalTest.cpp
@@ -11,6 +11,8 @@
 #include "testingHelpers/NumThreadGuard.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace SlicedTraversalTest {
+
 using ::testing::_;
 
 void testSlicedTraversal(const std::array<size_t, 3> &edgeLength) {
@@ -79,3 +81,5 @@ TEST_F(SlicedTraversalTest, testIsApplicableOkOnlyOneDim) {
 
   EXPECT_TRUE(slicedTraversal.isApplicable());
 }
+
+} // end namespace SlicedTraversalTest

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/SlicedTraversalTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/SlicedTraversalTest.h
@@ -8,9 +8,13 @@
 
 #include "AutoPasTestBase.h"
 
+namespace SlicedTraversalTest {
+
 class SlicedTraversalTest : public AutoPasTestBase {
  public:
   SlicedTraversalTest() = default;
 
   ~SlicedTraversalTest() override = default;
 };
+
+} // end namespace SlicedTraversalTest

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/SlicedTraversalTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/SlicedTraversalTest.h
@@ -17,4 +17,4 @@ class SlicedTraversalTest : public AutoPasTestBase {
   ~SlicedTraversalTest() override = default;
 };
 
-} // end namespace SlicedTraversalTest
+}  // end namespace SlicedTraversalTest

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalRaceConditionTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalRaceConditionTest.cpp
@@ -91,4 +91,4 @@ TEST_F(TraversalRaceConditionTest, testRCNonDeterministic) {
   }
 }
 
-} // end namespace TraversalRaceConditionTest
+}  // end namespace TraversalRaceConditionTest

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalRaceConditionTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalRaceConditionTest.cpp
@@ -10,6 +10,8 @@
 #include "autopasTools/generators/GridGenerator.h"
 #include "testingHelpers/NumThreadGuard.h"
 
+namespace TraversalRaceConditionTest {
+
 /**
  * Idea: create mesh of particles and iterate with the SimpleFunctor.
  * All non-border particles should have F=0 at the end.
@@ -88,3 +90,5 @@ TEST_F(TraversalRaceConditionTest, testRCNonDeterministic) {
     }
   }
 }
+
+} // end namespace TraversalRaceConditionTest

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalRaceConditionTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalRaceConditionTest.h
@@ -14,6 +14,8 @@
 #include "autopas/AutoPas.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace TraversalRaceConditionTest {
+
 class TraversalRaceConditionTest : public AutoPasTestBase {
  public:
   TraversalRaceConditionTest() = default;
@@ -75,3 +77,5 @@ class TraversalRaceConditionTest : public AutoPasTestBase {
     const double _cutoffSquare;
   };
 };
+
+} // end namespace TraversalRaceConditionTest

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalRaceConditionTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalRaceConditionTest.h
@@ -78,4 +78,4 @@ class TraversalRaceConditionTest : public AutoPasTestBase {
   };
 };
 
-} // end namespace TraversalRaceConditionTest
+}  // end namespace TraversalRaceConditionTest

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.cpp
@@ -14,6 +14,8 @@
 #include "autopas/selectors/TraversalSelectorInfo.h"
 #include "testingHelpers/NumThreadGuard.h"
 
+namespace TraversalTest {
+
 using ::testing::_;  // anything is ok
 using ::testing::Bool;
 using ::testing::Combine;
@@ -183,3 +185,5 @@ INSTANTIATE_TEST_SUITE_P(
       return res;
     }()),
     TraversalTest::PrintToStringParamName());
+
+} // end namespace TraversalTest

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.cpp
@@ -186,4 +186,4 @@ INSTANTIATE_TEST_SUITE_P(
     }()),
     TraversalTest::PrintToStringParamName());
 
-} // end namespace TraversalTest
+}  // end namespace TraversalTest

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.h
@@ -89,4 +89,4 @@ class TraversalTest
   };
 };
 
-} // end namespace TraversalTest
+}  // end namespace TraversalTest

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.h
@@ -17,6 +17,8 @@
 #include "mocks/MockFunctor.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace TraversalTest {
+
 /**
  * Test to check if all traversals consider all particles within cutoff
  */
@@ -86,3 +88,5 @@ class TraversalTest
     floatType _cutoffSquare;
   };
 };
+
+} // end namespace TraversalTest

--- a/tests/testAutopas/tests/containers/loadEstimators/LoadEstimatorTest.cpp
+++ b/tests/testAutopas/tests/containers/loadEstimators/LoadEstimatorTest.cpp
@@ -64,4 +64,4 @@ TEST(LoadEstimatorTest, testIncreasingDensitySquaredParticlesPerCell) {
   }
 }
 
-} // end namespace LoadEstimatorTest
+}  // end namespace LoadEstimatorTest

--- a/tests/testAutopas/tests/containers/loadEstimators/LoadEstimatorTest.cpp
+++ b/tests/testAutopas/tests/containers/loadEstimators/LoadEstimatorTest.cpp
@@ -10,6 +10,8 @@
 #include "autopasTools/generators/GridGenerator.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace LoadEstimatorTest {
+
 // using ::testing::_;
 
 TEST(LoadEstimatorTest, testEqualDistributionSquaredParticlesPerCell) {
@@ -61,3 +63,5 @@ TEST(LoadEstimatorTest, testIncreasingDensitySquaredParticlesPerCell) {
     EXPECT_EQ(load, expectedLoad);
   }
 }
+
+} // end namespace LoadEstimatorTest

--- a/tests/testAutopas/tests/containers/loadEstimators/LoadEstimatorTest.h
+++ b/tests/testAutopas/tests/containers/loadEstimators/LoadEstimatorTest.h
@@ -12,4 +12,4 @@ namespace LoadEstimatorTest {
 
 class LoadEstimatorTest : public AutoPasTestBase {};
 
-} // end namespace LoadEstimatorTest
+}  // end namespace LoadEstimatorTest

--- a/tests/testAutopas/tests/containers/loadEstimators/LoadEstimatorTest.h
+++ b/tests/testAutopas/tests/containers/loadEstimators/LoadEstimatorTest.h
@@ -8,4 +8,8 @@
 
 #include "AutoPasTestBase.h"
 
+namespace LoadEstimatorTest {
+
 class LoadEstimatorTest : public AutoPasTestBase {};
+
+} // end namespace LoadEstimatorTest

--- a/tests/testAutopas/tests/containers/verletClusterCells/VerletClusterCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletClusterCells/VerletClusterCellsTest.cpp
@@ -328,4 +328,4 @@ TEST_F(VerletClusterCellsTest, testVerletListRegionIterator) {
           << iter->getR()[2] << ")" << std::endl;
   }
 }
-} // end namespace VerletClusterCellsTest
+}  // end namespace VerletClusterCellsTest

--- a/tests/testAutopas/tests/containers/verletClusterCells/VerletClusterCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletClusterCells/VerletClusterCellsTest.cpp
@@ -10,6 +10,8 @@
 #include "autopas/containers/verletClusterCells/traversals/VCCClusterIterationCUDATraversal.h"
 #include "testingHelpers/TouchableParticle.h"
 
+namespace VerletClusterCellsTest {
+
 using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::Invoke;
@@ -326,3 +328,4 @@ TEST_F(VerletClusterCellsTest, testVerletListRegionIterator) {
           << iter->getR()[2] << ")" << std::endl;
   }
 }
+} // end namespace VerletClusterCellsTest

--- a/tests/testAutopas/tests/containers/verletClusterCells/VerletClusterCellsTest.h
+++ b/tests/testAutopas/tests/containers/verletClusterCells/VerletClusterCellsTest.h
@@ -14,4 +14,8 @@
 #include "mocks/MockFunctor.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace VerletClusterCellsTest {
+
 class VerletClusterCellsTest : public AutoPasTestBase {};
+
+} // end namespace VerletClusterCellsTest

--- a/tests/testAutopas/tests/containers/verletClusterCells/VerletClusterCellsTest.h
+++ b/tests/testAutopas/tests/containers/verletClusterCells/VerletClusterCellsTest.h
@@ -18,4 +18,4 @@ namespace VerletClusterCellsTest {
 
 class VerletClusterCellsTest : public AutoPasTestBase {};
 
-} // end namespace VerletClusterCellsTest
+}  // end namespace VerletClusterCellsTest

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
@@ -265,4 +265,4 @@ TEST_F(VerletClusterListsTest, testVerletListColoringTraversalNewton3NoDataRace)
 }
 
 #endif  // AUTOPAS_OPENMP
-} // end namespace VerletClusterListsTest
+}  // end namespace VerletClusterListsTest

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
@@ -10,6 +10,8 @@
 #include "autopas/containers/verletClusterLists/traversals/VCLC06Traversal.h"
 #include "autopas/containers/verletClusterLists/traversals/VCLClusterIterationTraversal.h"
 
+namespace VerletClusterListsTest {
+
 using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::Invoke;
@@ -263,3 +265,4 @@ TEST_F(VerletClusterListsTest, testVerletListColoringTraversalNewton3NoDataRace)
 }
 
 #endif  // AUTOPAS_OPENMP
+} // end namespace VerletClusterListsTest

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.h
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.h
@@ -17,6 +17,8 @@
 #include "mocks/MockFunctor.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace VerletClusterListsTest {
+
 class VerletClusterListsTest : public AutoPasTestBase {};
 
 class CollectParticlePairsFunctor : public autopas::Functor<autopas::Particle, CollectParticlePairsFunctor> {
@@ -110,3 +112,4 @@ class ColoringTraversalWithColorChangeNotify
   std::function<void(int)> _whenColorChanges;
 };
 #endif
+} // end namespace VerletClusterListsTest

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.h
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.h
@@ -112,4 +112,4 @@ class ColoringTraversalWithColorChangeNotify
   std::function<void(int)> _whenColorChanges;
 };
 #endif
-} // end namespace VerletClusterListsTest
+}  // end namespace VerletClusterListsTest

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterTowerTest.cpp
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterTowerTest.cpp
@@ -113,4 +113,4 @@ TEST_F(VerletClusterTowerTest, testIterator) {
     IDs.push_back(particle.getID());
   }
 }
-} // end namespace VerletClusterTowerTest
+}  // end namespace VerletClusterTowerTest

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterTowerTest.cpp
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterTowerTest.cpp
@@ -9,6 +9,8 @@
 #include "autopas/containers/verletClusterLists/ClusterTower.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace VerletClusterTowerTest {
+
 template <class Particle>
 using ClusterTower = autopas::internal::ClusterTower<Particle>;
 
@@ -111,3 +113,4 @@ TEST_F(VerletClusterTowerTest, testIterator) {
     IDs.push_back(particle.getID());
   }
 }
+} // end namespace VerletClusterTowerTest

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterTowerTest.h
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterTowerTest.h
@@ -10,4 +10,8 @@
 
 #include "AutoPasTestBase.h"
 
+namespace VerletClusterTowerTest {
+
 class VerletClusterTowerTest : public AutoPasTestBase {};
+
+} // end namespace VerletClusterTowerTest

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterTowerTest.h
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterTowerTest.h
@@ -14,4 +14,4 @@ namespace VerletClusterTowerTest {
 
 class VerletClusterTowerTest : public AutoPasTestBase {};
 
-} // end namespace VerletClusterTowerTest
+}  // end namespace VerletClusterTowerTest

--- a/tests/testAutopas/tests/containers/verletListsCellBased/varVerletLists/VarVerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/varVerletLists/VarVerletListsTest.cpp
@@ -296,4 +296,4 @@ TEST_F(VarVerletListsTest, testUpdateHaloParticle) {
   EXPECT_TRUE(verletLists.updateHaloParticle(p5));
 }
 
-} // end namespace VarVerletListsTest
+}  // end namespace VarVerletListsTest

--- a/tests/testAutopas/tests/containers/verletListsCellBased/varVerletLists/VarVerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/varVerletLists/VarVerletListsTest.cpp
@@ -13,6 +13,8 @@
 #include "autopas/containers/verletListsCellBased/varVerletLists/traversals/VVLAsBuildTraversal.h"
 #include "autopas/options/DataLayoutOption.h"
 
+namespace VarVerletListsTest {
+
 using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::Each;
@@ -293,3 +295,5 @@ TEST_F(VarVerletListsTest, testUpdateHaloParticle) {
   verletLists.addHaloParticle(p5);
   EXPECT_TRUE(verletLists.updateHaloParticle(p5));
 }
+
+} // end namespace VarVerletListsTest

--- a/tests/testAutopas/tests/containers/verletListsCellBased/varVerletLists/VarVerletListsTest.h
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/varVerletLists/VarVerletListsTest.h
@@ -18,4 +18,4 @@
 namespace VarVerletListsTest {
 
 class VarVerletListsTest : public AutoPasTestBase {};
-} // end namespace VarVerletListsTest
+}  // end namespace VarVerletListsTest

--- a/tests/testAutopas/tests/containers/verletListsCellBased/varVerletLists/VarVerletListsTest.h
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/varVerletLists/VarVerletListsTest.h
@@ -15,4 +15,7 @@
 #include "mocks/MockFunctor.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace VarVerletListsTest {
+
 class VarVerletListsTest : public AutoPasTestBase {};
+} // end namespace VarVerletListsTest

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.cpp
@@ -10,6 +10,8 @@
 #include "autopas/containers/verletListsCellBased/verletLists/traversals/VLListIterationTraversal.h"
 #include "autopas/molecularDynamics/LJFunctor.h"
 
+namespace VerletListsTest {
+
 using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::Each;
@@ -346,3 +348,4 @@ TEST_P(VerletListsTest, SoAvsAoSLJ) {
 }
 
 INSTANTIATE_TEST_SUITE_P(Generated, VerletListsTest, Values(1.0, 2.0), VerletListsTest::PrintToStringParamName());
+} // end namespace VerletListsTest

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.cpp
@@ -348,4 +348,4 @@ TEST_P(VerletListsTest, SoAvsAoSLJ) {
 }
 
 INSTANTIATE_TEST_SUITE_P(Generated, VerletListsTest, Values(1.0, 2.0), VerletListsTest::PrintToStringParamName());
-} // end namespace VerletListsTest
+}  // end namespace VerletListsTest

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.h
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.h
@@ -29,4 +29,4 @@ class VerletListsTest : public AutoPasTestBase, public ::testing::WithParamInter
   };
 };
 
-} // end namespace VerletListsTest
+}  // end namespace VerletListsTest

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.h
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.h
@@ -16,6 +16,8 @@
 #include "mocks/MockFunctor.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace VerletListsTest {
+
 class VerletListsTest : public AutoPasTestBase, public ::testing::WithParamInterface<double> {
  public:
   struct PrintToStringParamName {
@@ -26,3 +28,5 @@ class VerletListsTest : public AutoPasTestBase, public ::testing::WithParamInter
     }
   };
 };
+
+} // end namespace VerletListsTest

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/VerletListsCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/VerletListsCellsTest.cpp
@@ -57,4 +57,4 @@ TEST_F(VerletListsCellsTest, testVerletListBuild) {
 
   applyFunctor(emptyFunctor_cs2, 2.0);
 }
-} // end namespace VerletListsCellsTest
+}  // end namespace VerletListsCellsTest

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/VerletListsCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/VerletListsCellsTest.cpp
@@ -8,6 +8,8 @@
 #include "autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h"
 #include "autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCC18Traversal.h"
 
+namespace VerletListsCellsTest {
+
 using ::testing::_;
 using ::testing::AtLeast;
 
@@ -55,3 +57,4 @@ TEST_F(VerletListsCellsTest, testVerletListBuild) {
 
   applyFunctor(emptyFunctor_cs2, 2.0);
 }
+} // end namespace VerletListsCellsTest

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/VerletListsCellsTest.h
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/VerletListsCellsTest.h
@@ -19,4 +19,4 @@ namespace VerletListsCellsTest {
 
 class VerletListsCellsTest : public AutoPasTestBase {};
 
-} // end namespace VerletListsCellsTest
+}  // end namespace VerletListsCellsTest

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/VerletListsCellsTest.h
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/VerletListsCellsTest.h
@@ -15,4 +15,8 @@
 #include "mocks/MockFunctor.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace VerletListsCellsTest {
+
 class VerletListsCellsTest : public AutoPasTestBase {};
+
+} // end namespace VerletListsCellsTest

--- a/tests/testAutopas/tests/iterators/ParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/ParticleIteratorTest.cpp
@@ -255,4 +255,4 @@ TEST_F(ParticleIteratorTest, testIteratorBehaviorVerletLists) {
 
   testContainerIteratorBehavior(verletLists, mol, haloMol);
 }
-} // end namespace ParticleIteratorTest
+}  // end namespace ParticleIteratorTest

--- a/tests/testAutopas/tests/iterators/ParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/ParticleIteratorTest.cpp
@@ -12,6 +12,8 @@
 #include "autopas/iterators/ParticleIterator.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace ParticleIteratorTest {
+
 using namespace autopas;
 using namespace autopas::internal;
 
@@ -253,3 +255,4 @@ TEST_F(ParticleIteratorTest, testIteratorBehaviorVerletLists) {
 
   testContainerIteratorBehavior(verletLists, mol, haloMol);
 }
+} // end namespace ParticleIteratorTest

--- a/tests/testAutopas/tests/iterators/ParticleIteratorTest.h
+++ b/tests/testAutopas/tests/iterators/ParticleIteratorTest.h
@@ -41,4 +41,4 @@ class ParticleIteratorTest : public AutoPasTestBase {
   unsigned long _currentIndex;
 };
 
-} // end namespace ParticleIteratorTest
+}  // end namespace ParticleIteratorTest

--- a/tests/testAutopas/tests/iterators/ParticleIteratorTest.h
+++ b/tests/testAutopas/tests/iterators/ParticleIteratorTest.h
@@ -12,6 +12,8 @@
 #include "autopas/utils/WrapOpenMP.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace ParticleIteratorTest {
+
 class ParticleIteratorTest : public AutoPasTestBase {
  public:
   ParticleIteratorTest() : _currentIndex(0ul) {}
@@ -38,3 +40,5 @@ class ParticleIteratorTest : public AutoPasTestBase {
   std::vector<Molecule> _vecOfMolecules;
   unsigned long _currentIndex;
 };
+
+} // end namespace ParticleIteratorTest

--- a/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
@@ -10,6 +10,8 @@
 #include "autopas/utils/ArrayUtils.h"
 #include "autopas/utils/WrapOpenMP.h"
 
+namespace RegionParticleIteratorTest {
+
 using namespace autopas;
 
 /********************************** Linked Cells Tests **********************************/
@@ -634,3 +636,5 @@ void RegionParticleIteratorTest::checkTouches(LCTouch &lcContainer, std::array<d
   }
   EXPECT_GE(numTouches, 0) << "No Particles were checked!";
 }
+
+} // end namespace RegionParticleIteratorTest

--- a/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
@@ -637,4 +637,4 @@ void RegionParticleIteratorTest::checkTouches(LCTouch &lcContainer, std::array<d
   EXPECT_GE(numTouches, 0) << "No Particles were checked!";
 }
 
-} // end namespace RegionParticleIteratorTest
+}  // end namespace RegionParticleIteratorTest

--- a/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.h
+++ b/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.h
@@ -14,6 +14,8 @@
 #include "autopasTools/generators/RandomGenerator.h"
 #include "testingHelpers/TouchableParticle.h"
 
+namespace RegionParticleIteratorTest {
+
 class RegionParticleIteratorTest : public AutoPasTestBase {
  public:
   using LCTouch = autopas::LinkedCells<TouchableParticle>;
@@ -50,3 +52,5 @@ class RegionParticleIteratorTest : public AutoPasTestBase {
 
   double _cutoff;
 };
+
+} // end namespace RegionParticleIteratorTest

--- a/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.h
+++ b/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.h
@@ -53,4 +53,4 @@ class RegionParticleIteratorTest : public AutoPasTestBase {
   double _cutoff;
 };
 
-} // end namespace RegionParticleIteratorTest
+}  // end namespace RegionParticleIteratorTest

--- a/tests/testAutopas/tests/iterators/SingleCellIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/SingleCellIteratorTest.cpp
@@ -8,6 +8,8 @@
 
 #include <gtest/gtest.h>
 
+namespace SingleCellIteratorTest {
+
 using namespace autopas;
 
 void SingleCellIteratorTest::SetUp() {
@@ -37,3 +39,5 @@ TEST_F(SingleCellIteratorTest, testFullParticleCell) {
     ASSERT_EQ(iter->getID(), _vecOfMolecules[i].getID());
   }
 }
+
+} // end namespace SingleCellIteratorTest

--- a/tests/testAutopas/tests/iterators/SingleCellIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/SingleCellIteratorTest.cpp
@@ -40,4 +40,4 @@ TEST_F(SingleCellIteratorTest, testFullParticleCell) {
   }
 }
 
-} // end namespace SingleCellIteratorTest
+}  // end namespace SingleCellIteratorTest

--- a/tests/testAutopas/tests/iterators/SingleCellIteratorTest.h
+++ b/tests/testAutopas/tests/iterators/SingleCellIteratorTest.h
@@ -36,4 +36,4 @@ class SingleCellIteratorTest : public AutoPasTestBase {
   std::vector<Molecule> _vecOfMolecules;
 };
 
-} // end namespace SingleCellIteratorTest
+}  // end namespace SingleCellIteratorTest

--- a/tests/testAutopas/tests/iterators/SingleCellIteratorTest.h
+++ b/tests/testAutopas/tests/iterators/SingleCellIteratorTest.h
@@ -11,6 +11,8 @@
 #include "AutoPasTestBase.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace SingleCellIteratorTest {
+
 class SingleCellIteratorTest : public AutoPasTestBase {
  public:
   SingleCellIteratorTest() = default;
@@ -33,3 +35,5 @@ class SingleCellIteratorTest : public AutoPasTestBase {
   // for each unit test.
   std::vector<Molecule> _vecOfMolecules;
 };
+
+} // end namespace SingleCellIteratorTest

--- a/tests/testAutopas/tests/molecularDynamics/AoSvsCudaTest.cpp
+++ b/tests/testAutopas/tests/molecularDynamics/AoSvsCudaTest.cpp
@@ -117,5 +117,5 @@ static auto toString = [](const auto &info) {
 
 INSTANTIATE_TEST_SUITE_P(Generated, AoSvsCudaTest, ::testing::Combine(::testing::Bool()), toString);
 
-} // end namespace AoSvsCudaTest
+}  // end namespace AoSvsCudaTest
 #endif  // AUTOPAS_CUDA

--- a/tests/testAutopas/tests/molecularDynamics/AoSvsCudaTest.cpp
+++ b/tests/testAutopas/tests/molecularDynamics/AoSvsCudaTest.cpp
@@ -11,6 +11,8 @@
 #include "autopas/molecularDynamics/LJFunctor.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace AoSvsCudaTest {
+
 using namespace autopas;
 
 constexpr size_t PARTICLES_PER_DIM = 16;
@@ -115,4 +117,5 @@ static auto toString = [](const auto &info) {
 
 INSTANTIATE_TEST_SUITE_P(Generated, AoSvsCudaTest, ::testing::Combine(::testing::Bool()), toString);
 
+} // end namespace AoSvsCudaTest
 #endif  // AUTOPAS_CUDA

--- a/tests/testAutopas/tests/molecularDynamics/AoSvsCudaTest.h
+++ b/tests/testAutopas/tests/molecularDynamics/AoSvsCudaTest.h
@@ -15,6 +15,8 @@
 #include "AutoPasTestBase.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace AoSvsCudaTest {
+
 using TestingTuple = std::tuple<bool /*withDeletions*/>;
 
 class AoSvsCudaTest : public AutoPasTestBase, public ::testing::WithParamInterface<TestingTuple> {
@@ -22,4 +24,6 @@ class AoSvsCudaTest : public AutoPasTestBase, public ::testing::WithParamInterfa
   void generateParticles(std::vector<Molecule> *particles, bool withDeletions);
 };
 
+} // end namespace AoSvsCudaTest
 #endif  // AUTOPAS_CUDA
+

--- a/tests/testAutopas/tests/molecularDynamics/AoSvsCudaTest.h
+++ b/tests/testAutopas/tests/molecularDynamics/AoSvsCudaTest.h
@@ -24,6 +24,5 @@ class AoSvsCudaTest : public AutoPasTestBase, public ::testing::WithParamInterfa
   void generateParticles(std::vector<Molecule> *particles, bool withDeletions);
 };
 
-} // end namespace AoSvsCudaTest
+}  // end namespace AoSvsCudaTest
 #endif  // AUTOPAS_CUDA
-

--- a/tests/testAutopas/tests/molecularDynamics/AoSvsSoATest.cpp
+++ b/tests/testAutopas/tests/molecularDynamics/AoSvsSoATest.cpp
@@ -8,9 +8,11 @@
 
 #include "autopas/molecularDynamics/LJFunctor.h"
 
+namespace AoSvsSoATest {
+
 using namespace autopas;
 
-#define PARTICLES_PER_DIM 16
+constexpr size_t PARTICLES_PER_DIM = 16;
 
 /**
  * Generates a reproducible set of particles
@@ -83,3 +85,4 @@ TEST_F(AoSvsSoATest, testAoSvsSoA) {
     ASSERT_NEAR(particlesAoS[i].getF()[2], cell._particles[i].getF()[2], 1.0e-13);
   }
 }
+} // end namespace AoSvsSoATest

--- a/tests/testAutopas/tests/molecularDynamics/AoSvsSoATest.cpp
+++ b/tests/testAutopas/tests/molecularDynamics/AoSvsSoATest.cpp
@@ -85,4 +85,4 @@ TEST_F(AoSvsSoATest, testAoSvsSoA) {
     ASSERT_NEAR(particlesAoS[i].getF()[2], cell._particles[i].getF()[2], 1.0e-13);
   }
 }
-} // end namespace AoSvsSoATest
+}  // end namespace AoSvsSoATest

--- a/tests/testAutopas/tests/molecularDynamics/AoSvsSoATest.h
+++ b/tests/testAutopas/tests/molecularDynamics/AoSvsSoATest.h
@@ -21,4 +21,4 @@ class AoSvsSoATest : public AutoPasTestBase {
   void generateParticles(std::vector<Molecule> *particles);
 };
 
-} // end namespace AoSvsSoATest
+}  // end namespace AoSvsSoATest

--- a/tests/testAutopas/tests/molecularDynamics/AoSvsSoATest.h
+++ b/tests/testAutopas/tests/molecularDynamics/AoSvsSoATest.h
@@ -14,7 +14,11 @@
 #include "autopas/molecularDynamics/ParticlePropertiesLibrary.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace AoSvsSoATest {
+
 class AoSvsSoATest : public AutoPasTestBase {
  public:
   void generateParticles(std::vector<Molecule> *particles);
 };
+
+} // end namespace AoSvsSoATest

--- a/tests/testAutopas/tests/molecularDynamics/ForceCalculationTest.cpp
+++ b/tests/testAutopas/tests/molecularDynamics/ForceCalculationTest.cpp
@@ -85,4 +85,4 @@ TEST_F(ForceCalculationTest, testLJwithF0SoA) {
 
   testLJ(spacing, cutoff, autopas::DataLayoutOption::soa, expectedForces, tolerance);
 }
-} // end namespace ForceCalculationTest
+}  // end namespace ForceCalculationTest

--- a/tests/testAutopas/tests/molecularDynamics/ForceCalculationTest.cpp
+++ b/tests/testAutopas/tests/molecularDynamics/ForceCalculationTest.cpp
@@ -11,6 +11,8 @@
 #include "autopasTools/generators/GridGenerator.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace ForceCalculationTest {
+
 void ForceCalculationTest::testLJ(double particleSpacing, double cutoff, autopas::DataLayoutOption dataLayoutOption,
                                   std::array<std::array<double, 3>, 4> expectedForces, double tolerance) {
   autopas::AutoPas<Molecule> autoPas;
@@ -83,3 +85,4 @@ TEST_F(ForceCalculationTest, testLJwithF0SoA) {
 
   testLJ(spacing, cutoff, autopas::DataLayoutOption::soa, expectedForces, tolerance);
 }
+} // end namespace ForceCalculationTest

--- a/tests/testAutopas/tests/molecularDynamics/ForceCalculationTest.h
+++ b/tests/testAutopas/tests/molecularDynamics/ForceCalculationTest.h
@@ -36,4 +36,4 @@ class ForceCalculationTest : public AutoPasTestBase {
               std::array<std::array<double, 3>, 4> expectedForces, double tolerance);
 };
 
-} // end namespace ForceCalculationTest
+}  // end namespace ForceCalculationTest

--- a/tests/testAutopas/tests/molecularDynamics/ForceCalculationTest.h
+++ b/tests/testAutopas/tests/molecularDynamics/ForceCalculationTest.h
@@ -13,6 +13,8 @@
 #include "AutoPasTestBase.h"
 #include "autopas/options/DataLayoutOption.h"
 
+namespace ForceCalculationTest {
+
 class ForceCalculationTest : public AutoPasTestBase {
  public:
   ForceCalculationTest() = default;
@@ -33,3 +35,5 @@ class ForceCalculationTest : public AutoPasTestBase {
   void testLJ(double particleSpacing, double cutoff, autopas::DataLayoutOption dataLayoutOption,
               std::array<std::array<double, 3>, 4> expectedForces, double tolerance);
 };
+
+} // end namespace ForceCalculationTest

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorAVXTest.cpp
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorAVXTest.cpp
@@ -14,6 +14,8 @@
 #include "autopas/particles/Particle.h"
 #include "autopasTools/generators/RandomGenerator.h"
 
+namespace LJFunctorAVXTest {
+
 template <class SoAType>
 bool LJFunctorAVXTest::SoAParticlesEqual(autopas::SoA<SoAType> &soa1, autopas::SoA<SoAType> &soa2) {
   EXPECT_GT(soa1.getNumParticles(), 0);
@@ -391,3 +393,5 @@ INSTANTIATE_TEST_SUITE_P(Generated, LJFunctorAVXTest, ::testing::Combine(::testi
                          toString);
 
 #endif  // __AVX__
+
+} // end namespace LJFunctorAVXTest

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorAVXTest.cpp
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorAVXTest.cpp
@@ -392,6 +392,5 @@ static auto toString = [](const auto &info) {
 INSTANTIATE_TEST_SUITE_P(Generated, LJFunctorAVXTest, ::testing::Combine(::testing::Bool(), ::testing::Bool()),
                          toString);
 
-#endif  // __AVX__
-
 }  // end namespace LJFunctorAVXTest
+#endif  // __AVX__

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorAVXTest.cpp
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorAVXTest.cpp
@@ -394,4 +394,4 @@ INSTANTIATE_TEST_SUITE_P(Generated, LJFunctorAVXTest, ::testing::Combine(::testi
 
 #endif  // __AVX__
 
-} // end namespace LJFunctorAVXTest
+}  // end namespace LJFunctorAVXTest

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorAVXTest.h
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorAVXTest.h
@@ -99,6 +99,6 @@ class LJFunctorAVXTest : public AutoPasTestBase, public ::testing::WithParamInte
   const std::array<double, 3> _lowCorner{0., 0., 0.};
   const std::array<double, 3> _highCorner{6., 6., 6.};
 };
-#endif  // __AVX__
 
 }  // end namespace LJFunctorAVXTest
+#endif  // __AVX__

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorAVXTest.h
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorAVXTest.h
@@ -101,4 +101,4 @@ class LJFunctorAVXTest : public AutoPasTestBase, public ::testing::WithParamInte
 };
 #endif  // __AVX__
 
-} // end namespace LJFunctorAVXTest
+}  // end namespace LJFunctorAVXTest

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorAVXTest.h
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorAVXTest.h
@@ -12,6 +12,8 @@
 #include "autopas/utils/SoA.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace LJFunctorAVXTest {
+
 using LJFunctorAVXTestingTuple = std::tuple<bool /*newton3*/, bool /*doDeleteSomeParticles*/>;
 
 class LJFunctorAVXTest : public AutoPasTestBase, public ::testing::WithParamInterface<LJFunctorAVXTestingTuple> {
@@ -98,3 +100,5 @@ class LJFunctorAVXTest : public AutoPasTestBase, public ::testing::WithParamInte
   const std::array<double, 3> _highCorner{6., 6., 6.};
 };
 #endif  // __AVX__
+
+} // end namespace LJFunctorAVXTest

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorCudaTest.cpp
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorCudaTest.cpp
@@ -268,6 +268,5 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::ValuesIn({0, 1, 4, 16, 31, 32, 33, 55, 64, 65}) /* numParticlesSecondCell */),
     toString);
 
-} // end namespace LJFunctorCudaTest
+}  // end namespace LJFunctorCudaTest
 #endif  // AUTOPAS_CUDA
-

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorCudaTest.cpp
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorCudaTest.cpp
@@ -13,6 +13,8 @@
 #include "autopas/utils/StaticBoolSelector.h"
 #include "autopasTools/generators/RandomGenerator.h"
 
+namespace LJFunctorCudaTest {
+
 template <class Particle>
 bool LJFunctorCudaTest::SoAParticlesEqual(autopas::SoA<typename Particle::SoAArraysType> &soa1,
                                           autopas::SoA<typename Particle::SoAArraysType> &soa2) {
@@ -266,4 +268,6 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::ValuesIn({0, 1, 4, 16, 31, 32, 33, 55, 64, 65}) /* numParticlesSecondCell */),
     toString);
 
+} // end namespace LJFunctorCudaTest
 #endif  // AUTOPAS_CUDA
+

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorCudaTest.h
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorCudaTest.h
@@ -11,6 +11,8 @@
 #include "autopas/utils/SoA.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace LJFunctorCudaTest {
+
 class LJFunctorCudaTest : public AutoPasTestBase,
                           public ::testing::WithParamInterface<
                               std::tuple<bool /*newton3 */, bool /*calculateGlobals*/, bool /*withDeletions*/,
@@ -83,4 +85,6 @@ class LJFunctorCudaTest : public AutoPasTestBase,
   const std::array<double, 3> _highCorner;
 };
 
+} // end namespace LJFunctorCudaTest
 #endif  // AUTOPAS_CUDA
+

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorCudaTest.h
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorCudaTest.h
@@ -85,6 +85,5 @@ class LJFunctorCudaTest : public AutoPasTestBase,
   const std::array<double, 3> _highCorner;
 };
 
-} // end namespace LJFunctorCudaTest
+}  // end namespace LJFunctorCudaTest
 #endif  // AUTOPAS_CUDA
-

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorTest.h
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorTest.h
@@ -77,4 +77,4 @@ struct LJFunAVXShiftMixGlob : public LJFunAVXMol<true, true, true> {
 struct LJFunAVXShiftNoMixGlob : public LJFunAVXMol<true, false, true> {
   using LJFunAVXMol<true, false, true>::LJFunctorAVX;
 };
-} // end namespace LJFunctorTest
+}  // end namespace LJFunctorTest

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorTest.h
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorTest.h
@@ -14,6 +14,8 @@
 #include "autopas/utils/ExceptionHandler.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace LJFunctorTest {
+
 class LJFunctorTest : public AutoPasTestBase {
  public:
   LJFunctorTest() : AutoPasTestBase() {}
@@ -75,3 +77,4 @@ struct LJFunAVXShiftMixGlob : public LJFunAVXMol<true, true, true> {
 struct LJFunAVXShiftNoMixGlob : public LJFunAVXMol<true, false, true> {
   using LJFunAVXMol<true, false, true>::LJFunctorAVX;
 };
+} // end namespace LJFunctorTest

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorTestGlobals.cpp
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorTestGlobals.cpp
@@ -6,6 +6,8 @@
 
 #include "LJFunctorTestGlobals.h"
 
+namespace LJFunctorTestGlobals {
+
 TYPED_TEST_SUITE_P(LJFunctorTestGlobals);
 
 template <class FuncType>
@@ -348,10 +350,12 @@ REGISTER_TYPED_TEST_SUITE_P(LJFunctorTestGlobals, testAoSFunctorGlobals, testAoS
                             testSoAFunctorGlobalsOwn, testSoAFunctorGlobalsPair, testSoAFunctorGlobalsVerlet,
                             testFunctorGlobalsThrowBad);
 
-using MyTypes = ::testing::Types<LJFunShiftNoMixGlob
+using MyTypes = ::testing::Types<LJFunctorTest::LJFunShiftNoMixGlob
 #ifdef __AVX__
                                  ,
-                                 LJFunAVXShiftNoMixGlob
+                                 LJFunctorTest::LJFunAVXShiftNoMixGlob
 #endif
                                  >;
 INSTANTIATE_TYPED_TEST_SUITE_P(GeneratedTyped, LJFunctorTestGlobals, MyTypes);
+
+}  // end namespace LJFunctorTestGlobals

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorTestGlobals.h
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorTestGlobals.h
@@ -12,13 +12,14 @@
 #include "autopas/molecularDynamics/ParticlePropertiesLibrary.h"
 #include "autopasTools/generators/RandomGenerator.h"
 
+namespace LJFunctorTestGlobals {
 template <class FuncType>
-class LJFunctorTestGlobals : public LJFunctorTest {
+class LJFunctorTestGlobals : public LJFunctorTest::LJFunctorTest {
  public:
   LJFunctorTestGlobals() : LJFunctorTest() {}
 
-  static void testAoSGlobals(where_type where, bool newton3);
-  static void testSoAGlobals(where_type where, bool newton3, InteractionType interactionType,
+  static void testAoSGlobals(LJFunctorTest::where_type where, bool newton3);
+  static void testSoAGlobals(LJFunctorTest::where_type where, bool newton3, LJFunctorTest::InteractionType interactionType,
                              size_t additionalParticlesToVerletNumber, uint64_t numParticleReplicas);
 
   constexpr static double cutoff{1.};
@@ -29,3 +30,5 @@ class LJFunctorTestGlobals : public LJFunctorTest {
   constexpr static double expectedEnergy{529783.50857210846};
   constexpr static double absDelta{1e-7};
 };
+
+} // end namespace LJFunctorTestGlobals

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorTestGlobals.h
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorTestGlobals.h
@@ -19,8 +19,9 @@ class LJFunctorTestGlobals : public LJFunctorTest::LJFunctorTest {
   LJFunctorTestGlobals() : LJFunctorTest() {}
 
   static void testAoSGlobals(LJFunctorTest::where_type where, bool newton3);
-  static void testSoAGlobals(LJFunctorTest::where_type where, bool newton3, LJFunctorTest::InteractionType interactionType,
-                             size_t additionalParticlesToVerletNumber, uint64_t numParticleReplicas);
+  static void testSoAGlobals(LJFunctorTest::where_type where, bool newton3,
+                             LJFunctorTest::InteractionType interactionType, size_t additionalParticlesToVerletNumber,
+                             uint64_t numParticleReplicas);
 
   constexpr static double cutoff{1.};
   constexpr static double epsilon{1.};
@@ -31,4 +32,4 @@ class LJFunctorTestGlobals : public LJFunctorTest::LJFunctorTest {
   constexpr static double absDelta{1e-7};
 };
 
-} // end namespace LJFunctorTestGlobals
+}  // end namespace LJFunctorTestGlobals

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorTestNoGlobals.cpp
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorTestNoGlobals.cpp
@@ -6,6 +6,8 @@
 
 #include "LJFunctorTestNoGlobals.h"
 
+namespace LJFunctorTestNoGlobals {
+
 TYPED_TEST_SUITE_P(LJFunctorTestNoGlobals);
 
 TYPED_TEST_P(LJFunctorTestNoGlobals, testAoSNoGlobals) {
@@ -255,12 +257,14 @@ struct Newton3True : public TypeWrapper<FuncType, true> {};
 template <class FuncType>
 struct Newton3False : public TypeWrapper<FuncType, false> {};
 
-using MyTypes = ::testing::Types<Newton3True<LJFunShiftMixNoGlob>, Newton3False<LJFunShiftMixNoGlob>,
-                                 Newton3True<LJFunShiftNoMixNoGlob>, Newton3False<LJFunShiftNoMixNoGlob>
+using MyTypes = ::testing::Types<Newton3True<LJFunctorTest::LJFunShiftMixNoGlob>, Newton3False<LJFunctorTest::LJFunShiftMixNoGlob>,
+                                 Newton3True<LJFunctorTest::LJFunShiftNoMixNoGlob>, Newton3False<LJFunctorTest::LJFunShiftNoMixNoGlob>
 #ifdef __AVX__
                                  ,
-                                 Newton3True<LJFunAVXShiftMixNoGlob>, Newton3False<LJFunAVXShiftMixNoGlob>,
-                                 Newton3True<LJFunAVXShiftNoMixNoGlob>, Newton3False<LJFunAVXShiftNoMixNoGlob>
+                                 Newton3True<LJFunctorTest::LJFunAVXShiftMixNoGlob>, Newton3False<LJFunctorTest::LJFunAVXShiftMixNoGlob>,
+                                 Newton3True<LJFunctorTest::LJFunAVXShiftNoMixNoGlob>, Newton3False<LJFunctorTest::LJFunAVXShiftNoMixNoGlob>
 #endif
                                  >;
 INSTANTIATE_TYPED_TEST_SUITE_P(GeneratedTyped, LJFunctorTestNoGlobals, MyTypes);
+
+} // end namespace LJFunctorTestNoGlobals

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorTestNoGlobals.cpp
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorTestNoGlobals.cpp
@@ -257,14 +257,15 @@ struct Newton3True : public TypeWrapper<FuncType, true> {};
 template <class FuncType>
 struct Newton3False : public TypeWrapper<FuncType, false> {};
 
-using MyTypes = ::testing::Types<Newton3True<LJFunctorTest::LJFunShiftMixNoGlob>, Newton3False<LJFunctorTest::LJFunShiftMixNoGlob>,
-                                 Newton3True<LJFunctorTest::LJFunShiftNoMixNoGlob>, Newton3False<LJFunctorTest::LJFunShiftNoMixNoGlob>
+using MyTypes = ::testing::Types<
+    Newton3True<LJFunctorTest::LJFunShiftMixNoGlob>, Newton3False<LJFunctorTest::LJFunShiftMixNoGlob>,
+    Newton3True<LJFunctorTest::LJFunShiftNoMixNoGlob>, Newton3False<LJFunctorTest::LJFunShiftNoMixNoGlob>
 #ifdef __AVX__
-                                 ,
-                                 Newton3True<LJFunctorTest::LJFunAVXShiftMixNoGlob>, Newton3False<LJFunctorTest::LJFunAVXShiftMixNoGlob>,
-                                 Newton3True<LJFunctorTest::LJFunAVXShiftNoMixNoGlob>, Newton3False<LJFunctorTest::LJFunAVXShiftNoMixNoGlob>
+    ,
+    Newton3True<LJFunctorTest::LJFunAVXShiftMixNoGlob>, Newton3False<LJFunctorTest::LJFunAVXShiftMixNoGlob>,
+    Newton3True<LJFunctorTest::LJFunAVXShiftNoMixNoGlob>, Newton3False<LJFunctorTest::LJFunAVXShiftNoMixNoGlob>
 #endif
-                                 >;
+    >;
 INSTANTIATE_TYPED_TEST_SUITE_P(GeneratedTyped, LJFunctorTestNoGlobals, MyTypes);
 
-} // end namespace LJFunctorTestNoGlobals
+}  // end namespace LJFunctorTestNoGlobals

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorTestNoGlobals.h
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorTestNoGlobals.h
@@ -33,4 +33,4 @@ class LJFunctorTestNoGlobals : public LJFunctorTest::LJFunctorTest {
   constexpr static double absDelta{1e-7};
 };
 
-} // end namespace LJFunctorTestNoGlobals
+}  // end namespace LJFunctorTestNoGlobals

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorTestNoGlobals.h
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorTestNoGlobals.h
@@ -12,8 +12,10 @@
 #include "autopas/molecularDynamics/ParticlePropertiesLibrary.h"
 #include "autopasTools/generators/RandomGenerator.h"
 
+namespace LJFunctorTestNoGlobals {
+
 template <class FuncType>
-class LJFunctorTestNoGlobals : public LJFunctorTest {
+class LJFunctorTestNoGlobals : public LJFunctorTest::LJFunctorTest {
  public:
   LJFunctorTestNoGlobals() : LJFunctorTest() {}
 
@@ -30,3 +32,5 @@ class LJFunctorTestNoGlobals : public LJFunctorTest {
 
   constexpr static double absDelta{1e-7};
 };
+
+} // end namespace LJFunctorTestNoGlobals

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorTestVs.cpp
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorTestVs.cpp
@@ -110,4 +110,4 @@ using MyTypes = ::testing::Types<
     >;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(GeneratedTyped, LJFunctorTestVs, MyTypes);
-} // end namespace LJFunctorTestVs
+}  // end namespace LJFunctorTestVs

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorTestVs.cpp
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorTestVs.cpp
@@ -6,6 +6,8 @@
 
 #include "LJFunctorTestVs.h"
 
+namespace LJFunctorTestVs {
+
 TYPED_TEST_SUITE_P(LJFunctorTestVs);
 
 TYPED_TEST_P(LJFunctorTestVs, testSetPropertiesVSPPLSoA) {
@@ -95,16 +97,17 @@ REGISTER_TYPED_TEST_SUITE_P(LJFunctorTestVs, testSetPropertiesVSPPLSoA, testSetP
  */
 using MyTypes = ::testing::Types<
     // LJFunctor<mixing> VS LJFunctor<not mixing>
-    std::tuple<LJFunShiftMixGlob, LJFunShiftNoMixGlob>
+    std::tuple<LJFunctorTest::LJFunShiftMixGlob, LJFunctorTest::LJFunShiftNoMixGlob>
 #ifdef __AVX__
     ,
     // LJFunctorAVX<mixing> VS LJFunctorAVX<not mixing>
-    std::tuple<LJFunAVXShiftMixGlob, LJFunAVXShiftNoMixGlob>,
+    std::tuple<LJFunctorTest::LJFunAVXShiftMixGlob, LJFunctorTest::LJFunAVXShiftNoMixGlob>,
     // LJFunctor<mixing> VS LJFunctorAVX<not mixing>
-    std::tuple<LJFunShiftMixGlob, LJFunAVXShiftNoMixGlob>,
+    std::tuple<LJFunctorTest::LJFunShiftMixGlob, LJFunctorTest::LJFunAVXShiftNoMixGlob>,
     // LJFunctorAVX<mixing> VS LJFunctor<not mixing>
-    std::tuple<LJFunAVXShiftMixGlob, LJFunShiftNoMixGlob>
+    std::tuple<LJFunctorTest::LJFunAVXShiftMixGlob, LJFunctorTest::LJFunShiftNoMixGlob>
 #endif
     >;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(GeneratedTyped, LJFunctorTestVs, MyTypes);
+} // end namespace LJFunctorTestVs

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorTestVs.h
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorTestVs.h
@@ -13,8 +13,10 @@
 #include "autopas/molecularDynamics/ParticlePropertiesLibrary.h"
 #include "autopasTools/generators/RandomGenerator.h"
 
+namespace LJFunctorTestVs {
+
 template <class FuncType>
-class LJFunctorTestVs : public LJFunctorTest {
+class LJFunctorTestVs : public LJFunctorTest::LJFunctorTest {
  public:
   LJFunctorTestVs() : LJFunctorTest() {}
 
@@ -22,3 +24,5 @@ class LJFunctorTestVs : public LJFunctorTest {
   constexpr static double epsilon{1.};
   constexpr static double sigma{1.};
 };
+
+} // end namespace LJFunctorTestVs

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorTestVs.h
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorTestVs.h
@@ -25,4 +25,4 @@ class LJFunctorTestVs : public LJFunctorTest::LJFunctorTest {
   constexpr static double sigma{1.};
 };
 
-} // end namespace LJFunctorTestVs
+}  // end namespace LJFunctorTestVs

--- a/tests/testAutopas/tests/options/OptionTest.cpp
+++ b/tests/testAutopas/tests/options/OptionTest.cpp
@@ -162,4 +162,4 @@ using OptionTypes = ::testing::Types<autopas::AcquisitionFunctionOption, autopas
                                      autopas::TraversalOption, autopas::TuningStrategyOption>;
 INSTANTIATE_TYPED_TEST_SUITE_P(GeneratedTyped, OptionTest, OptionTypes);
 
-} // end namespace OptionTest
+}  // end namespace OptionTest

--- a/tests/testAutopas/tests/options/OptionTest.cpp
+++ b/tests/testAutopas/tests/options/OptionTest.cpp
@@ -15,6 +15,8 @@
 #include "autopas/options/TuningStrategyOption.h"
 #include "tests/utils/StringUtilsTest.h"
 
+namespace OptionTest {
+
 // parseOptions tests
 // these tests shall not (yet :) be generated since we here want to pass strings that do not match exactly.
 
@@ -159,3 +161,5 @@ using OptionTypes = ::testing::Types<autopas::AcquisitionFunctionOption, autopas
                                      autopas::DataLayoutOption, autopas::Newton3Option, autopas::SelectorStrategyOption,
                                      autopas::TraversalOption, autopas::TuningStrategyOption>;
 INSTANTIATE_TYPED_TEST_SUITE_P(GeneratedTyped, OptionTest, OptionTypes);
+
+} // end namespace OptionTest

--- a/tests/testAutopas/tests/options/OptionTest.h
+++ b/tests/testAutopas/tests/options/OptionTest.h
@@ -11,6 +11,8 @@
 #include "AutoPasTestBase.h"
 #include "autopas/utils/ArrayUtils.h"
 
+namespace OptionTest {
+
 /**
  * Tests for all Options derived from autopas::Option.
  * @tparam T Template needed for Type-Parameterized Tests
@@ -54,3 +56,5 @@ void testParseOptionsCombined(const std::map<T, std::string> &mapOptionString) {
       << "Incorrect number of options parsed! Following options were found: "
       << autopas::utils::ArrayUtils::to_string(parsedOptions);
 }
+
+} // end namespace OptionTest

--- a/tests/testAutopas/tests/options/OptionTest.h
+++ b/tests/testAutopas/tests/options/OptionTest.h
@@ -57,4 +57,4 @@ void testParseOptionsCombined(const std::map<T, std::string> &mapOptionString) {
       << autopas::utils::ArrayUtils::to_string(parsedOptions);
 }
 
-} // end namespace OptionTest
+}  // end namespace OptionTest

--- a/tests/testAutopas/tests/pairwiseFunctors/FlopCounterTest.cpp
+++ b/tests/testAutopas/tests/pairwiseFunctors/FlopCounterTest.cpp
@@ -183,4 +183,4 @@ TEST_F(FlopCounterTest, testFlopCounterSoAOpenMP) {
   }
 }
 
-} // end namespace FlopCounterTest
+}  // end namespace FlopCounterTest

--- a/tests/testAutopas/tests/pairwiseFunctors/FlopCounterTest.cpp
+++ b/tests/testAutopas/tests/pairwiseFunctors/FlopCounterTest.cpp
@@ -9,6 +9,8 @@
 #include "autopas/AutoPas.h"
 #include "autopas/pairwiseFunctors/FlopCounterFunctor.h"
 
+namespace FlopCounterTest {
+
 /**
  * Generates a square of four particles, iterates over it with the FlopCounter and checks its values
  * @param dataLayoutOption
@@ -180,3 +182,5 @@ TEST_F(FlopCounterTest, testFlopCounterSoAOpenMP) {
     }
   }
 }
+
+} // end namespace FlopCounterTest

--- a/tests/testAutopas/tests/pairwiseFunctors/FlopCounterTest.h
+++ b/tests/testAutopas/tests/pairwiseFunctors/FlopCounterTest.h
@@ -9,6 +9,8 @@
 #include "AutoPasTestBase.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace FlopCounterTest {
+
 class FlopCounterTest : public AutoPasTestBase {
  public:
   FlopCounterTest() = default;
@@ -17,3 +19,5 @@ class FlopCounterTest : public AutoPasTestBase {
 
   void test(autopas::DataLayoutOption dataLayoutOption);
 };
+
+} // end namespace FlopCounterTest

--- a/tests/testAutopas/tests/pairwiseFunctors/FlopCounterTest.h
+++ b/tests/testAutopas/tests/pairwiseFunctors/FlopCounterTest.h
@@ -20,4 +20,4 @@ class FlopCounterTest : public AutoPasTestBase {
   void test(autopas::DataLayoutOption dataLayoutOption);
 };
 
-} // end namespace FlopCounterTest
+}  // end namespace FlopCounterTest

--- a/tests/testAutopas/tests/particles/myMoleculeTest.cpp
+++ b/tests/testAutopas/tests/particles/myMoleculeTest.cpp
@@ -8,6 +8,8 @@
 
 #include "autopas/particles/Particle.h"
 
+namespace myMoleculeTest {
+
 using namespace autopas;
 
 class MyMolecule : public Particle {
@@ -49,3 +51,5 @@ TEST(myMoleculeTest, testConstructorAndGetters) {
   ASSERT_EQ(id, m.getID());
   ASSERT_EQ(myvar, m.getMyvar());
 }
+
+} // end namespace myMoleculeTest

--- a/tests/testAutopas/tests/particles/myMoleculeTest.cpp
+++ b/tests/testAutopas/tests/particles/myMoleculeTest.cpp
@@ -52,4 +52,4 @@ TEST(myMoleculeTest, testConstructorAndGetters) {
   ASSERT_EQ(myvar, m.getMyvar());
 }
 
-} // end namespace myMoleculeTest
+}  // end namespace myMoleculeTest

--- a/tests/testAutopas/tests/selectors/AutoTunerTest.cpp
+++ b/tests/testAutopas/tests/selectors/AutoTunerTest.cpp
@@ -11,6 +11,8 @@
 #include "autopas/selectors/tuningStrategy/FullSearch.h"
 #include "autopasTools/generators/GridGenerator.h"
 
+namespace AutoTunerTest {
+
 using ::testing::_;
 
 TEST_F(AutoTunerTest, testAllConfigurations) {
@@ -392,3 +394,5 @@ TEST_F(AutoTunerTest, testLastConfigThrownOut) {
   bool doRebuild = true;
   EXPECT_THROW(tuner.iteratePairwise(&functor, doRebuild), autopas::utils::ExceptionHandler::AutoPasException);
 }
+
+} // end namespace AutoTunerTest

--- a/tests/testAutopas/tests/selectors/AutoTunerTest.cpp
+++ b/tests/testAutopas/tests/selectors/AutoTunerTest.cpp
@@ -395,4 +395,4 @@ TEST_F(AutoTunerTest, testLastConfigThrownOut) {
   EXPECT_THROW(tuner.iteratePairwise(&functor, doRebuild), autopas::utils::ExceptionHandler::AutoPasException);
 }
 
-} // end namespace AutoTunerTest
+}  // end namespace AutoTunerTest

--- a/tests/testAutopas/tests/selectors/AutoTunerTest.h
+++ b/tests/testAutopas/tests/selectors/AutoTunerTest.h
@@ -13,6 +13,8 @@
 #include "autopas/selectors/AutoTuner.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace AutoTunerTest {
+
 class AutoTunerTest : public AutoPasTestBase {
  public:
   AutoTunerTest() = default;
@@ -33,3 +35,5 @@ class AutoTunerTest : public AutoPasTestBase {
   void testFastest(autopas::SelectorStrategyOption strategy, mapConfigTime configAndTimes,
                    autopas::Configuration expectedBest, mapConfigTime ignoredConfigAndTimes = {});
 };
+
+} // end namespace AutoTunerTest

--- a/tests/testAutopas/tests/selectors/AutoTunerTest.h
+++ b/tests/testAutopas/tests/selectors/AutoTunerTest.h
@@ -36,4 +36,4 @@ class AutoTunerTest : public AutoPasTestBase {
                    autopas::Configuration expectedBest, mapConfigTime ignoredConfigAndTimes = {});
 };
 
-} // end namespace AutoTunerTest
+}  // end namespace AutoTunerTest

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
@@ -6,6 +6,8 @@
 
 #include "ContainerSelectorTest.h"
 
+namespace ContainerSelectorTest {
+
 using ::testing::Combine;
 using ::testing::UnorderedElementsAreArray;
 using ::testing::ValuesIn;
@@ -132,3 +134,5 @@ INSTANTIATE_TEST_SUITE_P(Generated, ContainerSelectorTest,
                          Combine(ValuesIn(autopas::ContainerOption::getAllOptions()),
                                  ValuesIn(autopas::ContainerOption::getAllOptions())),
                          ContainerSelectorTest::PrintToStringParamName());
+
+} // end namespace ContainerSelectorTest

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
@@ -135,4 +135,4 @@ INSTANTIATE_TEST_SUITE_P(Generated, ContainerSelectorTest,
                                  ValuesIn(autopas::ContainerOption::getAllOptions())),
                          ContainerSelectorTest::PrintToStringParamName());
 
-} // end namespace ContainerSelectorTest
+}  // end namespace ContainerSelectorTest

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTest.h
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTest.h
@@ -12,6 +12,8 @@
 #include "autopas/selectors/ContainerSelector.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace ContainerSelectorTest {
+
 class ContainerSelectorTest
     : public AutoPasTestBase,
       public ::testing::WithParamInterface<std::tuple<autopas::ContainerOption, autopas::ContainerOption>> {
@@ -31,3 +33,5 @@ class ContainerSelectorTest
     }
   };
 };
+
+} // end namespace ContainerSelectorTest

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTest.h
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTest.h
@@ -34,4 +34,4 @@ class ContainerSelectorTest
   };
 };
 
-} // end namespace ContainerSelectorTest
+}  // end namespace ContainerSelectorTest

--- a/tests/testAutopas/tests/selectors/FeatureVectorTest.cpp
+++ b/tests/testAutopas/tests/selectors/FeatureVectorTest.cpp
@@ -12,6 +12,8 @@
 #include "autopas/containers/CompatibleLoadEstimators.h"
 #include "autopas/containers/CompatibleTraversals.h"
 
+namespace FeatureVectorTest {
+
 using namespace autopas;
 
 FeatureVectorTest::FeatureVectorTest() {
@@ -247,3 +249,5 @@ TEST_F(FeatureVectorTest, clusterNeighboursManhattan1Container) {
     }
   }
 }
+
+} // end namespace FeatureVectorTest

--- a/tests/testAutopas/tests/selectors/FeatureVectorTest.cpp
+++ b/tests/testAutopas/tests/selectors/FeatureVectorTest.cpp
@@ -250,4 +250,4 @@ TEST_F(FeatureVectorTest, clusterNeighboursManhattan1Container) {
   }
 }
 
-} // end namespace FeatureVectorTest
+}  // end namespace FeatureVectorTest

--- a/tests/testAutopas/tests/selectors/FeatureVectorTest.h
+++ b/tests/testAutopas/tests/selectors/FeatureVectorTest.h
@@ -22,4 +22,4 @@ class FeatureVectorTest : public AutoPasTestBase {
   std::vector<autopas::Newton3Option> allNewton3;
 };
 
-} // end namespace FeatureVectorTest
+}  // end namespace FeatureVectorTest

--- a/tests/testAutopas/tests/selectors/FeatureVectorTest.h
+++ b/tests/testAutopas/tests/selectors/FeatureVectorTest.h
@@ -11,6 +11,8 @@
 #include "AutoPasTestBase.h"
 #include "autopas/selectors/FeatureVectorEncoder.h"
 
+namespace FeatureVectorTest {
+
 class FeatureVectorTest : public AutoPasTestBase {
  public:
   FeatureVectorTest();
@@ -19,3 +21,5 @@ class FeatureVectorTest : public AutoPasTestBase {
   std::vector<autopas::DataLayoutOption> allDataLayouts;
   std::vector<autopas::Newton3Option> allNewton3;
 };
+
+} // end namespace FeatureVectorTest

--- a/tests/testAutopas/tests/selectors/OptimumSelectorTest.cpp
+++ b/tests/testAutopas/tests/selectors/OptimumSelectorTest.cpp
@@ -8,6 +8,8 @@
 
 #include "autopas/selectors/OptimumSelector.h"
 
+namespace OptimumSelectorTest {
+
 TEST(OptimumSelectorTest, min) {
   std::vector<unsigned long> vals = {5, 6, 3, 1, 7};
 
@@ -31,3 +33,5 @@ TEST(OptimumSelectorTest, median) {
 
   EXPECT_EQ(5, median);
 }
+
+} // end namespace OptimumSelectorTest

--- a/tests/testAutopas/tests/selectors/OptimumSelectorTest.cpp
+++ b/tests/testAutopas/tests/selectors/OptimumSelectorTest.cpp
@@ -34,4 +34,4 @@ TEST(OptimumSelectorTest, median) {
   EXPECT_EQ(5, median);
 }
 
-} // end namespace OptimumSelectorTest
+}  // end namespace OptimumSelectorTest

--- a/tests/testAutopas/tests/selectors/OptimumSelectorTest.h
+++ b/tests/testAutopas/tests/selectors/OptimumSelectorTest.h
@@ -8,8 +8,12 @@
 
 #include "AutoPasTestBase.h"
 
+namespace OptimumSelectorTest {
+
 class OptimumSelectorTest : public AutoPasTestBase {
  public:
   OptimumSelectorTest() = default;
   ~OptimumSelectorTest() = default;
 };
+
+} // end namespace OptimumSelectorTest

--- a/tests/testAutopas/tests/selectors/OptimumSelectorTest.h
+++ b/tests/testAutopas/tests/selectors/OptimumSelectorTest.h
@@ -16,4 +16,4 @@ class OptimumSelectorTest : public AutoPasTestBase {
   ~OptimumSelectorTest() = default;
 };
 
-} // end namespace OptimumSelectorTest
+}  // end namespace OptimumSelectorTest

--- a/tests/testAutopas/tests/selectors/TraversalSelectorTest.cpp
+++ b/tests/testAutopas/tests/selectors/TraversalSelectorTest.cpp
@@ -6,6 +6,8 @@
 
 #include "TraversalSelectorTest.h"
 
+namespace TraversalSelectorTest {
+
 using ::testing::Return;
 
 /**
@@ -28,3 +30,5 @@ TEST_F(TraversalSelectorTest, testSelectAndGetCurrentTraversal) {
         << "Is the domain size large enough for the processors' thread count?";
   }
 }
+
+} // end namespace TraversalSelectorTest

--- a/tests/testAutopas/tests/selectors/TraversalSelectorTest.cpp
+++ b/tests/testAutopas/tests/selectors/TraversalSelectorTest.cpp
@@ -31,4 +31,4 @@ TEST_F(TraversalSelectorTest, testSelectAndGetCurrentTraversal) {
   }
 }
 
-} // end namespace TraversalSelectorTest
+}  // end namespace TraversalSelectorTest

--- a/tests/testAutopas/tests/selectors/TraversalSelectorTest.h
+++ b/tests/testAutopas/tests/selectors/TraversalSelectorTest.h
@@ -14,8 +14,12 @@
 #include "mocks/MockFunctor.h"
 #include "testingHelpers/commonTypedefs.h"
 
+namespace TraversalSelectorTest {
+
 class TraversalSelectorTest : public AutoPasTestBase {
  public:
   TraversalSelectorTest() = default;
   ~TraversalSelectorTest() override = default;
 };
+
+} // end namespace TraversalSelectorTest

--- a/tests/testAutopas/tests/selectors/TraversalSelectorTest.h
+++ b/tests/testAutopas/tests/selectors/TraversalSelectorTest.h
@@ -22,4 +22,4 @@ class TraversalSelectorTest : public AutoPasTestBase {
   ~TraversalSelectorTest() override = default;
 };
 
-} // end namespace TraversalSelectorTest
+}  // end namespace TraversalSelectorTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/ActiveHarmonyTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/ActiveHarmonyTest.cpp
@@ -9,6 +9,4 @@
 #include <gmock/gmock-matchers.h>
 #include <gmock/gmock-more-matchers.h>
 
-namespace ActiveHarmonyTest {
-
-} // end namespace ActiveHarmonyTest
+namespace ActiveHarmonyTest {}  // end namespace ActiveHarmonyTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/ActiveHarmonyTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/ActiveHarmonyTest.cpp
@@ -8,3 +8,7 @@
 
 #include <gmock/gmock-matchers.h>
 #include <gmock/gmock-more-matchers.h>
+
+namespace ActiveHarmonyTest {
+
+} // end namespace ActiveHarmonyTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/ActiveHarmonyTest.h
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/ActiveHarmonyTest.h
@@ -15,4 +15,4 @@ namespace ActiveHarmonyTest {
 
 class ActiveHarmonyTest : public AutoPasTestBase {};
 
-} // end namespace ActiveHarmonyTest
+}  // end namespace ActiveHarmonyTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/ActiveHarmonyTest.h
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/ActiveHarmonyTest.h
@@ -11,4 +11,8 @@
 #include "AutoPasTestBase.h"
 #include "autopas/selectors/tuningStrategy/ActiveHarmony.h"
 
+namespace ActiveHarmonyTest {
+
 class ActiveHarmonyTest : public AutoPasTestBase {};
+
+} // end namespace ActiveHarmonyTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/BayesianClusterSearchTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/BayesianClusterSearchTest.cpp
@@ -9,6 +9,8 @@
 #include <gmock/gmock-matchers.h>
 #include <gmock/gmock-more-matchers.h>
 
+namespace BayesianClusterSearchTest {
+
 TEST_F(BayesianClusterSearchTest, testMaxEvidence) {
   size_t maxEvidence = 4;
   autopas::BayesianClusterSearch bayesClusterSearch(
@@ -220,3 +222,5 @@ TEST_F(BayesianClusterSearchTest, testFindBestVeryDifferent) {
   long bestTime = dummyTimeFun2(best2);
   EXPECT_NEAR(predictionTime, bestTime, timePerDistanceSquared * 0.25);
 }
+
+} // end namespace BayesianClusterSearchTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/BayesianClusterSearchTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/BayesianClusterSearchTest.cpp
@@ -223,4 +223,4 @@ TEST_F(BayesianClusterSearchTest, testFindBestVeryDifferent) {
   EXPECT_NEAR(predictionTime, bestTime, timePerDistanceSquared * 0.25);
 }
 
-} // end namespace BayesianClusterSearchTest
+}  // end namespace BayesianClusterSearchTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/BayesianClusterSearchTest.h
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/BayesianClusterSearchTest.h
@@ -15,4 +15,4 @@ namespace BayesianClusterSearchTest {
 
 class BayesianClusterSearchTest : public AutoPasTestBase {};
 
-} // end namespace BayesianClusterSearchTest
+}  // end namespace BayesianClusterSearchTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/BayesianClusterSearchTest.h
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/BayesianClusterSearchTest.h
@@ -11,4 +11,8 @@
 #include "AutoPasTestBase.h"
 #include "autopas/selectors/tuningStrategy/BayesianClusterSearch.h"
 
+namespace BayesianClusterSearchTest {
+
 class BayesianClusterSearchTest : public AutoPasTestBase {};
+
+} // end namespace BayesianClusterSearchTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/BayesianSearchTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/BayesianSearchTest.cpp
@@ -9,6 +9,8 @@
 #include <gmock/gmock-matchers.h>
 #include <gmock/gmock-more-matchers.h>
 
+namespace BayesianSearchTest {
+
 TEST_F(BayesianSearchTest, testMaxEvidence) {
   size_t maxEvidence = 4;
   autopas::BayesianSearch bayesSearch(
@@ -56,3 +58,5 @@ TEST_F(BayesianSearchTest, testFindBest) {
   autopas::FeatureVector prediction(bayesSearch.getCurrentConfiguration());
   EXPECT_EQ(prediction, best);
 }
+
+} // end namespace BayesianSearchTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/BayesianSearchTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/BayesianSearchTest.cpp
@@ -59,4 +59,4 @@ TEST_F(BayesianSearchTest, testFindBest) {
   EXPECT_EQ(prediction, best);
 }
 
-} // end namespace BayesianSearchTest
+}  // end namespace BayesianSearchTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/BayesianSearchTest.h
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/BayesianSearchTest.h
@@ -11,4 +11,8 @@
 #include "AutoPasTestBase.h"
 #include "autopas/selectors/tuningStrategy/BayesianSearch.h"
 
+namespace BayesianSearchTest {
+
 class BayesianSearchTest : public AutoPasTestBase {};
+
+} // end namespace BayesianSearchTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/BayesianSearchTest.h
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/BayesianSearchTest.h
@@ -15,4 +15,4 @@ namespace BayesianSearchTest {
 
 class BayesianSearchTest : public AutoPasTestBase {};
 
-} // end namespace BayesianSearchTest
+}  // end namespace BayesianSearchTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/FullSearchTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/FullSearchTest.cpp
@@ -54,4 +54,4 @@ TEST_F(FullSearchTest, testTune) {
   EXPECT_EQ(optimalConfig, fullSearch.getCurrentConfiguration());
 }
 
-} // end namespace FullSearchTest
+}  // end namespace FullSearchTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/FullSearchTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/FullSearchTest.cpp
@@ -9,6 +9,8 @@
 #include <gmock/gmock-matchers.h>
 #include <gmock/gmock-more-matchers.h>
 
+namespace FullSearchTest {
+
 TEST_F(FullSearchTest, testSearchSpaceEmpty) {
   autopas::FullSearch fullSearch({});
   EXPECT_TRUE(fullSearch.searchSpaceIsEmpty());
@@ -51,3 +53,5 @@ TEST_F(FullSearchTest, testTune) {
   fullSearch.tune();
   EXPECT_EQ(optimalConfig, fullSearch.getCurrentConfiguration());
 }
+
+} // end namespace FullSearchTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/FullSearchTest.h
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/FullSearchTest.h
@@ -15,4 +15,4 @@ namespace FullSearchTest {
 
 class FullSearchTest : public AutoPasTestBase {};
 
-} // end namespace FullSearchTest
+}  // end namespace FullSearchTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/FullSearchTest.h
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/FullSearchTest.h
@@ -11,4 +11,8 @@
 #include "AutoPasTestBase.h"
 #include "autopas/selectors/tuningStrategy/FullSearch.h"
 
+namespace FullSearchTest {
+
 class FullSearchTest : public AutoPasTestBase {};
+
+} // end namespace FullSearchTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/GaussianModel/GaussianClusterTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/GaussianModel/GaussianClusterTest.cpp
@@ -6,6 +6,8 @@
 
 #include "GaussianClusterTest.h"
 
+namespace GaussianClusterTest {
+
 using namespace autopas;
 
 TEST_F(GaussianClusterTest, wrongDimension) {
@@ -147,3 +149,5 @@ void GaussianClusterTest::printEvidence(const Eigen::VectorXi &vecDiscrete, cons
   std::cout << "Evidence " << evidenceNum << ": " << vecDiscrete[0] << "," << vecContinuous[0] << ","
             << vecContinuous[1] << " -> " << out << std::endl;
 }
+
+} // end namespace GaussianClusterTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/GaussianModel/GaussianClusterTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/GaussianModel/GaussianClusterTest.cpp
@@ -150,4 +150,4 @@ void GaussianClusterTest::printEvidence(const Eigen::VectorXi &vecDiscrete, cons
             << vecContinuous[1] << " -> " << out << std::endl;
 }
 
-} // end namespace GaussianClusterTest
+}  // end namespace GaussianClusterTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/GaussianModel/GaussianClusterTest.h
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/GaussianModel/GaussianClusterTest.h
@@ -115,4 +115,4 @@ class GaussianClusterTest : public AutoPasTestBase {
                             size_t evidenceNum);
 };
 
-} // end namespace GaussianClusterTest
+}  // end namespace GaussianClusterTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/GaussianModel/GaussianClusterTest.h
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/GaussianModel/GaussianClusterTest.h
@@ -15,6 +15,8 @@
 #include "autopas/utils/NumberSet.h"
 #include "autopas/utils/Random.h"
 
+namespace GaussianClusterTest {
+
 class GaussianClusterTest : public AutoPasTestBase {
  protected:
   /**
@@ -112,3 +114,5 @@ class GaussianClusterTest : public AutoPasTestBase {
   static void printEvidence(const Eigen::VectorXi &vecDiscrete, const Eigen::VectorXd &vecContinuous, double out,
                             size_t evidenceNum);
 };
+
+} // end namespace GaussianClusterTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/GaussianModel/GaussianProcessTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/GaussianModel/GaussianProcessTest.cpp
@@ -267,4 +267,4 @@ void GaussianProcessTest::printMap(int xChunks, int yChunks, const autopas::Numb
   }
 }
 
-} // end namespace GaussianProcessTest
+}  // end namespace GaussianProcessTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/GaussianModel/GaussianProcessTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/GaussianModel/GaussianProcessTest.cpp
@@ -6,6 +6,8 @@
 
 #include "GaussianProcessTest.h"
 
+namespace GaussianProcessTest {
+
 using namespace autopas;
 
 TEST_F(GaussianProcessTest, wrongDimension) {
@@ -264,3 +266,5 @@ void GaussianProcessTest::printMap(int xChunks, int yChunks, const autopas::Numb
     std::cout << "\033[0m" << std::endl;
   }
 }
+
+} // end namespace GaussianProcessTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/GaussianModel/GaussianProcessTest.h
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/GaussianModel/GaussianProcessTest.h
@@ -15,6 +15,8 @@
 #include "autopas/utils/NumberSet.h"
 #include "autopas/utils/Random.h"
 
+namespace GaussianProcessTest {
+
 class GaussianProcessTest : public AutoPasTestBase {
  protected:
   /**
@@ -87,3 +89,5 @@ class GaussianProcessTest : public AutoPasTestBase {
                        const autopas::NumberSet<double> &domainY, const autopas::GaussianProcess &gp,
                        autopas::AcquisitionFunctionOption af, double colorFactor);
 };
+
+} // end namespace GaussianProcessTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/GaussianModel/GaussianProcessTest.h
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/GaussianModel/GaussianProcessTest.h
@@ -90,4 +90,4 @@ class GaussianProcessTest : public AutoPasTestBase {
                        autopas::AcquisitionFunctionOption af, double colorFactor);
 };
 
-} // end namespace GaussianProcessTest
+}  // end namespace GaussianProcessTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/PredictiveTuningTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/PredictiveTuningTest.cpp
@@ -6,6 +6,8 @@
 
 #include "PredictiveTuningTest.h"
 
+namespace PredictiveTuningTest {
+
 autopas::PredictiveTuning PredictiveTuningTest::getPredictiveTuning(
     unsigned int testsUntilFirstPrediction, autopas::ExtrapolationMethodOption extrapolationMethodOption,
     double blacklistRange, const std::set<autopas::TraversalOption> &allowedTraversalOptions) {
@@ -277,3 +279,5 @@ TEST_F(PredictiveTuningTest, testBlacklist) {
 
   EXPECT_EQ(bestConfiguration, predictiveTuning.getCurrentConfiguration());
 }
+
+} // end namespace PredictiveTuningTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/PredictiveTuningTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/PredictiveTuningTest.cpp
@@ -280,4 +280,4 @@ TEST_F(PredictiveTuningTest, testBlacklist) {
   EXPECT_EQ(bestConfiguration, predictiveTuning.getCurrentConfiguration());
 }
 
-} // end namespace PredictiveTuningTest
+}  // end namespace PredictiveTuningTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/PredictiveTuningTest.h
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/PredictiveTuningTest.h
@@ -76,4 +76,4 @@ class PredictiveTuningTest : public AutoPasTestBase {
   static constexpr unsigned int evidenceFirstPrediction{2};
 };
 
-} // end namespace PredictiveTuningTest
+}  // end namespace PredictiveTuningTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/PredictiveTuningTest.h
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/PredictiveTuningTest.h
@@ -13,6 +13,8 @@
 #include "autopas/options/ExtrapolationMethodOption.h"
 #include "autopas/selectors/tuningStrategy/PredictiveTuning.h"
 
+namespace PredictiveTuningTest {
+
 class PredictiveTuningTest : public AutoPasTestBase {
  protected:
   /**
@@ -73,3 +75,5 @@ class PredictiveTuningTest : public AutoPasTestBase {
   static constexpr unsigned int maxTuningIterationsWithoutTest{5};
   static constexpr unsigned int evidenceFirstPrediction{2};
 };
+
+} // end namespace PredictiveTuningTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/RandomSearchTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/RandomSearchTest.cpp
@@ -8,3 +8,7 @@
 
 #include <gmock/gmock-matchers.h>
 #include <gmock/gmock-more-matchers.h>
+
+namespace RandomSearchTest {
+
+} // end namespace RandomSearchTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/RandomSearchTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/RandomSearchTest.cpp
@@ -9,6 +9,4 @@
 #include <gmock/gmock-matchers.h>
 #include <gmock/gmock-more-matchers.h>
 
-namespace RandomSearchTest {
-
-} // end namespace RandomSearchTest
+namespace RandomSearchTest {}  // end namespace RandomSearchTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/RandomSearchTest.h
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/RandomSearchTest.h
@@ -11,4 +11,8 @@
 #include "AutoPasTestBase.h"
 #include "autopas/selectors/tuningStrategy/RandomSearch.h"
 
+namespace RandomSearchTest {
+
 class RandomSearchTest : public AutoPasTestBase {};
+
+} // end namespace RandomSearchTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/RandomSearchTest.h
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/RandomSearchTest.h
@@ -15,4 +15,4 @@ namespace RandomSearchTest {
 
 class RandomSearchTest : public AutoPasTestBase {};
 
-} // end namespace RandomSearchTest
+}  // end namespace RandomSearchTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/TuningStrategyTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/TuningStrategyTest.cpp
@@ -9,6 +9,8 @@
 #include <gmock/gmock-matchers.h>
 #include <gmock/gmock-more-matchers.h>
 
+namespace TuningStrategyTest {
+
 /**
  * Generating a TuningStrategy without a valid configuration is expected to throw
  */
@@ -115,3 +117,5 @@ TEST_P(TuningStrategyTest, testRemoveN3OptionRemoveSome) {
 INSTANTIATE_TEST_SUITE_P(Generated, TuningStrategyTest,
                          testing::ValuesIn(autopas::TuningStrategyOption::getAllOptions()),
                          TuningStrategyTest::PrintToStringParamName());
+
+} // end namespace TuningStrategyTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/TuningStrategyTest.cpp
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/TuningStrategyTest.cpp
@@ -118,4 +118,4 @@ INSTANTIATE_TEST_SUITE_P(Generated, TuningStrategyTest,
                          testing::ValuesIn(autopas::TuningStrategyOption::getAllOptions()),
                          TuningStrategyTest::PrintToStringParamName());
 
-} // end namespace TuningStrategyTest
+}  // end namespace TuningStrategyTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/TuningStrategyTest.h
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/TuningStrategyTest.h
@@ -11,6 +11,8 @@
 #include "AutoPasTestBase.h"
 #include "autopas/selectors/tuningStrategy/TuningStrategyFactory.h"
 
+namespace TuningStrategyTest {
+
 class TuningStrategyTest : public AutoPasTestBase, public ::testing::WithParamInterface<autopas::TuningStrategyOption> {
  public:
   struct PrintToStringParamName {
@@ -23,3 +25,5 @@ class TuningStrategyTest : public AutoPasTestBase, public ::testing::WithParamIn
     }
   };
 };
+
+} // end namespace TuningStrategyTest

--- a/tests/testAutopas/tests/selectors/tuningStrategy/TuningStrategyTest.h
+++ b/tests/testAutopas/tests/selectors/tuningStrategy/TuningStrategyTest.h
@@ -26,4 +26,4 @@ class TuningStrategyTest : public AutoPasTestBase, public ::testing::WithParamIn
   };
 };
 
-} // end namespace TuningStrategyTest
+}  // end namespace TuningStrategyTest

--- a/tests/testAutopas/tests/sph/SPHTest.cpp
+++ b/tests/testAutopas/tests/sph/SPHTest.cpp
@@ -9,6 +9,8 @@
 #include "autopas/containers/linkedCells/LinkedCells.h"
 #include "autopas/containers/verletListsCellBased/verletLists/VerletLists.h"
 
+namespace SPHTest {
+
 using DensityFunctorType = autopas::sph::SPHCalcDensityFunctor<autopas::sph::SPHParticle>;
 
 using HydroForceFunctorType = autopas::sph::SPHCalcHydroForceFunctor<autopas::sph::SPHParticle>;
@@ -760,3 +762,4 @@ INSTANTIATE_TEST_SUITE_P(Generated, SPHTest,
                                                               autopas::DataLayoutOption::soa),
                                             ::testing::Values(SPHFunctorType::density, SPHFunctorType::hydro)),
                          SPHTest::PrintToStringParamName());
+} // end namespace SPHTest

--- a/tests/testAutopas/tests/sph/SPHTest.cpp
+++ b/tests/testAutopas/tests/sph/SPHTest.cpp
@@ -762,4 +762,4 @@ INSTANTIATE_TEST_SUITE_P(Generated, SPHTest,
                                                               autopas::DataLayoutOption::soa),
                                             ::testing::Values(SPHFunctorType::density, SPHFunctorType::hydro)),
                          SPHTest::PrintToStringParamName());
-} // end namespace SPHTest
+}  // end namespace SPHTest

--- a/tests/testAutopas/tests/sph/SPHTest.h
+++ b/tests/testAutopas/tests/sph/SPHTest.h
@@ -40,4 +40,4 @@ class SPHTest : public AutoPasTestBase,
   };
 };
 
-} // end namespace SPHTest
+}  // end namespace SPHTest

--- a/tests/testAutopas/tests/sph/SPHTest.h
+++ b/tests/testAutopas/tests/sph/SPHTest.h
@@ -14,6 +14,8 @@
 #include "autopas/sph/autopassph.h"
 #include "autopasTools/generators/RandomGenerator.h"
 
+namespace SPHTest {
+
 enum SPHFunctorType { density, hydro };
 
 class SPHTest : public AutoPasTestBase,
@@ -37,3 +39,5 @@ class SPHTest : public AutoPasTestBase,
     }
   };
 };
+
+} // end namespace SPHTest

--- a/tests/testAutopas/tests/utils/ArrayMathTest.cpp
+++ b/tests/testAutopas/tests/utils/ArrayMathTest.cpp
@@ -116,4 +116,4 @@ TEST(ArrayMathTest, testNormalizeNullVector) {
   }
 }
 
-} // end namespace ArrayMathTest
+}  // end namespace ArrayMathTest

--- a/tests/testAutopas/tests/utils/ArrayMathTest.cpp
+++ b/tests/testAutopas/tests/utils/ArrayMathTest.cpp
@@ -8,6 +8,8 @@
 
 #include "autopas/utils/ArrayMath.h"
 
+namespace ArrayMathTest {
+
 using namespace autopas;
 
 TEST(ArrayMathTest, testAddInt) {
@@ -113,3 +115,5 @@ TEST(ArrayMathTest, testNormalizeNullVector) {
     ASSERT_TRUE(std::isnan(result[d]));
   }
 }
+
+} // end namespace ArrayMathTest

--- a/tests/testAutopas/tests/utils/ArrayUtilsTest.cpp
+++ b/tests/testAutopas/tests/utils/ArrayUtilsTest.cpp
@@ -8,6 +8,8 @@
 
 #include "autopas/utils/ArrayUtils.h"
 
+namespace ArrayUtilsTest {
+
 using namespace autopas;
 
 TEST(ArrayUtilsTest, teststatic_cast_array) {
@@ -40,3 +42,5 @@ TEST(ArrayUtilsTest, testto_string) {
   EXPECT_EQ("[1, 2, 3]", utils::ArrayUtils::to_string(bStringContainer));
   EXPECT_EQ("1x2x3", utils::ArrayUtils::to_string(bStringContainer, "x", {"", ""}));
 }
+
+} // end namespace ArrayUtilsTest

--- a/tests/testAutopas/tests/utils/ArrayUtilsTest.cpp
+++ b/tests/testAutopas/tests/utils/ArrayUtilsTest.cpp
@@ -43,4 +43,4 @@ TEST(ArrayUtilsTest, testto_string) {
   EXPECT_EQ("1x2x3", utils::ArrayUtils::to_string(bStringContainer, "x", {"", ""}));
 }
 
-} // end namespace ArrayUtilsTest
+}  // end namespace ArrayUtilsTest

--- a/tests/testAutopas/tests/utils/CudaDeviceVectorTest.cpp
+++ b/tests/testAutopas/tests/utils/CudaDeviceVectorTest.cpp
@@ -12,6 +12,8 @@
 
 #include "autopas/utils/CudaDeviceVector.h"
 
+namespace CudaDeviceVectorTest {
+
 TEST_F(CudaDeviceVectorTest, CopyTest) {
   std::vector<int> source = {1, -2, 3, -4, 5, -6, 7};
   autopas::utils::CudaDeviceVector<int> test_vector;
@@ -25,4 +27,5 @@ TEST_F(CudaDeviceVectorTest, CopyTest) {
   }
 }
 
+}  // end namespace CudaDeviceVectorTest
 #endif

--- a/tests/testAutopas/tests/utils/CudaDeviceVectorTest.h
+++ b/tests/testAutopas/tests/utils/CudaDeviceVectorTest.h
@@ -14,6 +14,5 @@ namespace CudaDeviceVectorTest {
 
 class CudaDeviceVectorTest : public AutoPasTestBase {};
 
-} // end namespace CudaDeviceVectorTest
+}  // end namespace CudaDeviceVectorTest
 #endif
-

--- a/tests/testAutopas/tests/utils/CudaDeviceVectorTest.h
+++ b/tests/testAutopas/tests/utils/CudaDeviceVectorTest.h
@@ -10,6 +10,10 @@
 
 #include "AutoPasTestBase.h"
 
+namespace CudaDeviceVectorTest {
+
 class CudaDeviceVectorTest : public AutoPasTestBase {};
 
+} // end namespace CudaDeviceVectorTest
 #endif
+

--- a/tests/testAutopas/tests/utils/ExceptionHandlerTest.cpp
+++ b/tests/testAutopas/tests/utils/ExceptionHandlerTest.cpp
@@ -103,7 +103,6 @@ TEST_F(ExceptionHandlerTest, TestTryRethrow) {
 
 #include <omp.h>
 
-
 TEST_F(ExceptionHandlerTest, TestThreadSafe) {
   if (omp_get_max_threads() > 1) {
 #pragma omp parallel
@@ -140,4 +139,4 @@ TEST_F(ExceptionHandlerTest, TestThreadSafe) {
   }
 }
 #endif
-} // end namespace ExceptionHandlerTest
+}  // end namespace ExceptionHandlerTest

--- a/tests/testAutopas/tests/utils/ExceptionHandlerTest.cpp
+++ b/tests/testAutopas/tests/utils/ExceptionHandlerTest.cpp
@@ -6,6 +6,8 @@
 
 #include "ExceptionHandlerTest.h"
 
+namespace ExceptionHandlerTest {
+
 using autopas::utils::ExceptionBehavior;
 using autopas::utils::ExceptionHandler;
 
@@ -101,6 +103,7 @@ TEST_F(ExceptionHandlerTest, TestTryRethrow) {
 
 #include <omp.h>
 
+
 TEST_F(ExceptionHandlerTest, TestThreadSafe) {
   if (omp_get_max_threads() > 1) {
 #pragma omp parallel
@@ -137,3 +140,4 @@ TEST_F(ExceptionHandlerTest, TestThreadSafe) {
   }
 }
 #endif
+} // end namespace ExceptionHandlerTest

--- a/tests/testAutopas/tests/utils/ExceptionHandlerTest.h
+++ b/tests/testAutopas/tests/utils/ExceptionHandlerTest.h
@@ -11,8 +11,12 @@
 #include "AutoPasTestBase.h"
 #include "autopas/utils/ExceptionHandler.h"
 
+namespace ExceptionHandlerTest {
+
 class ExceptionHandlerTest : public AutoPasTestBase {
   void SetUp() override;
 
   void TearDown() override;
 };
+
+} // end namespace ExceptionHandlerTest

--- a/tests/testAutopas/tests/utils/ExceptionHandlerTest.h
+++ b/tests/testAutopas/tests/utils/ExceptionHandlerTest.h
@@ -19,4 +19,4 @@ class ExceptionHandlerTest : public AutoPasTestBase {
   void TearDown() override;
 };
 
-} // end namespace ExceptionHandlerTest
+}  // end namespace ExceptionHandlerTest

--- a/tests/testAutopas/tests/utils/InBoxTest.cpp
+++ b/tests/testAutopas/tests/utils/InBoxTest.cpp
@@ -8,6 +8,8 @@
 
 #include "autopas/utils/inBox.h"
 
+namespace InBoxTest {
+
 TEST(InBoxTest, testInBox) {
   std::array<double, 3> lowCorner{1. / 3., 0., 2. / 3.};
   std::array<double, 3> highCorner{2. / 3., 2. / 3., 1.};
@@ -41,3 +43,4 @@ TEST(InBoxTest, testNotInBox) {
     }
   }
 }
+} // end namespace InBoxTest

--- a/tests/testAutopas/tests/utils/InBoxTest.cpp
+++ b/tests/testAutopas/tests/utils/InBoxTest.cpp
@@ -43,4 +43,4 @@ TEST(InBoxTest, testNotInBox) {
     }
   }
 }
-} // end namespace InBoxTest
+}  // end namespace InBoxTest

--- a/tests/testAutopas/tests/utils/LoggerTest.cpp
+++ b/tests/testAutopas/tests/utils/LoggerTest.cpp
@@ -6,6 +6,8 @@
 
 #include "LoggerTest.h"
 
+namespace LoggerTest {
+
 void LoggerTest::SetUp() { autopas::Logger::create(stream); }
 
 void LoggerTest::TearDown() { autopas::Logger::unregister(); }
@@ -50,3 +52,4 @@ TEST_F(LoggerTest, LogLevelTestDisabled) {
   EXPECT_EQ(testLevel(autopas::Logger::LogLevel::critical, false), 0);
   EXPECT_EQ(testLevel(autopas::Logger::LogLevel::off, false), 0);
 }
+} // end namespace LoggerTest

--- a/tests/testAutopas/tests/utils/LoggerTest.cpp
+++ b/tests/testAutopas/tests/utils/LoggerTest.cpp
@@ -52,4 +52,4 @@ TEST_F(LoggerTest, LogLevelTestDisabled) {
   EXPECT_EQ(testLevel(autopas::Logger::LogLevel::critical, false), 0);
   EXPECT_EQ(testLevel(autopas::Logger::LogLevel::off, false), 0);
 }
-} // end namespace LoggerTest
+}  // end namespace LoggerTest

--- a/tests/testAutopas/tests/utils/LoggerTest.h
+++ b/tests/testAutopas/tests/utils/LoggerTest.h
@@ -13,6 +13,8 @@
 
 #include "AutoPasTestBase.h"
 
+namespace LoggerTest {
+
 class LoggerTest : public AutoPasTestBase {
  public:
   void SetUp() override;
@@ -40,3 +42,4 @@ class ScopedRedirect {
   std::ostream &mOriginal;
   std::ostream &mRedirect;
 };
+} // end namespace LoggerTest

--- a/tests/testAutopas/tests/utils/LoggerTest.h
+++ b/tests/testAutopas/tests/utils/LoggerTest.h
@@ -42,4 +42,4 @@ class ScopedRedirect {
   std::ostream &mOriginal;
   std::ostream &mRedirect;
 };
-} // end namespace LoggerTest
+}  // end namespace LoggerTest

--- a/tests/testAutopas/tests/utils/NumberSetTest.cpp
+++ b/tests/testAutopas/tests/utils/NumberSetTest.cpp
@@ -12,6 +12,8 @@
 #include "autopas/utils/NumberSet.h"
 #include "autopas/utils/NumberSetFinite.h"
 
+namespace NumberSetTest {
+
 using namespace autopas;
 
 TEST(NumberSetTest, testFiniteSet) {
@@ -148,3 +150,5 @@ TEST(NumberSetTest, testStringRepresentation) {
   NumberSetFinite<double> fSet({1., 2., 3.});
   EXPECT_EQ("[1, 2, 3]", fSet.to_string());
 }
+
+} // end namespace NumberSetTest

--- a/tests/testAutopas/tests/utils/NumberSetTest.cpp
+++ b/tests/testAutopas/tests/utils/NumberSetTest.cpp
@@ -151,4 +151,4 @@ TEST(NumberSetTest, testStringRepresentation) {
   EXPECT_EQ("[1, 2, 3]", fSet.to_string());
 }
 
-} // end namespace NumberSetTest
+}  // end namespace NumberSetTest

--- a/tests/testAutopas/tests/utils/SoATest.cpp
+++ b/tests/testAutopas/tests/utils/SoATest.cpp
@@ -6,6 +6,8 @@
 
 #include "SoATest.h"
 
+namespace SoATest {
+
 TEST_F(SoATest, testInitialization) { autopas::SoA<autopas::Particle::SoAArraysType> soa; }
 
 TEST_F(SoATest, SoATypeTest) {
@@ -356,3 +358,4 @@ TEST_F(SoATest, SoATestComplicatedAccess) {
   EXPECT_EQ(res[1], 8.);
   EXPECT_EQ(res[2], 9.);
 }
+} // end namespace SoATest

--- a/tests/testAutopas/tests/utils/SoATest.cpp
+++ b/tests/testAutopas/tests/utils/SoATest.cpp
@@ -358,4 +358,4 @@ TEST_F(SoATest, SoATestComplicatedAccess) {
   EXPECT_EQ(res[1], 8.);
   EXPECT_EQ(res[2], 9.);
 }
-} // end namespace SoATest
+}  // end namespace SoATest

--- a/tests/testAutopas/tests/utils/SoATest.h
+++ b/tests/testAutopas/tests/utils/SoATest.h
@@ -15,4 +15,4 @@ namespace SoATest {
 
 class SoATest : public AutoPasTestBase {};
 
-} // end namespace SoATest
+}  // end namespace SoATest

--- a/tests/testAutopas/tests/utils/SoATest.h
+++ b/tests/testAutopas/tests/utils/SoATest.h
@@ -11,4 +11,8 @@
 #include "autopas/utils/SoA.h"
 #include "autopas/utils/SoAType.h"
 
+namespace SoATest {
+
 class SoATest : public AutoPasTestBase {};
+
+} // end namespace SoATest

--- a/tests/testAutopas/tests/utils/StringUtilsTest.cpp
+++ b/tests/testAutopas/tests/utils/StringUtilsTest.cpp
@@ -6,6 +6,8 @@
 
 #include "StringUtilsTest.h"
 
+namespace StringUtilsTest {
+
 TEST(StringUtilsTest, parseDoublesTest) {
   auto parsedOptions = autopas::utils::StringUtils::parseDoubles("1.,1.5, 2,3.00,2e1");
 
@@ -26,3 +28,5 @@ TEST(StringUtilsTest, parseNumberIntervalTest) {
   EXPECT_EQ(numberInterval->getMin(), 1.);
   EXPECT_EQ(numberInterval->getMax(), 2e1);
 }
+
+} // end namespace StringUtilsTest

--- a/tests/testAutopas/tests/utils/StringUtilsTest.cpp
+++ b/tests/testAutopas/tests/utils/StringUtilsTest.cpp
@@ -29,4 +29,4 @@ TEST(StringUtilsTest, parseNumberIntervalTest) {
   EXPECT_EQ(numberInterval->getMax(), 2e1);
 }
 
-} // end namespace StringUtilsTest
+}  // end namespace StringUtilsTest

--- a/tests/testAutopas/tests/utils/StringUtilsTest.h
+++ b/tests/testAutopas/tests/utils/StringUtilsTest.h
@@ -13,4 +13,8 @@
 #include "AutoPasTestBase.h"
 #include "autopas/utils/StringUtils.h"
 
+namespace StringUtilsTest {
+
 class StringUtilsTest : public AutoPasTestBase {};
+
+} // end namespace StringUtilsTest

--- a/tests/testAutopas/tests/utils/StringUtilsTest.h
+++ b/tests/testAutopas/tests/utils/StringUtilsTest.h
@@ -17,4 +17,4 @@ namespace StringUtilsTest {
 
 class StringUtilsTest : public AutoPasTestBase {};
 
-} // end namespace StringUtilsTest
+}  // end namespace StringUtilsTest

--- a/tests/testAutopas/tests/utils/TimerTest.cpp
+++ b/tests/testAutopas/tests/utils/TimerTest.cpp
@@ -11,6 +11,8 @@
 
 #include "autopas/utils/Timer.h"
 
+namespace TimerTest {
+
 TEST(DISABLED_TimerTest, testTimer) {
   autopas::utils::Timer timer;
   timer.start();
@@ -26,3 +28,4 @@ TEST(DISABLED_TimerTest, testTimer) {
   // time should be close to 50ms
   ASSERT_NEAR(time, .05, .03);
 }
+} // end namespace TimerTest

--- a/tests/testAutopas/tests/utils/TimerTest.cpp
+++ b/tests/testAutopas/tests/utils/TimerTest.cpp
@@ -28,4 +28,4 @@ TEST(DISABLED_TimerTest, testTimer) {
   // time should be close to 50ms
   ASSERT_NEAR(time, .05, .03);
 }
-} // end namespace TimerTest
+}  // end namespace TimerTest


### PR DESCRIPTION
# Description

Adds the possibility to glob together all tests into one big cpp file.

Timings (debug mode, clang10, target=runTests):

|          | noglob | glob| 
| ------ | -------------- | ----------- | 
-j 1      | 8:50 | 4:22 |
-j10     | 2:55 | 3:58 |

Can be enabled with option `AUTOPAS_USE_TEST_GLOB`

This PR adds -DAUTOPAS_USE_TEST_GLOB=On to relevant jenkins calls to cmake.