### PR TITLE
Cleanup of MPI linkings

### DIFF
--- a/cmake/modules/autopas_mpi.cmake
+++ b/cmake/modules/autopas_mpi.cmake
@@ -1,11 +1,18 @@
 option(AUTOPAS_INTERNODE_TUNING "Activates distributed tuning in MPI parallel simulations" OFF)
 
+# messages first
 if (AUTOPAS_INTERNODE_TUNING)
-    message(STATUS "MPI enabled.")
-    find_package(MPI REQUIRED)
-    if (NOT ${MPI_CXX_FOUND})
-        message(FATAL_ERROR "cxx mpi could not be found")
-    endif ()
+    message(STATUS "Internode tuning enabled. Adding MPI.")
 else ()
-    message(STATUS "MPI disabled.")
+    message(STATUS "Internode tuning disabled.")
+endif ()
+
+if (MD_FLEXIBLE_USE_MPI)
+    message(STATUS "Adding MPI for md-flexible.")
+endif ()
+
+# actual action
+if (AUTOPAS_INTERNODE_TUNING OR MD_FLEXIBLE_USE_MPI)
+    find_package(MPI REQUIRED)
+    message(STATUS "MPI compiler found: ${MPI_CXX_COMPILER}")
 endif ()

--- a/examples/md-flexible/CMakeLists.txt
+++ b/examples/md-flexible/CMakeLists.txt
@@ -10,22 +10,7 @@ target_include_directories(md-flexible PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 include(autopas_yaml-cpp)
 
-option(AUTOPAS_INCLUDE_MPI "Enable this variable to use MPI." OFF)
-
-if (AUTOPAS_INCLUDE_MPI)
-    message(STATUS "AUTOPAS_INCLUDE_MPI set, searching for mpi to link against md-flexible ...")
-    find_package(MPI)
-
-    if (NOT ${MPI_CXX_FOUND})
-        message(FATAL_ERROR "cxx mpi could not be found, even though AUTOPAS_INCLUDE_MPI was set.")
-    else ()
-        message(STATUS "cxx mpi found: ${MPI_CXX_COMPILER}")
-        set(MD_FLEXIBLE_USE_MPI ON)
-        add_definitions(-DAUTOPAS_INCLUDE_MPI)
-    endif ()
-else ()
-    message(STATUS "AUTOPAS_INCLUDE_MPI not set, not linking MPI to md-flexible.")
-endif ()
+option(MD_FLEXIBLE_USE_MPI "Enable MPI parallelism for md-flexible." OFF)
 
 target_link_libraries(md-flexible PUBLIC autopas autopasTools yaml-cpp $<$<BOOL:${MD_FLEXIBLE_USE_MPI}>:MPI::MPI_CXX>)
 

--- a/examples/md-flexible/tests/CMakeLists.txt
+++ b/examples/md-flexible/tests/CMakeLists.txt
@@ -22,21 +22,6 @@ endforeach ()
 
 add_executable(mdFlexTests ${MDFlexTest_SRC})
 
-if (AUTOPAS_INCLUDE_MPI)
-    message(STATUS "AUTOPAS_INCLUDE_MPI set, searching for mpi to link against md-flexible ...")
-    find_package(MPI)
-
-    if (NOT ${MPI_CXX_FOUND})
-        message(FATAL_ERROR "cxx mpi could not be found, even though AUTOPAS_INCLUDE_MPI was set.")
-    else ()
-        message(STATUS "cxx mpi found: ${MPI_CXX_COMPILER}")
-        set(MD_FLEXIBLE_USE_MPI ON)
-        add_definitions(-DAUTOPAS_INCLUDE_MPI)
-    endif ()
-else ()
-    message(STATUS "AUTOPAS_INCLUDE_MPI not set, not linking MPI to md-flexible.")
-endif ()
-
 target_compile_definitions(
     mdFlexTests PRIVATE
     YAMLDIRECTORY=\"${PROJECT_SOURCE_DIR}/examples/md-flexible/tests/yamlTestFiles/\"

--- a/examples/sph-mpi/CMakeLists.txt
+++ b/examples/sph-mpi/CMakeLists.txt
@@ -5,14 +5,14 @@ file(
     "*.h"
 )
 
-message(STATUS "searching for mpi...")
+message(STATUS "sph-mpi: searching for mpi...")
 find_package(MPI)
 
 if (NOT ${MPI_CXX_FOUND})
-    message(STATUS "cxx mpi not found, not building sph-main-mpi")
+    message(STATUS "MPI compiler NOT found! Not building sph-main-mpi.")
     return()
 else ()
-    message(STATUS "cxx mpi found: ${MPI_CXX_COMPILER}")
+    message(STATUS "MPI compiler found: ${MPI_CXX_COMPILER}")
 endif ()
 
 include_directories(SYSTEM ${MPI_INCLUDE_PATH})

--- a/src/autopas/CMakeLists.txt
+++ b/src/autopas/CMakeLists.txt
@@ -14,21 +14,6 @@ file(
 
 add_library(autopas STATIC ${MY_SRC})
 
-if (AUTOPAS_INCLUDE_MPI)
-    message(STATUS "AUTOPAS_INCLUDE_MPI set, searching for mpi to link against md-flexible ...")
-    find_package(MPI)
-
-    if (NOT ${MPI_CXX_FOUND})
-        message(FATAL_ERROR "cxx mpi could not be found, even though AUTOPAS_INCLUDE_MPI was set.")
-    else ()
-        message(STATUS "cxx mpi found: ${MPI_CXX_COMPILER}")
-        set(AUTOPAS_INCLUDE_MPI ON)
-        add_definitions(-DAUTOPAS_INCLUDE_MPI)
-    endif ()
-else ()
-    message(STATUS "AUTOPAS_INCLUDE_MPI not set, not linking MPI to md-flexible.")
-endif ()
-
 target_link_libraries(
     autopas
     PUBLIC
@@ -36,7 +21,7 @@ target_link_libraries(
         ${CMAKE_THREAD_LIBS_INIT} # required for Logger and ExceptionHandler
         $<$<BOOL:${AUTOPAS_OPENMP}>:OpenMP::OpenMP_CXX>
         spdlog::spdlog
-        $<$<BOOL:${AUTOPAS_INCLUDE_MPI}>:MPI::MPI_CXX>
+        $<$<OR$<BOOL:${AUTOPAS_INTERNODE_TUNING}>,$<BOOL:${MD_FLEXIBLE_USE_MPI}>>:MPI::MPI_CXX>
     PRIVATE
         # harmony and Eigen3 are only needed privately when building AutoPas.
         harmony Eigen3
@@ -50,6 +35,7 @@ target_compile_definitions(
     $<$<BOOL:${AUTOPAS_OPENMP}>:AUTOPAS_OPENMP>
     $<$<NOT:$<BOOL:${AUTOPAS_OPENMP}>>:EIGEN_DONT_PARALLELIZE>
     $<$<BOOL:${AUTOPAS_INCLUDE_MPI}>:AUTOPAS_INCLUDE_MPI>
+    $<$<BOOL:${AUTOPAS_INTERNODE_TUNING}>:AUTOPAS_INTERNODE_TUNING>
     _USE_MATH_DEFINES
 )
 

--- a/src/autopas/CMakeLists.txt
+++ b/src/autopas/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(
         ${CMAKE_THREAD_LIBS_INIT} # required for Logger and ExceptionHandler
         $<$<BOOL:${AUTOPAS_OPENMP}>:OpenMP::OpenMP_CXX>
         spdlog::spdlog
-        $<$<OR$<BOOL:${AUTOPAS_INTERNODE_TUNING}>,$<BOOL:${MD_FLEXIBLE_USE_MPI}>>:MPI::MPI_CXX>
+        $<$<OR:$<BOOL:${AUTOPAS_INTERNODE_TUNING}>,$<BOOL:${MD_FLEXIBLE_USE_MPI}>>:MPI::MPI_CXX>
     PRIVATE
         # harmony and Eigen3 are only needed privately when building AutoPas.
         harmony Eigen3


### PR DESCRIPTION

# Description

Cleanup of MPI linkings:
 - [x] remove duplicate find_package(MPI) blocks
 - [x] more expressive log messages
 - [x] only add definitions to targets not globally

## Related Pull Requests

- merges into #597. If the former is merged into master before this one was merged (which I would be ok with) we need to point this one to master.

## ~Resolved Issues~

# How Has This Been Tested?

NOT YET! @J0llyver please test this and tick the box when you have.

- [ ] tested by @J0llyver 