### PR TITLE
Progress Bar

### DIFF
--- a/examples/md-flexible/CMakeLists.txt
+++ b/examples/md-flexible/CMakeLists.txt
@@ -70,6 +70,7 @@ add_test(
         --periodic false
         --deltaT 0.
         --no-end-config
+        --no-progress-bar
         CONFIGURATIONS checkExamples
 )
 
@@ -92,6 +93,7 @@ add_test(
         --deltaT 0.005
         --no-end-config
         --no-flops
+        --no-progress-bar
         CONFIGURATIONS checkExamples
 )
 
@@ -135,6 +137,7 @@ if (HAS_AVX)
             --log-level debug
             --traversal lc_c04_combined_SoA
             --particles-total 71
+            --no-progress-bar
             CONFIGURATIONS checkExamples
     )
 else ()

--- a/examples/md-flexible/scripts/measurePerf.sh
+++ b/examples/md-flexible/scripts/measurePerf.sh
@@ -142,6 +142,7 @@ do
                             --newton3 ${newton3Opt} \
                             --no-end-config \
                             --no-flops \
+                            --no-progress-bar \
                             --particle-generator uniform \
                             --particles-total ${Mols[$i]} \
                             --periodic false \

--- a/examples/md-flexible/src/Simulation.h
+++ b/examples/md-flexible/src/Simulation.h
@@ -729,7 +729,10 @@ void Simulation<Particle>::printProgress(size_t iterationProgress, size_t maxIte
 template <class Particle>
 std::tuple<size_t, bool> Simulation<Particle>::estimateNumIterations() const {
   if (_config->tuningPhases.value > 0) {
-    auto estimate = _config->tuningInterval.value * _config->tuningPhases.value + 100;
+    // @TODO: this can be improved by considering the tuning strategy
+    // 30 is just a random number for the number of tested configurations per tuning phase
+    auto estimate = (_config->tuningPhases.value - 1) * _config->tuningInterval.value +
+                    (_config->tuningPhases.value * _config->tuningSamples.value * 30);
     return {estimate, false};
   } else {
     return {_config->iterations.value, true};

--- a/examples/md-flexible/src/Simulation.h
+++ b/examples/md-flexible/src/Simulation.h
@@ -5,7 +5,11 @@
  */
 #pragma once
 
+#include <sys/ioctl.h>
+#include <unistd.h>
+
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 
 #include "BoundaryConditions.h"
@@ -97,6 +101,12 @@ class Simulation {
   [[nodiscard]] bool needsMoreIterations() const;
 
   /**
+   * Gives an estimate of how many iterations the simulation will do in total.
+   * @return The estimate and true iff this is the correct number and not only an estimate.
+   */
+  [[nodiscard]] std::tuple<size_t, bool> estimateNumIterations() const;
+
+  /**
    * Prints statistics like duration of calculation etc of the Simulation.
    * @param autopas
    */
@@ -116,6 +126,16 @@ class Simulation {
   double calculateHomogeneity(autopas::AutoPas<Particle> &autopas);
 
  private:
+  /**
+   * Print a progressbar and progress information to the console.
+   * @note Calling this function deletes the whole current line in the terminal.
+   *
+   * @param iteration
+   * @param maxIterations
+   * @param maxIsPrecise Indicate whether maxIterations is precise (true) or an estimate (false).
+   */
+  void printProgress(size_t iteration, size_t maxIterations, bool maxIsPrecise);
+
   using ParticlePropertiesLibraryType = ParticlePropertiesLibrary<double, size_t>;
   constexpr static bool _shifting = true;
   constexpr static bool _mixing = true;
@@ -319,10 +339,15 @@ void Simulation<Particle>::simulate(autopas::AutoPas<Particle> &autopas) {
   this->homogeneity = Simulation::calculateHomogeneity(autopas);
   _timers.simulate.start();
 
+  auto [maxIterationsEstimate, maxIterationsIsPrecice] = estimateNumIterations();
+
   // main simulation loop
   for (; needsMoreIterations(); ++iteration) {
     if (autopas::Logger::get()->level() <= autopas::Logger::LogLevel::debug) {
       std::cout << "Iteration " << iteration << std::endl;
+    }
+    if (not _config->dontShowProgressBar.value) {
+      printProgress(iteration, maxIterationsEstimate, maxIterationsIsPrecice);
     }
 
     if (_config->deltaT.value != 0) {
@@ -380,6 +405,10 @@ void Simulation<Particle>::simulate(autopas::AutoPas<Particle> &autopas) {
         _timers.thermostat.stop();
       }
     }
+  }
+  // final update for a full progress bar
+  if (not _config->dontShowProgressBar.value) {
+    printProgress(iteration, maxIterationsEstimate, maxIterationsIsPrecice);
   }
 
   // update temperature for generated config output
@@ -649,4 +678,47 @@ double Simulation<Particle>::calculateHomogeneity(autopas::AutoPas<Particle> &au
 
   // finally calculate standard deviation
   return sqrt(variance);
+}
+
+template <class Particle>
+void Simulation<Particle>::printProgress(size_t iteration, size_t maxIterations, bool maxIsPrecise) {
+  // percentage of iterations complete
+  double fractionDone = static_cast<double>(iteration) / maxIterations;
+
+  // length of the number of maxIterations
+  size_t numCharsOfMaxIterations = std::to_string(maxIterations).size();
+
+  // trailing information string
+  std::stringstream info;
+  info << std::setw(3) << std::round(fractionDone * 100) << "% " << std::setw(numCharsOfMaxIterations) << iteration
+       << "/";
+  if (not maxIsPrecise) {
+    info << "~";
+  }
+  info << maxIterations;
+
+  // actual progress bar
+  std::stringstream progressbar;
+  progressbar << "[";
+  // get current terminal width
+  struct winsize w;
+  ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
+  auto terminalWidth = w.ws_col;
+  // the bar should fill the terminal window so subtract everything else (-2 for "] ")
+  size_t maxBarWidth = terminalWidth - info.str().size() - progressbar.str().size() - 2;
+  size_t barWidth = std::max(std::min(static_cast<size_t>(maxBarWidth * (fractionDone)), maxBarWidth), 1ul);
+  progressbar << std::string(barWidth - 1, '=') << '>' << std::string(maxBarWidth - barWidth, ' ') << "] ";
+  // clear current line (=delete previous progress bar)
+  std::cout << std::string(terminalWidth, '\r');
+  // print everything
+  std::cout << progressbar.str() << info.str() << std::flush;
+}
+template <class Particle>
+std::tuple<size_t, bool> Simulation<Particle>::estimateNumIterations() const {
+  if (_config->tuningPhases.value > 0) {
+    auto estimate = _config->tuningInterval.value * _config->tuningPhases.value + 100;
+    return {estimate, false};
+  } else {
+    return {_config->iterations.value, true};
+  }
 }

--- a/examples/md-flexible/src/Simulation.h
+++ b/examples/md-flexible/src/Simulation.h
@@ -339,7 +339,7 @@ void Simulation<Particle>::simulate(autopas::AutoPas<Particle> &autopas) {
   this->homogeneity = Simulation::calculateHomogeneity(autopas);
   _timers.simulate.start();
 
-  auto [maxIterationsEstimate, maxIterationsIsPrecice] = estimateNumIterations();
+  auto [maxIterationsEstimate, maxIterationsIsPrecise] = estimateNumIterations();
 
   // main simulation loop
   for (; needsMoreIterations(); ++iteration) {
@@ -347,7 +347,7 @@ void Simulation<Particle>::simulate(autopas::AutoPas<Particle> &autopas) {
       std::cout << "Iteration " << iteration << std::endl;
     }
     if (not _config->dontShowProgressBar.value) {
-      printProgress(iteration, maxIterationsEstimate, maxIterationsIsPrecice);
+      printProgress(iteration, maxIterationsEstimate, maxIterationsIsPrecise);
     }
 
     if (_config->deltaT.value != 0) {

--- a/examples/md-flexible/src/Simulation.h
+++ b/examples/md-flexible/src/Simulation.h
@@ -408,7 +408,8 @@ void Simulation<Particle>::simulate(autopas::AutoPas<Particle> &autopas) {
   }
   // final update for a full progress bar
   if (not _config->dontShowProgressBar.value) {
-    printProgress(iteration, maxIterationsEstimate, maxIterationsIsPrecice);
+    // The last update is precise, so we know the number of iterations.
+    printProgress(iteration, iteration, true);
   }
 
   // update temperature for generated config output

--- a/examples/md-flexible/src/Simulation.h
+++ b/examples/md-flexible/src/Simulation.h
@@ -410,7 +410,7 @@ void Simulation<Particle>::simulate(autopas::AutoPas<Particle> &autopas) {
   if (not _config->dontShowProgressBar.value) {
     // The last update is precise, so we know the number of iterations.
     printProgress(iteration, iteration, true);
-    // The progress bar does not end the line. Since this is the last progress bar end the line here.
+    // The progress bar does not end the line. Since this is the last progress bar, end the line here.
     std::cout << std::endl;
   }
 

--- a/examples/md-flexible/src/Simulation.h
+++ b/examples/md-flexible/src/Simulation.h
@@ -410,6 +410,8 @@ void Simulation<Particle>::simulate(autopas::AutoPas<Particle> &autopas) {
   if (not _config->dontShowProgressBar.value) {
     // The last update is precise, so we know the number of iterations.
     printProgress(iteration, iteration, true);
+    // The progress bar does not end the line. Since this is the last progress bar end the line here.
+    std::cout << std::endl;
   }
 
   // update temperature for generated config output

--- a/examples/md-flexible/src/Simulation.h
+++ b/examples/md-flexible/src/Simulation.h
@@ -733,9 +733,14 @@ template <class Particle>
 std::tuple<size_t, bool> Simulation<Particle>::estimateNumIterations() const {
   if (_config->tuningPhases.value > 0) {
     // @TODO: this can be improved by considering the tuning strategy
-    // 30 is just a random number for the number of tested configurations per tuning phase
+    // This is just a randomly guessed number but seems to fit roughly for default settings.
+    size_t configsTestedPerTuningPhase = 90;
+    if(_config->tuningStrategyOption.value == autopas::TuningStrategyOption::bayesianSearch or
+        _config->tuningStrategyOption.value == autopas::TuningStrategyOption::bayesianSearch) {
+      configsTestedPerTuningPhase = _config->tuningMaxEvidence.value;
+    }
     auto estimate = (_config->tuningPhases.value - 1) * _config->tuningInterval.value +
-                    (_config->tuningPhases.value * _config->tuningSamples.value * 30);
+                    (_config->tuningPhases.value * _config->tuningSamples.value * configsTestedPerTuningPhase);
     return {estimate, false};
   } else {
     return {_config->iterations.value, true};

--- a/examples/md-flexible/src/Simulation.h
+++ b/examples/md-flexible/src/Simulation.h
@@ -714,6 +714,13 @@ void Simulation<Particle>::printProgress(size_t iterationProgress, size_t maxIte
     return;
   }
   auto barWidth = std::max(std::min(static_cast<decltype(maxBarWidth)>(maxBarWidth * (fractionDone)), maxBarWidth), 1);
+  // don't print arrow tip if >= 100%
+  if (iterationProgress >= maxIterations) {
+    progressbar << std::string(barWidth, '=');
+  } else {
+    progressbar << std::string(barWidth - 1, '=') << '>' << std::string(maxBarWidth - barWidth, ' ');
+  }
+  progressbar << "] ";
   // clear current line (=delete previous progress bar)
   std::cout << std::string(terminalWidth, '\r');
   // print everything

--- a/examples/md-flexible/src/Simulation.h
+++ b/examples/md-flexible/src/Simulation.h
@@ -735,7 +735,7 @@ std::tuple<size_t, bool> Simulation<Particle>::estimateNumIterations() const {
     // @TODO: this can be improved by considering the tuning strategy
     // This is just a randomly guessed number but seems to fit roughly for default settings.
     size_t configsTestedPerTuningPhase = 90;
-    if(_config->tuningStrategyOption.value == autopas::TuningStrategyOption::bayesianSearch or
+    if (_config->tuningStrategyOption.value == autopas::TuningStrategyOption::bayesianSearch or
         _config->tuningStrategyOption.value == autopas::TuningStrategyOption::bayesianClusterSearch) {
       configsTestedPerTuningPhase = _config->tuningMaxEvidence.value;
     }

--- a/examples/md-flexible/src/Simulation.h
+++ b/examples/md-flexible/src/Simulation.h
@@ -736,7 +736,7 @@ std::tuple<size_t, bool> Simulation<Particle>::estimateNumIterations() const {
     // This is just a randomly guessed number but seems to fit roughly for default settings.
     size_t configsTestedPerTuningPhase = 90;
     if(_config->tuningStrategyOption.value == autopas::TuningStrategyOption::bayesianSearch or
-        _config->tuningStrategyOption.value == autopas::TuningStrategyOption::bayesianSearch) {
+        _config->tuningStrategyOption.value == autopas::TuningStrategyOption::bayesianClusterSearch) {
       configsTestedPerTuningPhase = _config->tuningMaxEvidence.value;
     }
     auto estimate = (_config->tuningPhases.value - 1) * _config->tuningInterval.value +

--- a/examples/md-flexible/src/parsing/CLIParser.cpp
+++ b/examples/md-flexible/src/parsing/CLIParser.cpp
@@ -31,15 +31,15 @@ MDFlexParser::exitCodes MDFlexParser::CLIParser::parseInput(int argc, char **arg
   static const auto relevantOptions{std::make_tuple(
       config.newton3Options, config.checkpointfile, config.acquisitionFunctionOption, config.cellSizeFactors,
       config.boxLength, config.containerOptions, config.cutoff, config.dataLayoutOptions, config.deltaT,
-      config.dontCreateEndConfig, config.tuningMaxEvidence, config.extrapolationMethodOption,
-      config.evidenceFirstPrediction, config.functorOption, config.dontMeasureFlops, config.generatorOption,
-      config.iterations, config.tuningInterval, config.logLevel, config.logFileName, config.distributionMean,
-      config.maxTuningPhasesWithoutTest, config.particlesPerDim, config.particlesTotal, config.relativeOptimumRange,
-      config.relativeBlacklistRange, config.periodic, config.tuningPhases, config.verletClusterSize,
-      config.verletSkinRadius, config.particleSpacing, config.tuningSamples, config.traversalOptions,
-      config.tuningStrategyOption, config.mpiStrategyOption, config.useThermostat, config.verletRebuildFrequency,
-      config.vtkFileName, config.vtkWriteFrequency, config.selectorStrategy, config.yamlFilename,
-      config.distributionStdDev, config.globalForce, zshCompletionsOption, helpOption)};
+      config.dontCreateEndConfig, config.dontShowProgressBar, config.tuningMaxEvidence,
+      config.extrapolationMethodOption, config.evidenceFirstPrediction, config.functorOption, config.dontMeasureFlops,
+      config.generatorOption, config.iterations, config.tuningInterval, config.logLevel, config.logFileName,
+      config.distributionMean, config.maxTuningPhasesWithoutTest, config.particlesPerDim, config.particlesTotal,
+      config.relativeOptimumRange, config.relativeBlacklistRange, config.periodic, config.tuningPhases,
+      config.verletClusterSize, config.verletSkinRadius, config.particleSpacing, config.tuningSamples,
+      config.traversalOptions, config.tuningStrategyOption, config.mpiStrategyOption, config.useThermostat,
+      config.verletRebuildFrequency, config.vtkFileName, config.vtkWriteFrequency, config.selectorStrategy,
+      config.yamlFilename, config.distributionStdDev, config.globalForce, zshCompletionsOption, helpOption)};
 
   constexpr auto relevantOptionsSize = std::tuple_size_v<decltype(relevantOptions)>;
 
@@ -159,6 +159,10 @@ MDFlexParser::exitCodes MDFlexParser::CLIParser::parseInput(int argc, char **arg
       }
       case decltype(config.dontCreateEndConfig)::getoptChar: {
         config.dontCreateEndConfig.value = false;
+        break;
+      }
+      case decltype(config.dontShowProgressBar)::getoptChar: {
+        config.dontShowProgressBar.value = true;
         break;
       }
       case decltype(config.tuningMaxEvidence)::getoptChar: {

--- a/examples/md-flexible/src/parsing/MDFlexConfig.cpp
+++ b/examples/md-flexible/src/parsing/MDFlexConfig.cpp
@@ -127,6 +127,7 @@ std::string MDFlexConfig::to_string() const {
 
   os << setw(valueOffset) << dontMeasureFlops.name << ":  " << (not dontMeasureFlops.value) << endl;
   os << setw(valueOffset) << dontCreateEndConfig.name << ":  " << (not dontCreateEndConfig.value) << endl;
+  os << setw(valueOffset) << dontShowProgressBar.name << ":  " << (dontShowProgressBar.value) << endl;
   return os.str();
 }
 

--- a/examples/md-flexible/src/parsing/MDFlexConfig.h
+++ b/examples/md-flexible/src/parsing/MDFlexConfig.h
@@ -348,6 +348,11 @@ class MDFlexConfig {
   MDFlexOption<bool, __LINE__> dontCreateEndConfig{
       true, "no-end-config", false, "Set to omit the creation of a yaml file at the end of a simulation."};
   /**
+   * Omit the output of the progress bar and progress information. This might be useful if this upsets your output.
+   */
+  MDFlexOption<bool, __LINE__> dontShowProgressBar{false, "no-progress-bar", false,
+                                                   "Set to omit printing the progress bar."};
+  /**
    * deltaT
    */
   MDFlexOption<double, __LINE__> deltaT{0.001, "deltaT", true,

--- a/examples/md-flexible/src/parsing/YamlParser.cpp
+++ b/examples/md-flexible/src/parsing/YamlParser.cpp
@@ -72,6 +72,9 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
     // "not" needed because of semantics
     config.dontCreateEndConfig.value = not node[config.dontCreateEndConfig.name].as<bool>();
   }
+  if (node[config.dontShowProgressBar.name]) {
+    config.dontShowProgressBar.value = node[config.dontShowProgressBar.name].as<bool>();
+  }
   if (node[config.newton3Options.name]) {
     config.newton3Options.value = autopas::Newton3Option::parseOptions(
         autopas::utils::ArrayUtils::to_string(node[config.newton3Options.name], ", ", {"", ""}));


### PR DESCRIPTION
# Description

- [x] Progress bar for md-flex
- [x] Progress bar adapts itself to terminal width
- [x] additional progress info
- [x] toggleable via cli
- [x] toggleable via yaml

## ~Related Pull Requests~

## ~Resolved Issues~

# How Has This Been Tested?

- [x] Looked at the output with bar enabled
- [x] Looked at the output with bar disabled

## Screenshots 
When number of iterations is only an estimate:
![progress_1](https://user-images.githubusercontent.com/2656700/108345078-29a09400-71de-11eb-8778-78c55cccf2ce.png)
When number of iterations is known exactly:
![progress_32](https://user-images.githubusercontent.com/2656700/108345085-2b6a5780-71de-11eb-92e1-82899e46e5a7.png)
![progress_100](https://user-images.githubusercontent.com/2656700/108345096-2dccb180-71de-11eb-9c65-77a97e8f77b8.png)

