### PR TITLE
Md flex/review feedback

### DIFF
--- a/examples/md-flexible/CMakeLists.txt
+++ b/examples/md-flexible/CMakeLists.txt
@@ -13,7 +13,7 @@ target_include_directories(md-flexible PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 include(autopas_yaml-cpp)
 
-set(AUTOPAS_INCLUDE_MPI "$ENV{AUTOPAS_INCLUDE_MPI}")
+option(AUTOPAS_INCLUDE_MPI "Links MPI libraries to the target. This is required if you want to use MPI." ON)
 
 if (AUTOPAS_INTERNODE_TUNING OR AUTOPAS_INCLUDE_MPI)
     message(STATUS "AUTOPAS_INTERNODE_TUNING set, searching for mpi to link against md-flexible ...")

--- a/examples/md-flexible/CMakeLists.txt
+++ b/examples/md-flexible/CMakeLists.txt
@@ -5,21 +5,6 @@ file(
         "src/*.h"
 )
 
-set(AUTOPAS_INCLUDE_MPI "$ENV{AUTOPAS_INCLUDE_MPI}")
-
-if (AUTOPAS_INTERNODE_TUNING OR AUTOPAS_INCLUDE_MPI)
-    message(STATUS "AUTOPAS_INTERNODE_TUNING set, searching for mpi to link against md-flexible ...")
-    find_package(MPI)
-
-    if (NOT ${MPI_CXX_FOUND})
-        message(FATAL_ERROR "cxx mpi could not be found, even though AUTOPAS_INTERNODE_TUNING was set.")
-    else ()
-        message(STATUS "cxx mpi found: ${MPI_CXX_COMPILER}")
-    endif ()
-else ()
-    message(STATUS "AUTOPAS_INTERNODE_TUNING not set, not linking MPI to md-flexible.")
-endif (AUTOPAS_INTERNODE_TUNING)
-
 include_directories(SYSTEM ${MPI_INCLUDE_PATH})
 
 add_executable(md-flexible ${MDFlex_SRC})
@@ -28,7 +13,24 @@ target_include_directories(md-flexible PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 include(autopas_yaml-cpp)
 
-target_link_libraries(md-flexible PUBLIC autopas autopasTools yaml-cpp $<$<BOOL:${AUTOPAS_INTERNODE_TUNING}>:MPI::MPI_CXX>)
+set(AUTOPAS_INCLUDE_MPI "$ENV{AUTOPAS_INCLUDE_MPI}")
+
+if (AUTOPAS_INTERNODE_TUNING OR AUTOPAS_INCLUDE_MPI)
+    message(STATUS "AUTOPAS_INTERNODE_TUNING set, searching for mpi to link against md-flexible ...")
+    find_package(MPI)
+
+    if (NOT ${MPI_CXX_FOUND})
+        message(FATAL_ERROR "cxx mpi could not be found, even though AUTOPAS_INTERNODE_TUNING was set.")
+        target_link_libraries(md-flexible PUBLIC autopas autopasTools yaml-cpp)
+    else ()
+        message(STATUS "cxx mpi found: ${MPI_CXX_COMPILER}")
+        target_link_libraries(md-flexible PUBLIC autopas autopasTools yaml-cpp ${MPI_CXX_LIBRARIES})
+    endif ()
+else ()
+    target_link_libraries(md-flexible PUBLIC autopas autopasTools yaml-cpp)
+    message(STATUS "AUTOPAS_INTERNODE_TUNING not set, not linking MPI to md-flexible.")
+endif (AUTOPAS_INTERNODE_TUNING OR AUTOPAS_INCLUDE_MPI)
+
 
 # --- copy script files to build dir ---
 file(

--- a/examples/md-flexible/src/TimeDiscretization.cpp
+++ b/examples/md-flexible/src/TimeDiscretization.cpp
@@ -48,8 +48,7 @@ void calculatePositions(autopas::AutoPas<ParticleType> &autoPasContainer,
  * @param deltaT time step width
  */
 void calculateVelocities(autopas::AutoPas<ParticleType> &autoPasContainer,
-                         const ParticlePropertiesLibraryType &particlePropertiesLibrary, const double &deltaT,
-                         const bool &useThermostat, const double &targetTemperature) {
+                         const ParticlePropertiesLibraryType &particlePropertiesLibrary, const double &deltaT) {
   // helper declarations for operations with vector
   using autopas::utils::ArrayMath::add;
   using autopas::utils::ArrayMath::mulScalar;
@@ -63,10 +62,6 @@ void calculateVelocities(autopas::AutoPas<ParticleType> &autoPasContainer,
     auto oldForce = iter->getOldF();
     auto newV = mulScalar((add(force, oldForce)), deltaT / (2 * m));
     iter->addV(newV);
-  }
-
-  if (useThermostat) {
-    Thermostat::apply(autoPasContainer, particlePropertiesLibrary, targetTemperature, deltaT);
   }
 }
 

--- a/examples/md-flexible/src/TimeDiscretization.h
+++ b/examples/md-flexible/src/TimeDiscretization.h
@@ -27,13 +27,9 @@ void calculatePositions(autopas::AutoPas<ParticleType> &autoPasContainer,
  * @param autoPasContainer The container for which to update the velocities.
  * @param particlePropertiesLibrary The particle properties library for the particles in the container.
  * @param deltaT The time step width.
- * @param useThermmostat Decides if a thermostat should be used.
- * @param targetTemperature The target temperature used for the thermostat. If useThermostat is false,
- * 	this value does not matter.
  */
 void calculateVelocities(autopas::AutoPas<ParticleType> &autoPasContainer,
-                         const ParticlePropertiesLibraryType &particlePropertiesLibrary, const double &deltaT,
-                         const bool &useThermostat, const double &targetTemperature);
+                         const ParticlePropertiesLibraryType &particlePropertiesLibrary, const double &deltaT);
 
 /**
  * Calculates the pairwise forces between particles in an autopas container.

--- a/examples/md-flexible/src/configuration/objects/CubeGauss.h
+++ b/examples/md-flexible/src/configuration/objects/CubeGauss.h
@@ -92,14 +92,18 @@ class CubeGauss : public Object {
    */
   void generate(std::vector<ParticleAttributes> &particles) const override {
     ParticleAttributes particle = getDummyParticle(particles.size());
+
     std::default_random_engine generator(42);
     std::array<std::normal_distribution<double>, 3> distributions = {
         std::normal_distribution<double>{_distributionMean[0], _distributionStdDev[0]},
         std::normal_distribution<double>{_distributionMean[1], _distributionStdDev[1]},
         std::normal_distribution<double>{_distributionMean[2], _distributionStdDev[2]}};
+
     for (int i = 0; i < _numParticles; ++i) {
       particle.id++;
-      particle.position = {distributions[0](generator), distributions[1](generator), distributions[2](generator)};
+      particle.position[0] = _bottomLeftCorner[0] + distributions[0](generator);
+      particle.position[1] = _bottomLeftCorner[1] + distributions[1](generator);
+      particle.position[2] = _bottomLeftCorner[2] + distributions[2](generator);
       particles.push_back(particle);
     }
   }

--- a/examples/md-flexible/src/configuration/objects/CubeGrid.h
+++ b/examples/md-flexible/src/configuration/objects/CubeGrid.h
@@ -94,15 +94,14 @@ class CubeGrid : public Object {
    */
   void generate(std::vector<ParticleAttributes> &particles) const override {
     ParticleAttributes particle = getDummyParticle(particles.size());
-    std::array<double, 3> offset = {0.0, 0.0, 0.0};
 
     for (unsigned long z = 0; z < _particlesPerDim[2]; ++z) {
       for (unsigned long y = 0; y < _particlesPerDim[1]; ++y) {
         for (unsigned long x = 0; x < _particlesPerDim[0]; ++x) {
           particle.id++;
-          particle.position[0] = (static_cast<double>(x) * _particleSpacing + offset[0]);
-          particle.position[1] = (static_cast<double>(y) * _particleSpacing + offset[1]);
-          particle.position[2] = (static_cast<double>(z) * _particleSpacing + offset[2]);
+          particle.position[0] = _bottomLeftCorner[0] + static_cast<double>(x) * _particleSpacing;
+          particle.position[1] = _bottomLeftCorner[1] + static_cast<double>(y) * _particleSpacing;
+          particle.position[2] = _bottomLeftCorner[2] + static_cast<double>(z) * _particleSpacing;
 
           particles.push_back(particle);
         }

--- a/examples/md-flexible/src/domainDecomposition/DomainTools.cpp.orig
+++ b/examples/md-flexible/src/domainDecomposition/DomainTools.cpp.orig
@@ -18,6 +18,8 @@ bool isInsideDomain(const std::vector<double> &coordinates, std::vector<double> 
   }
   return isInsideLocalDomain;
 }
+<<<<<<< Updated upstream
+=======
 
 void generateDecomposition(unsigned int subdomainCount, int dimensionCount, std::vector<int> &oDecomposition) {
   std::list<int> primeFactors;
@@ -51,4 +53,5 @@ void generateDecomposition(unsigned int subdomainCount, int dimensionCount, std:
     }
   }
 }
+>>>>>>> Stashed changes
 }

--- a/examples/md-flexible/src/domainDecomposition/DomainTools.h.orig
+++ b/examples/md-flexible/src/domainDecomposition/DomainTools.h.orig
@@ -15,6 +15,8 @@ namespace DomainTools {
  * @param boxMax the maximum boundaries of the box domain
  */
 bool isInsideDomain(const std::vector<double> &coordinates, std::vector<double> &boxMin, std::vector<double> &boxMax);
+<<<<<<< Updated upstream
+=======
 
 /**
  * Generates a decomposition with a secific number of subdomains.
@@ -24,4 +26,5 @@ bool isInsideDomain(const std::vector<double> &coordinates, std::vector<double> 
  * @param oDecomposition The resulting decomposition.
  */
 void generateDecomposition(unsigned int subdomainCount, int dimensionCount, std::vector<int> &oDecomposition);
+>>>>>>> Stashed changes
 }

--- a/examples/md-flexible/src/domainDecomposition/RegularGrid.cpp.orig
+++ b/examples/md-flexible/src/domainDecomposition/RegularGrid.cpp.orig
@@ -5,14 +5,19 @@
  */
 #include "RegularGrid.h"
 
+#include <math.h>
+
 #include <algorithm>
 #include <functional>
+<<<<<<< Updated upstream
+#include <list>
+=======
 #include <math.h>
+>>>>>>> Stashed changes
 #include <numeric>
 
-
-#include "autopas/utils/ArrayUtils.h"
 #include "DomainTools.h"
+#include "autopas/utils/ArrayUtils.h"
 #include "src/ParticleSerializationTools.h"
 
 namespace {
@@ -36,7 +41,7 @@ void calculatePrimeFactors(unsigned int number, std::list<unsigned int> &oPrimeF
 }
 }
 
-RegularGrid::RegularGrid(const int &dimensionCount, const std::vector<double> &globalBoxMin,
+RegularGrid::RegularGrid(int argc, char **argv, const int &dimensionCount, const std::vector<double> &globalBoxMin,
                          const std::vector<double> &globalBoxMax) {
   _dimensionCount = dimensionCount;
 

--- a/examples/md-flexible/src/domainDecomposition/RegularGrid.h
+++ b/examples/md-flexible/src/domainDecomposition/RegularGrid.h
@@ -72,6 +72,12 @@ class RegularGrid final : public DomainDecomposition {
   std::vector<double> getLocalBoxMax() override { return _localBoxMax; }
 
   /**
+   * Sets the halo width.
+   * If it is not set manually the halo width depends on the size of the local box.
+   */
+  void setHaloWidth(double width);
+
+  /**
    * Checks if the provided coordinates are located in the local domain.
    */
   bool isInsideLocalDomain(const std::vector<double> &coordinates) override;
@@ -106,11 +112,6 @@ class RegularGrid final : public DomainDecomposition {
    * @param neighbour The neighbour to which the data will be sent.
    */
   void sendDataToNeighbour(std::vector<char> sendBuffer, const int &neighbour);
-
-  /**
-   * Synchronizes all processes which own a domain in this decomposition.
-   */
-  void synchronizeDomains();
 
   /** 
    * Waits for all send requests to be finished.
@@ -157,6 +158,11 @@ class RegularGrid final : public DomainDecomposition {
    * The MPI communicator containing all processes which own a subdomain in this decomposition.
    */
   MPI_Comm _communicator;
+
+  /**
+   * Stores the halo width.
+   */
+  double _haloWidth;
 
   /**
    * The index of the current processor's domain.

--- a/examples/md-flexible/src/domainDecomposition/RegularGrid.h.orig
+++ b/examples/md-flexible/src/domainDecomposition/RegularGrid.h.orig
@@ -5,12 +5,10 @@
  */
 #pragma once
 
-#include <list>
 #include <memory>
 
-#include "autopas/AutoPas.h"
 #include "DomainDecomposition.h"
-#include "mpi.h"
+#include "autopas/AutoPas.h"
 #include "src/TypeDefinitions.h"
 
 /**
@@ -27,7 +25,7 @@ class RegularGrid final : public DomainDecomposition {
   * @param globalBoxMin The minimum coordinates of the global domain.
   * @param globalBoxMax The maximum coordinates of the global domain.
   */
-  RegularGrid(const int &dimensionCount, const std::vector<double> &globalBoxMin,
+  RegularGrid(int argc, char **argv, const int &dimensionCount, const std::vector<double> &globalBoxMin,
               const std::vector<double> &globalBoxMax);
 
   /**
@@ -122,11 +120,14 @@ class RegularGrid final : public DomainDecomposition {
    */
   int getDomainIndex() { return _domainIndex; }
 
+<<<<<<< Updated upstream
+=======
   /** 
    * Returns the number of domains in each dimension
    */
    std::vector<int> getDecomposition() { return _decomposition; }
 
+>>>>>>> Stashed changes
  private:
   /**
    * The number of dimensions in this decomposition.

--- a/examples/md-flexible/src/main.cpp
+++ b/examples/md-flexible/src/main.cpp
@@ -4,6 +4,8 @@
  * @author F. Gratl
  */
 
+#include "mpi.h"
+
 #include "simulations/MDFlexMPI.h"
 #include "simulations/MDFlexSingleRank.h"
 
@@ -14,8 +16,10 @@
  * @return
  */
 int main(int argc, char **argv) {
+  MPI_Init(&argc, &argv);
   MDFlexMPI simulation(3, argc, argv);
   simulation.run();
 
+  MPI_Finalize();
   return EXIT_SUCCESS;
 }

--- a/examples/md-flexible/src/simulations/MDFlexMPI.cpp
+++ b/examples/md-flexible/src/simulations/MDFlexMPI.cpp
@@ -48,7 +48,7 @@ void MDFlexMPI::initializeDomainDecomposition(int &dimensionCount) {
   std::vector<double> boxMin(_configuration->boxMin.value.begin(), _configuration->boxMin.value.end());
   std::vector<double> boxMax(_configuration->boxMax.value.begin(), _configuration->boxMax.value.end());
 
-  _domainDecomposition = std::make_shared<RegularGrid>(_argc, _argv, dimensionCount, boxMin, boxMax);
+  _domainDecomposition = std::make_shared<RegularGrid>(dimensionCount, boxMin, boxMax);
 
   std::vector<double> localBoxMin = _domainDecomposition->getLocalBoxMin();
   std::vector<double> localBoxMax = _domainDecomposition->getLocalBoxMax();

--- a/examples/md-flexible/src/simulations/MDFlexSimulation.cpp
+++ b/examples/md-flexible/src/simulations/MDFlexSimulation.cpp
@@ -273,9 +273,15 @@ void MDFlexSimulation::updateVelocities() {
 
   if (deltaT != 0) {
     _timers.velocityUpdate.start();
-    TimeDiscretization::calculateVelocities(*_autoPasContainer, particlePropertiesLibrary, deltaT, useThermostat,
-                                            _configuration->targetTemperature.value);
+    TimeDiscretization::calculateVelocities(*_autoPasContainer, particlePropertiesLibrary, deltaT);
     _timers.velocityUpdate.stop();
+  }
+}
+
+void MDFlexSimulation::updateThermostat() {
+  if(_configuration->useThermostat.value and (_iteration % _configuration->thermostatInterval.value) == 0){
+    Thermostat::apply(*_autoPasContainer, *(_configuration->getParticlePropertiesLibrary()),
+      _configuration->targetTemperature.value, _configuration->deltaTemp.value);
   }
 }
 

--- a/examples/md-flexible/src/simulations/MDFlexSimulation.h
+++ b/examples/md-flexible/src/simulations/MDFlexSimulation.h
@@ -133,7 +133,8 @@ class MDFlexSimulation {
 
   /**
    * Initializes the simulation.
-   * Call this function in the constructor of derived classes.
+   * This function needs to be called in the constructor of the deriving class, because initializeDomainDecomposition
+   * can not be called by the constructor of MDFlexSimulation, because it is a pure virtual function.
    */
   void initialize(int dimensionCount, int argc, char **argv);
 
@@ -181,6 +182,12 @@ class MDFlexSimulation {
    * Updates the velocities of particles in the local AutoPas container.
    */
   void updateVelocities();
+
+  /**
+   * Updates the thermostat of for the local domain.
+   * @todo The thermostat shoud act globally and therefore needs to be communicated to all processes.
+   */
+  void updateThermostat();
 
  private:
   /**

--- a/examples/md-flexible/src/simulations/MDFlexSingleRank.cpp
+++ b/examples/md-flexible/src/simulations/MDFlexSingleRank.cpp
@@ -13,7 +13,7 @@
 #include "src/Thermostat.h"
 
 MDFlexSingleRank::MDFlexSingleRank(int dimensionCount, int argc, char **argv) {
-  MDFlexSimulation::initialize(dimensionCount, argc, argv);
+    this->initialize(dimensionCount, argc, argv);
 }
 
 void MDFlexSingleRank::run() {
@@ -62,6 +62,7 @@ void MDFlexSingleRank::run() {
     }
 
     updateVelocities();
+    updateThermostat();
   }
 
   // final update for a full progress bar

--- a/examples/md-flexible/tests/CMakeLists.txt
+++ b/examples/md-flexible/tests/CMakeLists.txt
@@ -22,7 +22,7 @@ endforeach ()
 
 add_executable(mdFlexTests ${MDFlexTest_SRC})
 
-set(AUTOPAS_INCLUDE_MPI "$ENV{AUTOPAS_INCLUDE_MPI}")
+option(AUTOPAS_INCLUDE_MPI "Links MPI libraries to the target. This is required if you want to use MPI." ON)
 
 if (AUTOPAS_INTERNODE_TUNING OR AUTOPAS_INCLUDE_MPI)
     message(STATUS "AUTOPAS_INTERNODE_TUNING set, searching for mpi to link against md-flexible ...")

--- a/examples/md-flexible/tests/CMakeLists.txt
+++ b/examples/md-flexible/tests/CMakeLists.txt
@@ -22,6 +22,24 @@ endforeach ()
 
 add_executable(mdFlexTests ${MDFlexTest_SRC})
 
+set(AUTOPAS_INCLUDE_MPI "$ENV{AUTOPAS_INCLUDE_MPI}")
+
+if (AUTOPAS_INTERNODE_TUNING OR AUTOPAS_INCLUDE_MPI)
+    message(STATUS "AUTOPAS_INTERNODE_TUNING set, searching for mpi to link against md-flexible ...")
+    find_package(MPI)
+
+    if (NOT ${MPI_CXX_FOUND})
+        message(FATAL_ERROR "cxx mpi could not be found, even though AUTOPAS_INTERNODE_TUNING was set.")
+        target_link_libraries( mdFlexTests PUBLIC autopas autopasTools gmock yaml-cpp)
+    else ()
+        message(STATUS "cxx mpi found: ${MPI_CXX_COMPILER}")
+        target_link_libraries(mdFlexTests PUBLIC autopas autopasTools gmock yaml-cpp ${MPI_CXX_LIBRARIES})
+    endif ()
+else ()
+    message(STATUS "AUTOPAS_INTERNODE_TUNING not set, not linking MPI to md-flexible.")
+    target_link_libraries( mdFlexTests PUBLIC autopas autopasTools gmock yaml-cpp)
+endif (AUTOPAS_INTERNODE_TUNING OR AUTOPAS_INCLUDE_MPI)
+
 target_compile_definitions(
     mdFlexTests PRIVATE
     YAMLDIRECTORY=\"${PROJECT_SOURCE_DIR}/examples/md-flexible/tests/yamlTestFiles/\"
@@ -31,14 +49,6 @@ target_include_directories(
     PUBLIC ${PROJECT_SOURCE_DIR}/tests/testAutopas ${PROJECT_SOURCE_DIR}/examples/md-flexible
 )
 
-target_link_libraries(
-    mdFlexTests
-    PUBLIC
-        autopas
-        autopasTools
-        gmock # gmock includes the gtest target
-        yaml-cpp
-)
 
 # this cmake module was only introduced in 3.10
 include(GoogleTest)

--- a/src/autopas/selectors/Smoothing.h
+++ b/src/autopas/selectors/Smoothing.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstdlib>
 #include <tuple>
 #include <vector>
 


### PR DESCRIPTION
# Description
Implementation of the changes suggested in the last review of md-flex/cart-decomposition.
Some of the suggestions have been adapted slightly.
I created a separate function for updateThermostat.
Instead of using a environment variable in the CMakeLists, a cmake option is used to set AUTOPAS_INCLUDE_MPI.

Here is a very informal list of the suggestions:
* bottomLeftCorner issue
* Describe why you have to call initialize in the derived classes constructor
* this in Simulatinons constructor
* comment to updated velocities: mention the thermostat
* Remove synchronization in executeSiuperstep
* Halo size is cuttof + skin
* std::static_pointer_cast in getDomainDecomposition verwenden
* set environment variable rausscheissen -> uses cmake option now

# How Has This Been Tested?
By running the single rank md-flex falling drop scenario.
The fix for the tests will be pushed on a different branch along with some new tests.