### PR TITLE
Faster Particle Iteration in Octree

### DIFF
--- a/src/autopas/containers/octree/OctreeNodeWrapper.h
+++ b/src/autopas/containers/octree/OctreeNodeWrapper.h
@@ -183,11 +183,18 @@ class OctreeNodeWrapper : public ParticleCell<Particle> {
     // TODO(johannes): This needs severe improvement. If we just copy out all particles, the implementation becomes
     //  unsafe for threading. We need a way to iterate the octree using a better traversal idea.
     //  Referenced in https://github.com/AutoPas/AutoPas/issues/625
-    std::vector<Particle *> ps;
-    _pointer->appendAllParticles(ps);
+
+    lock.lock();
+    if(ps.empty() || index == 0) {
+      ps.clear();
+      _pointer->appendAllParticles(ps);
+    }
+    lock.unlock();
     return *ps[index];
   }
 
   std::unique_ptr<OctreeNodeInterface<Particle>> _pointer;
+  mutable std::vector<Particle *> ps;
+  mutable AutoPasLock lock;
 };
 }  // namespace autopas


### PR DESCRIPTION
# Description

As described in #625 in more detail, iterating the particles of the octree is very slow at the moment. This branch contains a "hack" that tries to fix the speed issues that arise from copying the particles at each access. Since the method is marked `const`, one cannot add a trivial member variable that contains an instance of a lock. However, marking a member variable as `mutable` makes it available even inside `const` methods. 

https://github.com/AutoPas/AutoPas/blob/c3d5511946ae707fe8b0c7155e2943295097de73/src/autopas/containers/octree/OctreeNodeWrapper.h#L197-L198

Now, the `getFromReloadingIterator` method can use the `mutable` field and is able to provide thread-safe particle caching for later access.

## Related Pull Requests

- Relates to the code of #610 

## Resolved Issues

- [ ] fixes #625

# How Has This Been Tested?

- [ ] Run the test suite in a parallel context
