### PR TITLE
Force retune

### DIFF
--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -137,7 +137,7 @@ class AutoPas {
   /**
    * Force the internal tuner to enter a new tuning phase upon the next call to iteratePairwise().
    */
-  void forceRetune() { _autoTuner.forceRetune(); }
+  void forceRetune() { _autoTuner->forceRetune(); }
 
   /**
    * Free the AutoPas MPI communicator.

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -137,9 +137,7 @@ class AutoPas {
   /**
    * Force the internal tuner to enter a new tuning phase upon the next call to iteratePairwise().
    */
-  void forceRetune() {
-    _autoTuner.forceRetune();
-  }
+  void forceRetune() { _autoTuner.forceRetune(); }
 
   /**
    * Free the AutoPas MPI communicator.

--- a/src/autopas/AutoPas.h
+++ b/src/autopas/AutoPas.h
@@ -135,6 +135,13 @@ class AutoPas {
   }
 
   /**
+   * Force the internal tuner to enter a new tuning phase upon the next call to iteratePairwise().
+   */
+  void forceRetune() {
+    _autoTuner.forceRetune();
+  }
+
+  /**
    * Free the AutoPas MPI communicator.
    * To be called before MPI_Finalize.
    * If no MPI is used just call this at the end of the program.

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -154,7 +154,6 @@ class AutoTuner {
     if (_tuningStrategy->searchSpaceIsTrivial()) {
       return false;
     }
-    // TODO This will not return true if forceRetune is called during a tuning phase while sampling something.
     return _iterationsSinceTuning >= _tuningInterval and _samples.size() >= _maxSamples;
   }
 

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -291,6 +291,7 @@ void AutoTuner<Particle>::selectCurrentContainer() {
 template <class Particle>
 void AutoTuner<Particle>::forceRetune() {
   _iterationsSinceTuning = _tuningInterval;
+  _samples.resize(_maxSamples);
 }
 
 template <class Particle>

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -103,6 +103,11 @@ class AutoTuner {
   }
 
   /**
+   * @copydoc AutoPas::forceRetune()
+   */
+  void forceRetune();
+
+  /**
    * Getter for the current container.
    * @return Smart pointer to the current container.
    */
@@ -149,7 +154,7 @@ class AutoTuner {
     if (_tuningStrategy->searchSpaceIsTrivial()) {
       return false;
     }
-
+    // TODO This will not return true if forceRetune is called during a tuning phase while sampling something.
     return _iterationsSinceTuning >= _tuningInterval and _samples.size() >= _maxSamples;
   }
 
@@ -281,6 +286,11 @@ void AutoTuner<Particle>::selectCurrentContainer() {
   auto conf = _tuningStrategy->getCurrentConfiguration();
   _containerSelector.selectContainer(
       conf.container, ContainerSelectorInfo(conf.cellSizeFactor, _verletSkin, _verletClusterSize, conf.loadEstimator));
+}
+
+template <class Particle>
+void AutoTuner<Particle>::forceRetune() {
+  _iterationsSinceTuning = _tuningInterval;
 }
 
 template <class Particle>

--- a/tests/testAutopas/tests/selectors/AutoTunerTest.cpp
+++ b/tests/testAutopas/tests/selectors/AutoTunerTest.cpp
@@ -315,8 +315,10 @@ TEST_F(AutoTunerTest, testForceRetuneBetweenPhases) {
   // first iteration after tuning phase
   EXPECT_FALSE(autoTuner.iteratePairwise(&emptyFunctor, false)) << "Tuner should be done be tuning.";
 
+  EXPECT_FALSE(autoTuner.willRebuild()) << "No rebuilding expected here.";
   // instead of waiting the full tuning interval restart tuning immediately
   autoTuner.forceRetune();
+  EXPECT_TRUE(autoTuner.willRebuild()) << "willRebuild() does not recognize forceRetune()";
 
   // expect a full tuning phase
   for (size_t i = 0; i < numExpectedTuningIterations; ++i) {
@@ -368,6 +370,7 @@ TEST_F(AutoTunerTest, testForceRetuneInPhase) {
   }
   // restart the full tuning phase
   autoTuner.forceRetune();
+  EXPECT_TRUE(autoTuner.willRebuild()) << "willRebuild() does not recognize forceRetune()";
 
   // expect a full tuning phase
   for (size_t i = 0; i < numExpectedTuningIterations; ++i, ++iteration) {

--- a/tests/testAutopas/tests/selectors/AutoTunerTest.cpp
+++ b/tests/testAutopas/tests/selectors/AutoTunerTest.cpp
@@ -10,7 +10,6 @@
 #include "autopas/selectors/AutoTuner.h"
 #include "autopas/selectors/tuningStrategy/FullSearch.h"
 #include "autopasTools/generators/GridGenerator.h"
-
 #include "testingHelpers/EmptyFunctor.h"
 
 using ::testing::_;
@@ -288,15 +287,15 @@ TEST_F(AutoTunerTest, testForceRetuneBetweenPhases) {
   const unsigned int verletClusterSize = 4;
   const unsigned int maxSamples = 3;
 
-  autopas::Configuration confLc_c01(autopas::ContainerOption::linkedCells, cellSizeFactor, autopas::TraversalOption::lc_c01,
-                                autopas::LoadEstimatorOption::none, autopas::DataLayoutOption::aos,
-                                autopas::Newton3Option::disabled);
-  autopas::Configuration confLc_c04(autopas::ContainerOption::linkedCells, cellSizeFactor, autopas::TraversalOption::lc_c04,
-                                autopas::LoadEstimatorOption::none, autopas::DataLayoutOption::aos,
-                                autopas::Newton3Option::disabled);
-  autopas::Configuration confLc_c08(autopas::ContainerOption::linkedCells, cellSizeFactor, autopas::TraversalOption::lc_c08,
-                                autopas::LoadEstimatorOption::none, autopas::DataLayoutOption::aos,
-                                autopas::Newton3Option::disabled);
+  autopas::Configuration confLc_c01(autopas::ContainerOption::linkedCells, cellSizeFactor,
+                                    autopas::TraversalOption::lc_c01, autopas::LoadEstimatorOption::none,
+                                    autopas::DataLayoutOption::aos, autopas::Newton3Option::disabled);
+  autopas::Configuration confLc_c04(autopas::ContainerOption::linkedCells, cellSizeFactor,
+                                    autopas::TraversalOption::lc_c04, autopas::LoadEstimatorOption::none,
+                                    autopas::DataLayoutOption::aos, autopas::Newton3Option::disabled);
+  autopas::Configuration confLc_c08(autopas::ContainerOption::linkedCells, cellSizeFactor,
+                                    autopas::TraversalOption::lc_c08, autopas::LoadEstimatorOption::none,
+                                    autopas::DataLayoutOption::aos, autopas::Newton3Option::disabled);
 
   auto configsList = {confLc_c01, confLc_c04, confLc_c08};
 
@@ -328,7 +327,6 @@ TEST_F(AutoTunerTest, testForceRetuneBetweenPhases) {
   EXPECT_FALSE(autoTuner.iteratePairwise(&emptyFunctor, false)) << "Tuner should be done be tuning.";
 }
 
-
 TEST_F(AutoTunerTest, testForceRetuneInPhase) {
   std::array<double, 3> bBoxMin = {0, 0, 0}, bBoxMax = {2, 4, 2};
   const double cutoff = 1;
@@ -337,15 +335,15 @@ TEST_F(AutoTunerTest, testForceRetuneInPhase) {
   const unsigned int verletClusterSize = 4;
   const unsigned int maxSamples = 3;
 
-  autopas::Configuration confLc_c01(autopas::ContainerOption::linkedCells, cellSizeFactor, autopas::TraversalOption::lc_c01,
-                                    autopas::LoadEstimatorOption::none, autopas::DataLayoutOption::aos,
-                                    autopas::Newton3Option::disabled);
-  autopas::Configuration confLc_c04(autopas::ContainerOption::linkedCells, cellSizeFactor, autopas::TraversalOption::lc_c04,
-                                    autopas::LoadEstimatorOption::none, autopas::DataLayoutOption::aos,
-                                    autopas::Newton3Option::disabled);
-  autopas::Configuration confLc_c08(autopas::ContainerOption::linkedCells, cellSizeFactor, autopas::TraversalOption::lc_c08,
-                                    autopas::LoadEstimatorOption::none, autopas::DataLayoutOption::aos,
-                                    autopas::Newton3Option::disabled);
+  autopas::Configuration confLc_c01(autopas::ContainerOption::linkedCells, cellSizeFactor,
+                                    autopas::TraversalOption::lc_c01, autopas::LoadEstimatorOption::none,
+                                    autopas::DataLayoutOption::aos, autopas::Newton3Option::disabled);
+  autopas::Configuration confLc_c04(autopas::ContainerOption::linkedCells, cellSizeFactor,
+                                    autopas::TraversalOption::lc_c04, autopas::LoadEstimatorOption::none,
+                                    autopas::DataLayoutOption::aos, autopas::Newton3Option::disabled);
+  autopas::Configuration confLc_c08(autopas::ContainerOption::linkedCells, cellSizeFactor,
+                                    autopas::TraversalOption::lc_c08, autopas::LoadEstimatorOption::none,
+                                    autopas::DataLayoutOption::aos, autopas::Newton3Option::disabled);
 
   auto configsList = {confLc_c01, confLc_c04, confLc_c08};
 
@@ -365,7 +363,8 @@ TEST_F(AutoTunerTest, testForceRetuneInPhase) {
     // since we don't actually do anything doRebuild can always be false.
     EXPECT_TRUE(autoTuner.iteratePairwise(&emptyFunctor, false)) << "Tuner should still be tuning.\n"
                                                                     "Phase 1\n"
-                                                                    "Iteration " << iteration;
+                                                                    "Iteration "
+                                                                 << iteration;
   }
   // restart the full tuning phase
   autoTuner.forceRetune();
@@ -375,11 +374,13 @@ TEST_F(AutoTunerTest, testForceRetuneInPhase) {
     // since we don't actually do anything doRebuild can always be false.
     EXPECT_TRUE(autoTuner.iteratePairwise(&emptyFunctor, false)) << "Tuner should still be tuning.\n"
                                                                     "Phase 2\n"
-                                                                    "Iteration " << iteration;
+                                                                    "Iteration "
+                                                                 << iteration;
   }
   // first iteration after tuning phase
   EXPECT_FALSE(autoTuner.iteratePairwise(&emptyFunctor, false)) << "Tuner should be done be tuning.\n"
-                                                                   "Iteration " << iteration;
+                                                                   "Iteration "
+                                                                << iteration;
 }
 
 /**


### PR DESCRIPTION
# Description

Add a trigger to force restart of the tuning process upon the next call to `iteratePairwise()`

## ~Related Pull Requests~

## ~Resolved Issues~

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] New Tests (`testForceRetuneInPhase` and `testForceRetuneBetweenPhases`=
