### PR TITLE
Iter force sequential

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ for(auto iter = autoPas.getRegionIterator(lowCorner, highCorner); iter != autoPa
 Both `begin()` and `getRegionIterator()` can also take the additional parameter `IteratorBehavior`,
 which indicates over which particles the iteration should be performed. See [autopas::IteratorBehavior
 ](https://autopas.github.io/doxygen_documentation/git-master/namespaceautopas.html#a520fefd51e4555074cd16e7c3fd19c42) for possible options and details.
-The default parameter is `haloAndOwned`, which is also used for range-based for loops.
+The default parameter is `ownedOrHalo`, which is also used for range-based for loops.
 
 Analogously to `begin()`, `cbegin()` is also defined, which guarantees to return a `const_iterator`.
 

--- a/examples/md-flexible/src/BoundaryConditions.h
+++ b/examples/md-flexible/src/BoundaryConditions.h
@@ -119,7 +119,7 @@ std::vector<Particle> BoundaryConditions<Particle>::identifyAndSendHaloParticles
           }
         }
         // here it is important to only iterate over the owned particles!
-        for (auto iter = autoPas.getRegionIterator(min, max, autopas::IteratorBehavior::ownedOnly); iter.isValid();
+        for (auto iter = autoPas.getRegionIterator(min, max, autopas::IteratorBehavior::owned); iter.isValid();
              ++iter) {
           auto particleCopy = *iter;
           particleCopy.addR(shiftVec);

--- a/examples/md-flexible/src/TimeDiscretization.h
+++ b/examples/md-flexible/src/TimeDiscretization.h
@@ -24,7 +24,7 @@ void calculatePositions(AutoPasTemplate &autopas, const ParticlePropertiesLibrar
 #ifdef AUTOPAS_OPENMP
 #pragma omp parallel
 #endif
-  for (auto iter = autopas.begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
+  for (auto iter = autopas.begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
     auto v = iter->getV();
     auto m = particlePropertiesLibrary.getMass(iter->getTypeId());
     auto f = iter->getF();
@@ -49,7 +49,7 @@ void calculateVelocities(AutoPasTemplate &autopas, const ParticlePropertiesLibra
 #ifdef AUTOPAS_OPENMP
 #pragma omp parallel
 #endif
-  for (auto iter = autopas.begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
+  for (auto iter = autopas.begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
     auto m = particlePropertiesLibrary.getMass(iter->getTypeId());
     auto force = iter->getF();
     auto old_force = iter->getOldf();

--- a/examples/sph-mpi/sph-main-mpi.cpp
+++ b/examples/sph-mpi/sph-main-mpi.cpp
@@ -49,7 +49,7 @@ void SetupIC(AutoPasContainer &sphSystem, double *end_time, const std::array<dou
     throw std::runtime_error("No particle added in sph-main-mpi::SetupIC.");
   }
 
-  for (auto part = sphSystem.begin(autopas::IteratorBehavior::ownedOnly); part.isValid(); ++part) {
+  for (auto part = sphSystem.begin(autopas::IteratorBehavior::owned); part.isValid(); ++part) {
     part->setMass(part->getMass() * bBoxMax[0] * bBoxMax[1] * bBoxMax[2] / (double)(i));
   }
 
@@ -67,7 +67,7 @@ void SetupIC(AutoPasContainer &sphSystem, double *end_time, const std::array<dou
 
 void Initialize(AutoPasContainer &sphSystem) {
   std::cout << "initialize... started" << std::endl;
-  for (auto part = sphSystem.begin(autopas::IteratorBehavior::ownedOnly); part.isValid(); ++part) {
+  for (auto part = sphSystem.begin(autopas::IteratorBehavior::owned); part.isValid(); ++part) {
     part->calcPressure();
   }
   std::cout << "initialize... completed" << std::endl;
@@ -75,7 +75,7 @@ void Initialize(AutoPasContainer &sphSystem) {
 
 double getTimeStepGlobal(AutoPasContainer &sphSystem, MPI_Comm &comm) {
   double dt = 1.0e+30;  // set VERY LARGE VALUE
-  for (auto part = sphSystem.begin(autopas::IteratorBehavior::ownedOnly); part.isValid(); ++part) {
+  for (auto part = sphSystem.begin(autopas::IteratorBehavior::owned); part.isValid(); ++part) {
     part->calcDt();
     if (part->getDt() < 0.002) {
       std::cout << "small time step for particle " << part->getID() << " at [" << part->getR()[0] << ", "
@@ -92,7 +92,7 @@ double getTimeStepGlobal(AutoPasContainer &sphSystem, MPI_Comm &comm) {
 }
 
 void leapfrogInitialKick(AutoPasContainer &sphSystem, const double dt) {
-  for (auto part = sphSystem.begin(autopas::IteratorBehavior::ownedOnly); part.isValid(); ++part) {
+  for (auto part = sphSystem.begin(autopas::IteratorBehavior::owned); part.isValid(); ++part) {
     part->setVel_half(autopas::utils::ArrayMath::add(
         part->getV(), autopas::utils::ArrayMath::mulScalar(part->getAcceleration(), 0.5 * dt)));
     part->setEng_half(part->getEnergy() + 0.5 * dt * part->getEngDot());
@@ -101,20 +101,20 @@ void leapfrogInitialKick(AutoPasContainer &sphSystem, const double dt) {
 
 void leapfrogFullDrift(AutoPasContainer &sphSystem, const double dt) {
   // time becomes t + dt;
-  for (auto part = sphSystem.begin(autopas::IteratorBehavior::ownedOnly); part.isValid(); ++part) {
+  for (auto part = sphSystem.begin(autopas::IteratorBehavior::owned); part.isValid(); ++part) {
     part->addR(autopas::utils::ArrayMath::mulScalar(part->getVel_half(), dt));
   }
 }
 
 void leapfrogPredict(AutoPasContainer &sphSystem, const double dt) {
-  for (auto part = sphSystem.begin(autopas::IteratorBehavior::ownedOnly); part.isValid(); ++part) {
+  for (auto part = sphSystem.begin(autopas::IteratorBehavior::owned); part.isValid(); ++part) {
     part->addV(autopas::utils::ArrayMath::mulScalar(part->getAcceleration(), dt));
     part->addEnergy(part->getEngDot() * dt);
   }
 }
 
 void leapfrogFinalKick(AutoPasContainer &sphSystem, const double dt) {
-  for (auto part = sphSystem.begin(autopas::IteratorBehavior::ownedOnly); part.isValid(); ++part) {
+  for (auto part = sphSystem.begin(autopas::IteratorBehavior::owned); part.isValid(); ++part) {
     part->setV(autopas::utils::ArrayMath::add(part->getVel_half(),
                                               autopas::utils::ArrayMath::mulScalar(part->getAcceleration(), 0.5 * dt)));
     part->setEnergy(part->getEng_half() + 0.5 * dt * part->getEngDot());
@@ -122,7 +122,7 @@ void leapfrogFinalKick(AutoPasContainer &sphSystem, const double dt) {
 }
 
 void setPressure(AutoPasContainer &sphSystem) {
-  for (auto part = sphSystem.begin(autopas::IteratorBehavior::ownedOnly); part.isValid(); ++part) {
+  for (auto part = sphSystem.begin(autopas::IteratorBehavior::owned); part.isValid(); ++part) {
     part->calcPressure();
   }
 }
@@ -288,7 +288,7 @@ void updateHaloParticles(AutoPasContainer &sphSystem, MPI_Comm &comm, const std:
         }
 
         for (auto iterator =
-                 sphSystem.getRegionIterator(requiredHaloMin, requiredHaloMax, autopas::IteratorBehavior::ownedOnly);
+                 sphSystem.getRegionIterator(requiredHaloMin, requiredHaloMax, autopas::IteratorBehavior::owned);
              iterator.isValid(); ++iterator) {
           Particle p = *iterator;  // copies Particle
           p.addR(shift);
@@ -376,7 +376,7 @@ void densityPressureHydroForce(AutoPasContainer &sphSystem, MPI_Comm &comm, cons
   updateHaloParticles(sphSystem, comm, globalBoxMin, globalBoxMax);
 
   // 1.2 then calculate density
-  for (auto part = sphSystem.begin(autopas::IteratorBehavior::ownedOnly); part.isValid(); ++part) {
+  for (auto part = sphSystem.begin(autopas::IteratorBehavior::owned); part.isValid(); ++part) {
     part->setDensity(0.);
     densityFunctor.AoSFunctor(*part, *part);
     part->setDensity(part->getDensity() / 2);
@@ -392,7 +392,7 @@ void densityPressureHydroForce(AutoPasContainer &sphSystem, MPI_Comm &comm, cons
   updateHaloParticles(sphSystem, comm, globalBoxMin, globalBoxMax);
 
   // 0.3.2 then calculate hydro force
-  for (auto part = sphSystem.begin(autopas::IteratorBehavior::ownedOnly); part.isValid(); ++part) {
+  for (auto part = sphSystem.begin(autopas::IteratorBehavior::owned); part.isValid(); ++part) {
     // self interaction leeds to:
     // 1) vsigmax = 2*part->getSoundSpeed()
     // 2) no change in acceleration
@@ -407,7 +407,7 @@ void densityPressureHydroForce(AutoPasContainer &sphSystem, MPI_Comm &comm, cons
 void printConservativeVariables(AutoPasContainer &sphSystem, MPI_Comm &comm) {
   std::array<double, 3> momSum = {0., 0., 0.};  // total momentum
   double energySum = 0.;                        // total energy
-  for (auto it = sphSystem.begin(autopas::IteratorBehavior::ownedOnly); it.isValid(); ++it) {
+  for (auto it = sphSystem.begin(autopas::IteratorBehavior::owned); it.isValid(); ++it) {
     momSum = autopas::utils::ArrayMath::add(momSum, autopas::utils::ArrayMath::mulScalar(it->getV(), it->getMass()));
     energySum += (it->getEnergy() + 0.5 * autopas::utils::ArrayMath::dot(it->getV(), it->getV())) * it->getMass();
   }
@@ -546,7 +546,7 @@ int main(int argc, char *argv[]) {
     // 1.6 Leap frog: final Kick
     leapfrogFinalKick(sphSystem, dt);
 
-    //    for (auto part = sphSystem.begin(autopas::IteratorBehavior::ownedOnly); part.isValid(); ++part) {
+    //    for (auto part = sphSystem.begin(autopas::IteratorBehavior::owned); part.isValid(); ++part) {
     //      printf(
     //          "%lu\t%lf\t%lf\t%lf\t%lf\t%lf\t"
     //          "%lf\t%lf\t%lf\t%lf\t%lf\t%lf\t%lf\t%lf\t%lf\t%lf\n",

--- a/examples/sph/sph-main.cpp
+++ b/examples/sph/sph-main.cpp
@@ -40,7 +40,7 @@ void SetupIC(AutoPasContainer &sphSystem, double *end_time, const std::array<dou
       }
     }
   }
-  for (auto part = sphSystem.begin(autopas::IteratorBehavior::ownedOnly); part.isValid(); ++part) {
+  for (auto part = sphSystem.begin(autopas::IteratorBehavior::owned); part.isValid(); ++part) {
     part->setMass(part->getMass() * bBoxMax[0] * bBoxMax[1] * bBoxMax[2] / (double)(i));
   }
   std::cout << "# of particles is... " << i << std::endl;
@@ -55,7 +55,7 @@ void SetupIC(AutoPasContainer &sphSystem, double *end_time, const std::array<dou
 
 void Initialize(AutoPasContainer &sphSystem) {
   std::cout << "initialize... started" << std::endl;
-  for (auto part = sphSystem.begin(autopas::IteratorBehavior::ownedOnly); part.isValid(); ++part) {
+  for (auto part = sphSystem.begin(autopas::IteratorBehavior::owned); part.isValid(); ++part) {
     part->calcPressure();
   }
   std::cout << "initialize... completed" << std::endl;
@@ -63,7 +63,7 @@ void Initialize(AutoPasContainer &sphSystem) {
 
 double getTimeStepGlobal(AutoPasContainer &sphSystem) {
   double dt = 1.0e+30;  // set VERY LARGE VALUE
-  for (auto part = sphSystem.begin(autopas::IteratorBehavior::ownedOnly); part.isValid(); ++part) {
+  for (auto part = sphSystem.begin(autopas::IteratorBehavior::owned); part.isValid(); ++part) {
     part->calcDt();
     if (part->getDt() < 0.002) {
       std::cout << "small time step for particle " << part->getID() << " at ["
@@ -76,7 +76,7 @@ double getTimeStepGlobal(AutoPasContainer &sphSystem) {
 }
 
 void leapfrogInitialKick(AutoPasContainer &sphSystem, const double dt) {
-  for (auto part = sphSystem.begin(autopas::IteratorBehavior::ownedOnly); part.isValid(); ++part) {
+  for (auto part = sphSystem.begin(autopas::IteratorBehavior::owned); part.isValid(); ++part) {
     part->setVel_half(autopas::utils::ArrayMath::add(
         part->getV(), autopas::utils::ArrayMath::mulScalar(part->getAcceleration(), 0.5 * dt)));
     part->setEng_half(part->getEnergy() + 0.5 * dt * part->getEngDot());
@@ -85,20 +85,20 @@ void leapfrogInitialKick(AutoPasContainer &sphSystem, const double dt) {
 
 void leapfrogFullDrift(AutoPasContainer &sphSystem, const double dt) {
   // time becomes t + dt;
-  for (auto part = sphSystem.begin(autopas::IteratorBehavior::ownedOnly); part.isValid(); ++part) {
+  for (auto part = sphSystem.begin(autopas::IteratorBehavior::owned); part.isValid(); ++part) {
     part->addR(autopas::utils::ArrayMath::mulScalar(part->getVel_half(), dt));
   }
 }
 
 void leapfrogPredict(AutoPasContainer &sphSystem, const double dt) {
-  for (auto part = sphSystem.begin(autopas::IteratorBehavior::ownedOnly); part.isValid(); ++part) {
+  for (auto part = sphSystem.begin(autopas::IteratorBehavior::owned); part.isValid(); ++part) {
     part->addV(autopas::utils::ArrayMath::mulScalar(part->getAcceleration(), dt));
     part->addEnergy(part->getEngDot() * dt);
   }
 }
 
 void leapfrogFinalKick(AutoPasContainer &sphSystem, const double dt) {
-  for (auto part = sphSystem.begin(autopas::IteratorBehavior::ownedOnly); part.isValid(); ++part) {
+  for (auto part = sphSystem.begin(autopas::IteratorBehavior::owned); part.isValid(); ++part) {
     part->setV(autopas::utils::ArrayMath::add(part->getVel_half(),
                                               autopas::utils::ArrayMath::mulScalar(part->getAcceleration(), 0.5 * dt)));
     part->setEnergy(part->getEng_half() + 0.5 * dt * part->getEngDot());
@@ -106,7 +106,7 @@ void leapfrogFinalKick(AutoPasContainer &sphSystem, const double dt) {
 }
 
 void setPressure(AutoPasContainer &sphSystem) {
-  for (auto part = sphSystem.begin(autopas::IteratorBehavior::ownedOnly); part.isValid(); ++part) {
+  for (auto part = sphSystem.begin(autopas::IteratorBehavior::owned); part.isValid(); ++part) {
     part->calcPressure();
   }
 }
@@ -189,7 +189,7 @@ void updateHaloParticles(AutoPasContainer &sphSystem) {
                           shift[i]);
         }
         for (auto iterator =
-                 sphSystem.getRegionIterator(requiredHaloMin, requiredHaloMax, autopas::IteratorBehavior::ownedOnly);
+                 sphSystem.getRegionIterator(requiredHaloMin, requiredHaloMax, autopas::IteratorBehavior::owned);
              iterator.isValid(); ++iterator) {
           Particle p = *iterator;
           p.addR(shift);
@@ -224,7 +224,7 @@ void densityPressureHydroForce(AutoPasContainer &sphSystem) {
   std::cout << "particles... " << innerparts << std::endl;
 
   // 1.2 then calculate density
-  for (auto part = sphSystem.begin(autopas::IteratorBehavior::ownedOnly); part.isValid(); ++part) {
+  for (auto part = sphSystem.begin(autopas::IteratorBehavior::owned); part.isValid(); ++part) {
     part->setDensity(0.);
     densityFunctor.AoSFunctor(*part, *part);
     part->setDensity(part->getDensity() / 2);
@@ -257,7 +257,7 @@ void densityPressureHydroForce(AutoPasContainer &sphSystem) {
   std::cout << "particles... " << innerparts << std::endl;
 
   // 0.3.2 then calculate hydro force
-  for (auto part = sphSystem.begin(autopas::IteratorBehavior::ownedOnly); part.isValid(); ++part) {
+  for (auto part = sphSystem.begin(autopas::IteratorBehavior::owned); part.isValid(); ++part) {
     // self interaction leeds to:
     // 1) vsigmax = 2*part->getSoundSpeed()
     // 2) no change in acceleration
@@ -275,7 +275,7 @@ void densityPressureHydroForce(AutoPasContainer &sphSystem) {
 void printConservativeVariables(AutoPasContainer &sphSystem) {
   std::array<double, 3> momSum = {0., 0., 0.};  // total momentum
   double energySum = 0.0;                       // total energy
-  for (auto it = sphSystem.begin(autopas::IteratorBehavior::ownedOnly); it.isValid(); ++it) {
+  for (auto it = sphSystem.begin(autopas::IteratorBehavior::owned); it.isValid(); ++it) {
     momSum = autopas::utils::ArrayMath::add(momSum, autopas::utils::ArrayMath::mulScalar(it->getV(), it->getMass()));
     energySum += (it->getEnergy() + 0.5 * autopas::utils::ArrayMath::dot(it->getV(), it->getV())) * it->getMass();
   }

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -221,30 +221,23 @@ class AutoPas {
    * for(auto iter = autoPas.begin(); iter.isValid(); ++iter)
    * @param behavior The behavior of the iterator. You can specify whether to iterate over owned particles, halo
    * particles, or both.
-   * @param forceSequential Whether to force the iterator to behave as if it is not parallel.
    * @return iterator to the first particle.
    */
-  iterator_t begin(IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) {
-    return _logicHandler->begin(behavior, forceSequential);
-  }
+  iterator_t begin(IteratorBehavior behavior = IteratorBehavior::ownedOrHalo) { return _logicHandler->begin(behavior); }
 
   /**
    * @copydoc begin()
    * @note const version
    */
-  const_iterator_t begin(IteratorBehavior behavior = IteratorBehavior::ownedOrHalo,
-                         bool forceSequential = false) const {
-    return std::as_const(*_logicHandler).begin(behavior, forceSequential);
+  const_iterator_t begin(IteratorBehavior behavior = IteratorBehavior::ownedOrHalo) const {
+    return std::as_const(*_logicHandler).begin(behavior);
   }
 
   /**
    * @copydoc begin()
    * @note cbegin will guarantee to return a const_iterator.
    */
-  const_iterator_t cbegin(IteratorBehavior behavior = IteratorBehavior::ownedOrHalo,
-                          bool forceSequential = false) const {
-    return begin(behavior, forceSequential);
-  }
+  const_iterator_t cbegin(IteratorBehavior behavior = IteratorBehavior::ownedOrHalo) const { return begin(behavior); }
 
   /**
    * End of the iterator.
@@ -261,13 +254,11 @@ class AutoPas {
    * @param higherCorner higher corner of the region
    * @param behavior the behavior of the iterator. You can specify whether to iterate over owned particles, halo
    * particles, or both.
-   * @param forceSequential Whether to force the iterator to behave as if it is not parallel.
    * @return iterator to iterate over all particles in a specific region
    */
   iterator_t getRegionIterator(std::array<double, 3> lowerCorner, std::array<double, 3> higherCorner,
-                               IteratorBehavior behavior = IteratorBehavior::ownedOrHalo,
-                               bool forceSequential = false) {
-    return _logicHandler->getRegionIterator(lowerCorner, higherCorner, behavior, forceSequential);
+                               IteratorBehavior behavior = IteratorBehavior::ownedOrHalo) {
+    return _logicHandler->getRegionIterator(lowerCorner, higherCorner, behavior);
   }
 
   /**
@@ -275,9 +266,8 @@ class AutoPas {
    * @note const version
    */
   const_iterator_t getRegionIterator(std::array<double, 3> lowerCorner, std::array<double, 3> higherCorner,
-                                     IteratorBehavior behavior = IteratorBehavior::ownedOrHalo,
-                                     bool forceSequential = false) const {
-    return std::as_const(*_logicHandler).getRegionIterator(lowerCorner, higherCorner, behavior, forceSequential);
+                                     IteratorBehavior behavior = IteratorBehavior::ownedOrHalo) const {
+    return std::as_const(*_logicHandler).getRegionIterator(lowerCorner, higherCorner, behavior);
   }
 
   /**

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -219,8 +219,9 @@ class AutoPas {
   /**
    * Iterate over all particles by using
    * for(auto iter = autoPas.begin(); iter.isValid(); ++iter)
-   * @param behavior the behavior of the iterator. You can specify whether to iterate over owned particles, halo
+   * @param behavior The behavior of the iterator. You can specify whether to iterate over owned particles, halo
    * particles, or both.
+   * @param forceSequential Whether to force the iterator to behave as if it is not parallel.
    * @return iterator to the first particle.
    */
   iterator_t begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) {
@@ -260,6 +261,7 @@ class AutoPas {
    * @param higherCorner higher corner of the region
    * @param behavior the behavior of the iterator. You can specify whether to iterate over owned particles, halo
    * particles, or both.
+   * @param forceSequential Whether to force the iterator to behave as if it is not parallel.
    * @return iterator to iterate over all particles in a specific region
    */
   iterator_t getRegionIterator(std::array<double, 3> lowerCorner, std::array<double, 3> higherCorner,

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -223,23 +223,27 @@ class AutoPas {
    * particles, or both.
    * @return iterator to the first particle.
    */
-  iterator_t begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) {
-    return _logicHandler->begin(behavior);
+  iterator_t begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) {
+    return _logicHandler->begin(behavior, forceSequential);
   }
 
   /**
    * @copydoc begin()
    * @note const version
    */
-  const_iterator_t begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const {
-    return std::as_const(*_logicHandler).begin(behavior);
+  const_iterator_t begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
+                         bool forceSequential = false) const {
+    return std::as_const(*_logicHandler).begin(behavior, forceSequential);
   }
 
   /**
    * @copydoc begin()
    * @note cbegin will guarantee to return a const_iterator.
    */
-  const_iterator_t cbegin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const { return begin(behavior); }
+  const_iterator_t cbegin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
+                          bool forceSequential = false) const {
+    return begin(behavior, forceSequential);
+  }
 
   /**
    * End of the iterator.
@@ -259,8 +263,9 @@ class AutoPas {
    * @return iterator to iterate over all particles in a specific region
    */
   iterator_t getRegionIterator(std::array<double, 3> lowerCorner, std::array<double, 3> higherCorner,
-                               IteratorBehavior behavior = IteratorBehavior::haloAndOwned) {
-    return _logicHandler->getRegionIterator(lowerCorner, higherCorner, behavior);
+                               IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
+                               bool forceSequential = false) {
+    return _logicHandler->getRegionIterator(lowerCorner, higherCorner, behavior, forceSequential);
   }
 
   /**
@@ -268,8 +273,9 @@ class AutoPas {
    * @note const version
    */
   const_iterator_t getRegionIterator(std::array<double, 3> lowerCorner, std::array<double, 3> higherCorner,
-                                     IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const {
-    return std::as_const(*_logicHandler).getRegionIterator(lowerCorner, higherCorner, behavior);
+                                     IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
+                                     bool forceSequential = false) const {
+    return std::as_const(*_logicHandler).getRegionIterator(lowerCorner, higherCorner, behavior, forceSequential);
   }
 
   /**

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -244,27 +244,25 @@ class LogicHandler {
   /**
    * @copydoc AutoPas::begin()
    */
-  autopas::ParticleIteratorWrapper<Particle, true> begin(IteratorBehavior behavior = IteratorBehavior::ownedOrHalo,
-                                                         bool forceSequential = false) {
+  autopas::ParticleIteratorWrapper<Particle, true> begin(IteratorBehavior behavior) {
     /// @todo: we might have to add a rebuild here, if the verlet cluster lists are used.
-    return _autoTuner.getContainer()->begin(behavior, forceSequential);
+    return _autoTuner.getContainer()->begin(behavior);
   }
 
   /**
    * @copydoc AutoPas::begin()
    */
-  autopas::ParticleIteratorWrapper<Particle, false> begin(IteratorBehavior behavior = IteratorBehavior::ownedOrHalo,
-                                                          bool forceSequential = false) const {
+  autopas::ParticleIteratorWrapper<Particle, false> begin(IteratorBehavior behavior) const {
     /// @todo: we might have to add a rebuild here, if the verlet cluster lists are used.
-    return std::as_const(_autoTuner).getContainer()->begin(behavior, forceSequential);
+    return std::as_const(_autoTuner).getContainer()->begin(behavior);
   }
 
   /**
    * @copydoc AutoPas::getRegionIterator()
    */
-  autopas::ParticleIteratorWrapper<Particle, true> getRegionIterator(
-      std::array<double, 3> lowerCorner, std::array<double, 3> higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) {
+  autopas::ParticleIteratorWrapper<Particle, true> getRegionIterator(std::array<double, 3> lowerCorner,
+                                                                     std::array<double, 3> higherCorner,
+                                                                     IteratorBehavior behavior) {
     // sanity check: Most of our stuff depends on `inBox` which does not handle lowerCorner > higherCorner well.
     for (size_t d = 0; d < 3; ++d) {
       if (lowerCorner > higherCorner) {
@@ -277,15 +275,15 @@ class LogicHandler {
     }
 
     /// @todo: we might have to add a rebuild here, if the verlet cluster lists are used.
-    return _autoTuner.getContainer()->getRegionIterator(lowerCorner, higherCorner, behavior, forceSequential);
+    return _autoTuner.getContainer()->getRegionIterator(lowerCorner, higherCorner, behavior);
   }
 
   /**
    * @copydoc AutoPas::getRegionIterator()
    */
-  autopas::ParticleIteratorWrapper<Particle, false> getRegionIterator(
-      std::array<double, 3> lowerCorner, std::array<double, 3> higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) const {
+  autopas::ParticleIteratorWrapper<Particle, false> getRegionIterator(std::array<double, 3> lowerCorner,
+                                                                      std::array<double, 3> higherCorner,
+                                                                      IteratorBehavior behavior) const {
     // sanity check: Most of our stuff depends on `inBox` which does not handle lowerCorner > higherCorner well.
     for (size_t d = 0; d < 3; ++d) {
       if (lowerCorner > higherCorner) {
@@ -298,9 +296,7 @@ class LogicHandler {
     }
 
     /// @todo: we might have to add a rebuild here, if the verlet cluster lists are used.
-    return std::as_const(_autoTuner)
-        .getContainer()
-        ->getRegionIterator(lowerCorner, higherCorner, behavior, forceSequential);
+    return std::as_const(_autoTuner).getContainer()->getRegionIterator(lowerCorner, higherCorner, behavior);
   }
 
   /**

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -168,11 +168,15 @@ class LogicHandler {
             utils::ExceptionHandler::exception(
                 "LogicHandler::addHaloParticle: wasn't able to update halo particle that is too close to "
                 "domain (more than cutoff + skin/2). Rebuild frequency not high enough / skin too small!\n"
-                "Cutoff       : {}\n" +
-                    "Skin         : {}\n" + "BoxMin       : {}\n" + "BoxMax       : {}\n" + "Dangerous Min: {}\n" +
-                    "Dangerous Max: {}\n" + "Particle     : {}\n" + container->getCutoff(),
-                container->getSkin(), container->getBoxMin(), container->getBoxMax(), dangerousBoxMin, dangerousBoxMax,
-                haloParticle.toString());
+                "Cutoff       : {}\n"
+                "Skin         : {}\n"
+                "BoxMin       : {}\n"
+                "BoxMax       : {}\n"
+                "Dangerous Min: {}\n"
+                "Dangerous Max: {}\n"
+                "Particle     : {}\n",
+                container->getCutoff(), container->getSkin(), container->getBoxMin(), container->getBoxMax(),
+                dangerousBoxMin, dangerousBoxMax, haloParticle.toString());
           }
         }
       } else {

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -169,13 +169,10 @@ class LogicHandler {
                 "LogicHandler::addHaloParticle: wasn't able to update halo particle that is too close to "
                 "domain (more than cutoff + skin/2). Rebuild frequency not high enough / skin too small!\n"
                 "Cutoff       : {}\n" +
-                "Skin         : {}\n" +
-                "BoxMin       : {}\n" +
-                "BoxMax       : {}\n" +
-                "Dangerous Min: {}\n" +
-                "Dangerous Max: {}\n" +
-                "Particle     : {}\n" +
-                container->getCutoff(), container->getSkin(), container->getBoxMin(), container->getBoxMax(), dangerousBoxMin, dangerousBoxMax, haloParticle.toString());
+                    "Skin         : {}\n" + "BoxMin       : {}\n" + "BoxMax       : {}\n" + "Dangerous Min: {}\n" +
+                    "Dangerous Max: {}\n" + "Particle     : {}\n" + container->getCutoff(),
+                container->getSkin(), container->getBoxMin(), container->getBoxMax(), dangerousBoxMin, dangerousBoxMax,
+                haloParticle.toString());
           }
         }
       } else {

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -244,7 +244,7 @@ class LogicHandler {
   /**
    * @copydoc AutoPas::begin()
    */
-  autopas::ParticleIteratorWrapper<Particle, true> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
+  autopas::ParticleIteratorWrapper<Particle, true> begin(IteratorBehavior behavior = IteratorBehavior::ownedOrHalo,
                                                          bool forceSequential = false) {
     /// @todo: we might have to add a rebuild here, if the verlet cluster lists are used.
     return _autoTuner.getContainer()->begin(behavior, forceSequential);
@@ -253,7 +253,7 @@ class LogicHandler {
   /**
    * @copydoc AutoPas::begin()
    */
-  autopas::ParticleIteratorWrapper<Particle, false> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
+  autopas::ParticleIteratorWrapper<Particle, false> begin(IteratorBehavior behavior = IteratorBehavior::ownedOrHalo,
                                                           bool forceSequential = false) const {
     /// @todo: we might have to add a rebuild here, if the verlet cluster lists are used.
     return std::as_const(_autoTuner).getContainer()->begin(behavior, forceSequential);
@@ -264,7 +264,7 @@ class LogicHandler {
    */
   autopas::ParticleIteratorWrapper<Particle, true> getRegionIterator(
       std::array<double, 3> lowerCorner, std::array<double, 3> higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) {
+      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) {
     // sanity check: Most of our stuff depends on `inBox` which does not handle lowerCorner > higherCorner well.
     for (size_t d = 0; d < 3; ++d) {
       if (lowerCorner > higherCorner) {
@@ -285,7 +285,7 @@ class LogicHandler {
    */
   autopas::ParticleIteratorWrapper<Particle, false> getRegionIterator(
       std::array<double, 3> lowerCorner, std::array<double, 3> higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) const {
+      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) const {
     // sanity check: Most of our stuff depends on `inBox` which does not handle lowerCorner > higherCorner well.
     for (size_t d = 0; d < 3; ++d) {
       if (lowerCorner > higherCorner) {

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -244,18 +244,19 @@ class LogicHandler {
   /**
    * @copydoc AutoPas::begin()
    */
-  autopas::ParticleIteratorWrapper<Particle, true> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) {
+  autopas::ParticleIteratorWrapper<Particle, true> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
+                                                         bool forceSequential = false) {
     /// @todo: we might have to add a rebuild here, if the verlet cluster lists are used.
-    return _autoTuner.getContainer()->begin(behavior);
+    return _autoTuner.getContainer()->begin(behavior, forceSequential);
   }
 
   /**
    * @copydoc AutoPas::begin()
    */
-  autopas::ParticleIteratorWrapper<Particle, false> begin(
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const {
+  autopas::ParticleIteratorWrapper<Particle, false> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
+                                                          bool forceSequential = false) const {
     /// @todo: we might have to add a rebuild here, if the verlet cluster lists are used.
-    return std::as_const(_autoTuner).getContainer()->begin(behavior);
+    return std::as_const(_autoTuner).getContainer()->begin(behavior, forceSequential);
   }
 
   /**
@@ -263,7 +264,7 @@ class LogicHandler {
    */
   autopas::ParticleIteratorWrapper<Particle, true> getRegionIterator(
       std::array<double, 3> lowerCorner, std::array<double, 3> higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) {
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) {
     // sanity check: Most of our stuff depends on `inBox` which does not handle lowerCorner > higherCorner well.
     for (size_t d = 0; d < 3; ++d) {
       if (lowerCorner > higherCorner) {
@@ -276,7 +277,7 @@ class LogicHandler {
     }
 
     /// @todo: we might have to add a rebuild here, if the verlet cluster lists are used.
-    return _autoTuner.getContainer()->getRegionIterator(lowerCorner, higherCorner, behavior);
+    return _autoTuner.getContainer()->getRegionIterator(lowerCorner, higherCorner, behavior, forceSequential);
   }
 
   /**
@@ -284,7 +285,7 @@ class LogicHandler {
    */
   autopas::ParticleIteratorWrapper<Particle, false> getRegionIterator(
       std::array<double, 3> lowerCorner, std::array<double, 3> higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const {
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) const {
     // sanity check: Most of our stuff depends on `inBox` which does not handle lowerCorner > higherCorner well.
     for (size_t d = 0; d < 3; ++d) {
       if (lowerCorner > higherCorner) {
@@ -297,7 +298,9 @@ class LogicHandler {
     }
 
     /// @todo: we might have to add a rebuild here, if the verlet cluster lists are used.
-    return std::as_const(_autoTuner).getContainer()->getRegionIterator(lowerCorner, higherCorner, behavior);
+    return std::as_const(_autoTuner)
+        .getContainer()
+        ->getRegionIterator(lowerCorner, higherCorner, behavior, forceSequential);
   }
 
   /**

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -176,21 +176,21 @@ class ParticleContainerInterface {
    * @return Iterator to the first particle.
    */
   [[nodiscard]] virtual ParticleIteratorWrapper<ParticleType, true> begin(
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) = 0;
+      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) = 0;
 
   /**
    * @copydoc begin()
    * @note const version
    */
   [[nodiscard]] virtual ParticleIteratorWrapper<ParticleType, false> begin(
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) const = 0;
+      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) const = 0;
 
   /**
    * @copydoc begin()
    * @note cbegin will guarantee to return a const_iterator.
    */
   [[nodiscard]] virtual ParticleIteratorWrapper<ParticleType, false> cbegin(
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) const final {
+      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) const final {
     return begin(behavior);
   };
 
@@ -205,7 +205,7 @@ class ParticleContainerInterface {
    */
   [[nodiscard]] virtual ParticleIteratorWrapper<ParticleType, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) = 0;
+      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) = 0;
 
   /**
    * @copydoc getRegionIterator()
@@ -213,7 +213,7 @@ class ParticleContainerInterface {
    */
   [[nodiscard]] virtual ParticleIteratorWrapper<ParticleType, false> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) const = 0;
+      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) const = 0;
 
   /**
    * End expression for all containers, this simply returns false.

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -172,25 +172,25 @@ class ParticleContainerInterface {
    * Iterate over all particles using
    * for(auto iter = container.begin(); iter.isValid(); ++iter) .
    * @param behavior Behavior of the iterator, see IteratorBehavior.
-   * @param forceSequential Whether to force the iterator to behave as if it is not parallel.
+   * @note Default argument necessary to enable range based for loops.
    * @return Iterator to the first particle.
    */
   [[nodiscard]] virtual ParticleIteratorWrapper<ParticleType, true> begin(
-      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) = 0;
+      IteratorBehavior behavior = autopas::IteratorBehavior::ownedOrHalo) = 0;
 
   /**
    * @copydoc begin()
    * @note const version
    */
   [[nodiscard]] virtual ParticleIteratorWrapper<ParticleType, false> begin(
-      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) const = 0;
+      IteratorBehavior behavior = autopas::IteratorBehavior::ownedOrHalo) const = 0;
 
   /**
    * @copydoc begin()
    * @note cbegin will guarantee to return a const_iterator.
    */
   [[nodiscard]] virtual ParticleIteratorWrapper<ParticleType, false> cbegin(
-      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) const final {
+      IteratorBehavior behavior = autopas::IteratorBehavior::ownedOrHalo) const final {
     return begin(behavior);
   };
 
@@ -200,12 +200,11 @@ class ParticleContainerInterface {
    * @param lowerCorner Lower corner of the region
    * @param higherCorner Higher corner of the region
    * @param behavior The behavior of the iterator (shall it iterate over halo particles as well?).
-   * @param forceSequential Whether to force the iterator to behave as if it is not parallel.
    * @return Iterator to iterate over all particles in a specific region.
    */
   [[nodiscard]] virtual ParticleIteratorWrapper<ParticleType, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) = 0;
+      IteratorBehavior behavior) = 0;
 
   /**
    * @copydoc getRegionIterator()
@@ -213,7 +212,7 @@ class ParticleContainerInterface {
    */
   [[nodiscard]] virtual ParticleIteratorWrapper<ParticleType, false> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) const = 0;
+      IteratorBehavior behavior) const = 0;
 
   /**
    * End expression for all containers, this simply returns false.

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -172,6 +172,7 @@ class ParticleContainerInterface {
    * Iterate over all particles using
    * for(auto iter = container.begin(); iter.isValid(); ++iter) .
    * @param behavior Behavior of the iterator, see IteratorBehavior.
+   * @param forceSequential Whether to force the iterator to behave as if it is not parallel.
    * @return Iterator to the first particle.
    */
   [[nodiscard]] virtual ParticleIteratorWrapper<ParticleType, true> begin(
@@ -199,6 +200,7 @@ class ParticleContainerInterface {
    * @param lowerCorner Lower corner of the region
    * @param higherCorner Higher corner of the region
    * @param behavior The behavior of the iterator (shall it iterate over halo particles as well?).
+   * @param forceSequential Whether to force the iterator to behave as if it is not parallel.
    * @return Iterator to iterate over all particles in a specific region.
    */
   [[nodiscard]] virtual ParticleIteratorWrapper<ParticleType, true> getRegionIterator(

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -175,21 +175,21 @@ class ParticleContainerInterface {
    * @return Iterator to the first particle.
    */
   [[nodiscard]] virtual ParticleIteratorWrapper<ParticleType, true> begin(
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) = 0;
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) = 0;
 
   /**
    * @copydoc begin()
    * @note const version
    */
   [[nodiscard]] virtual ParticleIteratorWrapper<ParticleType, false> begin(
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const = 0;
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) const = 0;
 
   /**
    * @copydoc begin()
    * @note cbegin will guarantee to return a const_iterator.
    */
   [[nodiscard]] virtual ParticleIteratorWrapper<ParticleType, false> cbegin(
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const final {
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) const final {
     return begin(behavior);
   };
 
@@ -203,7 +203,7 @@ class ParticleContainerInterface {
    */
   [[nodiscard]] virtual ParticleIteratorWrapper<ParticleType, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) = 0;
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) = 0;
 
   /**
    * @copydoc getRegionIterator()
@@ -211,7 +211,7 @@ class ParticleContainerInterface {
    */
   [[nodiscard]] virtual ParticleIteratorWrapper<ParticleType, false> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const = 0;
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) const = 0;
 
   /**
    * End expression for all containers, this simply returns false.

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -137,21 +137,21 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
   }
 
   [[nodiscard]] ParticleIteratorWrapper<ParticleType, true> begin(
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) override {
     return ParticleIteratorWrapper<ParticleType, true>(new internal::ParticleIterator<ParticleType, ParticleCell, true>(
-        &this->_cells, 0, &_cellBorderFlagManager, behavior));
+        &this->_cells, 0, &_cellBorderFlagManager, behavior, nullptr, forceSequential));
   }
 
   [[nodiscard]] ParticleIteratorWrapper<ParticleType, false> begin(
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const override {
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) const override {
     return ParticleIteratorWrapper<ParticleType, false>(
         new internal::ParticleIterator<ParticleType, ParticleCell, false>(&this->_cells, 0, &_cellBorderFlagManager,
-                                                                          behavior));
+                                                                          behavior, nullptr, forceSequential));
   }
 
   [[nodiscard]] ParticleIteratorWrapper<ParticleType, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) override {
     std::vector<size_t> cellsOfInterest;
 
     switch (behavior) {
@@ -171,13 +171,14 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
     }
 
     return ParticleIteratorWrapper<ParticleType, true>(
-        new internal::RegionParticleIterator<ParticleType, ParticleCell, true>(
-            &this->_cells, lowerCorner, higherCorner, cellsOfInterest, &_cellBorderFlagManager, behavior));
+        new internal::RegionParticleIterator<ParticleType, ParticleCell, true>(&this->_cells, lowerCorner, higherCorner,
+                                                                               cellsOfInterest, &_cellBorderFlagManager,
+                                                                               behavior, nullptr, forceSequential));
   }
 
   [[nodiscard]] ParticleIteratorWrapper<ParticleType, false> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const override {
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) const override {
     std::vector<size_t> cellsOfInterest;
 
     switch (behavior) {
@@ -198,7 +199,8 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
 
     return ParticleIteratorWrapper<ParticleType, false>(
         new internal::RegionParticleIterator<ParticleType, ParticleCell, false>(
-            &this->_cells, lowerCorner, higherCorner, cellsOfInterest, &_cellBorderFlagManager, behavior));
+            &this->_cells, lowerCorner, higherCorner, cellsOfInterest, &_cellBorderFlagManager, behavior, nullptr,
+            forceSequential));
   }
 
  private:

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -137,21 +137,21 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
   }
 
   [[nodiscard]] ParticleIteratorWrapper<ParticleType, true> begin(
-      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) override {
+      IteratorBehavior behavior = autopas::IteratorBehavior::ownedOrHalo) override {
     return ParticleIteratorWrapper<ParticleType, true>(new internal::ParticleIterator<ParticleType, ParticleCell, true>(
-        &this->_cells, 0, &_cellBorderFlagManager, behavior, nullptr, forceSequential));
+        &this->_cells, 0, &_cellBorderFlagManager, behavior, nullptr));
   }
 
   [[nodiscard]] ParticleIteratorWrapper<ParticleType, false> begin(
-      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) const override {
+      IteratorBehavior behavior = autopas::IteratorBehavior::ownedOrHalo) const override {
     return ParticleIteratorWrapper<ParticleType, false>(
         new internal::ParticleIterator<ParticleType, ParticleCell, false>(&this->_cells, 0, &_cellBorderFlagManager,
-                                                                          behavior, nullptr, forceSequential));
+                                                                          behavior, nullptr));
   }
 
-  [[nodiscard]] ParticleIteratorWrapper<ParticleType, true> getRegionIterator(
-      const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) override {
+  [[nodiscard]] ParticleIteratorWrapper<ParticleType, true> getRegionIterator(const std::array<double, 3> &lowerCorner,
+                                                                              const std::array<double, 3> &higherCorner,
+                                                                              IteratorBehavior behavior) override {
     std::vector<size_t> cellsOfInterest;
 
     if (behavior & IteratorBehavior::owned) {
@@ -166,14 +166,13 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
     }
 
     return ParticleIteratorWrapper<ParticleType, true>(
-        new internal::RegionParticleIterator<ParticleType, ParticleCell, true>(&this->_cells, lowerCorner, higherCorner,
-                                                                               cellsOfInterest, &_cellBorderFlagManager,
-                                                                               behavior, nullptr, forceSequential));
+        new internal::RegionParticleIterator<ParticleType, ParticleCell, true>(
+            &this->_cells, lowerCorner, higherCorner, cellsOfInterest, &_cellBorderFlagManager, behavior, nullptr));
   }
 
   [[nodiscard]] ParticleIteratorWrapper<ParticleType, false> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) const override {
+      IteratorBehavior behavior) const override {
     std::vector<size_t> cellsOfInterest;
 
     if (behavior & IteratorBehavior::owned) {
@@ -189,8 +188,7 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
 
     return ParticleIteratorWrapper<ParticleType, false>(
         new internal::RegionParticleIterator<ParticleType, ParticleCell, false>(
-            &this->_cells, lowerCorner, higherCorner, cellsOfInterest, &_cellBorderFlagManager, behavior, nullptr,
-            forceSequential));
+            &this->_cells, lowerCorner, higherCorner, cellsOfInterest, &_cellBorderFlagManager, behavior, nullptr));
   }
 
  private:

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -161,7 +161,7 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
       cellsOfInterest.push_back(1);
     }
     // sanity check
-    if (cellsOfInterest.size() == 0) {
+    if (cellsOfInterest.empty()) {
       utils::ExceptionHandler::exception("Encountered invalid iterator behavior!");
     }
 
@@ -182,7 +182,7 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
       cellsOfInterest.push_back(1);
     }
     // sanity check
-    if (cellsOfInterest.size() == 0) {
+    if (cellsOfInterest.empty()) {
       utils::ExceptionHandler::exception("Encountered invalid iterator behavior!");
     }
 

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -221,21 +221,21 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
   }
 
   [[nodiscard]] ParticleIteratorWrapper<ParticleType, true> begin(
-      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) override {
+      IteratorBehavior behavior = autopas::IteratorBehavior::ownedOrHalo) override {
     return ParticleIteratorWrapper<ParticleType, true>(new internal::ParticleIterator<ParticleType, ParticleCell, true>(
-        &this->_cells, 0, &_cellBlock, behavior, nullptr, forceSequential));
+        &this->_cells, 0, &_cellBlock, behavior, nullptr));
   }
 
   [[nodiscard]] ParticleIteratorWrapper<ParticleType, false> begin(
-      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) const override {
+      IteratorBehavior behavior = autopas::IteratorBehavior::ownedOrHalo) const override {
     return ParticleIteratorWrapper<ParticleType, false>(
         new internal::ParticleIterator<ParticleType, ParticleCell, false>(&this->_cells, 0, &_cellBlock, behavior,
-                                                                          nullptr, forceSequential));
+                                                                          nullptr));
   }
 
-  [[nodiscard]] ParticleIteratorWrapper<ParticleType, true> getRegionIterator(
-      const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) override {
+  [[nodiscard]] ParticleIteratorWrapper<ParticleType, true> getRegionIterator(const std::array<double, 3> &lowerCorner,
+                                                                              const std::array<double, 3> &higherCorner,
+                                                                              IteratorBehavior behavior) override {
     // We increase the search region by skin, as particles can move over cell borders.
     auto startIndex3D =
         this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getSkin()));
@@ -257,14 +257,13 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
     }
 
     return ParticleIteratorWrapper<ParticleType, true>(
-        new internal::RegionParticleIterator<ParticleType, ParticleCell, true>(&this->_cells, lowerCorner, higherCorner,
-                                                                               cellsOfInterest, &_cellBlock, behavior,
-                                                                               nullptr, forceSequential));
+        new internal::RegionParticleIterator<ParticleType, ParticleCell, true>(
+            &this->_cells, lowerCorner, higherCorner, cellsOfInterest, &_cellBlock, behavior, nullptr));
   }
 
   [[nodiscard]] ParticleIteratorWrapper<ParticleType, false> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) const override {
+      IteratorBehavior behavior) const override {
     // We increase the search region by skin, as particles can move over cell borders.
     auto startIndex3D =
         this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getSkin()));
@@ -287,8 +286,7 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
 
     return ParticleIteratorWrapper<ParticleType, false>(
         new internal::RegionParticleIterator<ParticleType, ParticleCell, false>(
-            &this->_cells, lowerCorner, higherCorner, cellsOfInterest, &_cellBlock, behavior, nullptr,
-            forceSequential));
+            &this->_cells, lowerCorner, higherCorner, cellsOfInterest, &_cellBlock, behavior, nullptr));
   }
 
   /**

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -221,13 +221,13 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
   }
 
   [[nodiscard]] ParticleIteratorWrapper<ParticleType, true> begin(
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) override {
+      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) override {
     return ParticleIteratorWrapper<ParticleType, true>(new internal::ParticleIterator<ParticleType, ParticleCell, true>(
         &this->_cells, 0, &_cellBlock, behavior, nullptr, forceSequential));
   }
 
   [[nodiscard]] ParticleIteratorWrapper<ParticleType, false> begin(
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) const override {
+      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) const override {
     return ParticleIteratorWrapper<ParticleType, false>(
         new internal::ParticleIterator<ParticleType, ParticleCell, false>(&this->_cells, 0, &_cellBlock, behavior,
                                                                           nullptr, forceSequential));
@@ -235,7 +235,7 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
 
   [[nodiscard]] ParticleIteratorWrapper<ParticleType, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) override {
+      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) override {
     // We increase the search region by skin, as particles can move over cell borders.
     auto startIndex3D =
         this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getSkin()));
@@ -264,7 +264,7 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
 
   [[nodiscard]] ParticleIteratorWrapper<ParticleType, false> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) const override {
+      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) const override {
     // We increase the search region by skin, as particles can move over cell borders.
     auto startIndex3D =
         this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getSkin()));

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -221,20 +221,21 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
   }
 
   [[nodiscard]] ParticleIteratorWrapper<ParticleType, true> begin(
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
-    return ParticleIteratorWrapper<ParticleType, true>(
-        new internal::ParticleIterator<ParticleType, ParticleCell, true>(&this->_cells, 0, &_cellBlock, behavior));
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) override {
+    return ParticleIteratorWrapper<ParticleType, true>(new internal::ParticleIterator<ParticleType, ParticleCell, true>(
+        &this->_cells, 0, &_cellBlock, behavior, nullptr, forceSequential));
   }
 
   [[nodiscard]] ParticleIteratorWrapper<ParticleType, false> begin(
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const override {
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) const override {
     return ParticleIteratorWrapper<ParticleType, false>(
-        new internal::ParticleIterator<ParticleType, ParticleCell, false>(&this->_cells, 0, &_cellBlock, behavior));
+        new internal::ParticleIterator<ParticleType, ParticleCell, false>(&this->_cells, 0, &_cellBlock, behavior,
+                                                                          nullptr, forceSequential));
   }
 
   [[nodiscard]] ParticleIteratorWrapper<ParticleType, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) override {
     // We increase the search region by skin, as particles can move over cell borders.
     auto startIndex3D =
         this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getSkin()));
@@ -257,12 +258,13 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
 
     return ParticleIteratorWrapper<ParticleType, true>(
         new internal::RegionParticleIterator<ParticleType, ParticleCell, true>(&this->_cells, lowerCorner, higherCorner,
-                                                                               cellsOfInterest, &_cellBlock, behavior));
+                                                                               cellsOfInterest, &_cellBlock, behavior,
+                                                                               nullptr, forceSequential));
   }
 
   [[nodiscard]] ParticleIteratorWrapper<ParticleType, false> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const override {
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) const override {
     // We increase the search region by skin, as particles can move over cell borders.
     auto startIndex3D =
         this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getSkin()));
@@ -285,7 +287,8 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
 
     return ParticleIteratorWrapper<ParticleType, false>(
         new internal::RegionParticleIterator<ParticleType, ParticleCell, false>(
-            &this->_cells, lowerCorner, higherCorner, cellsOfInterest, &_cellBlock, behavior));
+            &this->_cells, lowerCorner, higherCorner, cellsOfInterest, &_cellBlock, behavior, nullptr,
+            forceSequential));
   }
 
   /**

--- a/src/autopas/containers/linkedCells/LinkedCellsReferences.h
+++ b/src/autopas/containers/linkedCells/LinkedCellsReferences.h
@@ -256,21 +256,23 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
                                  this->getCellBlock().getCellLength(), 0);
   }
 
-  ParticleIteratorWrapper<ParticleType, true> begin(
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
+  ParticleIteratorWrapper<ParticleType, true> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
+                                                    bool forceSequential = false) override {
     return ParticleIteratorWrapper<ParticleType, true>(
-        new internal::ParticleIterator<ParticleType, ReferenceCell, true>(&this->_cells, 0, &_cellBlock, behavior));
+        new internal::ParticleIterator<ParticleType, ReferenceCell, true>(&this->_cells, 0, &_cellBlock, behavior,
+                                                                          nullptr, forceSequential));
   }
 
-  ParticleIteratorWrapper<ParticleType, false> begin(
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const override {
+  ParticleIteratorWrapper<ParticleType, false> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
+                                                     bool forceSequential = false) const override {
     return ParticleIteratorWrapper<ParticleType, false>(
-        new internal::ParticleIterator<ParticleType, ReferenceCell, false>(&this->_cells, 0, &_cellBlock, behavior));
+        new internal::ParticleIterator<ParticleType, ReferenceCell, false>(&this->_cells, 0, &_cellBlock, behavior,
+                                                                           nullptr, forceSequential));
   }
 
   ParticleIteratorWrapper<ParticleType, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) override {
     // We increase the search region by skin, as particles can move over cell borders.
     auto startIndex3D =
         this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getSkin()));
@@ -293,12 +295,13 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
 
     return ParticleIteratorWrapper<ParticleType, true>(
         new internal::RegionParticleIterator<ParticleType, ReferenceCell, true>(
-            &this->_cells, lowerCorner, higherCorner, cellsOfInterest, &_cellBlock, behavior));
+            &this->_cells, lowerCorner, higherCorner, cellsOfInterest, &_cellBlock, behavior, nullptr,
+            forceSequential));
   }
 
   ParticleIteratorWrapper<ParticleType, false> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const override {
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) const override {
     // We increase the search region by skin, as particles can move over cell borders.
     auto startIndex3D =
         this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getSkin()));
@@ -321,7 +324,8 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
 
     return ParticleIteratorWrapper<ParticleType, false>(
         new internal::RegionParticleIterator<ParticleType, ReferenceCell, false>(
-            &this->_cells, lowerCorner, higherCorner, cellsOfInterest, &_cellBlock, behavior));
+            &this->_cells, lowerCorner, higherCorner, cellsOfInterest, &_cellBlock, behavior, nullptr,
+            forceSequential));
   }
 
   /**

--- a/src/autopas/containers/linkedCells/LinkedCellsReferences.h
+++ b/src/autopas/containers/linkedCells/LinkedCellsReferences.h
@@ -256,14 +256,14 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
                                  this->getCellBlock().getCellLength(), 0);
   }
 
-  ParticleIteratorWrapper<ParticleType, true> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
+  ParticleIteratorWrapper<ParticleType, true> begin(IteratorBehavior behavior = IteratorBehavior::ownedOrHalo,
                                                     bool forceSequential = false) override {
     return ParticleIteratorWrapper<ParticleType, true>(
         new internal::ParticleIterator<ParticleType, ReferenceCell, true>(&this->_cells, 0, &_cellBlock, behavior,
                                                                           nullptr, forceSequential));
   }
 
-  ParticleIteratorWrapper<ParticleType, false> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
+  ParticleIteratorWrapper<ParticleType, false> begin(IteratorBehavior behavior = IteratorBehavior::ownedOrHalo,
                                                      bool forceSequential = false) const override {
     return ParticleIteratorWrapper<ParticleType, false>(
         new internal::ParticleIterator<ParticleType, ReferenceCell, false>(&this->_cells, 0, &_cellBlock, behavior,
@@ -272,7 +272,7 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
 
   ParticleIteratorWrapper<ParticleType, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) override {
+      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) override {
     // We increase the search region by skin, as particles can move over cell borders.
     auto startIndex3D =
         this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getSkin()));
@@ -301,7 +301,7 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
 
   ParticleIteratorWrapper<ParticleType, false> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) const override {
+      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) const override {
     // We increase the search region by skin, as particles can move over cell borders.
     auto startIndex3D =
         this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getSkin()));

--- a/src/autopas/containers/linkedCells/LinkedCellsReferences.h
+++ b/src/autopas/containers/linkedCells/LinkedCellsReferences.h
@@ -256,23 +256,23 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
                                  this->getCellBlock().getCellLength(), 0);
   }
 
-  ParticleIteratorWrapper<ParticleType, true> begin(IteratorBehavior behavior = IteratorBehavior::ownedOrHalo,
-                                                    bool forceSequential = false) override {
+  ParticleIteratorWrapper<ParticleType, true> begin(
+      IteratorBehavior behavior = autopas::IteratorBehavior::ownedOrHalo) override {
     return ParticleIteratorWrapper<ParticleType, true>(
         new internal::ParticleIterator<ParticleType, ReferenceCell, true>(&this->_cells, 0, &_cellBlock, behavior,
-                                                                          nullptr, forceSequential));
+                                                                          nullptr));
   }
 
-  ParticleIteratorWrapper<ParticleType, false> begin(IteratorBehavior behavior = IteratorBehavior::ownedOrHalo,
-                                                     bool forceSequential = false) const override {
+  ParticleIteratorWrapper<ParticleType, false> begin(
+      IteratorBehavior behavior = autopas::IteratorBehavior::ownedOrHalo) const override {
     return ParticleIteratorWrapper<ParticleType, false>(
         new internal::ParticleIterator<ParticleType, ReferenceCell, false>(&this->_cells, 0, &_cellBlock, behavior,
-                                                                           nullptr, forceSequential));
+                                                                           nullptr));
   }
 
-  ParticleIteratorWrapper<ParticleType, true> getRegionIterator(
-      const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) override {
+  ParticleIteratorWrapper<ParticleType, true> getRegionIterator(const std::array<double, 3> &lowerCorner,
+                                                                const std::array<double, 3> &higherCorner,
+                                                                IteratorBehavior behavior) override {
     // We increase the search region by skin, as particles can move over cell borders.
     auto startIndex3D =
         this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getSkin()));
@@ -295,13 +295,12 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
 
     return ParticleIteratorWrapper<ParticleType, true>(
         new internal::RegionParticleIterator<ParticleType, ReferenceCell, true>(
-            &this->_cells, lowerCorner, higherCorner, cellsOfInterest, &_cellBlock, behavior, nullptr,
-            forceSequential));
+            &this->_cells, lowerCorner, higherCorner, cellsOfInterest, &_cellBlock, behavior, nullptr));
   }
 
-  ParticleIteratorWrapper<ParticleType, false> getRegionIterator(
-      const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) const override {
+  ParticleIteratorWrapper<ParticleType, false> getRegionIterator(const std::array<double, 3> &lowerCorner,
+                                                                 const std::array<double, 3> &higherCorner,
+                                                                 IteratorBehavior behavior) const override {
     // We increase the search region by skin, as particles can move over cell borders.
     auto startIndex3D =
         this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getSkin()));
@@ -324,8 +323,7 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
 
     return ParticleIteratorWrapper<ParticleType, false>(
         new internal::RegionParticleIterator<ParticleType, ReferenceCell, false>(
-            &this->_cells, lowerCorner, higherCorner, cellsOfInterest, &_cellBlock, behavior, nullptr,
-            forceSequential));
+            &this->_cells, lowerCorner, higherCorner, cellsOfInterest, &_cellBlock, behavior, nullptr));
   }
 
   /**

--- a/src/autopas/containers/verletClusterCells/VerletClusterCells.h
+++ b/src/autopas/containers/verletClusterCells/VerletClusterCells.h
@@ -128,9 +128,9 @@ class VerletClusterCells : public CellBasedParticleContainer<FullParticleCell<Pa
     Particle pCopy = haloParticle;
     pCopy.setOwnershipState(OwnershipState::halo);
 
-    for (auto it = getRegionIterator(utils::ArrayMath::subScalar(pCopy.getR(), this->getSkin() / 2),
-                                     utils::ArrayMath::addScalar(pCopy.getR(), this->getSkin() / 2),
-                                     IteratorBehavior::haloOnly);
+    for (auto it =
+             getRegionIterator(utils::ArrayMath::subScalar(pCopy.getR(), this->getSkin() / 2),
+                               utils::ArrayMath::addScalar(pCopy.getR(), this->getSkin() / 2), IteratorBehavior::halo);
          it.isValid(); ++it) {
       if (pCopy.getID() == it->getID()) {
         *it = pCopy;
@@ -211,7 +211,7 @@ class VerletClusterCells : public CellBasedParticleContainer<FullParticleCell<Pa
 #endif
     {
       std::vector<Particle> myInvalidParticles;
-      for (auto iter = this->begin(IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
+      for (auto iter = this->begin(IteratorBehavior::owned); iter.isValid(); ++iter) {
         if (not utils::inBox(iter->getR(), this->getBoxMin(), this->getBoxMax())) {
           myInvalidParticles.push_back(*iter);
           internal::deleteParticle(iter);
@@ -235,7 +235,7 @@ class VerletClusterCells : public CellBasedParticleContainer<FullParticleCell<Pa
                                  _clusterSize);
   }
 
-  ParticleIteratorWrapper<Particle, true> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
+  ParticleIteratorWrapper<Particle, true> begin(IteratorBehavior behavior = IteratorBehavior::ownedOrHalo,
                                                 bool forceSequential = false) override {
     return ParticleIteratorWrapper<Particle, true>(
         new internal::VerletClusterCellsParticleIterator<Particle, FullParticleCell<Particle>, true>(
@@ -245,7 +245,7 @@ class VerletClusterCells : public CellBasedParticleContainer<FullParticleCell<Pa
             _isValid != ValidityState::invalid ? this : nullptr));
   }
 
-  ParticleIteratorWrapper<Particle, false> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
+  ParticleIteratorWrapper<Particle, false> begin(IteratorBehavior behavior = IteratorBehavior::ownedOrHalo,
                                                  bool forceSequential = false) const override {
     return ParticleIteratorWrapper<Particle, false>(
         new internal::VerletClusterCellsParticleIterator<Particle, FullParticleCell<Particle>, false>(
@@ -254,7 +254,7 @@ class VerletClusterCells : public CellBasedParticleContainer<FullParticleCell<Pa
 
   ParticleIteratorWrapper<Particle, true> getRegionIterator(const std::array<double, 3> &lowerCorner,
                                                             const std::array<double, 3> &higherCorner,
-                                                            IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
+                                                            IteratorBehavior behavior = IteratorBehavior::ownedOrHalo,
                                                             bool forceSequential = false) override {
     // Special iterator requires sorted cells
 #ifdef AUTOPAS_OPENMP
@@ -301,7 +301,7 @@ class VerletClusterCells : public CellBasedParticleContainer<FullParticleCell<Pa
 
   ParticleIteratorWrapper<Particle, false> getRegionIterator(const std::array<double, 3> &lowerCorner,
                                                              const std::array<double, 3> &higherCorner,
-                                                             IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
+                                                             IteratorBehavior behavior = IteratorBehavior::ownedOrHalo,
                                                              bool forceSequential = false) const override {
     // restrict search area to the region where particles are
     const auto lowerCornerInBounds = utils::ArrayMath::max(lowerCorner, _boxMinWithHalo);

--- a/src/autopas/containers/verletClusterCells/VerletClusterCells.h
+++ b/src/autopas/containers/verletClusterCells/VerletClusterCells.h
@@ -235,8 +235,8 @@ class VerletClusterCells : public CellBasedParticleContainer<FullParticleCell<Pa
                                  _clusterSize);
   }
 
-  ParticleIteratorWrapper<Particle, true> begin(IteratorBehavior behavior = IteratorBehavior::ownedOrHalo,
-                                                bool forceSequential = false) override {
+  ParticleIteratorWrapper<Particle, true> begin(
+      IteratorBehavior behavior = autopas::IteratorBehavior::ownedOrHalo) override {
     return ParticleIteratorWrapper<Particle, true>(
         new internal::VerletClusterCellsParticleIterator<Particle, FullParticleCell<Particle>, true>(
             &this->_cells, _dummyStarts, _boxMaxWithHalo[0] + 8 * this->getInteractionLength(), behavior,
@@ -245,8 +245,8 @@ class VerletClusterCells : public CellBasedParticleContainer<FullParticleCell<Pa
             _isValid != ValidityState::invalid ? this : nullptr));
   }
 
-  ParticleIteratorWrapper<Particle, false> begin(IteratorBehavior behavior = IteratorBehavior::ownedOrHalo,
-                                                 bool forceSequential = false) const override {
+  ParticleIteratorWrapper<Particle, false> begin(
+      IteratorBehavior behavior = autopas::IteratorBehavior::ownedOrHalo) const override {
     return ParticleIteratorWrapper<Particle, false>(
         new internal::VerletClusterCellsParticleIterator<Particle, FullParticleCell<Particle>, false>(
             &this->_cells, _dummyStarts, _boxMaxWithHalo[0] + 8 * this->getInteractionLength(), behavior));
@@ -254,8 +254,7 @@ class VerletClusterCells : public CellBasedParticleContainer<FullParticleCell<Pa
 
   ParticleIteratorWrapper<Particle, true> getRegionIterator(const std::array<double, 3> &lowerCorner,
                                                             const std::array<double, 3> &higherCorner,
-                                                            IteratorBehavior behavior = IteratorBehavior::ownedOrHalo,
-                                                            bool forceSequential = false) override {
+                                                            IteratorBehavior behavior) override {
     // Special iterator requires sorted cells
 #ifdef AUTOPAS_OPENMP
 #pragma omp single
@@ -301,8 +300,7 @@ class VerletClusterCells : public CellBasedParticleContainer<FullParticleCell<Pa
 
   ParticleIteratorWrapper<Particle, false> getRegionIterator(const std::array<double, 3> &lowerCorner,
                                                              const std::array<double, 3> &higherCorner,
-                                                             IteratorBehavior behavior = IteratorBehavior::ownedOrHalo,
-                                                             bool forceSequential = false) const override {
+                                                             IteratorBehavior behavior) const override {
     // restrict search area to the region where particles are
     const auto lowerCornerInBounds = utils::ArrayMath::max(lowerCorner, _boxMinWithHalo);
     const auto upperCornerInBounds = utils::ArrayMath::min(higherCorner, _boxMaxWithHalo);

--- a/src/autopas/containers/verletClusterCells/VerletClusterCells.h
+++ b/src/autopas/containers/verletClusterCells/VerletClusterCells.h
@@ -235,7 +235,8 @@ class VerletClusterCells : public CellBasedParticleContainer<FullParticleCell<Pa
                                  _clusterSize);
   }
 
-  ParticleIteratorWrapper<Particle, true> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
+  ParticleIteratorWrapper<Particle, true> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
+                                                bool forceSequential = false) override {
     return ParticleIteratorWrapper<Particle, true>(
         new internal::VerletClusterCellsParticleIterator<Particle, FullParticleCell<Particle>, true>(
             &this->_cells, _dummyStarts, _boxMaxWithHalo[0] + 8 * this->getInteractionLength(), behavior,
@@ -244,16 +245,17 @@ class VerletClusterCells : public CellBasedParticleContainer<FullParticleCell<Pa
             _isValid != ValidityState::invalid ? this : nullptr));
   }
 
-  ParticleIteratorWrapper<Particle, false> begin(
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const override {
+  ParticleIteratorWrapper<Particle, false> begin(IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
+                                                 bool forceSequential = false) const override {
     return ParticleIteratorWrapper<Particle, false>(
         new internal::VerletClusterCellsParticleIterator<Particle, FullParticleCell<Particle>, false>(
             &this->_cells, _dummyStarts, _boxMaxWithHalo[0] + 8 * this->getInteractionLength(), behavior));
   }
 
-  ParticleIteratorWrapper<Particle, true> getRegionIterator(
-      const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
+  ParticleIteratorWrapper<Particle, true> getRegionIterator(const std::array<double, 3> &lowerCorner,
+                                                            const std::array<double, 3> &higherCorner,
+                                                            IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
+                                                            bool forceSequential = false) override {
     // Special iterator requires sorted cells
 #ifdef AUTOPAS_OPENMP
 #pragma omp single
@@ -297,9 +299,10 @@ class VerletClusterCells : public CellBasedParticleContainer<FullParticleCell<Pa
             this));
   }
 
-  ParticleIteratorWrapper<Particle, false> getRegionIterator(
-      const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const override {
+  ParticleIteratorWrapper<Particle, false> getRegionIterator(const std::array<double, 3> &lowerCorner,
+                                                             const std::array<double, 3> &higherCorner,
+                                                             IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
+                                                             bool forceSequential = false) const override {
     // restrict search area to the region where particles are
     const auto lowerCornerInBounds = utils::ArrayMath::max(lowerCorner, _boxMinWithHalo);
     const auto upperCornerInBounds = utils::ArrayMath::min(higherCorner, _boxMaxWithHalo);

--- a/src/autopas/containers/verletClusterCells/VerletClusterCellsParticleIterator.h
+++ b/src/autopas/containers/verletClusterCells/VerletClusterCellsParticleIterator.h
@@ -51,6 +51,7 @@ class VerletClusterCellsParticleIterator : public ParticleIteratorInterfaceImpl<
         _offsetToDummy(offsetToDummy),
         _particleDeletedObserver(particleDeletedObserver) {
     // 1. set _cellId to thread number.
+    // FIXME: support forceSequential mode
     _cellId = autopas_get_thread_num();
 
     if (_cellId >= _vectorOfCells->size()) {

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -184,7 +184,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
 
     for (auto it = getRegionIterator(utils::ArrayMath::subScalar(pCopy.getR(), this->getSkin() / 2),
                                      utils::ArrayMath::addScalar(pCopy.getR(), this->getSkin() / 2),
-                                     IteratorBehavior::haloOnly, true);
+                                     IteratorBehavior::halo, true);
          it.isValid(); ++it) {
       if (pCopy.getID() == it->getID()) {
         *it = pCopy;
@@ -203,7 +203,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
 #pragma omp parallel reduction(|| : deletedSth)
 #endif
     {
-      for (auto iter = this->begin(IteratorBehavior::haloOnly); iter.isValid(); ++iter) {
+      for (auto iter = this->begin(IteratorBehavior::halo); iter.isValid(); ++iter) {
         internal::deleteParticle(iter);
         deletedSth = true;
       }
@@ -235,7 +235,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
 #endif
     {
       std::vector<Particle> myInvalidParticles;
-      for (auto iter = this->begin(IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
+      for (auto iter = this->begin(IteratorBehavior::owned); iter.isValid(); ++iter) {
         if (not utils::inBox(iter->getR(), this->getBoxMin(), this->getBoxMax())) {
           myInvalidParticles.push_back(*iter);
           internal::deleteParticle(iter);
@@ -272,8 +272,8 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
    * @copydoc ParticleContainerInterface::begin()
    * @note This function additionally rebuilds the towers if the tower-structure isn't valid.
    */
-  [[nodiscard]] ParticleIteratorWrapper<Particle, true> begin(
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) override {
+  [[nodiscard]] ParticleIteratorWrapper<Particle, true> begin(IteratorBehavior behavior = IteratorBehavior::ownedOrHalo,
+                                                              bool forceSequential = false) override {
     // For good openmp scalability we want the particles to be sorted into the clusters, so we do this!
 #ifdef AUTOPAS_OPENMP
 #pragma omp single
@@ -293,7 +293,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
    * @note This function additionally iterates over the _particlesToAdd vector if the tower-structure isn't valid.
    */
   [[nodiscard]] ParticleIteratorWrapper<Particle, false> begin(
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) const override {
+      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) const override {
     /// @todo use proper cellBorderAndFlagManager instead of the unknowing.
     if (_isValid != ValidityState::invalid) {
       if (not particlesToAddEmpty()) {
@@ -318,7 +318,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
    */
   [[nodiscard]] ParticleIteratorWrapper<Particle, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) override {
+      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) override {
     // Special iterator requires sorted cells.
     // Only one thread is allowed to rebuild the towers, so we do an omp single here.
 #ifdef AUTOPAS_OPENMP
@@ -345,7 +345,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
    */
   [[nodiscard]] ParticleIteratorWrapper<Particle, false> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) const override {
+      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) const override {
     if (_isValid != ValidityState::invalid && not particlesToAddEmpty()) {
       autopas::utils::ExceptionHandler::exception(
           "VerletClusterLists::begin() const: Error: particle container is valid, but _particlesToAdd isn't empty!");

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -128,8 +128,8 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
   /**
    * @copydoc autopas::ParticleContainerInterface::begin()
    */
-  [[nodiscard]] ParticleIteratorWrapper<Particle, true> begin(
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) override {
+  [[nodiscard]] ParticleIteratorWrapper<Particle, true> begin(IteratorBehavior behavior = IteratorBehavior::ownedOrHalo,
+                                                              bool forceSequential = false) override {
     return _linkedCells.begin(behavior, forceSequential);
   }
 
@@ -137,7 +137,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    * @copydoc autopas::ParticleContainerInterface::begin()
    */
   [[nodiscard]] ParticleIteratorWrapper<Particle, false> begin(
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) const override {
+      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) const override {
     return _linkedCells.begin(behavior, forceSequential);
   }
 
@@ -146,7 +146,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    */
   [[nodiscard]] ParticleIteratorWrapper<Particle, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) override {
+      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) override {
     return _linkedCells.getRegionIterator(lowerCorner, higherCorner, behavior, forceSequential);
   }
 
@@ -155,7 +155,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    */
   [[nodiscard]] ParticleIteratorWrapper<Particle, false> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) const override {
+      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) const override {
     return _linkedCells.getRegionIterator(lowerCorner, higherCorner, behavior, forceSequential);
   }
 

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -128,35 +128,35 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
   /**
    * @copydoc autopas::ParticleContainerInterface::begin()
    */
-  [[nodiscard]] ParticleIteratorWrapper<Particle, true> begin(IteratorBehavior behavior = IteratorBehavior::ownedOrHalo,
-                                                              bool forceSequential = false) override {
-    return _linkedCells.begin(behavior, forceSequential);
+  [[nodiscard]] ParticleIteratorWrapper<Particle, true> begin(
+      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo) override {
+    return _linkedCells.begin(behavior);
   }
 
   /**
    * @copydoc autopas::ParticleContainerInterface::begin()
    */
   [[nodiscard]] ParticleIteratorWrapper<Particle, false> begin(
-      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) const override {
-    return _linkedCells.begin(behavior, forceSequential);
+      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo) const override {
+    return _linkedCells.begin(behavior);
   }
 
   /**
    * @copydoc autopas::ParticleContainerInterface::getRegionIterator()
    */
-  [[nodiscard]] ParticleIteratorWrapper<Particle, true> getRegionIterator(
-      const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) override {
-    return _linkedCells.getRegionIterator(lowerCorner, higherCorner, behavior, forceSequential);
+  [[nodiscard]] ParticleIteratorWrapper<Particle, true> getRegionIterator(const std::array<double, 3> &lowerCorner,
+                                                                          const std::array<double, 3> &higherCorner,
+                                                                          IteratorBehavior behavior) override {
+    return _linkedCells.getRegionIterator(lowerCorner, higherCorner, behavior);
   }
 
   /**
    * @copydoc autopas::ParticleContainerInterface::getRegionIterator()
    */
-  [[nodiscard]] ParticleIteratorWrapper<Particle, false> getRegionIterator(
-      const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo, bool forceSequential = false) const override {
-    return _linkedCells.getRegionIterator(lowerCorner, higherCorner, behavior, forceSequential);
+  [[nodiscard]] ParticleIteratorWrapper<Particle, false> getRegionIterator(const std::array<double, 3> &lowerCorner,
+                                                                           const std::array<double, 3> &higherCorner,
+                                                                           IteratorBehavior behavior) const override {
+    return _linkedCells.getRegionIterator(lowerCorner, higherCorner, behavior);
   }
 
   /**

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -129,16 +129,16 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    * @copydoc autopas::ParticleContainerInterface::begin()
    */
   [[nodiscard]] ParticleIteratorWrapper<Particle, true> begin(
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
-    return _linkedCells.begin(behavior);
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) override {
+    return _linkedCells.begin(behavior, forceSequential);
   }
 
   /**
    * @copydoc autopas::ParticleContainerInterface::begin()
    */
   [[nodiscard]] ParticleIteratorWrapper<Particle, false> begin(
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const override {
-    return _linkedCells.begin(behavior);
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) const override {
+    return _linkedCells.begin(behavior, forceSequential);
   }
 
   /**
@@ -146,8 +146,8 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    */
   [[nodiscard]] ParticleIteratorWrapper<Particle, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) override {
-    return _linkedCells.getRegionIterator(lowerCorner, higherCorner, behavior);
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) override {
+    return _linkedCells.getRegionIterator(lowerCorner, higherCorner, behavior, forceSequential);
   }
 
   /**
@@ -155,8 +155,8 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    */
   [[nodiscard]] ParticleIteratorWrapper<Particle, false> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner,
-      IteratorBehavior behavior = IteratorBehavior::haloAndOwned) const override {
-    return _linkedCells.getRegionIterator(lowerCorner, higherCorner, behavior);
+      IteratorBehavior behavior = IteratorBehavior::haloAndOwned, bool forceSequential = false) const override {
+    return _linkedCells.getRegionIterator(lowerCorner, higherCorner, behavior, forceSequential);
   }
 
   /**

--- a/src/autopas/containers/verletListsCellBased/varVerletLists/neighborLists/asBuild/VerletNeighborListAsBuild.h
+++ b/src/autopas/containers/verletListsCellBased/varVerletLists/neighborLists/asBuild/VerletNeighborListAsBuild.h
@@ -171,7 +171,7 @@ class VerletNeighborListAsBuild : public VerletNeighborListInterface<Particle>, 
     _aos2soaMap.reserve(_baseLinkedCells->getNumParticles());
     size_t i = 0;
     // needs to iterate also over dummies!
-    for (auto iter = _baseLinkedCells->begin(IteratorBehavior::haloOwnedAndDummy); iter.isValid(); ++iter, ++i) {
+    for (auto iter = _baseLinkedCells->begin(IteratorBehavior::ownedOrHaloOrDummy); iter.isValid(); ++iter, ++i) {
       _aos2soaMap[&(*iter)] = i;
     }
 

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -163,7 +163,7 @@ class VerletLists : public VerletListsLinkedBase<Particle> {
     _aosNeighborLists.clear();
     // DON'T simply parallelize this loop!!! this needs modifications if you want to parallelize it!
     // We have to iterate also over dummy particles here to ensure a correct size of the arrays.
-    for (auto iter = this->begin(IteratorBehavior::haloOwnedAndDummy); iter.isValid(); ++iter, ++numParticles) {
+    for (auto iter = this->begin(IteratorBehavior::ownedOrHaloOrDummy); iter.isValid(); ++iter, ++numParticles) {
       // create the verlet list entries for all particles
       _aosNeighborLists[&(*iter)];
     }
@@ -185,7 +185,7 @@ class VerletLists : public VerletListsLinkedBase<Particle> {
 
     // Here we have to iterate over all particles, as particles might be later on marked for deletion, and we cannot
     // differentiate them from particles already marked for deletion.
-    for (auto iter = this->begin(IteratorBehavior::haloOwnedAndDummy); iter.isValid(); ++iter, ++index) {
+    for (auto iter = this->begin(IteratorBehavior::ownedOrHaloOrDummy); iter.isValid(); ++iter, ++index) {
       // set the map
       _particlePtr2indexMap[&(*iter)] = index;
     }

--- a/src/autopas/iterators/ParticleIterator.h
+++ b/src/autopas/iterators/ParticleIterator.h
@@ -70,7 +70,7 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle, modifiab
         _additionalParticleVectorToIterateState(additionalVectorsToIterate
                                                     ? AdditionalParticleVectorToIterateState::notStarted
                                                     : AdditionalParticleVectorToIterateState::ignore),
-        _additionalVectorIndex(forceSequential ? autopas_get_thread_num() : 0),
+        _additionalVectorIndex(forceSequential ? 0 : autopas_get_thread_num()),
         _additionalVectorPosition(0),
         _additionalVectors(additionalVectorsToIterate) {}
 

--- a/src/autopas/iterators/ParticleIterator.h
+++ b/src/autopas/iterators/ParticleIterator.h
@@ -107,8 +107,9 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle, modifiab
       return;
     }
 
-    if (not (behavior & IteratorBehavior::ownedOrHalo) and flagManager == nullptr) {
-      utils::ExceptionHandler::exception("ParticleIterator::ParticleIterator() Behavior is not ownedOrHalo, but flagManager is nullptr!");
+    if (not(behavior & IteratorBehavior::ownedOrHalo) and flagManager == nullptr) {
+      utils::ExceptionHandler::exception(
+          "ParticleIterator::ParticleIterator() Behavior is not ownedOrHalo, but flagManager is nullptr!");
     }
 
     if (_additionalParticleVectorToIterateState != AdditionalParticleVectorToIterateState::iterating) {

--- a/src/autopas/iterators/ParticleIterator.h
+++ b/src/autopas/iterators/ParticleIterator.h
@@ -57,20 +57,18 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle, modifiab
    * Can be nullptr if the behavior is ownedOrHalo.
    * @param behavior The IteratorBehavior that specifies which type of cells shall be iterated through.
    * @param additionalVectorsToIterate Thread buffers of additional Particle Vector to iterate over.
-   * @param forceSequential Whether to force the iterator to behave as if it is not parallel.
    */
   ParticleIterator(CellVecType *cont, const CellBorderAndFlagManagerType *flagManager, IteratorBehavior behavior,
-                   ParticleVecType *additionalVectorsToIterate, bool forceSequential)
+                   ParticleVecType *additionalVectorsToIterate)
       : _vectorOfCells(cont),
         _iteratorAcrossCells(cont->begin()),
         _iteratorWithinOneCell(cont->begin()->begin()),
         _flagManager(flagManager),
         _behavior(behavior),
-        _forceSequential(forceSequential),
         _additionalParticleVectorToIterateState(additionalVectorsToIterate
                                                     ? AdditionalParticleVectorToIterateState::notStarted
                                                     : AdditionalParticleVectorToIterateState::ignore),
-        _additionalVectorIndex(forceSequential ? 0 : autopas_get_thread_num()),
+        _additionalVectorIndex((behavior & IteratorBehavior::forceSequential) ? 0 : autopas_get_thread_num()),
         _additionalVectorPosition(0),
         _additionalVectors(additionalVectorsToIterate) {}
 
@@ -88,14 +86,13 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle, modifiab
    * Can be nullptr if the behavior is ownedOrHalo.
    * @param behavior The IteratorBehavior that specifies which type of cells shall be iterated through.
    * @param additionalVectorsToIterate Additional Particle Vector to iterate over.
-   * @param forceSequential Whether to force the iterator to behave as if it is not parallel.
    */
   explicit ParticleIterator(CellVecType *cont, size_t offset = 0, CellBorderAndFlagManagerType *flagManager = nullptr,
                             IteratorBehavior behavior = IteratorBehavior::ownedOrHalo,
-                            ParticleVecType *additionalVectorsToIterate = nullptr, bool forceSequential = false)
-      : ParticleIterator(cont, flagManager, behavior, additionalVectorsToIterate, forceSequential) {
+                            ParticleVecType *additionalVectorsToIterate = nullptr)
+      : ParticleIterator(cont, flagManager, behavior, additionalVectorsToIterate) {
     auto myThreadId = autopas_get_thread_num();
-    if (not _forceSequential) {
+    if (not(_behavior & IteratorBehavior::forceSequential)) {
       offset += myThreadId;
     }
 
@@ -168,7 +165,7 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle, modifiab
         ++_additionalVectorPosition;
         // if we reach the end of this buffer jump to the next
         if (_additionalVectorPosition >= (*_additionalVectors)[_additionalVectorIndex].size()) {
-          _additionalVectorIndex += _forceSequential ? 1 : autopas_get_num_threads();
+          _additionalVectorIndex += (_behavior & IteratorBehavior::forceSequential) ? 1 : autopas_get_num_threads();
           _additionalVectorPosition = 0;
         }
         // continue looking for valid iterator positions until there are no buffers left
@@ -237,7 +234,7 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle, modifiab
    */
   virtual void next_non_empty_cell() {
     // find the next non-empty cell
-    const int stride = _forceSequential ? 1 : autopas_get_num_threads();
+    const int stride = (_behavior & IteratorBehavior::forceSequential) ? 1 : autopas_get_num_threads();
     for (_iteratorAcrossCells += stride; _iteratorAcrossCells < _vectorOfCells->end(); _iteratorAcrossCells += stride) {
       if (_iteratorAcrossCells >= _vectorOfCells->end()) {
         break;
@@ -336,12 +333,6 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle, modifiab
    * The behavior of the iterator.
    */
   const IteratorBehavior _behavior;
-
-  /**
-   * Switch to force the iterator to behave as if it is the only iterator (visit every cell), as if it was not in
-   * parallel mode even if it is. This is useful if a serial iterator is needed in a forceSequential region.
-   */
-  bool _forceSequential;
 
   /**
    * Enum class that specifies the iterating state of the additional particle vector.

--- a/src/autopas/iterators/ParticleIterator.h
+++ b/src/autopas/iterators/ParticleIterator.h
@@ -107,8 +107,7 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle, modifiab
       return;
     }
 
-    if ((behavior != IteratorBehavior::ownedOrHalo and behavior != IteratorBehavior::ownedOrHaloOrDummy) and
-        flagManager == nullptr) {
+    if ((behavior & IteratorBehavior::ownedOrHalo) and flagManager == nullptr) {
       AutoPasLog(error, "Behavior is not ownedOrHalo, but flagManager is nullptr!");
       utils::ExceptionHandler::exception("Behavior is not ownedOrHalo, but flagManager is nullptr!");
     }

--- a/src/autopas/iterators/ParticleIterator.h
+++ b/src/autopas/iterators/ParticleIterator.h
@@ -107,9 +107,8 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle, modifiab
       return;
     }
 
-    if ((behavior & IteratorBehavior::ownedOrHalo) and flagManager == nullptr) {
-      AutoPasLog(error, "Behavior is not ownedOrHalo, but flagManager is nullptr!");
-      utils::ExceptionHandler::exception("Behavior is not ownedOrHalo, but flagManager is nullptr!");
+    if (not (behavior & IteratorBehavior::ownedOrHalo) and flagManager == nullptr) {
+      utils::ExceptionHandler::exception("ParticleIterator::ParticleIterator() Behavior is not ownedOrHalo, but flagManager is nullptr!");
     }
 
     if (_additionalParticleVectorToIterateState != AdditionalParticleVectorToIterateState::iterating) {

--- a/src/autopas/iterators/ParticleIterator.h
+++ b/src/autopas/iterators/ParticleIterator.h
@@ -250,7 +250,7 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle, modifiab
   [[nodiscard]] bool isCellTypeBehaviorCorrect() const {
     // IMPORTANT: `this->` is necessary here! Without it clang 7, 8 and 9 fail due to an compiler bug:
     // https://stackoverflow.com/questions/55359614/clang-complains-about-constexpr-function-in-case-for-switch-statement
-    switch (this->_behavior) {
+    switch (this->_behavior & ~IteratorBehavior::forceSequential) {
       case IteratorBehavior::ownedOrHaloOrDummy:
         [[fallthrough]];
       case IteratorBehavior::ownedOrHalo:
@@ -260,7 +260,8 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle, modifiab
       case IteratorBehavior::owned:
         return _flagManager->cellCanContainOwnedParticles(_iteratorAcrossCells - _vectorOfCells->begin());
       default:
-        utils::ExceptionHandler::exception("unknown iterator behavior");
+        utils::ExceptionHandler::exception(
+            "ParticleIterator::isCellTypeBehaviorCorrect() encountered unknown iterator behavior: {}", this->_behavior);
         return false;
     }
   }
@@ -272,7 +273,7 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle, modifiab
   [[nodiscard]] bool particleHasCorrectOwnershipState() const {
     // IMPORTANT: `this->` is necessary here! Without it clang 7, 8 and 9 fail due to an compiler bug:
     // https://stackoverflow.com/questions/55359614/clang-complains-about-constexpr-function-in-case-for-switch-statement
-    switch (this->_behavior) {
+    switch (this->_behavior & ~IteratorBehavior::forceSequential) {
       case IteratorBehavior::ownedOrHaloOrDummy:
         return true;
       case IteratorBehavior::ownedOrHalo:
@@ -294,7 +295,9 @@ class ParticleIterator : public ParticleIteratorInterfaceImpl<Particle, modifiab
           return _iteratorWithinOneCell->isOwned();
         }
       default:
-        utils::ExceptionHandler::exception("unknown iterator behavior");
+        utils::ExceptionHandler::exception(
+            "ParticleIterator::particleHasCorrectOwnershipState() encountered unknown iterator behavior: {}",
+            this->_behavior);
         return false;
     }
   }

--- a/src/autopas/iterators/RegionParticleIterator.h
+++ b/src/autopas/iterators/RegionParticleIterator.h
@@ -75,15 +75,6 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell, m
       return;
     }
 
-    if ((behavior & IteratorBehavior::ownedOrHalo) and flagManager == nullptr) {
-      AutoPasLog(error,
-                 "Behavior is not ownedOrHalo, but flagManager is "
-                 "nullptr!");
-      utils::ExceptionHandler::exception(
-          "Behavior is not ownedOrHalo, but flagManager is "
-          "nullptr!");
-    }
-
     if (this->_additionalParticleVectorToIterateState !=
         decltype(this->_additionalParticleVectorToIterateState)::iterating) {
       if (not this->isCellTypeBehaviorCorrect()) {

--- a/src/autopas/iterators/RegionParticleIterator.h
+++ b/src/autopas/iterators/RegionParticleIterator.h
@@ -44,6 +44,7 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell, m
    * @param flagManager The CellBorderAndFlagManager that shall be used to query the cell types.
    * Can be nullptr if the behavior is haloAndOwned.
    * @param behavior The IteratorBehavior that specifies which type of cells shall be iterated through.
+   * @param forceSequential Whether to force the iterator to behave as if it is not parallel.
    * @param additionalParticleVectorToIterate Additional Particle Vector to iterate over.
    */
   explicit RegionParticleIterator(CellVecType *cont, std::array<double, 3> startRegion, std::array<double, 3> endRegion,

--- a/src/autopas/iterators/RegionParticleIterator.h
+++ b/src/autopas/iterators/RegionParticleIterator.h
@@ -75,7 +75,7 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell, m
       return;
     }
 
-    if (behavior != IteratorBehavior::ownedOrHalo and flagManager == nullptr) {
+    if ((behavior & IteratorBehavior::ownedOrHalo) and flagManager == nullptr) {
       AutoPasLog(error,
                  "Behavior is not ownedOrHalo, but flagManager is "
                  "nullptr!");

--- a/src/autopas/iterators/RegionParticleIterator.h
+++ b/src/autopas/iterators/RegionParticleIterator.h
@@ -42,7 +42,7 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell, m
    * @param endRegion Top corner of the region to iterate over.
    * @param indicesInRegion List of indices all threads will iterate over.
    * @param flagManager The CellBorderAndFlagManager that shall be used to query the cell types.
-   * Can be nullptr if the behavior is haloAndOwned.
+   * Can be nullptr if the behavior is ownedOrHalo.
    * @param behavior The IteratorBehavior that specifies which type of cells shall be iterated through.
    * @param forceSequential Whether to force the iterator to behave as if it is not parallel.
    * @param additionalParticleVectorToIterate Additional Particle Vector to iterate over.
@@ -50,7 +50,7 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell, m
   explicit RegionParticleIterator(CellVecType *cont, std::array<double, 3> startRegion, std::array<double, 3> endRegion,
                                   std::vector<size_t> &indicesInRegion,
                                   const CellBorderAndFlagManagerType *flagManager = nullptr,
-                                  IteratorBehavior behavior = IteratorBehavior::haloAndOwned,
+                                  IteratorBehavior behavior = IteratorBehavior::ownedOrHalo,
                                   ParticleVecType *additionalParticleVectorToIterate = nullptr,
                                   bool forceSequential = false)
       : ParticleIteratorType(cont, flagManager, behavior, additionalParticleVectorToIterate, forceSequential),
@@ -78,12 +78,12 @@ class RegionParticleIterator : public ParticleIterator<Particle, ParticleCell, m
       return;
     }
 
-    if (behavior != IteratorBehavior::haloAndOwned and flagManager == nullptr) {
+    if (behavior != IteratorBehavior::ownedOrHalo and flagManager == nullptr) {
       AutoPasLog(error,
-                 "Behavior is not haloAndOwned, but flagManager is "
+                 "Behavior is not ownedOrHalo, but flagManager is "
                  "nullptr!");
       utils::ExceptionHandler::exception(
-          "Behavior is not haloAndOwned, but flagManager is "
+          "Behavior is not ownedOrHalo, but flagManager is "
           "nullptr!");
     }
 

--- a/src/autopas/options/IteratorBehavior.h
+++ b/src/autopas/options/IteratorBehavior.h
@@ -18,10 +18,12 @@ inline namespace options {
  */
 class IteratorBehavior : public Option<IteratorBehavior> {
  public:
+  using Value_t = unsigned int;
+
   /**
    * Different possibilities for iterator behaviors.
    */
-  enum Value : unsigned int {
+  enum Value : Value_t {
     /**
      * Iterate only over owned particles.
      */
@@ -67,6 +69,14 @@ class IteratorBehavior : public Option<IteratorBehavior> {
    * @param option
    */
   constexpr IteratorBehavior(Value option) : _value(option) {}
+
+  /**
+   * Constructor from number value.
+   * This is useful when combining values and directly using the result as argument of type IteratorBehavior.
+   * This is necessary since e.g. owned & halo results in an object of Value_t instead of Value.
+   * @param option
+   */
+  constexpr IteratorBehavior(Value_t option) : _value(static_cast<IteratorBehavior::Value>(option)) {}
 
   /**
    * Cast to value.

--- a/src/autopas/options/IteratorBehavior.h
+++ b/src/autopas/options/IteratorBehavior.h
@@ -18,6 +18,9 @@ inline namespace options {
  */
 class IteratorBehavior : public Option<IteratorBehavior> {
  public:
+  /**
+   * Type used for the internal enum.
+   */
   using Value_t = unsigned int;
 
   /**

--- a/src/autopas/options/IteratorBehavior.h
+++ b/src/autopas/options/IteratorBehavior.h
@@ -89,7 +89,7 @@ class IteratorBehavior : public Option<IteratorBehavior> {
 
   /**
    * Set of options that are very unlikely to be interesting.
-   * Technically these options are nor discouraged but when fetching a set of desired behaviors these are probably
+   * Technically these options are not discouraged but when fetching a set of desired behaviors these are probably
    * not useful and would be excluded anyway.
    * @return
    */

--- a/src/autopas/selectors/ContainerSelector.h
+++ b/src/autopas/selectors/ContainerSelector.h
@@ -156,7 +156,7 @@ std::unique_ptr<autopas::ParticleContainerInterface<Particle>> ContainerSelector
 
   // copy particles so they do not get lost when container is switched
   if (_currentContainer != nullptr) {
-    for (auto particleIter = _currentContainer->begin(IteratorBehavior::haloAndOwned); particleIter.isValid();
+    for (auto particleIter = _currentContainer->begin(IteratorBehavior::ownedOrHalo); particleIter.isValid();
          ++particleIter) {
       // add particle as inner if it is owned
       if (particleIter->isOwned()) {

--- a/src/autopas/utils/logging/Logger.h
+++ b/src/autopas/utils/logging/Logger.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <spdlog/fmt/bundled/ranges.h>
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/ostream_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
@@ -115,7 +115,7 @@ auto identifyAndSendHaloParticles(autopas::AutoPas<Molecule> &autoPas) {
           }
         }
         // here it is important to only iterate over the owned particles!
-        for (auto iter = autoPas.getRegionIterator(min, max, autopas::IteratorBehavior::ownedOnly); iter.isValid();
+        for (auto iter = autoPas.getRegionIterator(min, max, autopas::IteratorBehavior::owned); iter.isValid();
              ++iter) {
           auto particleCopy = *iter;
           particleCopy.addR(shiftVec);
@@ -216,7 +216,7 @@ template <typename Functor>
 void doAssertions(autopas::AutoPas<Molecule> &autoPas, Functor *functor, unsigned long numParticlesExpected) {
   std::vector<Molecule> molecules(numParticlesExpected);
   size_t numParticles = 0;
-  for (auto iter = autoPas.begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
+  for (auto iter = autoPas.begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
     ASSERT_LT(numParticles, numParticlesExpected) << "Too many particles owned by this container.";
     molecules[numParticles++] = *iter;
   }
@@ -237,11 +237,11 @@ void doAssertions(autopas::AutoPas<Molecule> &autoPas1, autopas::AutoPas<Molecul
                   Functor *functor2) {
   std::array<Molecule, 2> molecules{};
   size_t numParticles = 0;
-  for (auto iter = autoPas1.begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
+  for (auto iter = autoPas1.begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
     ASSERT_LT(numParticles, 2) << "Too many owned particles.";
     molecules[numParticles++] = *iter;
   }
-  for (auto iter = autoPas2.begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
+  for (auto iter = autoPas2.begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
     ASSERT_LT(numParticles, 2) << "Too many owned particles.";
     molecules[numParticles++] = *iter;
   }
@@ -309,7 +309,7 @@ void testSimulationLoop(testingTuple options) {
   // update positions a bit (outside of domain!) + reset F
   {
     std::array<double, 3> moveVec{skin / 3., 0., 0.};
-    for (auto iter = autoPas.begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
+    for (auto iter = autoPas.begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
       iter->setR(autopas::utils::ArrayMath::add(iter->getR(), moveVec));
       iter->setF(zeroArr);
     }
@@ -322,7 +322,7 @@ void testSimulationLoop(testingTuple options) {
 
   // no position update this time, but resetF!
   {
-    for (auto iter = autoPas.begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
+    for (auto iter = autoPas.begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
       iter->setF(zeroArr);
     }
   }
@@ -467,12 +467,12 @@ TEST_P(AutoPasInterface1ContainersTest, testResize) {
 
   autoPas.init();
 
-  ASSERT_EQ(autoPas.getNumberOfParticles(autopas::IteratorBehavior::haloAndOwned), 0)
+  ASSERT_EQ(autoPas.getNumberOfParticles(autopas::IteratorBehavior::ownedOrHalo), 0)
       << "Container was not initialized empty!";
 
   // add three purposely placed particles
   auto expectedParticles = addParticlesMinMidMax(autoPas);
-  ASSERT_EQ(autoPas.getNumberOfParticles(autopas::IteratorBehavior::ownedOnly), expectedParticles.size())
+  ASSERT_EQ(autoPas.getNumberOfParticles(autopas::IteratorBehavior::owned), expectedParticles.size())
       << "Container did not receive all particles before resize()!";
 
   auto boxMinNew = autopas::utils::ArrayMath::add(autoPas.getBoxMin(), {.5, .5, .5});
@@ -562,7 +562,7 @@ void testSimulationLoop(autopas::ContainerOption containerOption1, autopas::Cont
   {
     std::array<double, 3> moveVec{skin / 3., 0., 0.};
     for (auto *aP : {&autoPas1, &autoPas2}) {
-      for (auto iter = aP->begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
+      for (auto iter = aP->begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
         iter->setR(autopas::utils::ArrayMath::add(iter->getR(), moveVec));
         iter->setF(zeroArr);
       }
@@ -576,7 +576,7 @@ void testSimulationLoop(autopas::ContainerOption containerOption1, autopas::Cont
 
   // reset F
   for (auto *aP : {&autoPas1, &autoPas2}) {
-    for (auto iter = aP->begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
+    for (auto iter = aP->begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
       iter->setF(zeroArr);
     }
   }

--- a/tests/testAutopas/tests/autopasInterface/AutoPasTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasTest.cpp
@@ -196,9 +196,9 @@ TEST_F(AutoPasTest, checkConstIterator) {
 }
 
 void AutoPasTest::expectedParticles(size_t expectedOwned, size_t expectedHalo) {
-  EXPECT_EQ(autoPas.getNumberOfParticles(autopas::IteratorBehavior::haloAndOwned), expectedHalo + expectedOwned);
-  EXPECT_EQ(autoPas.getNumberOfParticles(autopas::IteratorBehavior::ownedOnly), expectedOwned);
-  EXPECT_EQ(autoPas.getNumberOfParticles(autopas::IteratorBehavior::haloOnly), expectedHalo);
+  EXPECT_EQ(autoPas.getNumberOfParticles(autopas::IteratorBehavior::ownedOrHalo), expectedHalo + expectedOwned);
+  EXPECT_EQ(autoPas.getNumberOfParticles(autopas::IteratorBehavior::owned), expectedOwned);
+  EXPECT_EQ(autoPas.getNumberOfParticles(autopas::IteratorBehavior::halo), expectedHalo);
 }
 
 TEST_F(AutoPasTest, getNumParticlesTest) {

--- a/tests/testAutopas/tests/containers/TraversalComparison.cpp
+++ b/tests/testAutopas/tests/containers/TraversalComparison.cpp
@@ -48,7 +48,7 @@ void TraversalComparison::executeShift(ContainerPtrType containerPtr, double mag
     elem = randomShift(magnitude, generator);
   }
   size_t numIteratedParticles = 0;
-  for (auto iter = containerPtr->begin(autopas::IteratorBehavior::haloOwnedAndDummy); iter != containerPtr->end();
+  for (auto iter = containerPtr->begin(autopas::IteratorBehavior::ownedOrHaloOrDummy); iter != containerPtr->end();
        ++iter) {
     if (not iter->isDummy()) {
       iter->addR(shiftVectorByID[iter->getID()]);
@@ -147,7 +147,7 @@ std::tuple<std::vector<std::array<double, 3>>, TraversalComparison::Globals> Tra
   functor.endTraversal(newton3Option);
 
   std::vector<std::array<double, 3>> forces(numMolecules);
-  for (auto it = container->begin(autopas::IteratorBehavior::ownedOnly); it.isValid(); ++it) {
+  for (auto it = container->begin(autopas::IteratorBehavior::owned); it.isValid(); ++it) {
     EXPECT_TRUE(it->isOwned());
     forces.at(it->getID()) = it->getF();
   }

--- a/tests/testAutopas/tests/containers/directSum/DirectSumContainerTest.cpp
+++ b/tests/testAutopas/tests/containers/directSum/DirectSumContainerTest.cpp
@@ -41,7 +41,7 @@ TEST_F(DirectSumContainerTest, testUpdateContainerCloseToBoundary) {
   auto invalidParticles = directSum.updateContainer();
 
   // the particles should no longer be in the inner cells!
-  for (auto iter = directSum.begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
+  for (auto iter = directSum.begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
     EXPECT_EQ(movedIDs.count(iter->getID()), 0);
   }
 

--- a/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
@@ -111,7 +111,7 @@ TYPED_TEST_P(LinkedCellsTest, testUpdateContainerCloseToBoundary) {
   auto invalidParticles = this->_linkedCells.updateContainer();
 
   // the particles should no longer be in the inner cells!
-  for (auto iter = this->_linkedCells.begin(autopas::IteratorBehavior::ownedOnly); iter.isValid(); ++iter) {
+  for (auto iter = this->_linkedCells.begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
     EXPECT_EQ(movedIDs.count(iter->getID()), 0);
   }
 

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.cpp
@@ -198,7 +198,6 @@ TEST_P(VerletListsTest, testVerletListBuildHalo) {
 template <class Container, class Particle>
 bool moveUpdateAndExpectEqual(Container &container, Particle &particle, std::array<double, 3> newPosition) {
   particle.setR(newPosition);
-  /// @todo: uncomment
   bool updated = container.updateHaloParticle(particle);
   if (updated) {
     auto iter = container.begin();

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/VerletListsCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/VerletListsCellsTest.cpp
@@ -37,8 +37,9 @@ void applyFunctor(MockFunctor<Particle> &functor, const double cellSizefactor) {
   verletLists.iteratePairwise(&traversal);
 
   std::vector<Particle *> list;
-  for (auto iter = verletLists.begin(autopas::IteratorBehavior::ownedOrHalo); iter.isValid(); ++iter)
+  for (auto iter = verletLists.begin(autopas::IteratorBehavior::ownedOrHalo); iter.isValid(); ++iter) {
     list.push_back(&*iter);
+  }
 
   EXPECT_EQ(list.size(), 2);
   size_t partners = 0;

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/VerletListsCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/VerletListsCellsTest.cpp
@@ -37,7 +37,8 @@ void applyFunctor(MockFunctor<Particle> &functor, const double cellSizefactor) {
   verletLists.iteratePairwise(&traversal);
 
   std::vector<Particle *> list;
-  for (auto iter = verletLists.begin(); iter.isValid(); ++iter) list.push_back(&*iter);
+  for (auto iter = verletLists.begin(autopas::IteratorBehavior::ownedOrHalo); iter.isValid(); ++iter)
+    list.push_back(&*iter);
 
   EXPECT_EQ(list.size(), 2);
   size_t partners = 0;

--- a/tests/testAutopas/tests/iterators/IteratorTestHelper.h
+++ b/tests/testAutopas/tests/iterators/IteratorTestHelper.h
@@ -306,8 +306,9 @@ void findParticles(AutoPasT &autopas, FgetIter getIter, const std::vector<size_t
 
 /**
  * Generates a given amount of cells where only indicated cells contain a given amount of particles.
- * Particle coordinates are the same as their ID in every dimension, so particles are placed equidistant on
- * the main diagonal through space.
+ * Cells can be considered to be on the main diagonal through 3D space. So the xyz coordinates of each cell's lower
+ * corner are {cellID, cellID, cellID}. The particles are also placed along this line within their cells. Within each
+ * cell the particles are placed equidistant around the center.
  * @param numCells
  * @param cellsToFill
  * @param particlesPerCell
@@ -315,12 +316,16 @@ void findParticles(AutoPasT &autopas, FgetIter getIter, const std::vector<size_t
  */
 static std::vector<FMCell> generateCellsWithPattern(const size_t numCells, const std::vector<size_t> &cellsToFill,
                                                     const size_t particlesPerCell) {
+  constexpr double cellDiagonal = 1.;
+  // distance between particles within one cell
+  const double distBetweenParticles = cellDiagonal / (particlesPerCell + 1.);
+
   std::vector<FMCell> cells(numCells);
   size_t numParticlesAdded = 0;
   for (auto cellId : cellsToFill) {
     for (size_t i = 0; i < particlesPerCell; ++i) {
-      auto idAsDouble = static_cast<double>(numParticlesAdded);
-      Molecule m({idAsDouble, idAsDouble, idAsDouble}, {0, 0, 0}, numParticlesAdded++, 0);
+      auto position = cellId + distBetweenParticles * (i + 1.);
+      Molecule m({position, position, position}, {0, 0, 0}, numParticlesAdded++, 0);
       cells[cellId].addParticle(m);
     }
   }

--- a/tests/testAutopas/tests/iterators/IteratorTestHelper.h
+++ b/tests/testAutopas/tests/iterators/IteratorTestHelper.h
@@ -304,4 +304,26 @@ void findParticles(AutoPasT &autopas, FgetIter getIter, const std::vector<size_t
   EXPECT_THAT(particleIDsFound, ::testing::UnorderedElementsAreArray(particleIDsExpected));
 }
 
+/**
+ * Generates a given amount of cells where only indicated cells contain a given amount of particles.
+ * Particle coordinates are the same as their ID in every dimension, so particles are placed equidistant on
+ * the main diagonal through space.
+ * @param numCells
+ * @param cellsToFill
+ * @param particlesPerCell
+ * @return Vector of generated and filled cells.
+ */
+static std::vector<FMCell> generateCellsWithPattern(const size_t numCells, const std::vector<size_t> &cellsToFill,
+                                                    const size_t particlesPerCell) {
+  std::vector<FMCell> cells(numCells);
+  size_t numParticlesAdded = 0;
+  for (auto cellId : cellsToFill) {
+    for (size_t i = 0; i < particlesPerCell; ++i) {
+      auto idAsDouble = static_cast<double>(numParticlesAdded);
+      Molecule m({idAsDouble, idAsDouble, idAsDouble}, {0, 0, 0}, numParticlesAdded++, 0);
+      cells[cellId].addParticle(m);
+    }
+  }
+  return cells;
+}
 }  // namespace IteratorTestHelper

--- a/tests/testAutopas/tests/iterators/IteratorTestHelper.h
+++ b/tests/testAutopas/tests/iterators/IteratorTestHelper.h
@@ -97,8 +97,8 @@ auto fillContainerAroundBoundary(AutoPasT &autoPas, std::array<double, 3> boxOfI
   EXPECT_EQ(particleIDsOwned.size() + particleIDsHalo.size(),
             numParticles1dTotal * numParticles1dTotal * numParticles1dTotal);
   // getNumberOfParticles works via counters in the logic handler
-  EXPECT_EQ(autoPas.getNumberOfParticles(autopas::IteratorBehavior::ownedOnly), particleIDsOwned.size());
-  EXPECT_EQ(autoPas.getNumberOfParticles(autopas::IteratorBehavior::haloOnly), particleIDsHalo.size());
+  EXPECT_EQ(autoPas.getNumberOfParticles(autopas::IteratorBehavior::owned), particleIDsOwned.size());
+  EXPECT_EQ(autoPas.getNumberOfParticles(autopas::IteratorBehavior::halo), particleIDsHalo.size());
   return std::make_tuple(particleIDsOwned, particleIDsHalo, particleIDsInterestOwned, particleIDsInterestHalo);
 }
 

--- a/tests/testAutopas/tests/iterators/ParticleIteratorInterfaceTest.cpp
+++ b/tests/testAutopas/tests/iterators/ParticleIteratorInterfaceTest.cpp
@@ -7,6 +7,8 @@
 #include "ParticleIteratorInterfaceTest.h"
 
 #include "IteratorTestHelper.h"
+#include "autopas/AutoPas.h"
+#include "autopas/containers/CompatibleTraversals.h"
 #include "autopas/options/IteratorBehavior.h"
 #include "autopasTools/generators/RandomGenerator.h"
 #include "testingHelpers/EmptyFunctor.h"

--- a/tests/testAutopas/tests/iterators/ParticleIteratorInterfaceTest.h
+++ b/tests/testAutopas/tests/iterators/ParticleIteratorInterfaceTest.h
@@ -10,8 +10,8 @@
 
 #include <tuple>
 
-#include "autopas/AutoPas.h"
-#include "testingHelpers/commonTypedefs.h"
+#include "autopas/options/ContainerOption.h"
+#include "autopas/options/IteratorBehavior.h"
 
 using testingTuple =
     std::tuple<autopas::ContainerOption, double /*cell size factor*/, bool /*regionIterator (true) or regular (false)*/,

--- a/tests/testAutopas/tests/iterators/ParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/ParticleIteratorTest.cpp
@@ -112,7 +112,8 @@ const std::vector<size_t> threadNumsToTest{1};
 #endif
 
 INSTANTIATE_TEST_SUITE_P(Generated, ParticleIteratorTest,
-                         ::testing::Combine(::testing::ValuesIn(threadNumsToTest), ::testing::Values(0, 1, 2, 4)));
+                         ::testing::Combine(::testing::ValuesIn(threadNumsToTest), ::testing::Values(0, 1, 2, 4)),
+                         ParticleIteratorTest::PrintToStringParamName());
 
 template <class Iter>
 auto ParticleIteratorTest::iteratorsBehaveEqually(Iter &iter1, Iter &iter2) {

--- a/tests/testAutopas/tests/iterators/ParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/ParticleIteratorTest.cpp
@@ -172,20 +172,16 @@ TEST_F(ParticleIteratorTest, testForceSequential) {
     ++particleId;
   }
 
-  std::vector<size_t> foundParticles;
 #pragma omp parallel
   {
+    std::vector<size_t> foundParticles;
     constexpr bool modifyable = true;
     constexpr bool forceSequential = true;
     autopas::internal::ParticleIterator<Molecule, FMCell, modifyable> iter(
         &cells, 0, nullptr, IteratorBehavior::haloAndOwned, &additionalVectors, forceSequential);
-#pragma omp master
-    {
-      for (; iter.isValid(); ++iter) {
-        foundParticles.push_back(iter->getID());
-      }
+    for (; iter.isValid(); ++iter) {
+      foundParticles.push_back(iter->getID());
     }
+    ASSERT_THAT(foundParticles, ::testing::UnorderedElementsAreArray(expectedIndices));
   }
-
-  ASSERT_THAT(foundParticles, ::testing::UnorderedElementsAreArray(expectedIndices));
 }

--- a/tests/testAutopas/tests/iterators/ParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/ParticleIteratorTest.cpp
@@ -185,3 +185,23 @@ TEST_F(ParticleIteratorTest, testForceSequential) {
     EXPECT_THAT(foundParticles, ::testing::UnorderedElementsAreArray(expectedIndices));
   }
 }
+
+/**
+ * Make sure the iterator does not crash and immediately is marked invalid when offset behind the last cell.
+ */
+TEST_F(ParticleIteratorTest, testNothing) {
+  std::vector<FMCell> cells{5};
+  ParticleIterator<Molecule, FMCell, true> iter{&cells, cells.size()};
+  EXPECT_FALSE(iter.isValid());
+}
+
+/**
+ * Same as testNothing but also with additional particle vectors.
+ */
+TEST_F(ParticleIteratorTest, testNothingWithAdditionalVectors) {
+  std::vector<FMCell> cells{5};
+  std::vector<std::vector<Molecule>> additionalPartilcleVectors(3);
+  ParticleIterator<Molecule, FMCell, true> iter{&cells, cells.size(), nullptr, IteratorBehavior::ownedOrHaloOrDummy,
+                                                &additionalPartilcleVectors};
+  EXPECT_FALSE(iter.isValid());
+}

--- a/tests/testAutopas/tests/iterators/ParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/ParticleIteratorTest.cpp
@@ -47,7 +47,7 @@ void ParticleIteratorTest::testAllParticlesFoundPattern(const std::vector<size_t
 #endif
   {
     for (auto iter = ParticleIterator<Molecule, FMCell, true>(
-             &cells, 0, nullptr, IteratorBehavior::haloAndOwned,
+             &cells, 0, nullptr, IteratorBehavior::ownedOrHalo,
              numAdditionalParticleVectors > 0 ? &additionalParticles : nullptr);
          iter.isValid(); ++iter) {
       auto particleID = iter->getID();
@@ -130,7 +130,7 @@ TEST_F(ParticleIteratorTest, testCopyConstructor) {
 
   constexpr bool modifyable = true;
   autopas::internal::ParticleIterator<Molecule, FMCell, modifyable> iter(
-      &cells, 0, nullptr, IteratorBehavior::haloAndOwned, &additionalVectors);
+      &cells, 0, nullptr, IteratorBehavior::ownedOrHalo, &additionalVectors);
 
   auto iterCopy{iter};
   iteratorsBehaveEqually(iter, iterCopy);
@@ -145,7 +145,7 @@ TEST_F(ParticleIteratorTest, testCopyAssignment) {
 
   constexpr bool modifyable = true;
   autopas::internal::ParticleIterator<Molecule, FMCell, modifyable> iter(
-      &cells, 0, nullptr, IteratorBehavior::haloAndOwned, &additionalVectors);
+      &cells, 0, nullptr, IteratorBehavior::ownedOrHalo, &additionalVectors);
 
   auto iterCopy = iter;
   iteratorsBehaveEqually(iter, iterCopy);
@@ -178,7 +178,7 @@ TEST_F(ParticleIteratorTest, testForceSequential) {
     constexpr bool modifyable = true;
     constexpr bool forceSequential = true;
     autopas::internal::ParticleIterator<Molecule, FMCell, modifyable> iter(
-        &cells, 0, nullptr, IteratorBehavior::haloAndOwned, &additionalVectors, forceSequential);
+        &cells, 0, nullptr, IteratorBehavior::ownedOrHalo, &additionalVectors, forceSequential);
     for (; iter.isValid(); ++iter) {
       foundParticles.push_back(iter->getID());
     }

--- a/tests/testAutopas/tests/iterators/ParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/ParticleIteratorTest.cpp
@@ -178,7 +178,7 @@ TEST_F(ParticleIteratorTest, testForceSequential) {
     constexpr bool modifyable = true;
     constexpr bool forceSequential = true;
     autopas::internal::ParticleIterator<Molecule, FMCell, modifyable> iter(
-        &cells, 0, nullptr, IteratorBehavior::ownedOrHalo, &additionalVectors, forceSequential);
+        &cells, 0, nullptr, IteratorBehavior::ownedOrHalo | IteratorBehavior::forceSequential, &additionalVectors);
     for (; iter.isValid(); ++iter) {
       foundParticles.push_back(iter->getID());
     }

--- a/tests/testAutopas/tests/iterators/ParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/ParticleIteratorTest.cpp
@@ -152,9 +152,10 @@ TEST_F(ParticleIteratorTest, testCopyAssignment) {
 }
 
 /**
- * TODO also test region iter. Move to interface test?
+ * Generates an iterator in a parallel region but iterates with only one and expects to find everything.
+ * @note This behavior is needed by VerletClusterLists::updateHaloParticle().
  */
-TEST_F(ParticleIteratorTest, testSerialIteratorInParallelRegion) {
+TEST_F(ParticleIteratorTest, testForceSequential) {
   constexpr size_t particlesPerCell = 1;
   auto cells = generateCellsWithPattern(4, {0ul, 1ul, 2ul, 3ul}, particlesPerCell);
   auto particlesTotal = cells.size() * particlesPerCell;
@@ -175,9 +176,9 @@ TEST_F(ParticleIteratorTest, testSerialIteratorInParallelRegion) {
 #pragma omp parallel
   {
     constexpr bool modifyable = true;
-    constexpr bool forceSerial = true;
-    autopas::internal::ParticleIterator<Molecule, FMCell, modifyable, forceSerial> iter(
-        &cells, 0, nullptr, IteratorBehavior::haloAndOwned, &additionalVectors);
+    constexpr bool forceSequential = true;
+    autopas::internal::ParticleIterator<Molecule, FMCell, modifyable> iter(
+        &cells, 0, nullptr, IteratorBehavior::haloAndOwned, &additionalVectors, forceSequential);
 #pragma omp master
     {
       for (; iter.isValid(); ++iter) {

--- a/tests/testAutopas/tests/iterators/ParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/ParticleIteratorTest.cpp
@@ -182,6 +182,6 @@ TEST_F(ParticleIteratorTest, testForceSequential) {
     for (; iter.isValid(); ++iter) {
       foundParticles.push_back(iter->getID());
     }
-    ASSERT_THAT(foundParticles, ::testing::UnorderedElementsAreArray(expectedIndices));
+    EXPECT_THAT(foundParticles, ::testing::UnorderedElementsAreArray(expectedIndices));
   }
 }

--- a/tests/testAutopas/tests/iterators/ParticleIteratorTest.h
+++ b/tests/testAutopas/tests/iterators/ParticleIteratorTest.h
@@ -13,6 +13,20 @@
 #include "testingHelpers/commonTypedefs.h"
 
 class ParticleIteratorTest : public AutoPasTestBase, public ::testing::WithParamInterface<std::tuple<size_t, size_t>> {
+ public:
+  /**
+   * Converter functor for generated test names.
+   */
+  struct PrintToStringParamName {
+    template <class ParamType>
+    std::string operator()(const testing::TestParamInfo<ParamType> &info) const {
+      auto [numThreads, numAdditionalParticleVectors] = static_cast<ParamType>(info.param);
+      std::stringstream ss;
+      ss << "Threads" << numThreads << "_AdditionalParticleVectors" << numAdditionalParticleVectors;
+      return ss.str();
+    }
+  };
+
  protected:
   /**
    * Generates a given amount of cells where only indicated cells contain a given amount of particles.

--- a/tests/testAutopas/tests/iterators/ParticleIteratorTest.h
+++ b/tests/testAutopas/tests/iterators/ParticleIteratorTest.h
@@ -1,7 +1,7 @@
 /**
  * @file ParticleIteratorTest.h
- * @author tchipev
- * @date 19.01.18
+ * @author F. Gratl
+ * @date 08.03.21
  */
 
 #pragma once
@@ -9,8 +9,6 @@
 #include <gtest/gtest.h>
 
 #include "AutoPasTestBase.h"
-#include "autopas/utils/WrapOpenMP.h"
-#include "testingHelpers/commonTypedefs.h"
 
 class ParticleIteratorTest : public AutoPasTestBase, public ::testing::WithParamInterface<std::tuple<size_t, size_t>> {
  public:
@@ -28,16 +26,6 @@ class ParticleIteratorTest : public AutoPasTestBase, public ::testing::WithParam
   };
 
  protected:
-  /**
-   * Generates a given amount of cells where only indicated cells contain a given amount of particles.
-   * @param numCells
-   * @param cellsToFill
-   * @param particlesPerCell
-   * @return Vector of generated and filled cells.
-   */
-  static std::vector<FMCell> generateCellsWithPattern(size_t numCells, const std::vector<size_t> &cellsToFill,
-                                                      size_t particlesPerCell);
-
   /**
    * Checks that all particles in a vector of cells are accessed by the iterator.
    * @param cellsWithParticles Indices of cells that shall contain particles.

--- a/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
@@ -155,7 +155,6 @@ TEST_F(RegionParticleIteratorTest, testForceSequential) {
         autopas::IteratorBehavior::ownedOrHalo | autopas::IteratorBehavior::forceSequential, &additionalVectors);
     for (; iter.isValid(); ++iter) {
       foundParticles.push_back(iter->getID());
-      std::cout << autopas::utils::ArrayUtils::to_string(iter->getR()) << std::endl;
     }
     EXPECT_THAT(foundParticles, ::testing::UnorderedElementsAreArray(expectedIndices));
   }

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTestFromTo.cpp
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTestFromTo.cpp
@@ -24,13 +24,13 @@ using ::testing::ValuesIn;
 void getStatus(const std::array<double, 3> &bBoxMin, const std::array<double, 3> &bBoxMax, const double cutoff,
                autopas::ContainerSelector<Particle> &containerSelector, std::vector<Particle> &ListInner,
                std::vector<Particle> &ListHaloWithinCutoff, std::vector<Particle> &ListHaloOutsideCutoff) {
-  for (auto iter = containerSelector.getCurrentContainer()->begin(autopas::IteratorBehavior::ownedOnly); iter.isValid();
+  for (auto iter = containerSelector.getCurrentContainer()->begin(autopas::IteratorBehavior::owned); iter.isValid();
        ++iter) {
     ListInner.push_back(*iter);
   }
   const auto cutoffBoxMin = autopas::utils::ArrayMath::subScalar(bBoxMin, cutoff);
   const auto cutoffBoxMax = autopas::utils::ArrayMath::addScalar(bBoxMax, cutoff);
-  for (auto iter = containerSelector.getCurrentContainer()->begin(autopas::IteratorBehavior::haloOnly); iter.isValid();
+  for (auto iter = containerSelector.getCurrentContainer()->begin(autopas::IteratorBehavior::halo); iter.isValid();
        ++iter) {
     if (autopas::utils::inBox(iter->getR(), cutoffBoxMin, cutoffBoxMax)) {
       ListHaloWithinCutoff.push_back(*iter);


### PR DESCRIPTION
# Description

Introduce strict sequential mode for iterators where one iterator passes every particle even when started in a parallel section.

- [x] Make IteratorBehavior a bitmask
- [x] remove all internal default values

## Related Pull Requests

- merges into #580

## Resolved Issues

- [x] fixes #579 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] ParticleIteratorTest::testForceSequential
- [x] RegionParticleIteratorTest::testForceSequential
