### PR TITLE
Fix Smoothing Bugs

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -10,7 +10,7 @@ extraction:
     after_prepare:    # Customizable step used by all languages.
       # installs cmake!
       - cmake --version
-      - wget -O cmake.tar.gz https://github.com/Kitware/CMake/releases/download/v3.16.4/cmake-3.16.4.tar.gz
+      - wget -O cmake.tar.gz https://github.com/Kitware/CMake/releases/download/v3.20.2/cmake-3.20.2.tar.gz
       - tar zxf cmake.tar.gz
       - cd cmake-*/
       - mkdir build

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCSlicedTraversal.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCSlicedTraversal.h
@@ -70,6 +70,8 @@ class VLCSlicedTraversal
       case (ContainerOption::pairwiseVerletLists):
         return TraversalOption::vlp_sliced;
     }
+    // should never be reached.
+    return TraversalOption();
   }
 
   [[nodiscard]] bool isApplicable() const override {

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -522,6 +522,9 @@ void AutoTuner<Particle>::addTimeMeasurement(long time) {
       // smooth evidence to remove high outliers. If smoothing results in a higher value use the original value.
       const auto smoothedValue = std::min(reducedValue, smoothing::smoothLastPoint(evidenceCurrentConfig, 5));
 
+      // replace collected evidence with smoothed value to improve next smoothing
+      evidenceCurrentConfig.back().second = smoothedValue;
+
       _tuningStrategy->addEvidence(smoothedValue, _iteration);
 
       // print config, times and reduced value

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -184,8 +184,8 @@ class AutoTuner {
       if (_samples.size() == _maxSamples) {
         auto reducedValue = OptimumSelector::optimumValue(_samples, _selectorStrategy);
 
-        _evidences[currentConfig].emplace_back(_iteration, reducedValue);
-        auto smoothedValue = smoothing::smoothLastPoint(_evidences[currentConfig], 5);
+        _evidence[currentConfig].emplace_back(_iteration, reducedValue);
+        auto smoothedValue = smoothing::smoothLastPoint(_evidence[currentConfig], 5);
 
         _tuningStrategy->addEvidence(smoothedValue, _iteration);
 
@@ -275,7 +275,7 @@ class AutoTuner {
    * For each configuration the collection of all evidence (smoothed values) collected so far and in which iteration.
    * Configuration -> vector< iteration, time >
    */
-  std::map<Configuration, std::vector<std::pair<size_t, long>>> _evidences;
+  std::map<Configuration, std::vector<std::pair<size_t, long>>> _evidence;
 
   IterationLogger _iterationLogger;
   TuningResultLogger _tuningResultLogger;

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -134,8 +134,14 @@ class AutoTuner {
   bool configApplicable(const Configuration &conf, PairwiseFunctor &pairwiseFunctor);
 
   /**
-   * Function to iterate over all pairs of particles in the container.
-   * This function only handles short-range interactions.
+   * Whole tuning logic for one iteration.
+   * This function covers:
+   *  - Instantiation of the traversal to be used.
+   *  - Actual pairwise iteration for application of the functor.
+   *  - Management of tuning phases and calls to tune() if necessary.
+   *  - Measurement of timings and calls to addTimeMeasurement() if necessary.
+   *  - Calls to _iterationLogger if necessary.
+   *
    * @tparam PairwiseFunctor
    * @param f Functor that describes the pair-potential.
    * @param doListRebuild Indicates whether or not the verlet lists should be rebuild.

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -170,10 +170,8 @@ class AutoTuner {
    * on to the tuning strategy. This function expects that samples of the same configuration are taken consecutively.
    * The time argument is a long because std::chrono::duration::count returns a long.
    *
-   * @param pairwiseFunctor
    * @param time
    */
-  template <class PairwiseFunctor>
   void addTimeMeasurement(long time) {
     const auto &currentConfig = _tuningStrategy->getCurrentConfiguration();
 

--- a/tests/testAutopas/tests/selectors/AutoTunerTest.cpp
+++ b/tests/testAutopas/tests/selectors/AutoTunerTest.cpp
@@ -282,22 +282,11 @@ TEST_F(AutoTunerTest, testWillRebuildDL) {
 TEST_F(AutoTunerTest, testForceRetuneBetweenPhases) {
   std::array<double, 3> bBoxMin = {0, 0, 0}, bBoxMax = {2, 4, 2};
   const double cutoff = 1;
-  const double cellSizeFactor = 1;
   const double verletSkin = 0;
   const unsigned int verletClusterSize = 4;
   const unsigned int maxSamples = 3;
 
-  autopas::Configuration confLc_c01(autopas::ContainerOption::linkedCells, cellSizeFactor,
-                                    autopas::TraversalOption::lc_c01, autopas::LoadEstimatorOption::none,
-                                    autopas::DataLayoutOption::aos, autopas::Newton3Option::disabled);
-  autopas::Configuration confLc_c04(autopas::ContainerOption::linkedCells, cellSizeFactor,
-                                    autopas::TraversalOption::lc_c04, autopas::LoadEstimatorOption::none,
-                                    autopas::DataLayoutOption::aos, autopas::Newton3Option::disabled);
-  autopas::Configuration confLc_c08(autopas::ContainerOption::linkedCells, cellSizeFactor,
-                                    autopas::TraversalOption::lc_c08, autopas::LoadEstimatorOption::none,
-                                    autopas::DataLayoutOption::aos, autopas::Newton3Option::disabled);
-
-  auto configsList = {confLc_c01, confLc_c04, confLc_c08};
+  auto configsList = {_confLc_c01, _confLc_c04, _confLc_c08};
 
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
   autopas::AutoTuner<Particle> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkin, verletClusterSize,
@@ -420,17 +409,13 @@ TEST_F(AutoTunerTest, testNoConfig) {
  * Generates exactly one valid configuration.
  */
 TEST_F(AutoTunerTest, testOneConfig) {
-  autopas::Configuration conf(autopas::ContainerOption::linkedCells, 1., autopas::TraversalOption::lc_c08,
-                              autopas::LoadEstimatorOption::none, autopas::DataLayoutOption::aos,
-                              autopas::Newton3Option::enabled);
-
-  auto configsList = {conf};
+  auto configsList = {_confLc_c08};
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
   size_t maxSamples = 3;
   autopas::AutoTuner<Particle> tuner({0, 0, 0}, {10, 10, 10}, 1, 0, 64, std::move(tuningStrategy),
                                      autopas::SelectorStrategyOption::fastestAbs, 1000, maxSamples);
 
-  EXPECT_EQ(conf, tuner.getCurrentConfig());
+  EXPECT_EQ(_confLc_c08, tuner.getCurrentConfig());
 
   MFunctor functor;
   EXPECT_CALL(functor, isRelevantForTuning()).WillRepeatedly(::testing::Return(true));
@@ -446,7 +431,7 @@ TEST_F(AutoTunerTest, testOneConfig) {
     tuner.iteratePairwise(&functor, doRebuild);
     doRebuild = false;
     ++numSamples;
-    EXPECT_EQ(conf, tuner.getCurrentConfig());
+    EXPECT_EQ(_confLc_c08, tuner.getCurrentConfig());
   }
 }
 

--- a/tests/testAutopas/tests/selectors/AutoTunerTest.h
+++ b/tests/testAutopas/tests/selectors/AutoTunerTest.h
@@ -36,12 +36,12 @@ class AutoTunerTest : public AutoPasTestBase {
   const double _cellSizeFactor{1.};
 
   const autopas::Configuration _confLc_c01{autopas::ContainerOption::linkedCells, _cellSizeFactor,
-                                    autopas::TraversalOption::lc_c01, autopas::LoadEstimatorOption::none,
-                                    autopas::DataLayoutOption::aos, autopas::Newton3Option::disabled};
+                                           autopas::TraversalOption::lc_c01,      autopas::LoadEstimatorOption::none,
+                                           autopas::DataLayoutOption::aos,        autopas::Newton3Option::disabled};
   const autopas::Configuration _confLc_c04{autopas::ContainerOption::linkedCells, _cellSizeFactor,
-                                    autopas::TraversalOption::lc_c04, autopas::LoadEstimatorOption::none,
-                                    autopas::DataLayoutOption::aos, autopas::Newton3Option::disabled};
+                                           autopas::TraversalOption::lc_c04,      autopas::LoadEstimatorOption::none,
+                                           autopas::DataLayoutOption::aos,        autopas::Newton3Option::disabled};
   const autopas::Configuration _confLc_c08{autopas::ContainerOption::linkedCells, _cellSizeFactor,
-                                    autopas::TraversalOption::lc_c08, autopas::LoadEstimatorOption::none,
-                                    autopas::DataLayoutOption::aos, autopas::Newton3Option::disabled};
+                                           autopas::TraversalOption::lc_c08,      autopas::LoadEstimatorOption::none,
+                                           autopas::DataLayoutOption::aos,        autopas::Newton3Option::disabled};
 };

--- a/tests/testAutopas/tests/selectors/AutoTunerTest.h
+++ b/tests/testAutopas/tests/selectors/AutoTunerTest.h
@@ -32,4 +32,16 @@ class AutoTunerTest : public AutoPasTestBase {
    */
   void testFastest(autopas::SelectorStrategyOption strategy, mapConfigTime configAndTimes,
                    autopas::Configuration expectedBest, mapConfigTime ignoredConfigAndTimes = {});
+
+  const double _cellSizeFactor{1.};
+
+  const autopas::Configuration _confLc_c01{autopas::ContainerOption::linkedCells, _cellSizeFactor,
+                                    autopas::TraversalOption::lc_c01, autopas::LoadEstimatorOption::none,
+                                    autopas::DataLayoutOption::aos, autopas::Newton3Option::disabled};
+  const autopas::Configuration _confLc_c04{autopas::ContainerOption::linkedCells, _cellSizeFactor,
+                                    autopas::TraversalOption::lc_c04, autopas::LoadEstimatorOption::none,
+                                    autopas::DataLayoutOption::aos, autopas::Newton3Option::disabled};
+  const autopas::Configuration _confLc_c08{autopas::ContainerOption::linkedCells, _cellSizeFactor,
+                                    autopas::TraversalOption::lc_c08, autopas::LoadEstimatorOption::none,
+                                    autopas::DataLayoutOption::aos, autopas::Newton3Option::disabled};
 };


### PR DESCRIPTION
# Description

- [x] update CMake in LGTM script
- [x] some minor restructuring of AutoTuner.h
- [x] use min of reducedValue and smoothedValue for tuning 03a67d7
- [x] store smoothed values instead of reduced ones for future smoothing 62b826c

## ~Related Pull Requests~

## ~Resolved Issues~

# How Has This Been Tested?

Difficult to test. AutoTuner is one big state machine that does not allow to simply add measurements + actual tuning.
