### PR TITLE
Generic Particle::get() const

### DIFF
--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
@@ -87,9 +87,9 @@ class VerletListHelpers {
       if (soa.getNumParticles() == 0) return;
 
       auto **const __restrict ptrptr = soa.template begin<Particle::AttributeNames::ptr>();
-      double *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
-      double *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
-      double *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
+      const double *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
+      const double *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
+      const double *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
 
       size_t numPart = soa.getNumParticles();
       for (unsigned int i = 0; i < numPart; ++i) {
@@ -127,14 +127,14 @@ class VerletListHelpers {
       if (soa1.getNumParticles() == 0 || soa2.getNumParticles() == 0) return;
 
       auto **const __restrict ptr1ptr = soa1.template begin<Particle::AttributeNames::ptr>();
-      double *const __restrict x1ptr = soa1.template begin<Particle::AttributeNames::posX>();
-      double *const __restrict y1ptr = soa1.template begin<Particle::AttributeNames::posY>();
-      double *const __restrict z1ptr = soa1.template begin<Particle::AttributeNames::posZ>();
+      const double *const __restrict x1ptr = soa1.template begin<Particle::AttributeNames::posX>();
+      const double *const __restrict y1ptr = soa1.template begin<Particle::AttributeNames::posY>();
+      const double *const __restrict z1ptr = soa1.template begin<Particle::AttributeNames::posZ>();
 
       auto **const __restrict ptr2ptr = soa2.template begin<Particle::AttributeNames::ptr>();
-      double *const __restrict x2ptr = soa2.template begin<Particle::AttributeNames::posX>();
-      double *const __restrict y2ptr = soa2.template begin<Particle::AttributeNames::posY>();
-      double *const __restrict z2ptr = soa2.template begin<Particle::AttributeNames::posZ>();
+      const double *const __restrict x2ptr = soa2.template begin<Particle::AttributeNames::posX>();
+      const double *const __restrict y2ptr = soa2.template begin<Particle::AttributeNames::posY>();
+      const double *const __restrict z2ptr = soa2.template begin<Particle::AttributeNames::posZ>();
 
       size_t numPart1 = soa1.getNumParticles();
       for (unsigned int i = 0; i < numPart1; ++i) {

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -190,7 +190,7 @@ class VerletLists : public VerletListsLinkedBase<Particle> {
       _particlePtr2indexMap[&(*iter)] = index;
     }
     size_t accumulatedListSize = 0;
-    for (auto &[particlePtr, neighborPtrVector] : _aosNeighborLists) {
+    for (const auto &[particlePtr, neighborPtrVector] : _aosNeighborLists) {
       accumulatedListSize += neighborPtrVector.size();
       size_t i_id = _particlePtr2indexMap[particlePtr];
       // each soa neighbor list should be of the same size as for aos
@@ -219,7 +219,7 @@ class VerletLists : public VerletListsLinkedBase<Particle> {
    * Mapping of every particle, represented by its pointer, to an index.
    * The index indexes all particles in the container.
    */
-  std::unordered_map<Particle *, size_t> _particlePtr2indexMap;
+  std::unordered_map<const Particle *, size_t> _particlePtr2indexMap;
 
   /**
    * verlet list for SoA:

--- a/src/autopas/containers/verletListsCellBased/verletLists/traversals/VLTraversalInterface.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/traversals/VLTraversalInterface.h
@@ -34,8 +34,7 @@ class VLTraversalInterface {
    */
   virtual void setCellsAndNeighborLists(
       std::vector<LinkedParticleCell> &cells,
-      std::unordered_map<typename LinkedParticleCell::ParticleType *,
-                         std::vector<typename LinkedParticleCell::ParticleType *>> &aosNeighborLists,
+      typename VerletListHelpers<typename LinkedParticleCell::ParticleType>::NeighborListAoSType &aosNeighborLists,
       std::vector<std::vector<size_t, autopas::AlignedAllocator<size_t>>> &soaNeighborLists) {
     _cells = &cells;
     _aosNeighborLists = &aosNeighborLists;
@@ -50,8 +49,8 @@ class VLTraversalInterface {
   /**
    * The AoS neighbor list of the verlet lists container.
    */
-  std::unordered_map<typename LinkedParticleCell::ParticleType *,
-                     std::vector<typename LinkedParticleCell::ParticleType *>> *_aosNeighborLists = nullptr;
+  typename VerletListHelpers<typename LinkedParticleCell::ParticleType>::NeighborListAoSType *_aosNeighborLists =
+      nullptr;
   /**
    * The SoA neighbor list of the verlet lists container.
    */

--- a/src/autopas/molecularDynamics/MoleculeLJ.h
+++ b/src/autopas/molecularDynamics/MoleculeLJ.h
@@ -58,9 +58,9 @@ class MoleculeLJ final : public Particle {
    * @note The value of owned is return as floating point number (true = 1.0, false = 0.0).
    */
   template <AttributeNames attribute>
-  constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() {
+  constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() const {
     if constexpr (attribute == AttributeNames::ptr) {
-      return this;
+      return const_cast<typename std::tuple_element<attribute, SoAArraysType>::type::value_type>(this);
     } else if constexpr (attribute == AttributeNames::id) {
       return getID();
     } else if constexpr (attribute == AttributeNames::posX) {

--- a/src/autopas/molecularDynamics/MoleculeLJ.h
+++ b/src/autopas/molecularDynamics/MoleculeLJ.h
@@ -51,17 +51,19 @@ class MoleculeLJ final : public Particle {
                                        floatType /*z*/, floatType /*fx*/, floatType /*fy*/, floatType /*fz*/,
                                        size_t /*typeid*/, OwnershipState /*ownershipState*/>::Type;
 
+  template <AttributeNames attribute, std::enable_if_t<attribute == AttributeNames::ptr, bool> = true>
+  constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() {
+    return this;
+  }
   /**
    * Getter, which allows access to an attribute using the corresponding attribute name (defined in AttributeNames).
    * @tparam attribute Attribute name.
    * @return Value of the requested attribute.
    * @note The value of owned is return as floating point number (true = 1.0, false = 0.0).
    */
-  template <AttributeNames attribute>
+  template <AttributeNames attribute, std::enable_if_t<attribute != AttributeNames::ptr, bool> = true>
   constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() const {
-    if constexpr (attribute == AttributeNames::ptr) {
-      return const_cast<typename std::tuple_element<attribute, SoAArraysType>::type::value_type>(this);
-    } else if constexpr (attribute == AttributeNames::id) {
+    if constexpr (attribute == AttributeNames::id) {
       return getID();
     } else if constexpr (attribute == AttributeNames::posX) {
       return getR()[0];

--- a/src/autopas/molecularDynamics/MoleculeLJ.h
+++ b/src/autopas/molecularDynamics/MoleculeLJ.h
@@ -51,6 +51,11 @@ class MoleculeLJ final : public Particle {
                                        floatType /*z*/, floatType /*fx*/, floatType /*fy*/, floatType /*fz*/,
                                        size_t /*typeid*/, OwnershipState /*ownershipState*/>::Type;
 
+  /**
+   * Non-const getter for the pointer of this object.
+   * @tparam attribute Attribute name.
+   * @return this.
+   */
   template <AttributeNames attribute, std::enable_if_t<attribute == AttributeNames::ptr, bool> = true>
   constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() {
     return this;

--- a/src/autopas/particles/ParticleBase.h
+++ b/src/autopas/particles/ParticleBase.h
@@ -232,17 +232,20 @@ class ParticleBase {
                                        floatType /*y*/, floatType /*z*/, floatType /*fx*/, floatType /*fy*/,
                                        floatType /*fz*/, OwnershipState /*ownershipState*/>::Type;
 
+  template <AttributeNames attribute, std::enable_if_t<attribute == AttributeNames::ptr, bool> = true>
+  constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() {
+    return this;
+  }
+
   /**
    * Getter, which allows access to an attribute using the corresponding attribute name (defined in AttributeNames).
    * @tparam attribute Attribute name.
    * @return Value of the requested attribute.
    * @note The value of owned is return as floating point number (true = 1.0, false = 0.0).
    */
-  template <AttributeNames attribute>
+  template <AttributeNames attribute, std::enable_if_t<attribute != AttributeNames::ptr, bool> = true>
   constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() const {
-    if constexpr (attribute == AttributeNames::ptr) {
-      return const_cast<typename std::tuple_element<attribute, SoAArraysType>::type::value_type>(this);
-    } else if constexpr (attribute == AttributeNames::id) {
+    if constexpr (attribute == AttributeNames::id) {
       return getID();
     } else if constexpr (attribute == AttributeNames::posX) {
       return getR()[0];

--- a/src/autopas/particles/ParticleBase.h
+++ b/src/autopas/particles/ParticleBase.h
@@ -239,9 +239,9 @@ class ParticleBase {
    * @note The value of owned is return as floating point number (true = 1.0, false = 0.0).
    */
   template <AttributeNames attribute>
-  constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() {
+  constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() const {
     if constexpr (attribute == AttributeNames::ptr) {
-      return this;
+      return const_cast<typename std::tuple_element<attribute, SoAArraysType>::type::value_type>(this);
     } else if constexpr (attribute == AttributeNames::id) {
       return getID();
     } else if constexpr (attribute == AttributeNames::posX) {

--- a/src/autopas/particles/ParticleBase.h
+++ b/src/autopas/particles/ParticleBase.h
@@ -232,6 +232,11 @@ class ParticleBase {
                                        floatType /*y*/, floatType /*z*/, floatType /*fx*/, floatType /*fy*/,
                                        floatType /*fz*/, OwnershipState /*ownershipState*/>::Type;
 
+  /**
+   * Non-const getter for the pointer of this object.
+   * @tparam attribute Attribute name.
+   * @return this.
+   */
   template <AttributeNames attribute, std::enable_if_t<attribute == AttributeNames::ptr, bool> = true>
   constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() {
     return this;

--- a/src/autopas/sph/SPHParticle.h
+++ b/src/autopas/sph/SPHParticle.h
@@ -413,9 +413,9 @@ class SPHParticle : public autopas::Particle {
    * @return Value of the requested attribute.
    */
   template <AttributeNames attribute>
-  constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() {
+  constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() const {
     if constexpr (attribute == AttributeNames::ptr) {
-      return this;
+      return const_cast<typename std::tuple_element<attribute, SoAArraysType>::type::value_type>(this);
     } else if constexpr (attribute == AttributeNames::mass) {
       return getMass();
     } else if constexpr (attribute == AttributeNames::posX) {

--- a/src/autopas/sph/SPHParticle.h
+++ b/src/autopas/sph/SPHParticle.h
@@ -407,16 +407,19 @@ class SPHParticle : public autopas::Particle {
       autopas::utils::SoAType<SPHParticle *, double, double, double, double, double, double, double, double, double,
                               double, double, double, double, double, double, double, OwnershipState>::Type;
 
+  template <AttributeNames attribute, std::enable_if_t<attribute == AttributeNames::ptr, bool> = true>
+  constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() {
+    return this;
+  }
+
   /**
    * Getter, which allows access to an attribute using the corresponding attribute name (defined in AttributeNames).
    * @tparam attribute Attribute name.
    * @return Value of the requested attribute.
    */
-  template <AttributeNames attribute>
+  template <AttributeNames attribute, std::enable_if_t<attribute != AttributeNames::ptr, bool> = true>
   constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() const {
-    if constexpr (attribute == AttributeNames::ptr) {
-      return const_cast<typename std::tuple_element<attribute, SoAArraysType>::type::value_type>(this);
-    } else if constexpr (attribute == AttributeNames::mass) {
+    if constexpr (attribute == AttributeNames::mass) {
       return getMass();
     } else if constexpr (attribute == AttributeNames::posX) {
       return getR()[0];

--- a/src/autopas/sph/SPHParticle.h
+++ b/src/autopas/sph/SPHParticle.h
@@ -407,6 +407,11 @@ class SPHParticle : public autopas::Particle {
       autopas::utils::SoAType<SPHParticle *, double, double, double, double, double, double, double, double, double,
                               double, double, double, double, double, double, double, OwnershipState>::Type;
 
+  /**
+   * Non-const getter for the pointer of this object.
+   * @tparam attribute Attribute name.
+   * @return this.
+   */
   template <AttributeNames attribute, std::enable_if_t<attribute == AttributeNames::ptr, bool> = true>
   constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() {
     return this;

--- a/tests/testAutopas/testingHelpers/NonConstructibleParticle.h
+++ b/tests/testAutopas/testingHelpers/NonConstructibleParticle.h
@@ -38,9 +38,9 @@ class NonConstructibleParticle : public autopas::Particle {
    * @note The value of owned is return as floating point number (true = 1.0, false = 0.0).
    */
   template <AttributeNames attribute>
-  constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() {
+  constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() const {
     if constexpr (attribute == AttributeNames::ptr) {
-      return this;
+      return const_cast<typename std::tuple_element<attribute, SoAArraysType>::type::value_type>(this);
     } else if constexpr (attribute == AttributeNames::id) {
       return getID();
     } else if constexpr (attribute == AttributeNames::posX) {

--- a/tests/testAutopas/testingHelpers/NonConstructibleParticle.h
+++ b/tests/testAutopas/testingHelpers/NonConstructibleParticle.h
@@ -31,6 +31,11 @@ class NonConstructibleParticle : public autopas::Particle {
                                        double /*z*/, double /*fx*/, double /*fy*/, double /*fz*/,
                                        autopas::OwnershipState /*ownershipState*/>::Type;
 
+  /**
+   * Non-const getter for the pointer of this object.
+   * @tparam attribute Attribute name.
+   * @return this.
+   */
   template <AttributeNames attribute, std::enable_if_t<attribute == AttributeNames::ptr, bool> = true>
   constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() {
     return this;

--- a/tests/testAutopas/testingHelpers/NonConstructibleParticle.h
+++ b/tests/testAutopas/testingHelpers/NonConstructibleParticle.h
@@ -31,17 +31,20 @@ class NonConstructibleParticle : public autopas::Particle {
                                        double /*z*/, double /*fx*/, double /*fy*/, double /*fz*/,
                                        autopas::OwnershipState /*ownershipState*/>::Type;
 
+  template <AttributeNames attribute, std::enable_if_t<attribute == AttributeNames::ptr, bool> = true>
+  constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() {
+    return this;
+  }
+
   /**
    * Getter, which allows access to an attribute using the corresponding attribute name (defined in AttributeNames).
    * @tparam attribute Attribute name.
    * @return Value of the requested attribute.
    * @note The value of owned is return as floating point number (true = 1.0, false = 0.0).
    */
-  template <AttributeNames attribute>
+  template <AttributeNames attribute, std::enable_if_t<attribute != AttributeNames::ptr, bool> = true>
   constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() const {
-    if constexpr (attribute == AttributeNames::ptr) {
-      return const_cast<typename std::tuple_element<attribute, SoAArraysType>::type::value_type>(this);
-    } else if constexpr (attribute == AttributeNames::id) {
+    if constexpr (attribute == AttributeNames::id) {
       return getID();
     } else if constexpr (attribute == AttributeNames::posX) {
       return getR()[0];


### PR DESCRIPTION
# Description

- Make generic `Particle::get()` `const`
- ~needs `const` cast on this ptr as we use it non-const~
- Introduce non-const getter for this

Although the second point seems a bit hacky the overall result seems to be more const-correct than before.

## ~Related Pull Requests~

## ~Resolved Issues~

# How Has This Been Tested?