### PR TITLE
MPI_rank Suffix

### DIFF
--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -375,13 +375,13 @@ bool Simulation::needsMoreIterations() const {
 
 std::string Simulation::getMPISuffix() const {
   std::string suffix;
-  #ifdef AUTOPAS_MPI
-    int rank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    std::ostringstream output;
-    output << "mpi_rank_" << rank << "_";
-    suffix = output.str();
-  #endif
+#ifdef AUTOPAS_MPI
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  std::ostringstream output;
+  output << "mpi_rank_" << rank << "_";
+  suffix = output.str();
+#endif
   return suffix;
 }
 
@@ -393,7 +393,8 @@ void Simulation::writeVTKFile(autopas::AutoPas<ParticleType> &autopas) {
   const auto numParticles = autopas.getNumberOfParticles(autopas::IteratorBehavior::ownedOnly);
   std::ostringstream strstr;
   auto maxNumDigits = std::to_string(_config->iterations.value).length();
-  strstr << fileBaseName << "_" << getMPISuffix() << std::setfill('0') << std::setw(maxNumDigits) << _iteration << ".vtk";
+  strstr << fileBaseName << "_" << getMPISuffix() << std::setfill('0') << std::setw(maxNumDigits) << _iteration
+         << ".vtk";
   std::ofstream vtkFile;
   vtkFile.open(strstr.str());
 

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -8,7 +8,9 @@
 
 #include <sys/ioctl.h>
 #include <unistd.h>
+#ifdef AUTOPAS_MPI
 #include <mpi.h>
+#endif
 
 #include <iomanip>
 #include <iostream>
@@ -373,11 +375,13 @@ bool Simulation::needsMoreIterations() const {
 
 std::string Simulation::getMPISuffix() const {
   std::string suffix;
-  if (_config->mpiStrategyOption.value.divideAndConquer) {
+  #ifdef AUTOPAS_MPI
     int rank;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    suffix = "mpi_rank_" + std::to_string(rank) + "_";
-  }
+    std::ostringstream output;
+    output << "mpi_rank_" << rank << "_";
+    suffix = output.str();
+  #endif
   return suffix;
 }
 

--- a/examples/md-flexible/src/Simulation.h
+++ b/examples/md-flexible/src/Simulation.h
@@ -85,7 +85,7 @@ class Simulation {
   /**
    * Returns Suffix for the mpi rank the process is running on.
    * Otherwise returns empty string.
-   * @return
+   * @return suffix
    */
   [[nodiscard]] std::string getMPISuffix() const;
 

--- a/examples/md-flexible/src/Simulation.h
+++ b/examples/md-flexible/src/Simulation.h
@@ -83,6 +83,13 @@ class Simulation {
   [[nodiscard]] bool needsMoreIterations() const;
 
   /**
+   * Returns Suffix for the mpi rank the process is running on.
+   * Otherwise returns empty string.
+   * @return
+   */
+  [[nodiscard]] std::string getMPISuffix() const;
+
+  /**
    * Gives an estimate of how many iterations the simulation will do in total.
    * @return The estimate and true iff this is the correct number and not only an estimate.
    */


### PR DESCRIPTION
# Description

Added a Suffix to the AUTOPAS_LOG and .vtk files in md-flexible, if AUTOPAS_MPI is enabled.
The Suffix describes to which MPI rank the files belongs.

# How Has This Been Tested?
The Suffix should only be added when AUTOPAS_MPI is enabled and should correspond to the number of ranks.

- [x] With AUTOPAS_MPI not enabled Suffix is not added.
- [x] for "mpirun -n 4" there are 4 corresponding .csv and .vtk files
