### PR TITLE
Homogeneity not inf

### DIFF
--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -439,7 +439,6 @@ void Simulation::writeVTKFile(autopas::AutoPas<ParticleType> &autopas) {
 }
 
 double Simulation::calculateHomogeneity(autopas::AutoPas<ParticleType> &autopas) const {
-
   size_t numberOfParticles = autopas.getNumberOfParticles();
   // approximately the resolution we want to get.
   size_t numberOfCells = ceil(numberOfParticles / 10.);

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -439,6 +439,7 @@ void Simulation::writeVTKFile(autopas::AutoPas<ParticleType> &autopas) {
 }
 
 double Simulation::calculateHomogeneity(autopas::AutoPas<ParticleType> &autopas) const {
+
   size_t numberOfParticles = autopas.getNumberOfParticles();
   // approximately the resolution we want to get.
   size_t numberOfCells = ceil(numberOfParticles / 10.);
@@ -494,7 +495,7 @@ double Simulation::calculateHomogeneity(autopas::AutoPas<ParticleType> &autopas)
   // calculate density for each cell
   std::vector<double> densityPerCell(numberOfCells, 0.0);
   for (int i = 0; i < particlesPerCell.size(); i++) {
-    densityPerCell[i] = (particlesPerCell[i] == 0)
+    densityPerCell[i] = (allVolumes[i] == 0)
                             ? 0
                             : (particlesPerCell[i] / allVolumes[i]);  // make sure there is no division of zero
   }

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -494,9 +494,8 @@ double Simulation::calculateHomogeneity(autopas::AutoPas<ParticleType> &autopas)
   // calculate density for each cell
   std::vector<double> densityPerCell(numberOfCells, 0.0);
   for (int i = 0; i < particlesPerCell.size(); i++) {
-    densityPerCell[i] = (allVolumes[i] == 0)
-                            ? 0
-                            : (particlesPerCell[i] / allVolumes[i]);  // make sure there is no division of zero
+    densityPerCell[i] =
+        (allVolumes[i] == 0) ? 0 : (particlesPerCell[i] / allVolumes[i]);  // make sure there is no division of zero
   }
 
   // get mean and reserve variable for variance


### PR DESCRIPTION
# Description

To ensure that the function "calculateHomogeneity" does not return "inf" in certain but otherwise normal cases, it was necessary to ensure that for the calculation of "densityPerCell" no value is divided by zero.
