### PR TITLE
Compatibility arm64

### DIFF
--- a/cmake/modules/vectorization.cmake
+++ b/cmake/modules/vectorization.cmake
@@ -4,7 +4,7 @@ option(
 if (AUTOPAS_USE_VECTORIZATION)
     message(STATUS "Vectorization enabled.")
     # list of available options
-    set(VECTOR_INSTRUCTIONS_OPTIONS "NATIVE;SSE;AVX;AVX2;KNL")
+    set(VECTOR_INSTRUCTIONS_OPTIONS "NATIVE;DEFAULT;SSE;AVX;AVX2;KNL")
     # set instruction set type
     set(
         AUTOPAS_VECTOR_INSTRUCTIONS

--- a/src/autopas/molecularDynamics/LJFunctorAVX.h
+++ b/src/autopas/molecularDynamics/LJFunctorAVX.h
@@ -6,7 +6,9 @@
  */
 #pragma once
 
+#ifdef __AVX__
 #include <immintrin.h>
+#endif
 
 #include <array>
 
@@ -442,6 +444,7 @@ class LJFunctorAVX
 #endif
   }
 
+#ifdef __AVX__
   /**
    * Actual inner kernel of the SoAFunctors.
    *
@@ -480,7 +483,6 @@ class LJFunctorAVX
                         const size_t *const typeID2ptr, __m256d &fxacc, __m256d &fyacc, __m256d &fzacc,
                         __m256d *virialSumX, __m256d *virialSumY, __m256d *virialSumZ, __m256d *upotSum,
                         const unsigned int rest = 0) {
-#ifdef __AVX__
     __m256d epsilon24s = _epsilon24;
     __m256d sigmaSquares = _sigmaSquare;
     __m256d shift6s = _shift6;
@@ -608,8 +610,8 @@ class LJFunctorAVX
       *virialSumY = wrapperFMA(energyFactor, virialY, *virialSumY);
       *virialSumZ = wrapperFMA(energyFactor, virialZ, *virialSumZ);
     }
-#endif
   }
+#endif
 
  public:
   // clang-format off
@@ -960,6 +962,7 @@ class LJFunctorAVX
   }
 
  private:
+#ifdef __AVX__
   /**
    * Wrapper function for FMA. If FMA is not supported it executes first the multiplication then the addition.
    * @param factorA
@@ -978,6 +981,7 @@ class LJFunctorAVX
     return __m256d();
 #endif
   }
+#endif
 
   /**
    * This class stores internal data of each thread, make sure that this data has proper size, i.e. k*64 Bytes!


### PR DESCRIPTION
# Description

Made AutoPas run on my Raspberry Pi4 4GB with an aarch64 kernel. These are the changes that were necessary.

- [x] Offer default vectorization instructions (clang on arm does not offer `-march=native`)
- [x] Only include intrinsics stuff when actually needed (`immintrin.h` was missing on the Pi)

## ~Related Pull Requests~

## ~Resolved Issues~

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Compiled `md-flexible` and ran a few examples.
- [ ] Ran unit tests <- not possible. Not enough RAM to build the tests.
