### PR TITLE
deactivate traversalComparisonTests for globals == false

### DIFF
--- a/tests/testAutopas/tests/containers/TraversalComparison.cpp
+++ b/tests/testAutopas/tests/containers/TraversalComparison.cpp
@@ -275,7 +275,7 @@ auto TraversalComparison::getTestParams() {
               for (double cellSizeFactor : {0.5, 1., 2.}) {
                 for (auto numHalo : {/*0ul,*/ 200ul}) {
                   for (bool slightMove : {true, false}) {
-                    for (bool globals : {true, false}) {
+                    for (bool globals : {true, /*false*/}) {
                       for (DeletionPosition particleDeletionPosition :
                            {DeletionPosition::never, /*DeletionPosition::beforeLists, DeletionPosition::afterLists,*/
                             DeletionPosition::beforeAndAfterLists}) {


### PR DESCRIPTION
# Description

deactivate traversalComparisonTests for `globals == false` since it does not add any debugging information which globals == true does not already.

This reduces the amount of generated tests significantly and should speed up testing.

## ~Related Pull Requests~

## ~Resolved Issues~

# ~How Has This Been Tested?~
