### PR TITLE
Fix switching to 32-bit floating point precision

### DIFF
--- a/examples/md-flexible/src/BoundaryConditions.h
+++ b/examples/md-flexible/src/BoundaryConditions.h
@@ -107,7 +107,8 @@ std::vector<Particle> identifyNewHaloParticles(autopas::AutoPas<Particle> &autoP
         for (auto iter = autoPas.getRegionIterator(min, max, autopas::IteratorBehavior::owned); iter.isValid();
              ++iter) {
           auto particleCopy = *iter;
-          particleCopy.addR(shiftVec);
+          particleCopy.addR(autopas::utils::ArrayUtils::static_cast_array<typename Particle::ParticleSoAFloatPrecision>(
+              shiftVec));
           haloParticles.push_back(particleCopy);
         }
       }
@@ -117,7 +118,7 @@ std::vector<Particle> identifyNewHaloParticles(autopas::AutoPas<Particle> &autoP
 }
 
 /**
- * Insertes the given entering particles into the AutoPas object.
+ * Inserts the given entering particles into the AutoPas object.
  * @tparam Particle
  * @param autoPas
  * @param enteringParticles

--- a/examples/md-flexible/src/Checkpoint.h
+++ b/examples/md-flexible/src/Checkpoint.h
@@ -80,9 +80,10 @@ void loadParticles(AutoPasTemplate &autopas, const std::string &vtkFilename) {
   // creating Particles from checkpoint:
   for (auto i = 0ul; i < numParticles; ++i) {
     typename AutoPasTemplate::Particle_t p;
-    p.setR(positions[i]);
-    p.setV(velocities[i]);
-    p.setF(forces[i]);
+    using namespace autopas::utils::ArrayUtils;
+    p.setR(static_cast_array<typename AutoPasTemplate::Particle_t::ParticleSoAFloatPrecision>(positions[i]));
+    p.setV(static_cast_array<typename AutoPasTemplate::Particle_t::ParticleSoAFloatPrecision>(velocities[i]));
+    p.setF(static_cast_array<typename AutoPasTemplate::Particle_t::ParticleSoAFloatPrecision>(forces[i]));
     p.setTypeId(typeID[i]);
     p.setID(i);
     autopas.addParticle(p);

--- a/examples/md-flexible/src/Objects/Objects.h
+++ b/examples/md-flexible/src/Objects/Objects.h
@@ -23,6 +23,7 @@ class Object {
    * Type of all particles generated.
    */
   using ParticleType = ::ParticleType;
