### PR TITLE
Flush logger always

### DIFF
--- a/examples/md-flexible/src/parsing/MDFlexConfig.cpp
+++ b/examples/md-flexible/src/parsing/MDFlexConfig.cpp
@@ -31,7 +31,8 @@ std::string MDFlexConfig::to_string() const {
   os << setw(valueOffset) << left << traversalOptions.name << ":  "
      << autopas::utils::ArrayUtils::to_string(traversalOptions.value) << endl;
   os << setw(valueOffset) << left << tuningStrategyOption.name << ":  " << tuningStrategyOption.value << endl;
-  if (tuningStrategyOption.value == autopas::TuningStrategyOption::bayesianSearch) {
+  if (tuningStrategyOption.value == autopas::TuningStrategyOption::bayesianSearch or
+      tuningStrategyOption.value == autopas::TuningStrategyOption::bayesianClusterSearch) {
     os << setw(valueOffset) << left << acquisitionFunctionOption.name << ":  " << acquisitionFunctionOption.value
        << endl;
   }

--- a/src/autopas/utils/logging/TuningDataLogger.cpp
+++ b/src/autopas/utils/logging/TuningDataLogger.cpp
@@ -19,7 +19,7 @@ autopas::TuningDataLogger::TuningDataLogger(size_t numSamples, const std::string
   // set the pattern to the message only
   headerLogger->set_pattern("%v");
   std::stringstream samplesHeader;
-  for (int i = 0; i < numSamples; ++i) {
+  for (size_t i = 0; i < numSamples; ++i) {
     samplesHeader << ",sample" << i;
   }
   // print csv header

--- a/src/autopas/utils/logging/TuningResultLogger.cpp
+++ b/src/autopas/utils/logging/TuningResultLogger.cpp
@@ -12,19 +12,14 @@ autopas::TuningResultLogger::TuningResultLogger(const std::string &outputSuffix)
     : _loggerName("TuningResultLogger" + outputSuffix) {
 #ifdef AUTOPAS_LOG_TUNINGRESULTS
   auto outputFileName("AutoPas_tuningResults_" + outputSuffix + utils::Timer::getDateStamp() + ".csv");
-  // Start of workaround: Because we want to use an asynchronous logger we can't quickly switch patterns for the header.
-  // create and register a non-asychronous logger to write the header
-  auto headerLoggerName = _loggerName + "header";
-  auto headerLogger = spdlog::basic_logger_mt(headerLoggerName, outputFileName);
-  // set the pattern to the message only
-  headerLogger->set_pattern("%v");
-  // print csv header
-  headerLogger->info("Date,Iteration,{},tuning[ns]", Configuration().getCSVHeader());
-  spdlog::drop(headerLoggerName);
-  // End of workaround
-
   // create and register the actual logger
-  auto logger = spdlog::basic_logger_mt<spdlog::async_factory>(_loggerName, outputFileName);
+  auto logger = spdlog::basic_logger_mt(_loggerName, outputFileName);
+  // since this logger only writes rarely flush instantly in order to not lose any information if autopas is killed
+  logger->flush_on(spdlog::level::trace);
+  // set the pattern to the message only
+  logger->set_pattern("%v");
+  // print csv header
+  logger->info("Date,Iteration,{},tuning[ns]", Configuration().getCSVHeader());
   // set pattern to provide date
   logger->set_pattern("%Y-%m-%d %T,%v");
 #endif


### PR DESCRIPTION
# Description

- [x] flush tuning result logger always instantly so it does print its information if autopas is killed

Since this logger only writes once per tuning phase there is no significant (or measurable) performance drop.

## ~Related Pull Requests~

## ~Resolved Issues~

# How Has This Been Tested?

- [x] Ran it, killed it, looked at output