+  using floatType = ParticleType::ParticleSoAFloatPrecision;
 
   /**
    * Constructor that should be used by inheriting types.
@@ -52,7 +53,8 @@ class Object {
    */
   [[nodiscard]] ParticleType getDummyParticle(const autopas::AutoPas<ParticleType> &autopas) const {
     ParticleType dummyParticle;
-    dummyParticle.setV(_velocity);
+
+    dummyParticle.setV(autopas::utils::ArrayUtils::static_cast_array<floatType>(_velocity));
     dummyParticle.setID(autopas.getNumberOfParticles());
     dummyParticle.setTypeId(_typeId);
     return dummyParticle;

--- a/examples/md-flexible/src/Objects/Sphere.h
+++ b/examples/md-flexible/src/Objects/Sphere.h
@@ -120,7 +120,7 @@ class Sphere : public Object {
   void generate(autopas::AutoPas<ParticleType> &autopas) const override {
     ParticleType dummyParticle = getDummyParticle(autopas);
     iteratePositions([&](auto pos) {
-      dummyParticle.setR(pos);
+      dummyParticle.setR(autopas::utils::ArrayUtils::static_cast_array<floatType>(pos));
       autopas.addParticle(dummyParticle);
       dummyParticle.setID(dummyParticle.getID() + 1);
     });

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -165,7 +165,8 @@ void Simulation::globalForces(autopas::AutoPas<ParticleType> &autopas) {
 #pragma omp parallel default(none) shared(autopas)
 #endif
   for (auto particleItr = autopas.begin(autopas::IteratorBehavior::owned); particleItr.isValid(); ++particleItr) {
-    particleItr->addF(_config->globalForce.value);
+    particleItr->addF(autopas::utils::ArrayUtils::static_cast_array<ParticleType::ParticleSoAFloatPrecision>(
+        _config->globalForce.value));
   }
 }
 
@@ -346,7 +347,7 @@ void Simulation::printStatistics(autopas::AutoPas<ParticleType> &autopas) {
   }
 }
 
-const std::unique_ptr<ParticlePropertiesLibrary<double, size_t>> &Simulation::getPpl() const {
+const std::unique_ptr<ParticlePropertiesLibrary<FloatPrecision , size_t>> &Simulation::getPpl() const {
   return _particlePropertiesLibrary;
 }
 
@@ -489,7 +490,7 @@ double Simulation::calculateHomogeneity(autopas::AutoPas<ParticleType> &autopas)
 
   // add particles accordingly to their cell to get the amount of particles in each cell
   for (auto particleItr = autopas.begin(autopas::IteratorBehavior::owned); particleItr.isValid(); ++particleItr) {
-    std::array<double, 3> particleLocation = particleItr->getR();
+    auto particleLocation = particleItr->getR();
     std::array<size_t, 3> index = {};
     for (int i = 0; i < particleLocation.size(); i++) {
       index[i] = particleLocation[i] / cellLength;

--- a/examples/md-flexible/src/Simulation.h
+++ b/examples/md-flexible/src/Simulation.h
@@ -106,7 +106,7 @@ class Simulation {
    * @note Used for testing.
    * @return unique_prt(ParticlePropertiesLibrary)
    */
-  [[nodiscard]] const std::unique_ptr<ParticlePropertiesLibrary<double, size_t>> &getPpl() const;
+  [[nodiscard]] const std::unique_ptr<ParticlePropertiesLibrary<FloatPrecision, size_t>> &getPpl() const;
 
   /**
    * Calculate the homogeneity of the scenario by using the standard deviation.

--- a/examples/md-flexible/src/Thermostat.h
+++ b/examples/md-flexible/src/Thermostat.h
@@ -25,7 +25,8 @@ namespace {
  * @param randomEngine Random engine used for the generation of the velocity.
  * @param normalDistribution Distribution used for constructing the maxwell boltzmann distribution.
  */
-void addMaxwellBoltzmannDistributedVelocity(autopas::Particle &p, const double averageVelocity,
+template<typename ParticleType>
+void addMaxwellBoltzmannDistributedVelocity(ParticleType &p, const double averageVelocity,
                                             std::default_random_engine &randomEngine,
                                             std::normal_distribution<double> &normalDistribution) {
   // when adding independent normally distributed values to all velocity components
@@ -34,7 +35,8 @@ void addMaxwellBoltzmannDistributedVelocity(autopas::Particle &p, const double a
   for (double &v : randomVelocity) {
     v = averageVelocity * normalDistribution(randomEngine);
   }
-  p.setV(autopas::utils::ArrayMath::add(p.getV(), randomVelocity));
+  p.addV(autopas::utils::ArrayUtils::static_cast_array<typename ParticleType::ParticleSoAFloatPrecision>(
+      randomVelocity));
 }
 }  // namespace
 

--- a/examples/md-flexible/src/TypeDefinitions.h
+++ b/examples/md-flexible/src/TypeDefinitions.h
@@ -12,7 +12,7 @@
 /**
  * Precision used for particle representations. If you want to test other precisions change it here.
  */
-using FloatPrecision = double;
+using FloatPrecision = float;
 
 /**
  * Type of the Particles used in md-flexible.

--- a/examples/md-flexible/tests/GeneratorsTest.cpp
+++ b/examples/md-flexible/tests/GeneratorsTest.cpp
@@ -34,7 +34,7 @@ TEST_F(GeneratorsTest, GridFillwithBoxMin) {
  * This test expects multipleObjectsWithMultipleTypesTest.yaml to be placed in md-flexible/tests/yamlTestFiles
  */
 TEST_F(GeneratorsTest, MultipleObjectGeneration) {
-  auto autoPas = autopas::AutoPas<Molecule>(std::cout);
+  auto autoPas = autopas::AutoPas<ParticleType>(std::cout);
   MDFlexConfig config;
   config.yamlFilename.value = std::string(YAMLDIRECTORY) + "multipleObjectsWithMultipleTypesTest.yaml";
   MDFlexParser::YamlParser::parseYamlFile(config);
@@ -42,7 +42,7 @@ TEST_F(GeneratorsTest, MultipleObjectGeneration) {
   autoPas.setBoxMax(config.boxMax.value);
   autoPas.setBoxMin(config.boxMin.value);
   autoPas.init();
-  std::array<double, 3> velocity = {0., 0., 0.};
+  std::array<ParticleType::ParticleSoAFloatPrecision, 3> velocity = {0., 0., 0.};
   // parses the multiple Objects input of "multipleObjectsWithMultipleTypesTest" and generates a VTK File from the Input
   // yaml input file with all 4 different Object types
   auto cubeGrid(config.cubeGridObjects);

--- a/src/autopas/cells/SortedCellView.h
+++ b/src/autopas/cells/SortedCellView.h
@@ -12,6 +12,7 @@
 #include "autopas/cells/ParticleCell.h"
 #include "autopas/iterators/SingleCellIterator.h"
 #include "autopas/utils/ArrayMath.h"
+#include "autopas/utils/ArrayUtils.h"
 #include "autopas/utils/CudaSoA.h"
 #include "autopas/utils/SoA.h"
 #include "autopas/utils/WrapOpenMP.h"
@@ -37,7 +38,8 @@ class SortedCellView : public ParticleCell<Particle> {
   SortedCellView(ParticleCellType &cell, const std::array<double, 3> &r) : _cell(&cell) {
     _particles.reserve(cell.numParticles());
     for (auto p = getStaticCellIter(cell); p.isValid(); ++p) {
-      _particles.push_back(std::make_pair(utils::ArrayMath::dot(p->getR(), r), &(*p)));
+      auto castedParticlePosition = utils::ArrayUtils::static_cast_array<double>(p->getR());
+      _particles.push_back(std::make_pair(utils::ArrayMath::dot(castedParticlePosition, r), &(*p)));
     }
     std::sort(_particles.begin(), _particles.end(),
               [](const auto &a, const auto &b) -> bool { return a.first < b.first; });

--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -17,6 +17,7 @@
 #include "autopas/utils/ExceptionHandler.h"
 #include "autopas/utils/ThreeDimensionalMapping.h"
 #include "autopas/utils/inBox.h"
+#include "autopas/utils/ParticleTypeTrait.h"
 
 namespace autopas::internal {
 /**
@@ -32,6 +33,9 @@ class CellBlock3D : public CellBorderAndFlagManager {
    * the index type to access the particle cells
    */
   using index_t = std::size_t;
+
+  using ParticleFloatType = typename utils::ParticleTypeTrait<ParticleCell>::value::ParticleSoAFloatPrecision;
+
   /**
    * Constructor of CellBlock3D
    * @param vec vector of ParticleCells that this class manages
@@ -112,7 +116,7 @@ class CellBlock3D : public CellBorderAndFlagManager {
    * @param pos the position for which the cell is needed
    * @return cell at the given position
    */
-  ParticleCell &getContainingCell(const std::array<double, 3> &pos) const;
+  ParticleCell &getContainingCell(const std::array<ParticleFloatType, 3> &pos) const;
 
   /**
    * Get the lower and upper corner of the cell at the 1d index index1d
@@ -134,14 +138,16 @@ class CellBlock3D : public CellBorderAndFlagManager {
    * @param pos the position
    * @return the 3d index
    */
-  [[nodiscard]] std::array<index_t, 3> get3DIndexOfPosition(const std::array<double, 3> &pos) const;
+   template<typename FloatType>
+  [[nodiscard]] std::array<index_t, 3> get3DIndexOfPosition(const std::array<FloatType, 3> &pos) const;
 
   /**
    * get the 1d index of the cellblock for a given position
    * @param pos the position
    * @return the 1d index
    */
-  [[nodiscard]] index_t get1DIndexOfPosition(const std::array<double, 3> &pos) const;
+   template<typename FloatType>
+  [[nodiscard]] index_t get1DIndexOfPosition(const std::array<FloatType, 3> &pos) const;
 
   /**
    * get the dimension of the cellblock including the haloboxes
@@ -174,7 +180,8 @@ class CellBlock3D : public CellBorderAndFlagManager {
    * @param allowedDistance the maximal distance to the position
    * @return a container of references to nearby halo cells
    */
-  std::vector<ParticleCell *> getNearbyHaloCells(const std::array<double, 3> &position, double allowedDistance) const {
+  std::vector<ParticleCell *> getNearbyHaloCells(const std::array<ParticleFloatType, 3> &position,
+                                                 double allowedDistance) const {
     auto index3d = get3DIndexOfPosition(position);
 
     std::vector<ParticleCell *> closeHaloCells;
@@ -266,14 +273,16 @@ class CellBlock3D : public CellBorderAndFlagManager {
 };
 
 template <class ParticleCell>
+template <typename FloatType>
 inline typename CellBlock3D<ParticleCell>::index_t CellBlock3D<ParticleCell>::get1DIndexOfPosition(
-    const std::array<double, 3> &pos) const {
+    const std::array<FloatType, 3> &pos) const {
   return index1D(get3DIndexOfPosition(pos));
 }
 
 template <class ParticleCell>
+template <typename FloatType>
 inline std::array<typename CellBlock3D<ParticleCell>::index_t, 3> CellBlock3D<ParticleCell>::get3DIndexOfPosition(
-    const std::array<double, 3> &pos) const {
+    const std::array<FloatType, 3> &pos) const {
   std::array<typename CellBlock3D<ParticleCell>::index_t, 3> cellIndex{};
 
   for (size_t dim = 0; dim < 3; dim++) {
@@ -381,7 +390,7 @@ inline std::pair<std::array<double, 3>, std::array<double, 3>> CellBlock3D<Parti
 }
 
 template <class ParticleCell>
-inline ParticleCell &CellBlock3D<ParticleCell>::getContainingCell(const std::array<double, 3> &pos) const {
+inline ParticleCell &CellBlock3D<ParticleCell>::getContainingCell(const std::array<ParticleFloatType, 3> &pos) const {
   auto ind = get1DIndexOfPosition(pos);
   return getCell(ind);
 }

--- a/src/autopas/containers/verletClusterCells/VerletClusterCells.h
+++ b/src/autopas/containers/verletClusterCells/VerletClusterCells.h
@@ -129,8 +129,11 @@ class VerletClusterCells : public CellBasedParticleContainer<FullParticleCell<Pa
     pCopy.setOwnershipState(OwnershipState::halo);
 
     for (auto it =
-             getRegionIterator(utils::ArrayMath::subScalar(pCopy.getR(), this->getSkin() / 2),
-                               utils::ArrayMath::addScalar(pCopy.getR(), this->getSkin() / 2), IteratorBehavior::halo);
+             getRegionIterator(utils::ArrayUtils::static_cast_array<double>(
+                                   utils::ArrayMath::subScalar(pCopy.getR(), this->getSkin() / 2)),
+                               utils::ArrayUtils::static_cast_array<double>(
+                                   utils::ArrayMath::addScalar(pCopy.getR(), this->getSkin() / 2)),
+                               IteratorBehavior::halo);
          it.isValid(); ++it) {
       if (pCopy.getID() == it->getID()) {
         *it = pCopy;
@@ -472,9 +475,10 @@ class VerletClusterCells : public CellBasedParticleContainer<FullParticleCell<Pa
       if (numDummys != 0) {
         Particle dummyParticle = *(this->_cells[i].begin());
         for (unsigned int j = 0; j < numDummys; ++j) {
-          dummyParticle.setR({_boxMaxWithHalo[0] + 8 * this->getInteractionLength() + static_cast<double>(i),
-                              _boxMaxWithHalo[1] + 8 * this->getInteractionLength() + static_cast<double>(j),
-                              _boxMaxWithHalo[2] + 8 * this->getInteractionLength()});
+          dummyParticle.setR(utils::ArrayUtils::static_cast_array<typename Particle::ParticleSoAFloatPrecision>(
+              std::array{_boxMaxWithHalo[0] + 8 * this->getInteractionLength() + static_cast<double>(i),
+               _boxMaxWithHalo[1] + 8 * this->getInteractionLength() + static_cast<double>(j),
+               _boxMaxWithHalo[2] + 8 * this->getInteractionLength()}));
           dummyParticle.setID(std::numeric_limits<size_t>::max());
           dummyParticle.setOwnershipState(OwnershipState::dummy);
           this->_cells[i].addParticle(dummyParticle);
@@ -519,8 +523,8 @@ class VerletClusterCells : public CellBasedParticleContainer<FullParticleCell<Pa
    */
   void expandBoundingBox(std::array<double, 6> &box, const Particle &p) {
     for (int i = 0; i < 3; ++i) {
-      box[i] = std::min(box[i], p.getR()[i]);
-      box[3 + i] = std::max(box[3 + i], p.getR()[i]);
+      box[i] = std::min(box[i], static_cast<double>(p.getR()[i]));
+      box[3 + i] = std::max(box[3 + i], static_cast<double>(p.getR()[i]));
     }
   }
 

--- a/src/autopas/containers/verletClusterLists/ClusterTower.h
+++ b/src/autopas/containers/verletClusterLists/ClusterTower.h
@@ -11,6 +11,7 @@
 #include "autopas/containers/verletClusterLists/Cluster.h"
 #include "autopas/particles/OwnershipState.h"
 #include "autopas/utils/markParticleAsDeleted.h"
+#include "autopas/utils/ArrayUtils.h"
 
 namespace autopas::internal {
 
@@ -113,7 +114,8 @@ class ClusterTower : public ParticleCell<Particle> {
     for (size_t index = 1; index <= _numDummyParticles; index++) {
       lastCluster[_clusterSize - index] = lastCluster[0];  // use first Particle in last cluster as dummy particle!
       lastCluster[_clusterSize - index].setOwnershipState(OwnershipState::dummy);
-      lastCluster[_clusterSize - index].setR({dummyStartX, 0, dummyDistZ * index});
+      lastCluster[_clusterSize - index].setR(utils::ArrayUtils::static_cast_array<
+          typename Particle::ParticleSoAFloatPrecision>(std::array<double, 3>{dummyStartX, 0, dummyDistZ * index}));
       lastCluster[_clusterSize - index].setID(std::numeric_limits<size_t>::max());
     }
   }

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -183,9 +183,12 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
     pCopy.setOwnershipState(OwnershipState::halo);
 
     // this might be called from a parallel region so force this iterator to be sequential
-    for (auto it = getRegionIterator(utils::ArrayMath::subScalar(pCopy.getR(), this->getSkin() / 2),
-                                     utils::ArrayMath::addScalar(pCopy.getR(), this->getSkin() / 2),
-                                     IteratorBehavior::halo | IteratorBehavior::forceSequential);
+    for (auto it =
+             getRegionIterator(utils::ArrayUtils::static_cast_array<double>(
+                                   utils::ArrayMath::subScalar(pCopy.getR(), this->getSkin() / 2)),
+                               utils::ArrayUtils::static_cast_array<double>(
+                                   utils::ArrayMath::addScalar(pCopy.getR(), this->getSkin() / 2)),
+                               IteratorBehavior::halo | IteratorBehavior::forceSequential);
          it.isValid(); ++it) {
       if (pCopy.getID() == it->getID()) {
         *it = pCopy;

--- a/src/autopas/containers/verletClusterLists/VerletClusterListsRebuilder.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterListsRebuilder.h
@@ -418,9 +418,11 @@ class VerletClusterListsRebuilder {
    * If the location is outside of the domain, the tower nearest tower is returned.
    *
    * @param location The 3D coordinates.
+   * @tparam FloatType the floating point type of the array
    * @return Tower reference.
    */
-  auto &getTower(std::array<double, 3> location) {
+  template<typename FloatType>
+  auto &getTower(std::array<FloatType, 3> location) {
     auto [towerIndexX, towerIndexY] = getTowerCoordinates(location);
     return getTower(towerIndexX, towerIndexY);
   }
@@ -430,9 +432,11 @@ class VerletClusterListsRebuilder {
    * If the location is outside of the domain, the tower nearest tower is returned.
    *
    * @param location The 3D coordinates.
+   * @tparam FloatType the floating point type of the array
    * @return Tower reference.
    */
-  std::array<size_t, 2> getTowerCoordinates(std::array<double, 3> location) {
+  template<typename FloatType>
+  std::array<size_t, 2> getTowerCoordinates(std::array<FloatType, 3> location) {
     std::array<size_t, 2> towerIndex2D{};
 
     for (int dim = 0; dim < 2; dim++) {

--- a/src/autopas/containers/verletListsCellBased/varVerletLists/neighborLists/asBuild/AsBuildPairGeneratorFunctor.h
+++ b/src/autopas/containers/verletListsCellBased/varVerletLists/neighborLists/asBuild/AsBuildPairGeneratorFunctor.h
@@ -84,7 +84,7 @@ class AsBuildPairGeneratorFunctor
    */
   void AoSFunctor(Particle &i, Particle &j, bool newton3) override {
     auto dist = utils::ArrayMath::sub(i.getR(), j.getR());
-    double distsquare = utils::ArrayMath::dot(dist, dist);
+    auto distsquare = utils::ArrayMath::dot(dist, dist);
     if (distsquare < _cutoffskinsquared) {
       if (callCheckInstead) {
         _list.checkPair(&i, &j);
@@ -103,22 +103,22 @@ class AsBuildPairGeneratorFunctor
     if (soa.getNumParticles() == 0) return;
 
     auto **const __restrict ptrptr = soa.template begin<Particle::AttributeNames::ptr>();
-    double *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
+    auto *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
+    auto *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
+    auto *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
 
     size_t numPart = soa.getNumParticles();
     for (unsigned int i = 0; i < numPart; ++i) {
       for (unsigned int j = i + 1; j < numPart; ++j) {
-        const double drx = xptr[i] - xptr[j];
-        const double dry = yptr[i] - yptr[j];
-        const double drz = zptr[i] - zptr[j];
+        const auto drx = xptr[i] - xptr[j];
+        const auto dry = yptr[i] - yptr[j];
+        const auto drz = zptr[i] - zptr[j];
 
-        const double drx2 = drx * drx;
-        const double dry2 = dry * dry;
-        const double drz2 = drz * drz;
+        const auto drx2 = drx * drx;
+        const auto dry2 = dry * dry;
+        const auto drz2 = drz * drz;
 
-        const double dr2 = drx2 + dry2 + drz2;
+        const auto dr2 = drx2 + dry2 + drz2;
 
         if (dr2 < _cutoffskinsquared) {
           _list.addPair(ptrptr[i], ptrptr[j]);
@@ -139,28 +139,28 @@ class AsBuildPairGeneratorFunctor
     if (soa1.getNumParticles() == 0 || soa2.getNumParticles() == 0) return;
 
     auto **const __restrict ptrptr1 = soa1.template begin<Particle::AttributeNames::ptr>();
-    double *const __restrict x1ptr = soa1.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict y1ptr = soa1.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict z1ptr = soa1.template begin<Particle::AttributeNames::posZ>();
+    auto *const __restrict x1ptr = soa1.template begin<Particle::AttributeNames::posX>();
+    auto *const __restrict y1ptr = soa1.template begin<Particle::AttributeNames::posY>();
+    auto *const __restrict z1ptr = soa1.template begin<Particle::AttributeNames::posZ>();
 
     auto **const __restrict ptrptr2 = soa2.template begin<Particle::AttributeNames::ptr>();
-    double *const __restrict x2ptr = soa2.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict y2ptr = soa2.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict z2ptr = soa2.template begin<Particle::AttributeNames::posZ>();
+    auto *const __restrict x2ptr = soa2.template begin<Particle::AttributeNames::posX>();
+    auto *const __restrict y2ptr = soa2.template begin<Particle::AttributeNames::posY>();
+    auto *const __restrict z2ptr = soa2.template begin<Particle::AttributeNames::posZ>();
 
     size_t numPart1 = soa1.getNumParticles();
     for (unsigned int i = 0; i < numPart1; ++i) {
       size_t numPart2 = soa2.getNumParticles();
       for (unsigned int j = 0; j < numPart2; ++j) {
-        const double drx = x1ptr[i] - x2ptr[j];
-        const double dry = y1ptr[i] - y2ptr[j];
-        const double drz = z1ptr[i] - z2ptr[j];
+        const auto drx = x1ptr[i] - x2ptr[j];
+        const auto dry = y1ptr[i] - y2ptr[j];
+        const auto drz = z1ptr[i] - z2ptr[j];
 
-        const double drx2 = drx * drx;
-        const double dry2 = dry * dry;
-        const double drz2 = drz * drz;
+        const auto drx2 = drx * drx;
+        const auto dry2 = dry * dry;
+        const auto drz2 = drz * drz;
 
-        const double dr2 = drx2 + dry2 + drz2;
+        const auto dr2 = drx2 + dry2 + drz2;
 
         if (dr2 < _cutoffskinsquared) {
           _list.addPair(ptrptr1[i], ptrptr2[j]);

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
@@ -91,24 +91,24 @@ class VerletListHelpers {
       if (soa.getNumParticles() == 0) return;
 
       auto **const __restrict ptrptr = soa.template begin<Particle::AttributeNames::ptr>();
-      double *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
-      double *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
-      double *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
+      auto *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
+      auto *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
+      auto *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
 
       size_t numPart = soa.getNumParticles();
       for (unsigned int i = 0; i < numPart; ++i) {
         auto &currentList = _verletListsAoS.at(ptrptr[i]);
 
         for (unsigned int j = i + 1; j < numPart; ++j) {
-          const double drx = xptr[i] - xptr[j];
-          const double dry = yptr[i] - yptr[j];
-          const double drz = zptr[i] - zptr[j];
+          const auto drx = xptr[i] - xptr[j];
+          const auto dry = yptr[i] - yptr[j];
+          const auto drz = zptr[i] - zptr[j];
 
-          const double drx2 = drx * drx;
-          const double dry2 = dry * dry;
-          const double drz2 = drz * drz;
+          const auto drx2 = drx * drx;
+          const auto dry2 = dry * dry;
+          const auto drz2 = drz * drz;
 
-          const double dr2 = drx2 + dry2 + drz2;
+          const auto dr2 = drx2 + dry2 + drz2;
 
           if (dr2 < _interactionLengthSquared) {
             currentList.push_back(ptrptr[j]);
@@ -131,14 +131,14 @@ class VerletListHelpers {
       if (soa1.getNumParticles() == 0 || soa2.getNumParticles() == 0) return;
 
       auto **const __restrict ptr1ptr = soa1.template begin<Particle::AttributeNames::ptr>();
-      double *const __restrict x1ptr = soa1.template begin<Particle::AttributeNames::posX>();
-      double *const __restrict y1ptr = soa1.template begin<Particle::AttributeNames::posY>();
-      double *const __restrict z1ptr = soa1.template begin<Particle::AttributeNames::posZ>();
+      auto *const __restrict x1ptr = soa1.template begin<Particle::AttributeNames::posX>();
+      auto *const __restrict y1ptr = soa1.template begin<Particle::AttributeNames::posY>();
+      auto *const __restrict z1ptr = soa1.template begin<Particle::AttributeNames::posZ>();
 
       auto **const __restrict ptr2ptr = soa2.template begin<Particle::AttributeNames::ptr>();
-      double *const __restrict x2ptr = soa2.template begin<Particle::AttributeNames::posX>();
-      double *const __restrict y2ptr = soa2.template begin<Particle::AttributeNames::posY>();
-      double *const __restrict z2ptr = soa2.template begin<Particle::AttributeNames::posZ>();
+      auto *const __restrict x2ptr = soa2.template begin<Particle::AttributeNames::posX>();
+      auto *const __restrict y2ptr = soa2.template begin<Particle::AttributeNames::posY>();
+      auto *const __restrict z2ptr = soa2.template begin<Particle::AttributeNames::posZ>();
 
       size_t numPart1 = soa1.getNumParticles();
       for (unsigned int i = 0; i < numPart1; ++i) {
@@ -147,15 +147,15 @@ class VerletListHelpers {
         size_t numPart2 = soa2.getNumParticles();
 
         for (unsigned int j = 0; j < numPart2; ++j) {
-          const double drx = x1ptr[i] - x2ptr[j];
-          const double dry = y1ptr[i] - y2ptr[j];
-          const double drz = z1ptr[i] - z2ptr[j];
+          const auto drx = x1ptr[i] - x2ptr[j];
+          const auto dry = y1ptr[i] - y2ptr[j];
+          const auto drz = z1ptr[i] - z2ptr[j];
 
-          const double drx2 = drx * drx;
-          const double dry2 = dry * dry;
-          const double drz2 = drz * drz;
+          const auto drx2 = drx * drx;
+          const auto dry2 = dry * dry;
+          const auto drz2 = drz * drz;
 
-          const double dr2 = drx2 + dry2 + drz2;
+          const auto dr2 = drx2 + dry2 + drz2;
 
           if (dr2 < _interactionLengthSquared) {
             currentList.push_back(ptr2ptr[j]);

--- a/src/autopas/molecularDynamics/LJFunctor.h
+++ b/src/autopas/molecularDynamics/LJFunctor.h
@@ -104,7 +104,7 @@ class LJFunctor
    * @param cutoff
    * @param particlePropertiesLibrary
    */
-  explicit LJFunctor(double cutoff, ParticlePropertiesLibrary<double, size_t> &particlePropertiesLibrary)
+  explicit LJFunctor(double cutoff, ParticlePropertiesLibrary<SoAFloatPrecision, size_t> &particlePropertiesLibrary)
       : LJFunctor(cutoff, nullptr) {
     static_assert(useMixing,
                   "Not using Mixing but using a ParticlePropertiesLibrary is not allowed! Use a different constructor "
@@ -166,7 +166,7 @@ class LJFunctor
       j.subF(f);
     }
     if (calculateGlobals) {
-      auto virial = utils::ArrayMath::mul(dr, f);
+      auto virial = utils::ArrayUtils::static_cast_array<double>(utils::ArrayMath::mul(dr, f));
       double upot = epsilon24 * lj12m6 + shift6;
 
       const int threadnum = autopas_get_thread_num();

--- a/src/autopas/molecularDynamics/LJFunctorAVX.h
+++ b/src/autopas/molecularDynamics/LJFunctorAVX.h
@@ -44,6 +44,7 @@ class LJFunctorAVX
     : public Functor<Particle,
                      LJFunctorAVX<Particle, applyShift, useMixing, useNewton3, calculateGlobals, relevantForTuning>> {
   using SoAArraysType = typename Particle::SoAArraysType;
+  using SoAFloatPrecision = typename Particle::ParticleSoAFloatPrecision;
 
  public:
   /**
@@ -99,7 +100,7 @@ class LJFunctorAVX
    * @param cutoff
    * @param particlePropertiesLibrary
    */
-  explicit LJFunctorAVX(double cutoff, ParticlePropertiesLibrary<double, size_t> &particlePropertiesLibrary)
+  explicit LJFunctorAVX(double cutoff, ParticlePropertiesLibrary<SoAFloatPrecision, size_t> &particlePropertiesLibrary)
       : LJFunctorAVX(cutoff, nullptr) {
     static_assert(useMixing,
                   "Not using Mixing but using a ParticlePropertiesLibrary is not allowed! Use a different constructor "
@@ -153,7 +154,7 @@ class LJFunctorAVX
       j.subF(f);
     }
     if (calculateGlobals) {
-      auto virial = utils::ArrayMath::mul(dr, f);
+      auto virial = utils::ArrayUtils::static_cast_array<double>(utils::ArrayMath::mul(dr, f));
       double upot = epsilon24 * lj12m6 + shift6;
 
       const int threadnum = autopas_get_thread_num();
@@ -1022,7 +1023,7 @@ class LJFunctorAVX
   const double _cutoffsquareAoS = 0;
   double _epsilon24AoS, _sigmaSquareAoS, _shift6AoS = 0;
 
-  ParticlePropertiesLibrary<double, size_t> *_PPLibrary = nullptr;
+  ParticlePropertiesLibrary<SoAFloatPrecision, size_t> *_PPLibrary = nullptr;
 
   // sum of the potential energy, only calculated if calculateGlobals is true
   double _upotSum;

--- a/src/autopas/molecularDynamics/MoleculeLJ.h
+++ b/src/autopas/molecularDynamics/MoleculeLJ.h
@@ -17,7 +17,7 @@ namespace autopas {
  * Molecule class for the LJFunctor.
  */
 template <typename floatType = double>
-class MoleculeLJ final : public Particle {
+class MoleculeLJ final : public Particle<floatType> {
  public:
   MoleculeLJ() = default;
 
@@ -30,7 +30,7 @@ class MoleculeLJ final : public Particle {
    */
   explicit MoleculeLJ(std::array<floatType, 3> pos, std::array<floatType, 3> v, unsigned long moleculeId,
                       unsigned long typeId = 0)
-      : Particle(pos, v, moleculeId), _typeId(typeId) {}
+      : Particle<floatType>(pos, v, moleculeId), _typeId(typeId) {}
 
   ~MoleculeLJ() final = default;
 
@@ -78,19 +78,19 @@ class MoleculeLJ final : public Particle {
     if constexpr (attribute == AttributeNames::ptr) {
       return this;
     } else if constexpr (attribute == AttributeNames::id) {
-      return getID();
+      return this->getID();
     } else if constexpr (attribute == AttributeNames::posX) {
-      return getR()[0];
+      return this->getR()[0];
     } else if constexpr (attribute == AttributeNames::posY) {
-      return getR()[1];
+      return this->getR()[1];
     } else if constexpr (attribute == AttributeNames::posZ) {
-      return getR()[2];
+      return this->getR()[2];
     } else if constexpr (attribute == AttributeNames::forceX) {
-      return getF()[0];
+      return this->getF()[0];
     } else if constexpr (attribute == AttributeNames::forceY) {
-      return getF()[1];
+      return this->getF()[1];
     } else if constexpr (attribute == AttributeNames::forceZ) {
-      return getF()[2];
+      return this->getF()[2];
     } else if constexpr (attribute == AttributeNames::typeId) {
       return getTypeId();
     } else if constexpr (attribute == AttributeNames::ownershipState) {
@@ -111,17 +111,17 @@ class MoleculeLJ final : public Particle {
     if constexpr (attribute == AttributeNames::id) {
       setID(value);
     } else if constexpr (attribute == AttributeNames::posX) {
-      _r[0] = value;
+      this->_r[0] = value;
     } else if constexpr (attribute == AttributeNames::posY) {
-      _r[1] = value;
+      this->_r[1] = value;
     } else if constexpr (attribute == AttributeNames::posZ) {
-      _r[2] = value;
+      this->_r[2] = value;
     } else if constexpr (attribute == AttributeNames::forceX) {
-      _f[0] = value;
+      this->_f[0] = value;
     } else if constexpr (attribute == AttributeNames::forceY) {
-      _f[1] = value;
+      this->_f[1] = value;
     } else if constexpr (attribute == AttributeNames::forceZ) {
-      _f[2] = value;
+      this->_f[2] = value;
     } else if constexpr (attribute == AttributeNames::typeId) {
       setTypeId(value);
     } else if constexpr (attribute == AttributeNames::ownershipState) {
@@ -135,13 +135,13 @@ class MoleculeLJ final : public Particle {
    * Get the old force.
    * @return
    */
-  [[nodiscard]] std::array<double, 3> getOldf() const { return _oldF; }
+  [[nodiscard]] std::array<floatType, 3> getOldf() const { return _oldF; }
 
   /**
    * Set old force.
    * @param oldForce
    */
-  void setOldF(const std::array<double, 3> &oldForce) { _oldF = oldForce; }
+  void setOldF(const std::array<floatType, 3> &oldForce) { _oldF = oldForce; }
 
   /**
    * Get TypeId.
@@ -164,7 +164,7 @@ class MoleculeLJ final : public Particle {
   /**
    * Old Force of the particle experiences as 3D vector.
    */
-  std::array<double, 3> _oldF = {0., 0., 0.};
+  std::array<floatType, 3> _oldF = {0., 0., 0.};
 };
 
 }  // namespace autopas

--- a/src/autopas/pairwiseFunctors/FlopCounterFunctor.h
+++ b/src/autopas/pairwiseFunctors/FlopCounterFunctor.h
@@ -23,6 +23,7 @@ namespace autopas {
  */
 template <class Particle>
 class FlopCounterFunctor : public Functor<Particle, FlopCounterFunctor<Particle>> {
+  using SoAFloatPrecision = typename Particle::ParticleSoAFloatPrecision;
  public:
   bool isRelevantForTuning() override { return false; }
 
@@ -50,7 +51,7 @@ class FlopCounterFunctor : public Functor<Particle, FlopCounterFunctor<Particle>
       return;
     }
     auto dr = utils::ArrayMath::sub(i.getR(), j.getR());
-    double dr2 = utils::ArrayMath::dot(dr, dr);
+    auto dr2 = utils::ArrayMath::dot(dr, dr);
     _distanceCalculations.fetch_add(1, std::memory_order_relaxed);
 
     if (dr2 <= _cutoffSquare) {
@@ -65,9 +66,9 @@ class FlopCounterFunctor : public Functor<Particle, FlopCounterFunctor<Particle>
   void SoAFunctorSingle(SoAView<typename Particle::SoAArraysType> soa, bool /*newton3*/) override {
     if (soa.getNumParticles() == 0) return;
 
-    double *const __restrict x1ptr = soa.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict y1ptr = soa.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict z1ptr = soa.template begin<Particle::AttributeNames::posZ>();
+    auto *const __restrict x1ptr = soa.template begin<Particle::AttributeNames::posX>();
+    auto *const __restrict y1ptr = soa.template begin<Particle::AttributeNames::posY>();
+    auto *const __restrict z1ptr = soa.template begin<Particle::AttributeNames::posZ>();
 
     for (size_t i = 0; i < soa.getNumParticles(); ++i) {
       size_t distanceCalculationsAcc = 0;
@@ -79,15 +80,15 @@ class FlopCounterFunctor : public Functor<Particle, FlopCounterFunctor<Particle>
       for (size_t j = i + 1; j < soa.getNumParticles(); ++j) {
         ++distanceCalculationsAcc;
 
-        const double drx = x1ptr[i] - x1ptr[j];
-        const double dry = y1ptr[i] - y1ptr[j];
-        const double drz = z1ptr[i] - z1ptr[j];
+        const auto drx = x1ptr[i] - x1ptr[j];
+        const auto dry = y1ptr[i] - y1ptr[j];
+        const auto drz = z1ptr[i] - z1ptr[j];
 
-        const double drx2 = drx * drx;
-        const double dry2 = dry * dry;
-        const double drz2 = drz * drz;
+        const auto drx2 = drx * drx;
+        const auto dry2 = dry * dry;
+        const auto drz2 = drz * drz;
 
-        const double dr2 = drx2 + dry2 + drz2;
+        const auto dr2 = drx2 + dry2 + drz2;
 
         if (dr2 <= _cutoffSquare) {
           ++kernelCallsAcc;
@@ -105,12 +106,12 @@ class FlopCounterFunctor : public Functor<Particle, FlopCounterFunctor<Particle>
    */
   void SoAFunctorPair(SoAView<typename Particle::SoAArraysType> soa1, SoAView<typename Particle::SoAArraysType> soa2,
                       bool /*newton3*/) override {
-    double *const __restrict x1ptr = soa1.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict y1ptr = soa1.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict z1ptr = soa1.template begin<Particle::AttributeNames::posZ>();
-    double *const __restrict x2ptr = soa2.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict y2ptr = soa2.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict z2ptr = soa2.template begin<Particle::AttributeNames::posZ>();
+    auto *const __restrict x1ptr = soa1.template begin<Particle::AttributeNames::posX>();
+    auto *const __restrict y1ptr = soa1.template begin<Particle::AttributeNames::posY>();
+    auto *const __restrict z1ptr = soa1.template begin<Particle::AttributeNames::posZ>();
+    auto *const __restrict x2ptr = soa2.template begin<Particle::AttributeNames::posX>();
+    auto *const __restrict y2ptr = soa2.template begin<Particle::AttributeNames::posY>();
+    auto *const __restrict z2ptr = soa2.template begin<Particle::AttributeNames::posZ>();
 
     for (size_t i = 0; i < soa1.getNumParticles(); ++i) {
       size_t distanceCalculationsAcc = 0;
@@ -122,15 +123,15 @@ class FlopCounterFunctor : public Functor<Particle, FlopCounterFunctor<Particle>
       for (size_t j = 0; j < soa2.getNumParticles(); ++j) {
         ++distanceCalculationsAcc;
 
-        const double drx = x1ptr[i] - x2ptr[j];
-        const double dry = y1ptr[i] - y2ptr[j];
-        const double drz = z1ptr[i] - z2ptr[j];
+        const auto drx = x1ptr[i] - x2ptr[j];
+        const auto dry = y1ptr[i] - y2ptr[j];
+        const auto drz = z1ptr[i] - z2ptr[j];
 
-        const double drx2 = drx * drx;
-        const double dry2 = dry * dry;
-        const double drz2 = drz * drz;
+        const auto drx2 = drx * drx;
+        const auto dry2 = dry * dry;
+        const auto drz2 = drz * drz;
 
-        const double dr2 = drx2 + dry2 + drz2;
+        const auto dr2 = drx2 + dry2 + drz2;
 
         if (dr2 <= _cutoffSquare) {
           ++kernelCallsAcc;
@@ -154,9 +155,9 @@ class FlopCounterFunctor : public Functor<Particle, FlopCounterFunctor<Particle>
 
     if (numParts == 0) return;
 
-    double *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
+    auto *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
+    auto *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
+    auto *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
 
     const size_t listSizeI = neighborList.size();
     const size_t *const __restrict currentList = neighborList.data();
@@ -180,7 +181,7 @@ class FlopCounterFunctor : public Functor<Particle, FlopCounterFunctor<Particle>
     // if the size of the verlet list is larger than the given size vecsize,
     // we will use a vectorized version.
     if (listSizeI >= vecsize) {
-      alignas(64) std::array<double, vecsize> xtmp{}, ytmp{}, ztmp{}, xArr{}, yArr{}, zArr{};
+      alignas(64) std::array<SoAFloatPrecision, vecsize> xtmp{}, ytmp{}, ztmp{}, xArr{}, yArr{}, zArr{};
       // broadcast of the position of particle i
       for (size_t tmpj = 0; tmpj < vecsize; tmpj++) {
         xtmp[tmpj] = xptr[indexFirst];
@@ -207,15 +208,15 @@ class FlopCounterFunctor : public Functor<Particle, FlopCounterFunctor<Particle>
 #pragma omp simd reduction(+ : kernelCallsAcc, distanceCalculationsAcc) safelen(vecsize)
         for (size_t j = 0; j < vecsize; j++) {
           ++distanceCalculationsAcc;
-          const double drx = xtmp[j] - xArr[j];
-          const double dry = ytmp[j] - yArr[j];
-          const double drz = ztmp[j] - zArr[j];
+          const auto drx = xtmp[j] - xArr[j];
+          const auto dry = ytmp[j] - yArr[j];
+          const auto drz = ztmp[j] - zArr[j];
 
-          const double drx2 = drx * drx;
-          const double dry2 = dry * dry;
-          const double drz2 = drz * drz;
+          const auto drx2 = drx * drx;
+          const auto dry2 = dry * dry;
+          const auto drz2 = drz * drz;
 
-          const double dr2 = drx2 + dry2 + drz2;
+          const auto dr2 = drx2 + dry2 + drz2;
 
           const unsigned long mask = (dr2 <= _cutoffSquare) ? 1 : 0;
 
@@ -233,15 +234,15 @@ class FlopCounterFunctor : public Functor<Particle, FlopCounterFunctor<Particle>
       if (indexFirst == j) continue;
 
       ++distanceCalculationsAcc;
-      const double drx = xptr[indexFirst] - xptr[j];
-      const double dry = yptr[indexFirst] - yptr[j];
-      const double drz = zptr[indexFirst] - zptr[j];
+      const auto drx = xptr[indexFirst] - xptr[j];
+      const auto dry = yptr[indexFirst] - yptr[j];
+      const auto drz = zptr[indexFirst] - zptr[j];
 
-      const double drx2 = drx * drx;
-      const double dry2 = dry * dry;
-      const double drz2 = drz * drz;
+      const auto drx2 = drx * drx;
+      const auto dry2 = dry * dry;
+      const auto drz2 = drz * drz;
 
-      const double dr2 = drx2 + dry2 + drz2;
+      const auto dr2 = drx2 + dry2 + drz2;
 
       if (dr2 <= _cutoffSquare) {
         ++kernelCallsAcc;

--- a/src/autopas/particles/Particle.h
+++ b/src/autopas/particles/Particle.h
@@ -20,8 +20,9 @@ using ParticleFP32 = ParticleBase<float, unsigned long>;
  */
 using ParticleFP64 = ParticleBase<double, unsigned long>;
 /**
- * Alias for Particle with all variables in 64 bit precision
+ * Alias for Particle with unsigned long id
  */
-using Particle = ParticleFP64;
+template<typename floatType>
+using Particle = ParticleBase<floatType, unsigned long>;
 
 }  // namespace autopas

--- a/src/autopas/particles/ParticleBase.h
+++ b/src/autopas/particles/ParticleBase.h
@@ -39,7 +39,7 @@ class ParticleBase {
    * @param v Velocity of the particle.
    * @param id Id of the particle.
    */
-  ParticleBase(std::array<double, 3> r, std::array<double, 3> v, idType id)
+  ParticleBase(std::array<floatType, 3> r, std::array<floatType, 3> v, idType id)
       : _r(r), _v(v), _f({0.0, 0.0, 0.0}), _id(id) {}
 
   /**
@@ -94,25 +94,25 @@ class ParticleBase {
    * get the force acting on the particle
    * @return force
    */
-  [[nodiscard]] const std::array<double, 3> &getF() const { return _f; }
+  [[nodiscard]] const std::array<floatType, 3> &getF() const { return _f; }
 
   /**
    * Set the force acting on the particle
    * @param f force
    */
-  void setF(const std::array<double, 3> &f) { _f = f; }
+  void setF(const std::array<floatType, 3> &f) { _f = f; }
 
   /**
    * Add a partial force to the force acting on the particle
    * @param f partial force to be added
    */
-  void addF(const std::array<double, 3> &f) { _f = utils::ArrayMath::add(_f, f); }
+  void addF(const std::array<floatType, 3> &f) { _f = utils::ArrayMath::add(_f, f); }
 
   /**
    * Substract a partial force from the force acting on the particle
    * @param f partial force to be substracted
    */
-  void subF(const std::array<double, 3> &f) { _f = utils::ArrayMath::sub(_f, f); }
+  void subF(const std::array<floatType, 3> &f) { _f = utils::ArrayMath::sub(_f, f); }
 
   /**
    * Get the id of the particle
@@ -130,37 +130,37 @@ class ParticleBase {
    * Get the position of the particle
    * @return current position
    */
-  [[nodiscard]] const std::array<double, 3> &getR() const { return _r; }
+  [[nodiscard]] const std::array<floatType, 3> &getR() const { return _r; }
 
   /**
    * Set the position of the particle
    * @param r new position
    */
-  void setR(const std::array<double, 3> &r) { _r = r; }
+  void setR(const std::array<floatType, 3> &r) { _r = r; }
 
   /**
    * Add a distance vector to the position of the particle
    * @param r vector to be added
    */
-  void addR(const std::array<double, 3> &r) { _r = utils::ArrayMath::add(_r, r); }
+  void addR(const std::array<floatType, 3> &r) { _r = utils::ArrayMath::add(_r, r); }
 
   /**
    * Get the velocity of the particle
    * @return current velocity
    */
-  [[nodiscard]] const std::array<double, 3> &getV() const { return _v; }
+  [[nodiscard]] const std::array<floatType, 3> &getV() const { return _v; }
 
   /**
    * Set the velocity of the particle
    * @param v new velocity
    */
-  void setV(const std::array<double, 3> &v) { _v = v; }
+  void setV(const std::array<floatType, 3> &v) { _v = v; }
 
   /**
    * Add a vector to the current velocity of the particle
    * @param v vector to be added
    */
-  void addV(const std::array<double, 3> &v) { _v = utils::ArrayMath::add(_v, v); }
+  void addV(const std::array<floatType, 3> &v) { _v = utils::ArrayMath::add(_v, v); }
 
   /**
    * Creates a string containing all data of the particle.

--- a/src/autopas/sph/SPHParticle.h
+++ b/src/autopas/sph/SPHParticle.h
@@ -16,14 +16,14 @@ namespace sph {
 /**
  * Basic SPHParticle class.
  */
-class SPHParticle : public autopas::Particle {
+class SPHParticle : public autopas::ParticleFP64 {
  public:
   /**
    * Default constructor of SPHParticle.
    * Will initialize all values to some basic defaults.
    */
   SPHParticle()
-      : autopas::Particle(),
+      : autopas::ParticleFP64(),
         _density(0.),
         _pressure(0.),
         _mass(0.),
@@ -44,7 +44,7 @@ class SPHParticle : public autopas::Particle {
    * @param id id of the particle. This id should be unique
    */
   SPHParticle(std::array<double, 3> r, std::array<double, 3> v, unsigned long id)
-      : autopas::Particle(r, v, id),
+      : autopas::ParticleFP64(r, v, id),
         _density(0.),
         _pressure(0.),
         _mass(0.),
@@ -69,7 +69,7 @@ class SPHParticle : public autopas::Particle {
    * @param snds speed of sound (SouND Speed)
    */
   SPHParticle(std::array<double, 3> r, std::array<double, 3> v, unsigned long id, double mass, double smth, double snds)
-      : autopas::Particle(r, v, id),
+      : autopas::ParticleFP64(r, v, id),
         _density(0.),
         _pressure(0.),
         _mass(mass),

--- a/src/autopas/utils/ArrayMath.h
+++ b/src/autopas/utils/ArrayMath.h
@@ -118,15 +118,16 @@ template <class T, std::size_t SIZE>
 
 /**
  * Adds a scalar s to each element of array a and returns the result.
- * @tparam T floating point type
+ * @tparam T1 floating point type for array
+ * @tparam T2 floating point type for s
  * @tparam SIZE size of the array a
  * @param a the array
  * @param s the scalar to be added to each element of a
  * @return array who's elements are a[i]+s
  */
-template <class T, std::size_t SIZE>
-[[nodiscard]] constexpr std::array<T, SIZE> addScalar(const std::array<T, SIZE> &a, T s) {
-  std::array<T, SIZE> result{};
+template <class T1, class T2, std::size_t SIZE>
+[[nodiscard]] constexpr std::array<T1, SIZE> addScalar(const std::array<T1, SIZE> &a, T2 s) {
+  std::array<T1, SIZE> result{};
   for (std::size_t d = 0; d < SIZE; ++d) {
     result[d] = a[d] + s;
   }
@@ -135,15 +136,16 @@ template <class T, std::size_t SIZE>
 
 /**
  * Subtracts a scalar s from each element of array a and returns the result.
- * @tparam T floating point type
+ * @tparam T1 floating point type for array
+ * @tparam T2 floating point type for s
  * @tparam SIZE size of the array a
  * @param a the array
  * @param s the scalar to be subtracted from each element of a
  * @return array who's elements are a[i]-s
  */
-template <class T, std::size_t SIZE>
-[[nodiscard]] constexpr std::array<T, SIZE> subScalar(const std::array<T, SIZE> &a, T s) {
-  std::array<T, SIZE> result{};
+template <class T1, class T2, std::size_t SIZE>
+[[nodiscard]] constexpr std::array<T1, SIZE> subScalar(const std::array<T1, SIZE> &a, T2 s) {
+  std::array<T1, SIZE> result{};
   for (std::size_t d = 0; d < SIZE; ++d) {
     result[d] = a[d] - s;
   }
@@ -152,15 +154,16 @@ template <class T, std::size_t SIZE>
 
 /**
  * Multiplies a scalar s to each element of array a and returns the result.
- * @tparam T floating point type
+ * @tparam T1 floating point type for array
+ * @tparam T2 floating point type for s
  * @tparam SIZE size of the array a
  * @param a the array
  * @param s the scalar to be multiplied to each element of a
  * @return array who's elements are a[i]*s
  */
-template <class T, std::size_t SIZE>
-[[nodiscard]] constexpr std::array<T, SIZE> mulScalar(const std::array<T, SIZE> &a, T s) {
-  std::array<T, SIZE> result{};
+template <class T1, class T2, std::size_t SIZE>
+[[nodiscard]] constexpr std::array<T1, SIZE> mulScalar(const std::array<T1, SIZE> &a, T2 s) {
+  std::array<T1, SIZE> result{};
   for (std::size_t d = 0; d < SIZE; ++d) {
     result[d] = a[d] * s;
   }

--- a/src/autopas/utils/inBox.h
+++ b/src/autopas/utils/inBox.h
@@ -16,15 +16,17 @@ namespace autopas::utils {
  * The lower corner is included in, the upper is excluded from the box.
  * i.e. [low[0], high[0]) x [low[1], high[1]) x [low[2], high[2])
  *
- * @tparam T the type of floating point check
+ * @tparam T1 the type of floating point check for the position
+ * @tparam T2 the type of floating point check for the box
  * @param position the position that should be checked
  * @param low the lower corner of the box
  * @param high the upper corner of the box
  * @return true if position is inside the box, false otherwise
  */
-template <typename T>
-bool inBox(const std::array<T, 3> &position, const std::array<T, 3> &low, const std::array<T, 3> &high) {
-  static_assert(std::is_floating_point<T>::value, "inBox assumes floating point types");
+template <typename T1, typename T2>
+bool inBox(const std::array<T1, 3> &position, const std::array<T2, 3> &low, const std::array<T2, 3> &high) {
+  static_assert(std::is_floating_point<T1>::value, "inBox assumes floating point types");
+  static_assert(std::is_floating_point<T2>::value, "inBox assumes floating point types");
 
   bool inBox = true;
   for (int d = 0; d < 3; ++d) {
@@ -40,14 +42,15 @@ bool inBox(const std::array<T, 3> &position, const std::array<T, 3> &low, const 
  * The lower corner is included in, the upper is excluded from the box.
  * i.e. [low[0], high[0]) x [low[1], high[1]) x [low[2], high[2])
  *
- * @tparam T the type of floating point check
+ * @tparam T1 the type of floating point check for the position
+ * @tparam T2 the type of floating point check for the box
  * @param position the position that should be checked
  * @param low the lower corner of the box
  * @param high the upper corner of the box
  * @return true if position is not inside the box, false otherwise
  */
-template <typename T>
-bool notInBox(const std::array<T, 3> &position, const std::array<T, 3> &low, const std::array<T, 3> &high) {
+template <typename T1, typename T2>
+bool notInBox(const std::array<T1, 3> &position, const std::array<T2, 3> &low, const std::array<T2, 3> &high) {
   return not(inBox(position, low, high));
 }
 

--- a/tests/testAutopas/testingHelpers/NonConstructibleParticle.h
+++ b/tests/testAutopas/testingHelpers/NonConstructibleParticle.h
@@ -11,7 +11,7 @@
 /**
  * A particle class without an actual constructor (only copy, etc.).
  */
-class NonConstructibleParticle : public autopas::Particle {
+class NonConstructibleParticle : public autopas::ParticleFP64 {
  public:
   /**
    * Default constructor is deleted.
@@ -42,19 +42,19 @@ class NonConstructibleParticle : public autopas::Particle {
     if constexpr (attribute == AttributeNames::ptr) {
       return this;
     } else if constexpr (attribute == AttributeNames::id) {
-      return getID();
+      return this->getID();
     } else if constexpr (attribute == AttributeNames::posX) {
-      return getR()[0];
+      return this->getR()[0];
     } else if constexpr (attribute == AttributeNames::posY) {
-      return getR()[1];
+      return this->getR()[1];
     } else if constexpr (attribute == AttributeNames::posZ) {
-      return getR()[2];
+      return this->getR()[2];
     } else if constexpr (attribute == AttributeNames::forceX) {
-      return getF()[0];
+      return this->getF()[0];
     } else if constexpr (attribute == AttributeNames::forceY) {
-      return getF()[1];
+      return this->getF()[1];
     } else if constexpr (attribute == AttributeNames::forceZ) {
-      return getF()[2];
+      return this->getF()[2];
     } else if constexpr (attribute == AttributeNames::ownershipState) {
       return this->_ownershipState;
     } else {

--- a/tests/testAutopas/testingHelpers/commonTypedefs.h
+++ b/tests/testAutopas/testingHelpers/commonTypedefs.h
@@ -16,11 +16,11 @@
 /**
  * Short for AutoPas Particle
  */
-using Particle = autopas::Particle;
+using Particle = autopas::ParticleFP64;
 /**
  * Short for a FullParticle Cell with the AutoPas Particle
  */
-using FPCell = autopas::FullParticleCell<autopas::Particle>;
+using FPCell = autopas::FullParticleCell<autopas::ParticleFP64>;
 
 /**
  * Short for the AutoPas single center Lennard-Jones molecule
@@ -35,4 +35,4 @@ using FMCell = autopas::FullParticleCell<Molecule>;
 /**
  * Short for Mock Functor
  */
-using MFunctor = MockFunctor<autopas::Particle>;
+using MFunctor = MockFunctor<autopas::ParticleFP64>;

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.h
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.h
@@ -84,7 +84,7 @@ static inline auto getTestableContainerOptions() {
  * @param container
  * @return Vector of added particles
  */
-template <class Container, class ParticleType = autopas::Particle>
+template <class Container, class ParticleType = autopas::ParticleFP64>
 std::vector<ParticleType> addParticlesMinMidMax(Container &container) {
   constexpr size_t numParticles = 3;
   std::vector<ParticleType> addedParticles;

--- a/tests/testAutopas/tests/containers/AllContainersTests.cpp
+++ b/tests/testAutopas/tests/containers/AllContainersTests.cpp
@@ -62,7 +62,7 @@ TEST_P(AllContainersTests, testParticleAdding) {
                      boxMax[1] + .5, boxMax[1] + 1.5}) {
       for (double z : {boxMin[2] - 1.5, boxMin[2] - .5, boxMin[2], boxMin[2] + 5., boxMax[2] - 0.001, boxMax[2],
                        boxMax[2] + .5, boxMax[2] + 1.5}) {
-        autopas::Particle p({x, y, z}, {0., 0., 0.}, id++);
+        autopas::ParticleFP64 p({x, y, z}, {0., 0., 0.}, id++);
         if (x == -1.5 or y == -1.5 or z == -1.5 or x == 11.5 or y == 11.5 or z == 11.5) {
           EXPECT_ANY_THROW(container->addParticle(p));     // outside, therefore not ok!
           EXPECT_NO_THROW(container->addHaloParticle(p));  // much outside, still ok because it is ignored!
@@ -132,7 +132,7 @@ TEST_P(AllContainersTests, testDeleteHaloParticles) {
  */
 TEST_P(AllContainersTests, testUpdateContainerHalo) {
   auto container = getInitializedContainer();
-  autopas::Particle p({boxMin[0] - 0.5, boxMin[1] - 0.5, boxMin[2] - 0.5}, {0, 0, 0}, 42);
+  autopas::ParticleFP64 p({boxMin[0] - 0.5, boxMin[1] - 0.5, boxMin[2] - 0.5}, {0, 0, 0}, 42);
   container->addHaloParticle(p);
 
   EXPECT_EQ(container->getNumParticles(), 1);
@@ -155,12 +155,12 @@ TEST_P(AllContainersTests, testUpdateContainerHalo) {
 void AllContainersTests::testUpdateContainerDeletesDummy(bool previouslyOwned) {
   static std::atomic<unsigned long> numParticles = 0;
 
-  class TestParticle : public autopas::Particle {
+  class TestParticle : public autopas::ParticleFP64 {
    public:
-    TestParticle(std::array<double, 3> r, std::array<double, 3> v, unsigned long id) : Particle(r, v, id) {
+    TestParticle(std::array<double, 3> r, std::array<double, 3> v, unsigned long id) : autopas::ParticleFP64(r, v, id) {
       ++numParticles;
     }
-    TestParticle(const TestParticle &testParticle) : Particle(testParticle) { ++numParticles; }
+    TestParticle(const TestParticle &testParticle) : autopas::ParticleFP64(testParticle) { ++numParticles; }
     ~TestParticle() override { --numParticles; }
   };
 

--- a/tests/testAutopas/tests/containers/AllContainersTests.h
+++ b/tests/testAutopas/tests/containers/AllContainersTests.h
@@ -25,7 +25,7 @@ class AllContainersTests : public AutoPasTestBase, public ::testing::WithParamIn
   std::array<double, 3> boxMin = {0, 0, 0};
   std::array<double, 3> boxMax = {10, 10, 10};
 
-  template <class ParticleType = autopas::Particle>
+  template <class ParticleType = autopas::ParticleFP64>
   auto getInitializedContainer() {
     auto containerOptionToTest = GetParam();
     double cutoff = 1;

--- a/tests/testAutopas/tests/containers/directSum/DSSequentialTraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/directSum/DSSequentialTraversalTest.cpp
@@ -23,7 +23,7 @@ void DSSequentialTraversalTest::testTraversal(bool useSoA) {
   MFunctor functor;
   std::vector<FPCell> cells;
   cells.resize(2);
-  autopas::Particle defaultParticle;
+  autopas::ParticleFP64 defaultParticle;
 
   Particle particle;
   for (size_t i = 0; i < numParticles + numHaloParticles; ++i) {

--- a/tests/testAutopas/tests/containers/directSum/DirectSumContainerTest.cpp
+++ b/tests/testAutopas/tests/containers/directSum/DirectSumContainerTest.cpp
@@ -7,12 +7,12 @@
 #include "DirectSumContainerTest.h"
 
 TEST_F(DirectSumContainerTest, testUpdateContainerCloseToBoundary) {
-  autopas::DirectSum<autopas::Particle> directSum({0., 0., 0.}, {10., 10., 10.}, 1., 0.);
+  autopas::DirectSum<autopas::ParticleFP64> directSum({0., 0., 0.}, {10., 10., 10.}, 1., 0.);
   int id = 1;
   for (double x : {0., 5., 9.999}) {
     for (double y : {0., 5., 9.999}) {
       for (double z : {0., 5., 9.999}) {
-        autopas::Particle p({x, y, z}, {0., 0., 0.}, id++);
+        autopas::ParticleFP64 p({x, y, z}, {0., 0., 0.}, id++);
         EXPECT_NO_THROW(directSum.addParticle(p));  // inside, therefore ok!
       }
     }

--- a/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
@@ -14,11 +14,11 @@ TYPED_TEST_P(LinkedCellsTest, testUpdateContainer) {
   using LinkedCellsType = TypeParam;
   LinkedCellsType linkedCells({0., 0., 0.}, {3., 3., 3.}, 1., 0., 1.);
 
-  autopas::Particle p1({0.5, 0.5, 0.5}, {0, 0, 0}, 0);
-  autopas::Particle p2({1.5, 1.5, 1.5}, {0, 0, 0}, 1);
-  autopas::Particle p3({1.6, 1.5, 1.5}, {0, 0, 0}, 2);
-  autopas::Particle p4({2.5, 1.5, 1.5}, {0, 0, 0}, 3);
-  autopas::Particle p5({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
+  autopas::ParticleFP64 p1({0.5, 0.5, 0.5}, {0, 0, 0}, 0);
+  autopas::ParticleFP64 p2({1.5, 1.5, 1.5}, {0, 0, 0}, 1);
+  autopas::ParticleFP64 p3({1.6, 1.5, 1.5}, {0, 0, 0}, 2);
+  autopas::ParticleFP64 p4({2.5, 1.5, 1.5}, {0, 0, 0}, 3);
+  autopas::ParticleFP64 p5({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
 
   linkedCells.addParticle(p1);
   linkedCells.addParticle(p2);
@@ -82,7 +82,7 @@ TYPED_TEST_P(LinkedCellsTest, testUpdateContainerCloseToBoundary) {
   for (double x : {0., 5., 9.999}) {
     for (double y : {0., 5., 9.999}) {
       for (double z : {0., 5., 9.999}) {
-        autopas::Particle p({x, y, z}, {0., 0., 0.}, id++);
+        autopas::ParticleFP64 p({x, y, z}, {0., 0., 0.}, id++);
         EXPECT_NO_THROW(this->_linkedCells.addParticle(p));  // inside, therefore ok!
       }
     }

--- a/tests/testAutopas/tests/containers/linkedCells/ParticleVectorTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/ParticleVectorTest.cpp
@@ -14,15 +14,15 @@
 ParticleVectorTest::ParticleVectorTest() = default;
 
 TEST_F(ParticleVectorTest, testdirtySizeAfterMarkAsClean) {
-  auto particleVector = ParticleVector<autopas::Particle>();
+  auto particleVector = ParticleVector<autopas::ParticleFP64>();
 
-  autopas::Particle p1({0.5, 0.5, 0.5}, {0, 0, 0}, 0);
-  autopas::Particle p2({1.5, 1.5, 1.5}, {0, 0, 0}, 1);
-  autopas::Particle p3({1.6, 1.5, 1.5}, {0, 0, 0}, 2);
-  autopas::Particle p4({2.5, 1.5, 1.5}, {0, 0, 0}, 3);
-  autopas::Particle p5({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
-  autopas::Particle p6({2.5, 1.5, 1.5}, {0, 0, 0}, 3);
-  autopas::Particle p7({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
+  autopas::ParticleFP64 p1({0.5, 0.5, 0.5}, {0, 0, 0}, 0);
+  autopas::ParticleFP64 p2({1.5, 1.5, 1.5}, {0, 0, 0}, 1);
+  autopas::ParticleFP64 p3({1.6, 1.5, 1.5}, {0, 0, 0}, 2);
+  autopas::ParticleFP64 p4({2.5, 1.5, 1.5}, {0, 0, 0}, 3);
+  autopas::ParticleFP64 p5({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
+  autopas::ParticleFP64 p6({2.5, 1.5, 1.5}, {0, 0, 0}, 3);
+  autopas::ParticleFP64 p7({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
 
   particleVector.push_back(p1);
   particleVector.push_back(p2);
@@ -42,17 +42,17 @@ TEST_F(ParticleVectorTest, testdirtySizeAfterMarkAsClean) {
 }
 
 TEST_F(ParticleVectorTest, testDirtySizeAfterImplicitResize) {
-  auto particleVector = ParticleVector<autopas::Particle>();
+  auto particleVector = ParticleVector<autopas::ParticleFP64>();
 
-  autopas::Particle p1({0.5, 0.5, 0.5}, {0, 0, 0}, 0);
-  autopas::Particle p2({1.5, 1.5, 1.5}, {0, 0, 0}, 1);
-  autopas::Particle p3({1.6, 1.5, 1.5}, {0, 0, 0}, 2);
-  autopas::Particle p4({2.5, 1.5, 1.5}, {0, 0, 0}, 3);
-  autopas::Particle p5({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
-  autopas::Particle p6({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
-  autopas::Particle p7({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
-  autopas::Particle p8({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
-  autopas::Particle p9({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
+  autopas::ParticleFP64 p1({0.5, 0.5, 0.5}, {0, 0, 0}, 0);
+  autopas::ParticleFP64 p2({1.5, 1.5, 1.5}, {0, 0, 0}, 1);
+  autopas::ParticleFP64 p3({1.6, 1.5, 1.5}, {0, 0, 0}, 2);
+  autopas::ParticleFP64 p4({2.5, 1.5, 1.5}, {0, 0, 0}, 3);
+  autopas::ParticleFP64 p5({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
+  autopas::ParticleFP64 p6({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
+  autopas::ParticleFP64 p7({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
+  autopas::ParticleFP64 p8({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
+  autopas::ParticleFP64 p9({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
 
   particleVector.push_back(p1);
   particleVector.push_back(p2);

--- a/tests/testAutopas/tests/containers/verletClusterCells/VerletClusterCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletClusterCells/VerletClusterCellsTest.cpp
@@ -203,7 +203,7 @@ TEST_F(VerletClusterCellsTest, testParticleAdding) {
   for (double x : {-.5, 0., 5., 9.999, 10., 10.5}) {
     for (double y : {-.5, 0., 5., 9.999, 10., 10.5}) {
       for (double z : {-.5, 0., 5., 9.999, 10., 10.5}) {
-        autopas::Particle p({x, y, z}, {0., 0., 0.}, id++);
+        autopas::ParticleFP64 p({x, y, z}, {0., 0., 0.}, id++);
         if (x == 10. or y == 10. or z == 10. or x == -.5 or y == -.5 or z == -.5 or x == 10.5 or y == 10.5 or
             z == 10.5) {
           EXPECT_ANY_THROW(verletClusterCells.addParticle(p));     // outside, therefore not ok!

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
@@ -56,7 +56,7 @@ TEST_F(VerletClusterListsTest, testAddParticlesAndBuildTwice) {
   autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skin, clusterSize);
 
   autopasTools::generators::RandomGenerator::fillWithParticles(
-      verletLists, autopas::Particle{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
+      verletLists, autopas::ParticleFP64{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
 
   MockFunctor<Particle> emptyFunctor;
   autopas::VCLClusterIterationTraversal<FPCell, MFunctor, autopas::DataLayoutOption::aos, false> verletTraversal(
@@ -77,7 +77,7 @@ TEST_F(VerletClusterListsTest, testIterator) {
   autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skin, clusterSize);
 
   autopasTools::generators::RandomGenerator::fillWithParticles(
-      verletLists, autopas::Particle{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
+      verletLists, autopas::ParticleFP64{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
 
   MockFunctor<Particle> emptyFunctor;
   autopas::VCLClusterIterationTraversal<FPCell, MFunctor, autopas::DataLayoutOption::aos, false> verletTraversal(
@@ -93,8 +93,8 @@ TEST_F(VerletClusterListsTest, testIterator) {
   EXPECT_EQ(numParticlesInIterator, numParticles);
 }
 
-auto calculateValidPairs(const std::vector<autopas::Particle *> &particles, double cutoffSqr) {
-  std::vector<std::pair<autopas::Particle *, autopas::Particle *>> particlePairs;
+auto calculateValidPairs(const std::vector<autopas::ParticleFP64 *> &particles, double cutoffSqr) {
+  std::vector<std::pair<autopas::ParticleFP64 *, autopas::ParticleFP64 *>> particlePairs;
   for (auto *particlePtr : particles) {
     for (auto *neighborPtr : particles) {
       if (particlePtr != neighborPtr) {
@@ -108,8 +108,8 @@ auto calculateValidPairs(const std::vector<autopas::Particle *> &particles, doub
   return particlePairs;
 }
 
-void compareParticlePairs(const std::vector<std::pair<autopas::Particle *, autopas::Particle *>> &first,
-                          const std::vector<std::pair<autopas::Particle *, autopas::Particle *>> &second) {
+void compareParticlePairs(const std::vector<std::pair<autopas::ParticleFP64 *, autopas::ParticleFP64 *>> &first,
+                          const std::vector<std::pair<autopas::ParticleFP64 *, autopas::ParticleFP64 *>> &second) {
   EXPECT_EQ(first.size(), second.size());
   for (auto pair : first) {
     EXPECT_TRUE(std::find(second.begin(), second.end(), pair) != second.end());
@@ -127,13 +127,13 @@ TEST_F(VerletClusterListsTest, testNeighborListsValidAfterMovingLessThanHalfSkin
   autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skin, clusterSize);
 
   autopasTools::generators::RandomGenerator::fillWithParticles(
-      verletLists, autopas::Particle{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
+      verletLists, autopas::ParticleFP64{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
   CollectParticlePairsFunctor functor{cutoff, min, max};
   autopas::VCLClusterIterationTraversal<FPCell, CollectParticlePairsFunctor, autopas::DataLayoutOption::aos, false>
       verletTraversal(&functor, clusterSize);
   verletLists.rebuildNeighborLists(&verletTraversal);
 
-  std::vector<autopas::Particle *> particles;
+  std::vector<autopas::ParticleFP64 *> particles;
   for (auto it = verletLists.begin(); it.isValid(); ++it) {
     particles.push_back(&(*it));
   }
@@ -201,7 +201,7 @@ TEST_F(VerletClusterListsTest, testNewton3NeighborList) {
   autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skin, clusterSize);
 
   autopasTools::generators::RandomGenerator::fillWithParticles(
-      verletLists, autopas::Particle{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
+      verletLists, autopas::ParticleFP64{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
 
   MockFunctor<Particle> functor;
   autopas::VCLC06Traversal<FPCell, MFunctor, autopas::DataLayoutOption::aos, false> traversalNoN3(&functor,
@@ -236,7 +236,7 @@ TEST_F(VerletClusterListsTest, testVerletListColoringTraversalNewton3NoDataRace)
   size_t clusterSize = 4;
   autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skin, clusterSize);
 
-  autopasTools::generators::RandomGenerator::fillWithParticles(verletLists, autopas::Particle{}, min, max,
+  autopasTools::generators::RandomGenerator::fillWithParticles(verletLists, autopas::ParticleFP64{}, min, max,
                                                                numParticles);
 
   CollectParticlesPerThreadFunctor functor;

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.h
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.h
@@ -19,9 +19,9 @@
 
 class VerletClusterListsTest : public AutoPasTestBase {};
 
-class CollectParticlePairsFunctor : public autopas::Functor<autopas::Particle, CollectParticlePairsFunctor> {
+class CollectParticlePairsFunctor : public autopas::Functor<autopas::ParticleFP64, CollectParticlePairsFunctor> {
  public:
-  std::vector<std::pair<Particle *, Particle *>> _pairs{};
+  std::vector<std::pair<autopas::ParticleFP64 *, autopas::ParticleFP64 *>> _pairs{};
   std::array<double, 3> _min;
   std::array<double, 3> _max;
 
@@ -58,7 +58,7 @@ class CollectParticlePairsFunctor : public autopas::Functor<autopas::Particle, C
 };
 
 #if defined(AUTOPAS_OPENMP)
-class CollectParticlesPerThreadFunctor : public autopas::Functor<autopas::Particle, CollectParticlesPerThreadFunctor> {
+class CollectParticlesPerThreadFunctor : public autopas::Functor<autopas::ParticleFP64, CollectParticlesPerThreadFunctor> {
  public:
   int _currentColor{};
 

--- a/tests/testAutopas/tests/containers/verletListsCellBased/varVerletLists/VarVerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/varVerletLists/VarVerletListsTest.cpp
@@ -85,7 +85,7 @@ TEST_F(VarVerletListsTest, testVerletListBuild) {
   MockFunctor<Particle> emptyFunctor;
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, true)).Times(AtLeast(1));
 
-  autopas::VVLAsBuildTraversal<FPCell, autopas::Particle, MFunctor, autopas::DataLayoutOption::aos, true>
+  autopas::VVLAsBuildTraversal<FPCell, autopas::ParticleFP64, MFunctor, autopas::DataLayoutOption::aos, true>
       dummyTraversal(&emptyFunctor);
 
   verletLists.rebuildNeighborLists(&dummyTraversal);
@@ -112,7 +112,7 @@ TEST_F(VarVerletListsTest, testVerletList) {
   using ::testing::_;  // anything is ok
   EXPECT_CALL(mockFunctor, AoSFunctor(_, _, true));
 
-  autopas::VVLAsBuildTraversal<FPCell, autopas::Particle, MFunctor, autopas::DataLayoutOption::aos, true>
+  autopas::VVLAsBuildTraversal<FPCell, autopas::ParticleFP64, MFunctor, autopas::DataLayoutOption::aos, true>
       dummyTraversal(&mockFunctor);
   verletLists.rebuildNeighborLists(&dummyTraversal);
   verletLists.iteratePairwise(&dummyTraversal);
@@ -138,7 +138,7 @@ TEST_F(VarVerletListsTest, testVerletListInSkin) {
   using ::testing::_;  // anything is ok
   EXPECT_CALL(mockFunctor, AoSFunctor(_, _, true));
 
-  autopas::VVLAsBuildTraversal<FPCell, autopas::Particle, MFunctor, autopas::DataLayoutOption::aos, true>
+  autopas::VVLAsBuildTraversal<FPCell, autopas::ParticleFP64, MFunctor, autopas::DataLayoutOption::aos, true>
       dummyTraversal(&mockFunctor);
 
   verletLists.rebuildNeighborLists(&dummyTraversal);
@@ -164,7 +164,7 @@ TEST_F(VarVerletListsTest, testVerletListBuildTwice) {
   MockFunctor<Particle> emptyFunctor;
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, true)).Times(AtLeast(1));
 
-  autopas::VVLAsBuildTraversal<FPCell, autopas::Particle, MFunctor, autopas::DataLayoutOption::aos, true>
+  autopas::VVLAsBuildTraversal<FPCell, autopas::ParticleFP64, MFunctor, autopas::DataLayoutOption::aos, true>
       dummyTraversal(&emptyFunctor);
 
   verletLists.rebuildNeighborLists(&dummyTraversal);
@@ -196,7 +196,7 @@ TEST_F(VarVerletListsTest, testVerletListBuildFarAway) {
 
   MockFunctor<Particle> emptyFunctor;
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, true)).Times(AtLeast(1));
-  autopas::VVLAsBuildTraversal<FPCell, autopas::Particle, MFunctor, autopas::DataLayoutOption::aos, true>
+  autopas::VVLAsBuildTraversal<FPCell, autopas::ParticleFP64, MFunctor, autopas::DataLayoutOption::aos, true>
       dummyTraversal(&emptyFunctor);
   verletLists.rebuildNeighborLists(&dummyTraversal);
   verletLists.iteratePairwise(&dummyTraversal);
@@ -221,7 +221,7 @@ TEST_F(VarVerletListsTest, testVerletListBuildHalo) {
   MockFunctor<Particle> emptyFunctor;
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, true)).Times(AtLeast(1));
 
-  autopas::VVLAsBuildTraversal<FPCell, autopas::Particle, MFunctor, autopas::DataLayoutOption::aos, true>
+  autopas::VVLAsBuildTraversal<FPCell, autopas::ParticleFP64, MFunctor, autopas::DataLayoutOption::aos, true>
       dummyTraversal(&emptyFunctor);
 
   verletLists.rebuildNeighborLists(&dummyTraversal);

--- a/tests/testAutopas/tests/particles/myMoleculeTest.cpp
+++ b/tests/testAutopas/tests/particles/myMoleculeTest.cpp
@@ -10,11 +10,11 @@
 
 using namespace autopas;
 
-class MyMolecule : public Particle {
+class MyMolecule : public ParticleFP64 {
  public:
-  MyMolecule() : Particle(), _myvar(0) {}
+  MyMolecule() : ParticleFP64(), _myvar(0) {}
   MyMolecule(std::array<double, 3> r, std::array<double, 3> v, unsigned long i, int myvar)
-      : Particle(r, v, i), _myvar(myvar) {}
+      : ParticleFP64(r, v, i), _myvar(myvar) {}
   void print() {
     std::cout << "Molecule with position: ";
     for (auto &r : getR()) {

--- a/tests/testAutopas/tests/utils/SoATest.cpp
+++ b/tests/testAutopas/tests/utils/SoATest.cpp
@@ -6,7 +6,7 @@
 
 #include "SoATest.h"
 
-TEST_F(SoATest, testInitialization) { autopas::SoA<autopas::Particle::SoAArraysType> soa; }
+TEST_F(SoATest, testInitialization) { autopas::SoA<autopas::ParticleFP64::SoAArraysType> soa; }
 
 TEST_F(SoATest, SoATypeTest) {
   static_assert(std::is_same<autopas::utils::SoAType<size_t, double, double, double>::Type,
@@ -85,7 +85,7 @@ TEST_F(SoATest, SoAStorageTestApply) {
 
 TEST_F(SoATest, SoATestPush) {
   // default soa using autopas::Particle
-  using autopas::Particle;
+  using Particle = autopas::ParticleFP64;
   autopas::SoA<Particle::SoAArraysType> soa;
 
   EXPECT_EQ(soa.getNumParticles(), 0);
@@ -111,7 +111,7 @@ TEST_F(SoATest, SoATestPush) {
 
 TEST_F(SoATest, SoATestAppend) {
   // default soa using autopas::Particle
-  using autopas::Particle;
+  using Particle = autopas::ParticleFP64;
   std::array<autopas::SoA<Particle::SoAArraysType>, 2> soaBuffer;
 
   soaBuffer[0].push<Particle::AttributeNames::id>(2);
@@ -144,7 +144,7 @@ TEST_F(SoATest, SoATestAppend) {
 
 TEST_F(SoATest, SoATestSwap) {
   // default soa using autopas::Particle
-  using autopas::Particle;
+  using Particle = autopas::ParticleFP64;
   autopas::SoA<Particle::SoAArraysType> soa;
 
   soa.resizeArrays(2);
@@ -202,7 +202,7 @@ TEST_F(SoATest, SoATestSwap) {
 
 TEST_F(SoATest, SoATestMultiWriteRead) {
   // default soa using autopas::Particle
-  using autopas::Particle;
+  using Particle = autopas::ParticleFP64;
   autopas::SoA<Particle::SoAArraysType> soa;
 
   soa.resizeArrays(1);
@@ -239,7 +239,7 @@ TEST_F(SoATest, SoATestMultiWriteRead) {
 // this test makes certain that methods don't destroy the inner state of the test
 TEST_F(SoATest, SoATestComplicatedAccess) {
   // default soa using autopas::Particle
-  using autopas::Particle;
+  using Particle = autopas::ParticleFP64;
   autopas::SoA<Particle::SoAArraysType> soa;
 
   EXPECT_EQ(soa.getNumParticles(), 0);

--- a/tools/autopasTools/generators/ClosestPackingGenerator.h
+++ b/tools/autopasTools/generators/ClosestPackingGenerator.h
@@ -54,7 +54,8 @@ class ClosestPackingGenerator {
         double startx = evenRow ? boxMin[0] : boxMin[0] + xOffset;
         for (double x = startx; x < boxMax[0]; x += spacing) {
           auto p = defaultParticle;
-          p.setR({x, y, z});
+          using floatType = typename autopas::utils::ParticleTypeTrait<Container>::value::ParticleSoAFloatPrecision;
+          p.setR(autopas::utils::ArrayUtils::static_cast_array<floatType>(std::array{x, y, z}));
           p.setID(id++);
           container.addParticle(p);
         }

--- a/tools/autopasTools/generators/GaussianGenerator.h
+++ b/tools/autopasTools/generators/GaussianGenerator.h
@@ -75,7 +75,7 @@ void GaussianGenerator::fillWithParticles(
       position = {distributions[0](generator), distributions[1](generator), distributions[2](generator)};
     };
     auto p = defaultParticle;
-    p.setR(position);
+    p.setR(autopas::utils::ArrayUtils::static_cast_array<typename decltype(p)::ParticleSoAFloatPrecision>(position));
     p.setID(i);
     container.addParticle(p);
   }

--- a/tools/autopasTools/generators/GridGenerator.h
+++ b/tools/autopasTools/generators/GridGenerator.h
@@ -90,7 +90,9 @@ void GridGenerator::fillWithParticles(
     for (unsigned int y = 0; y < particlesPerDim[1]; ++y) {
       for (unsigned int x = 0; x < particlesPerDim[0]; ++x) {
         auto p = defaultParticle;
-        p.setR({x * spacing[0] + offset[0], y * spacing[1] + offset[1], z * spacing[2] + offset[2]});
+        using floatType = typename autopas::utils::ParticleTypeTrait<Container>::value::ParticleSoAFloatPrecision;
+        p.setR(autopas::utils::ArrayUtils::static_cast_array<floatType>(
+            std::array{x * spacing[0] + offset[0], y * spacing[1] + offset[1], z * spacing[2] + offset[2]}));
         p.setID(id++);
         container.addParticle(p);
       }

--- a/tools/autopasTools/generators/RandomGenerator.h
+++ b/tools/autopasTools/generators/RandomGenerator.h
@@ -10,6 +10,7 @@
 #include <functional>
 
 #include "autopas/utils/inBox.h"
+#include "autopas/utils/ArrayUtils.h"
 
 namespace autopasTools::generators {
 /**
@@ -109,7 +110,8 @@ void RandomGenerator::fillWithParticles(Container &container, const Particle &de
 
   for (unsigned long i = defaultParticle.getID(); i < defaultParticle.getID() + numParticles; ++i) {
     Particle particle(defaultParticle);
-    particle.setR(randomPosition(boxMin, boxMax));
+    particle.setR(autopas::utils::ArrayUtils::static_cast_array<typename Particle::ParticleSoAFloatPrecision>(
+        randomPosition(boxMin, boxMax)));
     particle.setID(i);
     container.addParticle(particle);
   }


### PR DESCRIPTION
# Description
This pull request fixes the compilation errors that happen when switching to 32-bit floating point precision in AutoPas or md-flexible. A lot of changes were necessary and some choices had to be made. I will post some discussion points shortly.

## Resolved Issues
- [ ] fixes #600 

# How Has This Been Tested?
Running the test suite.

## To Do
- [ ] Add a test that compiles AutoPas with a particle that uses 32-bit precision.
- [ ] Add 32-bit precision implementation for the AVX intrinsics stuff.
