### PR TITLE
Md flex/halo particle fix

### DIFF
--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -122,8 +122,8 @@ void RegularGridDecomposition::exchangeHaloParticles(SharedAutoPasContainer &aut
       std::vector<ParticleType> particlesForLeftNeighbour, particlesForRightNeighbour;
       std::array<double, _dimensionCount> haloBoxMin, haloBoxMax;
       if (j == i) {
-        haloBoxMin = {_localBoxMin[0] - _skinWidth, _localBoxMin[1] - _skinWidth, _localBoxMin[2] - _skinWidth};
         for (int k = 0; k < _dimensionCount; ++k) {
+          haloBoxMin[k] = _localBoxMin[k] - _skinWidth;
           haloBoxMax[k] = _skinWidth + _localBoxMax[k];
         }
         haloBoxMax[dimensionIndex] = _localBoxMin[dimensionIndex] + _cutoffWidth + _skinWidth;
@@ -144,9 +144,9 @@ void RegularGridDecomposition::exchangeHaloParticles(SharedAutoPasContainer &aut
 
         for (int k = 0; k < _dimensionCount; ++k) {
           haloBoxMin[k] = _localBoxMax[k] - _skinWidth - (_localBoxMax[k] - _localBoxMin[k]);
+          haloBoxMax[k] = _localBoxMax[k] + _skinWidth;
         }
         haloBoxMin[dimensionIndex] = _localBoxMax[dimensionIndex] - _cutoffWidth - _skinWidth;
-        haloBoxMax = {_localBoxMax[0] + _skinWidth, _localBoxMax[1] + _skinWidth, _localBoxMax[2] + _skinWidth};
 
         for (auto particleIterator =
                  autoPasContainer->getRegionIterator(haloBoxMin, haloBoxMax, autopas::IteratorBehavior::owned);

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -124,15 +124,15 @@ void RegularGridDecomposition::exchangeHaloParticles(SharedAutoPasContainer &aut
       if (j == i) {
         haloBoxMin = {_localBoxMin[0] - _skinWidth, _localBoxMin[1] - _skinWidth, _localBoxMin[2] - _skinWidth};
         for (int k = 0; k < _dimensionCount; ++k) {
-          haloBoxMax[k] = _localBoxMin[k] + _skinWidth + (_localBoxMax[k] - _localBoxMin[k]);
+          haloBoxMax[k] =  _skinWidth + _localBoxMax[k];
         }
         haloBoxMax[dimensionIndex] = _localBoxMin[dimensionIndex] + _cutoffWidth + _skinWidth;
 
-        for (auto particle =
+        for (auto particleIterator =
                  autoPasContainer->getRegionIterator(haloBoxMin, haloBoxMax, autopas::IteratorBehavior::owned);
-             particle.isValid(); ++particle) {
-          std::array<double, _dimensionCount> position = particle->getR();
-          particlesForLeftNeighbour.push_back(*particle);
+             particleIterator.isValid(); ++particleIterator) {
+          std::array<double, _dimensionCount> position = particleIterator->getR();
+          particlesForLeftNeighbour.push_back(*particleIterator);
 
           // Apply boundary condition
           if (_localBoxMin[dimensionIndex] == _globalBoxMin[dimensionIndex]) {
@@ -148,11 +148,11 @@ void RegularGridDecomposition::exchangeHaloParticles(SharedAutoPasContainer &aut
         haloBoxMin[dimensionIndex] = _localBoxMax[dimensionIndex] - _cutoffWidth - _skinWidth;
         haloBoxMax = {_localBoxMax[0] + _skinWidth, _localBoxMax[1] + _skinWidth, _localBoxMax[2] + _skinWidth};
 
-        for (auto particle =
+        for (auto particleIterator =
                  autoPasContainer->getRegionIterator(haloBoxMin, haloBoxMax, autopas::IteratorBehavior::owned);
-             particle.isValid(); ++particle) {
-          std::array<double, _dimensionCount> position = particle->getR();
-          particlesForRightNeighbour.push_back(*particle);
+             particleIterator.isValid(); ++particleIterator) {
+          std::array<double, _dimensionCount> position = particleIterator->getR();
+          particlesForRightNeighbour.push_back(*particleIterator);
 
           // Apply boundary condition
           if (_localBoxMax[dimensionIndex] == _globalBoxMax[dimensionIndex]) {
@@ -170,7 +170,7 @@ void RegularGridDecomposition::exchangeHaloParticles(SharedAutoPasContainer &aut
 
       for (const auto &particle : haloParticles) {
         std::array<double, _dimensionCount> position = particle.getR();
-        if (position[dimensionIndex] >= leftHaloMin && position[dimensionIndex] < leftHaloMax) {
+        if (position[dimensionIndex] >= leftHaloMin and position[dimensionIndex] < leftHaloMax) {
           particlesForLeftNeighbour.push_back(particle);
 
           // Apply boundary condition
@@ -179,7 +179,7 @@ void RegularGridDecomposition::exchangeHaloParticles(SharedAutoPasContainer &aut
                 position[dimensionIndex] + (_globalBoxMax[dimensionIndex] - _globalBoxMin[dimensionIndex]);
             particlesForLeftNeighbour.back().setR(position);
           }
-        } else if (position[dimensionIndex] >= rightHaloMin && position[dimensionIndex] < rightHaloMax) {
+        } else if (position[dimensionIndex] >= rightHaloMin and position[dimensionIndex] < rightHaloMax) {
           particlesForRightNeighbour.push_back(particle);
 
           // Apply boundary condition
@@ -217,7 +217,7 @@ void RegularGridDecomposition::exchangeMigratingParticles(SharedAutoPasContainer
       for (int j = i; j < _dimensionCount; ++j) {
         const size_t dimensionIndex = j % _dimensionCount;
 
-        std::vector<ParticleType> immigrants, migrants, remainingEmigrants;
+        std::vector<ParticleType> immigrants, remainingEmigrants;
         std::vector<ParticleType> particlesForLeftNeighbour;
         std::vector<ParticleType> particlesForRightNeighbour;
 
@@ -260,7 +260,7 @@ void RegularGridDecomposition::exchangeMigratingParticles(SharedAutoPasContainer
           if (isInsideLocalDomain(particle.getR())) {
             autoPasContainer->addParticle(particle);
           } else {
-            migrants.push_back(particle);
+            emigrants.push_back(particle);
           }
         }
 
@@ -318,7 +318,7 @@ void RegularGridDecomposition::sendAndReceiveParticlesLeftAndRight(const std::ve
                                                                    const std::vector<ParticleType> &particlesToRight,
                                                                    const int &leftNeighbour, const int &rightNeighbour,
                                                                    std::vector<ParticleType> &receivedParticles) {
-  if (_mpiIsEnabled && leftNeighbour != _domainIndex) {
+  if (_mpiIsEnabled and leftNeighbour != _domainIndex) {
     sendParticles(particlesToLeft, leftNeighbour);
     sendParticles(particlesToRight, rightNeighbour);
 

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -124,7 +124,7 @@ void RegularGridDecomposition::exchangeHaloParticles(SharedAutoPasContainer &aut
       if (j == i) {
         haloBoxMin = {_localBoxMin[0] - _skinWidth, _localBoxMin[1] - _skinWidth, _localBoxMin[2] - _skinWidth};
         for (int k = 0; k < _dimensionCount; ++k) {
-          haloBoxMax[k] =  _skinWidth + _localBoxMax[k];
+          haloBoxMax[k] = _skinWidth + _localBoxMax[k];
         }
         haloBoxMax[dimensionIndex] = _localBoxMin[dimensionIndex] + _cutoffWidth + _skinWidth;
 

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -121,44 +121,40 @@ void RegularGridDecomposition::exchangeHaloParticles(SharedAutoPasContainer &aut
 
       std::vector<ParticleType> particlesForLeftNeighbour, particlesForRightNeighbour;
       std::array<double, _dimensionCount> haloBoxMin, haloBoxMax;
-
-      haloBoxMin = {_localBoxMin[0] - _skinWidth, _localBoxMin[1] - _skinWidth, _localBoxMin[2] - _skinWidth};
-      for (int k = 0; k < _dimensionCount; ++k) {
-        haloBoxMax[k] = _localBoxMin[k] + _skinWidth + (_localBoxMax[k] - _localBoxMin[k]);
-      }
-      haloBoxMax[dimensionIndex] = _localBoxMin[dimensionIndex] + _cutoffWidth + _skinWidth;
-      //std::cout << "HaloBoxes: " << autopas::utils::ArrayUtils::to_string(haloBoxMin) << ", " << autopas::utils::ArrayUtils::to_string(haloBoxMax) << std::endl;
-
-      for (auto particle = autoPasContainer->getRegionIterator(haloBoxMin, haloBoxMax, autopas::IteratorBehavior::owned);
-           particle.isValid(); ++particle) {
-      //  std::cout << "OwnedParticle: " << particle->getID() << std::endl;
-        std::array<double, _dimensionCount> position = particle->getR();
-        particlesForLeftNeighbour.push_back(*particle);
-
-        // Apply boundary condition
-        if (_localBoxMin[dimensionIndex] == _globalBoxMin[dimensionIndex]) {
-          position[dimensionIndex] = position[dimensionIndex] + (_globalBoxMax[dimensionIndex] - _globalBoxMin[dimensionIndex]);
-          particlesForLeftNeighbour.back().setR(position);
+      if (j == i) {
+        haloBoxMin = {_localBoxMin[0] - _skinWidth, _localBoxMin[1] - _skinWidth, _localBoxMin[2] - _skinWidth};
+        for (int k = 0; k < _dimensionCount; ++k) {
+          haloBoxMax[k] = _localBoxMin[k] + _skinWidth + (_localBoxMax[k] - _localBoxMin[k]);
         }
-      }
+        haloBoxMax[dimensionIndex] = _localBoxMin[dimensionIndex] + _cutoffWidth + _skinWidth;
 
-      for (int k = 0; k < _dimensionCount; ++k) {
-        haloBoxMin[k] = _localBoxMax[k] - _skinWidth - (_localBoxMax[k] - _localBoxMin[k]);
-      }
-      haloBoxMin[dimensionIndex] = _localBoxMax[dimensionIndex] - _cutoffWidth - _skinWidth;
-      haloBoxMax = {_localBoxMax[0] + _skinWidth, _localBoxMax[1] + _skinWidth, _localBoxMax[2] + _skinWidth};
-     // std::cout << "HaloBoxes: " << autopas::utils::ArrayUtils::to_string(haloBoxMin) << ", " << autopas::utils::ArrayUtils::to_string(haloBoxMax) << std::endl;
+        for (auto particle = autoPasContainer->getRegionIterator(haloBoxMin, haloBoxMax, autopas::IteratorBehavior::owned);
+             particle.isValid(); ++particle) {
+          std::array<double, _dimensionCount> position = particle->getR(); particlesForLeftNeighbour.push_back(*particle);
 
-      for (auto particle = autoPasContainer->getRegionIterator(haloBoxMin, haloBoxMax, autopas::IteratorBehavior::owned);
-           particle.isValid(); ++particle) {
-    //    std::cout << "OwnedParticle: " << particle->getID() << std::endl;
-        std::array<double, _dimensionCount> position = particle->getR();
-        particlesForRightNeighbour.push_back(*particle);
+          // Apply boundary condition
+          if (_localBoxMin[dimensionIndex] == _globalBoxMin[dimensionIndex]) {
+            position[dimensionIndex] = position[dimensionIndex] + (_globalBoxMax[dimensionIndex] - _globalBoxMin[dimensionIndex]);
+            particlesForLeftNeighbour.back().setR(position);
+          }
+        }
 
-        // Apply boundary condition
-        if (_localBoxMax[dimensionIndex] == _globalBoxMax[dimensionIndex]) {
-          position[dimensionIndex] = position[dimensionIndex] - (_globalBoxMax[dimensionIndex] - _globalBoxMin[dimensionIndex]);
-          particlesForRightNeighbour.back().setR(position);
+        for (int k = 0; k < _dimensionCount; ++k) {
+          haloBoxMin[k] = _localBoxMax[k] - _skinWidth - (_localBoxMax[k] - _localBoxMin[k]);
+        }
+        haloBoxMin[dimensionIndex] = _localBoxMax[dimensionIndex] - _cutoffWidth - _skinWidth;
+        haloBoxMax = {_localBoxMax[0] + _skinWidth, _localBoxMax[1] + _skinWidth, _localBoxMax[2] + _skinWidth};
+
+        for (auto particle = autoPasContainer->getRegionIterator(haloBoxMin, haloBoxMax, autopas::IteratorBehavior::owned);
+             particle.isValid(); ++particle) {
+          std::array<double, _dimensionCount> position = particle->getR();
+          particlesForRightNeighbour.push_back(*particle);
+
+          // Apply boundary condition
+          if (_localBoxMax[dimensionIndex] == _globalBoxMax[dimensionIndex]) {
+            position[dimensionIndex] = position[dimensionIndex] - (_globalBoxMax[dimensionIndex] - _globalBoxMin[dimensionIndex]);
+            particlesForRightNeighbour.back().setR(position);
+          }
         }
       }
 

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -128,13 +128,16 @@ void RegularGridDecomposition::exchangeHaloParticles(SharedAutoPasContainer &aut
         }
         haloBoxMax[dimensionIndex] = _localBoxMin[dimensionIndex] + _cutoffWidth + _skinWidth;
 
-        for (auto particle = autoPasContainer->getRegionIterator(haloBoxMin, haloBoxMax, autopas::IteratorBehavior::owned);
+        for (auto particle =
+                 autoPasContainer->getRegionIterator(haloBoxMin, haloBoxMax, autopas::IteratorBehavior::owned);
              particle.isValid(); ++particle) {
-          std::array<double, _dimensionCount> position = particle->getR(); particlesForLeftNeighbour.push_back(*particle);
+          std::array<double, _dimensionCount> position = particle->getR();
+          particlesForLeftNeighbour.push_back(*particle);
 
           // Apply boundary condition
           if (_localBoxMin[dimensionIndex] == _globalBoxMin[dimensionIndex]) {
-            position[dimensionIndex] = position[dimensionIndex] + (_globalBoxMax[dimensionIndex] - _globalBoxMin[dimensionIndex]);
+            position[dimensionIndex] =
+                position[dimensionIndex] + (_globalBoxMax[dimensionIndex] - _globalBoxMin[dimensionIndex]);
             particlesForLeftNeighbour.back().setR(position);
           }
         }
@@ -145,14 +148,16 @@ void RegularGridDecomposition::exchangeHaloParticles(SharedAutoPasContainer &aut
         haloBoxMin[dimensionIndex] = _localBoxMax[dimensionIndex] - _cutoffWidth - _skinWidth;
         haloBoxMax = {_localBoxMax[0] + _skinWidth, _localBoxMax[1] + _skinWidth, _localBoxMax[2] + _skinWidth};
 
-        for (auto particle = autoPasContainer->getRegionIterator(haloBoxMin, haloBoxMax, autopas::IteratorBehavior::owned);
+        for (auto particle =
+                 autoPasContainer->getRegionIterator(haloBoxMin, haloBoxMax, autopas::IteratorBehavior::owned);
              particle.isValid(); ++particle) {
           std::array<double, _dimensionCount> position = particle->getR();
           particlesForRightNeighbour.push_back(*particle);
 
           // Apply boundary condition
           if (_localBoxMax[dimensionIndex] == _globalBoxMax[dimensionIndex]) {
-            position[dimensionIndex] = position[dimensionIndex] - (_globalBoxMax[dimensionIndex] - _globalBoxMin[dimensionIndex]);
+            position[dimensionIndex] =
+                position[dimensionIndex] - (_globalBoxMax[dimensionIndex] - _globalBoxMin[dimensionIndex]);
             particlesForRightNeighbour.back().setR(position);
           }
         }
@@ -170,7 +175,8 @@ void RegularGridDecomposition::exchangeHaloParticles(SharedAutoPasContainer &aut
 
           // Apply boundary condition
           if (_localBoxMin[dimensionIndex] == _globalBoxMin[dimensionIndex]) {
-            position[dimensionIndex] = position[dimensionIndex] + (_globalBoxMax[dimensionIndex] - _globalBoxMin[dimensionIndex]);
+            position[dimensionIndex] =
+                position[dimensionIndex] + (_globalBoxMax[dimensionIndex] - _globalBoxMin[dimensionIndex]);
             particlesForLeftNeighbour.back().setR(position);
           }
         } else if (position[dimensionIndex] >= rightHaloMin && position[dimensionIndex] < rightHaloMax) {
@@ -178,7 +184,8 @@ void RegularGridDecomposition::exchangeHaloParticles(SharedAutoPasContainer &aut
 
           // Apply boundary condition
           if (_localBoxMax[dimensionIndex] == _globalBoxMax[dimensionIndex]) {
-            position[dimensionIndex] = position[dimensionIndex] - (_globalBoxMax[dimensionIndex] - _globalBoxMin[dimensionIndex]);
+            position[dimensionIndex] =
+                position[dimensionIndex] - (_globalBoxMax[dimensionIndex] - _globalBoxMin[dimensionIndex]);
             particlesForRightNeighbour.back().setR(position);
           }
         }
@@ -186,7 +193,7 @@ void RegularGridDecomposition::exchangeHaloParticles(SharedAutoPasContainer &aut
 
       // See documentation for _neighbourDomainIndices to explain the indexing
       int leftNeighbour = _neighbourDomainIndices[(dimensionIndex * 2) % _neighbourCount];
-      int rightNeighbour = _neighbourDomainIndices[(dimensionIndex  * 2 + 1) % _neighbourCount];
+      int rightNeighbour = _neighbourDomainIndices[(dimensionIndex * 2 + 1) % _neighbourCount];
       sendAndReceiveParticlesLeftAndRight(particlesForLeftNeighbour, particlesForRightNeighbour, leftNeighbour,
                                           rightNeighbour, haloParticles);
     }
@@ -213,29 +220,31 @@ void RegularGridDecomposition::exchangeMigratingParticles(SharedAutoPasContainer
         std::vector<ParticleType> immigrants, migrants, remainingEmigrants;
         std::vector<ParticleType> particlesForLeftNeighbour;
         std::vector<ParticleType> particlesForRightNeighbour;
-  
+
         // See documentation for _neighbourDomainIndices to explain the indexing
         int leftNeighbour = _neighbourDomainIndices[(dimensionIndex * 2) % _neighbourCount];
         int rightNeighbour = _neighbourDomainIndices[(dimensionIndex * 2 + 1) % _neighbourCount];
-  
+
         std::array<double, _dimensionCount> position;
         for (const auto &particle : emigrants) {
           position = particle.getR();
           if (position[dimensionIndex] < _localBoxMin[dimensionIndex]) {
             particlesForLeftNeighbour.push_back(particle);
-  
+
             // Apply boundary condition
             if (_localBoxMin[dimensionIndex] == _globalBoxMin[dimensionIndex]) {
               position[dimensionIndex] =
-                  std::min(std::nextafter(_globalBoxMax[dimensionIndex], _globalBoxMin[dimensionIndex]), position[dimensionIndex] + globalBoxLength[dimensionIndex]);
+                  std::min(std::nextafter(_globalBoxMax[dimensionIndex], _globalBoxMin[dimensionIndex]),
+                           position[dimensionIndex] + globalBoxLength[dimensionIndex]);
               particlesForLeftNeighbour.back().setR(position);
             }
           } else if (position[dimensionIndex] >= _localBoxMax[dimensionIndex]) {
             particlesForRightNeighbour.push_back(particle);
-  
+
             // Apply boundary condition
             if (_localBoxMax[dimensionIndex] == _globalBoxMax[dimensionIndex]) {
-              position[dimensionIndex] = std::max(_globalBoxMin[dimensionIndex], position[dimensionIndex] - globalBoxLength[dimensionIndex]);
+              position[dimensionIndex] =
+                  std::max(_globalBoxMin[dimensionIndex], position[dimensionIndex] - globalBoxLength[dimensionIndex]);
               particlesForRightNeighbour.back().setR(position);
             }
           } else {
@@ -243,10 +252,10 @@ void RegularGridDecomposition::exchangeMigratingParticles(SharedAutoPasContainer
           }
         }
         emigrants = remainingEmigrants;
-  
+
         sendAndReceiveParticlesLeftAndRight(particlesForLeftNeighbour, particlesForRightNeighbour, leftNeighbour,
                                             rightNeighbour, immigrants);
-  
+
         for (const auto &particle : immigrants) {
           if (isInsideLocalDomain(particle.getR())) {
             autoPasContainer->addParticle(particle);
@@ -254,7 +263,7 @@ void RegularGridDecomposition::exchangeMigratingParticles(SharedAutoPasContainer
             migrants.push_back(particle);
           }
         }
-  
+
         immigrants.clear();
       }
     }

--- a/examples/md-flexible/tests/domainDecomposition/DomainToolsTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/DomainToolsTest.cpp
@@ -1,13 +1,13 @@
 /**
- * @file TestDomainTools.cpp
+ * @file DomainToolsTest.cpp
  * @author J. Körner
  * @date 27/05/21
  */
-#include "TestDomainTools.h"
+#include "DomainToolsTest.h"
 
 #include "src/domainDecomposition/DomainTools.h"
 
-TEST_F(TestDomainTools, testIsInsideDomain) {
+TEST_F(DomainToolsTest, testIsInsideDomain) {
   std::array<double, 3> globalBoxMin = {1.0, 1.0, 1.0};
   std::array<double, 3> globalBoxMax = {10.0, 10.0, 10.0};
 

--- a/examples/md-flexible/tests/domainDecomposition/DomainToolsTest.h
+++ b/examples/md-flexible/tests/domainDecomposition/DomainToolsTest.h
@@ -1,5 +1,5 @@
 /**
- * @file TestDomainTools.h
+ * @file DomainToolsTest.h
  * @author J. Körner
  * @date 27/05/21
  */
@@ -12,10 +12,10 @@
 /**
  * Test class for the DomainTools class.
  */
-class TestDomainTools : public AutoPasTestBase {
+class DomainToolsTest : public AutoPasTestBase {
  public:
   /**
    * Constructor.
    */
-  TestDomainTools() = default;
+  DomainToolsTest() = default;
 };

--- a/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
@@ -147,6 +147,7 @@ TEST_F(RegularGridDecompositionTest, testExchangeHaloParticles) {
       {-2.725, 8.5, 12.725},    {1.5, 8.5, 12.725},       {5, 8.5, 12.725},      {8.5, 8.5, 12.725},
       {12.725, 8.5, 12.725},    {-2.725, 12.725, 12.725}, {1.5, 12.725, 12.725}, {5, 12.725, 12.725},
       {8.5, 12.725, 12.725},    {12.725, 12.725, 12.725}};
+
   const size_t haloParticleCount = autoPasContainer->getNumberOfParticles(autopas::IteratorBehavior::halo);
 
   EXPECT_EQ(haloParticleCount, expectedHaloParticlePositions.size());

--- a/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
@@ -122,7 +122,7 @@ TEST_F(RegularGridDecompositionTest, testExchangeHaloParticles) {
   const size_t haloParticleCount = autoPasContainer->getNumberOfParticles(autopas::IteratorBehavior::halo);
 
   // The resulting haloParticleCount has to be 98 because, the 8 corner particles have to be replicated 7 times each,
-  // resulting in 56 halo particles resulting in 56 halo particles for the corner cells. The 12 particles contained
+  // resulting in 56 halo particles for the corner cells. The 12 particles contained
   // in the edge cells of the rubik's cube need to be replicated 3 times each raising the total number of halo particles
   // to 90. The remaining 6 particles with a single adjacent cell only produce a single halo particle each.
   // Therefor the total amount of particles is 98.

--- a/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
@@ -97,14 +97,11 @@ TEST_F(RegularGridDecompositionTest, testExchangeHaloParticles) {
   // 12 particles with two adjacent cells which are outside the cube and 6 particles with a single adjacent cell
   // outside the cube.
   std::vector<std::vector<double>> particlePositions = {
-      {1.5, 1.5, 1.5}, {5.0, 1.5, 1.5}, {8.5, 1.5, 1.5}, {1.5, 5.0, 1.5}, {5.0, 5.0, 1.5},
-      {8.5, 5.0, 1.5}, {1.5, 8.5, 1.5}, {5.0, 8.5, 1.5}, {8.5, 8.5, 1.5},
-
-      {1.5, 1.5, 5.0}, {5.0, 1.5, 5.0}, {8.5, 1.5, 5.0}, {1.5, 5.0, 5.0}, {5.0, 5.0, 5.0},
-      {8.5, 5.0, 5.0}, {1.5, 8.5, 5.0}, {5.0, 8.5, 5.0}, {8.5, 8.5, 5.0},
-
-      {1.5, 1.5, 8.5}, {5.0, 1.5, 8.5}, {8.5, 1.5, 8.5}, {1.5, 5.0, 8.5}, {5.0, 5.0, 8.5},
-      {8.5, 5.0, 8.5}, {1.5, 8.5, 8.5}, {5.0, 8.5, 8.5}, {8.5, 8.5, 8.5}};
+      {1.5, 1.5, 1.5}, {5.0, 1.5, 1.5}, {8.5, 1.5, 1.5}, {1.5, 5.0, 1.5}, {5.0, 5.0, 1.5}, {8.5, 5.0, 1.5},
+      {1.5, 8.5, 1.5}, {5.0, 8.5, 1.5}, {8.5, 8.5, 1.5}, {1.5, 1.5, 5.0}, {5.0, 1.5, 5.0}, {8.5, 1.5, 5.0},
+      {1.5, 5.0, 5.0}, {5.0, 5.0, 5.0}, {8.5, 5.0, 5.0}, {1.5, 8.5, 5.0}, {5.0, 8.5, 5.0}, {8.5, 8.5, 5.0},
+      {1.5, 1.5, 8.5}, {5.0, 1.5, 8.5}, {8.5, 1.5, 8.5}, {1.5, 5.0, 8.5}, {5.0, 5.0, 8.5}, {8.5, 5.0, 8.5},
+      {1.5, 8.5, 8.5}, {5.0, 8.5, 8.5}, {8.5, 8.5, 8.5}};
 
   size_t id = 0;
   for (const auto position : particlePositions) {
@@ -119,14 +116,50 @@ TEST_F(RegularGridDecompositionTest, testExchangeHaloParticles) {
 
   EXPECT_NO_THROW(domainDecomposition.exchangeHaloParticles(autoPasContainer));
 
-  const size_t haloParticleCount = autoPasContainer->getNumberOfParticles(autopas::IteratorBehavior::halo);
-
   // The resulting haloParticleCount has to be 98 because, the 8 corner particles have to be replicated 7 times each,
   // resulting in 56 halo particles for the corner cells. The 12 particles contained
   // in the edge cells of the rubik's cube need to be replicated 3 times each raising the total number of halo particles
   // to 90. The remaining 6 particles with a single adjacent cell only produce a single halo particle each.
   // Therefor the total amount of particles is 98.
-  EXPECT_EQ(haloParticleCount, 98);
+  std::vector<std::vector<double>> expectedHaloParticlePositions = {
+      {-2.725, -2.725, -2.725}, {1.5, -2.725, -2.725},    {5, -2.725, -2.725},   {8.5, -2.725, -2.725},
+      {12.725, -2.725, -2.725}, {-2.725, 1.5, -2.725},    {1.5, 1.5, -2.725},    {5, 1.5, -2.725},
+      {8.5, 1.5, -2.725},       {12.725, 1.5, -2.725},    {-2.725, 5, -2.725},   {1.5, 5, -2.725},
+      {5, 5, -2.725},           {8.5, 5, -2.725},         {12.725, 5, -2.725},   {-2.725, 8.5, -2.725},
+      {1.5, 8.5, -2.725},       {5, 8.5, -2.725},         {8.5, 8.5, -2.725},    {12.725, 8.5, -2.725},
+      {-2.725, 12.725, -2.725}, {1.5, 12.725, -2.725},    {5, 12.725, -2.725},   {8.5, 12.725, -2.725},
+      {12.725, 12.725, -2.725}, {-2.725, -2.725, 1.5},    {1.5, -2.725, 1.5},    {5, -2.725, 1.5},
+      {8.5, -2.725, 1.5},       {12.725, -2.725, 1.5},    {-2.725, 1.5, 1.5},    {12.725, 1.5, 1.5},
+      {-2.725, 5, 1.5},         {12.725, 5, 1.5},         {-2.725, 8.5, 1.5},    {12.725, 8.5, 1.5},
+      {-2.725, 12.725, 1.5},    {1.5, 12.725, 1.5},       {5, 12.725, 1.5},      {8.5, 12.725, 1.5},
+      {12.725, 12.725, 1.5},    {-2.725, -2.725, 5},      {1.5, -2.725, 5},      {5, -2.725, 5},
+      {8.5, -2.725, 5},         {12.725, -2.725, 5},      {-2.725, 1.5, 5},      {12.725, 1.5, 5},
+      {-2.725, 5, 5},           {12.725, 5, 5},           {-2.725, 8.5, 5},      {12.725, 8.5, 5},
+      {-2.725, 12.725, 5},      {1.5, 12.725, 5},         {5, 12.725, 5},        {8.5, 12.725, 5},
+      {12.725, 12.725, 5},      {-2.725, -2.725, 8.5},    {1.5, -2.725, 8.5},    {5, -2.725, 8.5},
+      {8.5, -2.725, 8.5},       {12.725, -2.725, 8.5},    {-2.725, 1.5, 8.5},    {12.725, 1.5, 8.5},
+      {-2.725, 5, 8.5},         {12.725, 5, 8.5},         {-2.725, 8.5, 8.5},    {12.725, 8.5, 8.5},
+      {-2.725, 12.725, 8.5},    {1.5, 12.725, 8.5},       {5, 12.725, 8.5},      {8.5, 12.725, 8.5},
+      {12.725, 12.725, 8.5},    {-2.725, -2.725, 12.725}, {1.5, -2.725, 12.725}, {5, -2.725, 12.725},
+      {8.5, -2.725, 12.725},    {12.725, -2.725, 12.725}, {-2.725, 1.5, 12.725}, {1.5, 1.5, 12.725},
+      {5, 1.5, 12.725},         {8.5, 1.5, 12.725},       {12.725, 1.5, 12.725}, {-2.725, 5, 12.725},
+      {1.5, 5, 12.725},         {5, 5, 12.725},           {8.5, 5, 12.725},      {12.725, 5, 12.725},
+      {-2.725, 8.5, 12.725},    {1.5, 8.5, 12.725},       {5, 8.5, 12.725},      {8.5, 8.5, 12.725},
+      {12.725, 8.5, 12.725},    {-2.725, 12.725, 12.725}, {1.5, 12.725, 12.725}, {5, 12.725, 12.725},
+      {8.5, 12.725, 12.725},    {12.725, 12.725, 12.725}};
+  const size_t haloParticleCount = autoPasContainer->getNumberOfParticles(autopas::IteratorBehavior::halo);
+
+  EXPECT_EQ(haloParticleCount, expectedHaloParticlePositions.size());
+
+  size_t index = 0;
+  for (auto particle = autoPasContainer->begin(autopas::IteratorBehavior::halo); particle.isValid(); ++particle) {
+    const auto particlePosition = particle->getR();
+    EXPECT_NEAR(particlePosition[0], expectedHaloParticlePositions[index][0], 1e-13);
+    EXPECT_NEAR(particlePosition[1], expectedHaloParticlePositions[index][1], 1e-13);
+    EXPECT_NEAR(particlePosition[2], expectedHaloParticlePositions[index][2], 1e-13);
+
+    ++index;
+  }
 }
 
 /**
@@ -154,14 +187,11 @@ TEST_F(RegularGridDecompositionTest, testExchangeMigratingParticles) {
 
   // Setup 27 particles. Imagine a rubik's cube where each cell contains a single particle.
   std::vector<std::vector<double>> particlePositions = {
-      {1.5, 1.5, 1.5}, {5.0, 1.5, 1.5}, {8.5, 1.5, 1.5}, {1.5, 5.0, 1.5}, {5.0, 5.0, 1.5},
-      {8.5, 5.0, 1.5}, {1.5, 8.5, 1.5}, {5.0, 8.5, 1.5}, {8.5, 8.5, 1.5},
-
-      {1.5, 1.5, 5.0}, {5.0, 1.5, 5.0}, {8.5, 1.5, 5.0}, {1.5, 5.0, 5.0}, {5.0, 5.0, 5.0},
-      {8.5, 5.0, 5.0}, {1.5, 8.5, 5.0}, {5.0, 8.5, 5.0}, {8.5, 8.5, 5.0},
-
-      {1.5, 1.5, 8.5}, {5.0, 1.5, 8.5}, {8.5, 1.5, 8.5}, {1.5, 5.0, 8.5}, {5.0, 5.0, 8.5},
-      {8.5, 5.0, 8.5}, {1.5, 8.5, 8.5}, {5.0, 8.5, 8.5}, {8.5, 8.5, 8.5}};
+      {1.5, 1.5, 1.5}, {5.0, 1.5, 1.5}, {8.5, 1.5, 1.5}, {1.5, 5.0, 1.5}, {5.0, 5.0, 1.5}, {8.5, 5.0, 1.5},
+      {1.5, 8.5, 1.5}, {5.0, 8.5, 1.5}, {8.5, 8.5, 1.5}, {1.5, 1.5, 5.0}, {5.0, 1.5, 5.0}, {8.5, 1.5, 5.0},
+      {1.5, 5.0, 5.0}, {5.0, 5.0, 5.0}, {8.5, 5.0, 5.0}, {1.5, 8.5, 5.0}, {5.0, 8.5, 5.0}, {8.5, 8.5, 5.0},
+      {1.5, 1.5, 8.5}, {5.0, 1.5, 8.5}, {8.5, 1.5, 8.5}, {1.5, 5.0, 8.5}, {5.0, 5.0, 8.5}, {8.5, 5.0, 8.5},
+      {1.5, 8.5, 8.5}, {5.0, 8.5, 8.5}, {8.5, 8.5, 8.5}};
 
   size_t id = 0;
   for (const auto position : particlePositions) {

--- a/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
@@ -124,7 +124,7 @@ TEST_F(RegularGridDecompositionTest, testExchangeHaloParticles) {
   // The resulting haloParticleCount has to be 98 because, the 8 corner particles have to be replicated 7 times each,
   // resulting in 56 halo particles for the corner cells. The 12 particles contained
   // in the edge cells of the rubik's cube need to be replicated 3 times each raising the total number of halo particles
-  // to 90. The remaining 6 particles with a single adjacent cell only produce a single halo particle each.
+  // to 90. The remaining 8 particles with a single adjacent cell only produce a single halo particle each.
   // Therefor the total amount of particles is 98.
   EXPECT_EQ(haloParticleCount, 98);
 }

--- a/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
@@ -124,7 +124,7 @@ TEST_F(RegularGridDecompositionTest, testExchangeHaloParticles) {
   // The resulting haloParticleCount has to be 98 because, the 8 corner particles have to be replicated 7 times each,
   // resulting in 56 halo particles for the corner cells. The 12 particles contained
   // in the edge cells of the rubik's cube need to be replicated 3 times each raising the total number of halo particles
-  // to 90. The remaining 8 particles with a single adjacent cell only produce a single halo particle each.
+  // to 90. The remaining 6 particles with a single adjacent cell only produce a single halo particle each.
   // Therefor the total amount of particles is 98.
   EXPECT_EQ(haloParticleCount, 98);
 }

--- a/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
@@ -92,10 +92,10 @@ TEST_F(RegularGridDecompositionTest, testExchangeHaloParticles) {
 
   initializeAutoPasContainer(autoPasContainer, configuration);
 
-  // Setup 27 particles of which 26 will be relevant during halo update. Imagine a rubik's cube where each cell 
+  // Setup 27 particles of which 26 will be relevant during halo update. Imagine a rubik's cube where each cell
   // contains a single particle. This layout contains 8 particles with 3 adjacent cell which is outside the cube,
-  // 12 particles with two adjacent cells which are outside the cube and 6 particles with a single adjacent cell 
-  // outside the cube. 
+  // 12 particles with two adjacent cells which are outside the cube and 6 particles with a single adjacent cell
+  // outside the cube.
   std::vector<std::vector<double>> particlePositions = {
       {1.5, 1.5, 1.5}, {5.0, 1.5, 1.5}, {8.5, 1.5, 1.5}, {1.5, 5.0, 1.5}, {5.0, 5.0, 1.5},
       {8.5, 5.0, 1.5}, {1.5, 8.5, 1.5}, {5.0, 8.5, 1.5}, {8.5, 8.5, 1.5},
@@ -174,7 +174,7 @@ TEST_F(RegularGridDecompositionTest, testExchangeMigratingParticles) {
     ++id;
   }
 
-  // Move particles outside the simulation box to make them migrate. 
+  // Move particles outside the simulation box to make them migrate.
   // Particles in corner cells (of the rubik's cube) will be moved diagonally in all dimensions.
   // Particles in edge cells will be sifted diagonally in two dimiensions.
   // Particles in surface cells which are neither a corner nor a edge will be moved along a single dimension.
@@ -202,34 +202,13 @@ TEST_F(RegularGridDecompositionTest, testExchangeMigratingParticles) {
   EXPECT_NO_THROW(domainDecomposition.exchangeMigratingParticles(autoPasContainer));
 
   std::vector<std::array<double, 3>> expectedPositionsAfterMigration = {
-    {9.725, 9.725, 9.725},
-    {5, 9.725, 9.725},
-    {0.275, 9.725, 9.725},
-    {9.725, 5, 9.725},
-    {5, 5, 9.725},
-    {0.275, 5, 9.725},
-    {9.725, 0.275, 9.725},
-    {5, 0.275, 9.725},
-    {0.275, 0.275, 9.725},
-    {9.725, 9.725, 5},
-    {5, 9.725, 5},
-    {0.275, 9.725, 5},
-    {9.725, 5, 5},
-    {5, 5, 5},
-    {0.275, 5, 5},
-    {9.725, 0.275, 5},
-    {5, 0.275, 5},
-    {0.275, 0.275, 5},
-    {9.725, 9.725, 0.275},
-    {5, 9.725, 0.275},
-    {0.275, 9.725, 0.275},
-    {9.725, 5, 0.275},
-    {5, 5, 0.275},
-    {0.275, 5, 0.275},
-    {9.725, 0.275, 0.275},
-    {5, 0.275, 0.275},
-    {0.275, 0.275, 0.275}
-  };
+      {9.725, 9.725, 9.725}, {5, 9.725, 9.725}, {0.275, 9.725, 9.725}, {9.725, 5, 9.725},
+      {5, 5, 9.725},         {0.275, 5, 9.725}, {9.725, 0.275, 9.725}, {5, 0.275, 9.725},
+      {0.275, 0.275, 9.725}, {9.725, 9.725, 5}, {5, 9.725, 5},         {0.275, 9.725, 5},
+      {9.725, 5, 5},         {5, 5, 5},         {0.275, 5, 5},         {9.725, 0.275, 5},
+      {5, 0.275, 5},         {0.275, 0.275, 5}, {9.725, 9.725, 0.275}, {5, 9.725, 0.275},
+      {0.275, 9.725, 0.275}, {9.725, 5, 0.275}, {5, 5, 0.275},         {0.275, 5, 0.275},
+      {9.725, 0.275, 0.275}, {5, 0.275, 0.275}, {0.275, 0.275, 0.275}};
 
   for (auto particle = autoPasContainer->begin(autopas::IteratorBehavior::owned); particle.isValid(); ++particle) {
     const auto id = particle->getID();

--- a/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.h
+++ b/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.h
@@ -1,5 +1,5 @@
 /**
- * @file TestRegularGridDecomposition.h
+ * @file RegularGridDecompositionTest.h
  * @author J. Körner
  * @date 27/05/21
  */
@@ -12,10 +12,10 @@
 /**
  * Test class for the RegularGridDecomposition domain decomposition class.
  */
-class TestRegularGridDecomposition : public AutoPasTestBase {
+class RegularGridDecompositionTest : public AutoPasTestBase {
  public:
   /**
    * Constructor.
    */
-  TestRegularGridDecomposition() = default;
+  RegularGridDecompositionTest() = default;
 };

--- a/examples/md-flexible/tests/domainDecomposition/TestRegularGridDecomposition.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/TestRegularGridDecomposition.cpp
@@ -75,9 +75,6 @@ TEST_F(TestRegularGridDecomposition, testExchangeHaloParticles) {
   char *argv[3] = {arguments[0].data(), arguments[1].data(), arguments[2].data()};
 
   MDFlexConfig configuration(3, argv);
-  std::cout << "Configuration: " << configuration.cutoff.value << ", " << configuration.verletSkinRadius.value << std::endl;
-  std::cout << "BoxMin: " << autopas::utils::ArrayUtils::to_string(configuration.boxMin.value) << std::endl;
-  std::cout << "BoxMax: " << autopas::utils::ArrayUtils::to_string(configuration.boxMax.value) << std::endl;
 
   std::array<double, 3> localBoxMin = configuration.boxMin.value;
   std::array<double, 3> localBoxMax = configuration.boxMax.value;

--- a/examples/md-flexible/tests/domainDecomposition/TestRegularGridDecomposition.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/TestRegularGridDecomposition.cpp
@@ -121,6 +121,7 @@ TEST_F(TestRegularGridDecomposition, testExchangeHaloParticles) {
 
   const size_t haloParticleCount = autoPasContainer->getNumberOfParticles(autopas::IteratorBehavior::halo);
   EXPECT_EQ(haloParticleCount,98);
+  EXPECT_EQ(true,false);
 }
 
 TEST_F(TestRegularGridDecomposition, testExchangeMigratingParticles) {

--- a/examples/md-flexible/tests/domainDecomposition/TestRegularGridDecomposition.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/TestRegularGridDecomposition.cpp
@@ -70,7 +70,8 @@ TEST_F(TestRegularGridDecomposition, testGetLocalDomain) {
 }
 
 TEST_F(TestRegularGridDecomposition, testExchangeHaloParticles) {
-  std::vector<std::string> arguments = {"md-flexible", "--yaml-filename", std::string(YAMLDIRECTORY) + "particleExchangeTest.yaml"};
+  std::vector<std::string> arguments = {"md-flexible", "--yaml-filename",
+                                        std::string(YAMLDIRECTORY) + "particleExchangeTest.yaml"};
 
   char *argv[3] = {arguments[0].data(), arguments[1].data(), arguments[2].data()};
 
@@ -79,45 +80,43 @@ TEST_F(TestRegularGridDecomposition, testExchangeHaloParticles) {
   std::array<double, 3> localBoxMin = configuration.boxMin.value;
   std::array<double, 3> localBoxMax = configuration.boxMax.value;
 
-  RegularGridDecomposition domainDecomposition(configuration.boxMin.value, configuration.boxMax.value, configuration.cutoff.value, configuration.verletSkinRadius.value);
+  RegularGridDecomposition domainDecomposition(configuration.boxMin.value, configuration.boxMax.value,
+                                               configuration.cutoff.value, configuration.verletSkinRadius.value);
 
   auto autoPasContainer = std::make_shared<autopas::AutoPas<ParticleType>>(std::cout);
 
   initializeAutoPasContainer(autoPasContainer, configuration);
 
   std::vector<std::vector<double>> particlePositions = {
-    {1.5, 1.5, 1.5}, {5.0, 1.5, 1.5}, {8.5, 1.5,  1.5},
-    {1.5, 5.0, 1.5}, {5.0, 5.0, 1.5}, {8.5, 5.0,  1.5},
-    {1.5, 8.5, 1.5}, {5.0, 8.5, 1.5}, {8.5, 8.5,  1.5},
+      {1.5, 1.5, 1.5}, {5.0, 1.5, 1.5}, {8.5, 1.5, 1.5}, {1.5, 5.0, 1.5}, {5.0, 5.0, 1.5},
+      {8.5, 5.0, 1.5}, {1.5, 8.5, 1.5}, {5.0, 8.5, 1.5}, {8.5, 8.5, 1.5},
 
-    {1.5, 1.5, 5.0}, {5.0, 1.5, 5.0}, {8.5, 1.5,  5.0},
-    {1.5, 5.0, 5.0}, {5.0, 5.0, 5.0}, {8.5, 5.0,  5.0},
-    {1.5, 8.5, 5.0}, {5.0, 8.5, 5.0}, {8.5, 8.5,  5.0},
+      {1.5, 1.5, 5.0}, {5.0, 1.5, 5.0}, {8.5, 1.5, 5.0}, {1.5, 5.0, 5.0}, {5.0, 5.0, 5.0},
+      {8.5, 5.0, 5.0}, {1.5, 8.5, 5.0}, {5.0, 8.5, 5.0}, {8.5, 8.5, 5.0},
 
-    {1.5, 1.5, 8.5}, {5.0, 1.5, 8.5}, {8.5, 1.5,  8.5},
-    {1.5, 5.0, 8.5}, {5.0, 5.0, 8.5}, {8.5, 5.0,  8.5},
-    {1.5, 8.5, 8.5}, {5.0, 8.5, 8.5}, {8.5, 8.5,  8.5}
-  };
-  
+      {1.5, 1.5, 8.5}, {5.0, 1.5, 8.5}, {8.5, 1.5, 8.5}, {1.5, 5.0, 8.5}, {5.0, 5.0, 8.5},
+      {8.5, 5.0, 8.5}, {1.5, 8.5, 8.5}, {5.0, 8.5, 8.5}, {8.5, 8.5, 8.5}};
+
   size_t id = 0;
   for (const auto position : particlePositions) {
-      ParticleType particle;
-      particle.setID(id);
-      particle.setR({position[0], position[1], position[2]});
+    ParticleType particle;
+    particle.setID(id);
+    particle.setR({position[0], position[1], position[2]});
 
-      autoPasContainer->addParticle(particle);
+    autoPasContainer->addParticle(particle);
 
-      ++id;
+    ++id;
   }
 
   EXPECT_NO_THROW(domainDecomposition.exchangeHaloParticles(autoPasContainer));
 
   const size_t haloParticleCount = autoPasContainer->getNumberOfParticles(autopas::IteratorBehavior::halo);
-  EXPECT_EQ(haloParticleCount,98);
+  EXPECT_EQ(haloParticleCount, 98);
 }
 
 TEST_F(TestRegularGridDecomposition, testExchangeMigratingParticles) {
-  std::vector<std::string> arguments = {"md-flexible", "--yaml-filename", std::string(YAMLDIRECTORY) + "particleExchangeTest.yaml"};
+  std::vector<std::string> arguments = {"md-flexible", "--yaml-filename",
+                                        std::string(YAMLDIRECTORY) + "particleExchangeTest.yaml"};
 
   char *argv[3] = {arguments[0].data(), arguments[1].data(), arguments[2].data()};
 
@@ -126,56 +125,49 @@ TEST_F(TestRegularGridDecomposition, testExchangeMigratingParticles) {
   std::array<double, 3> localBoxMin = configuration.boxMin.value;
   std::array<double, 3> localBoxMax = configuration.boxMax.value;
 
-  RegularGridDecomposition domainDecomposition(configuration.boxMin.value, configuration.boxMax.value, configuration.cutoff.value, configuration.verletSkinRadius.value);
+  RegularGridDecomposition domainDecomposition(configuration.boxMin.value, configuration.boxMax.value,
+                                               configuration.cutoff.value, configuration.verletSkinRadius.value);
 
   auto autoPasContainer = std::make_shared<autopas::AutoPas<ParticleType>>(std::cout);
 
   initializeAutoPasContainer(autoPasContainer, configuration);
 
   std::vector<std::vector<double>> particlePositions = {
-    {1.5, 1.5, 1.5}, {5.0, 1.5, 1.5}, {8.5, 1.5,  1.5},
-    {1.5, 5.0, 1.5}, {5.0, 5.0, 1.5}, {8.5, 5.0,  1.5},
-    {1.5, 8.5, 1.5}, {5.0, 8.5, 1.5}, {8.5, 8.5,  1.5},
+      {1.5, 1.5, 1.5}, {5.0, 1.5, 1.5}, {8.5, 1.5, 1.5}, {1.5, 5.0, 1.5}, {5.0, 5.0, 1.5},
+      {8.5, 5.0, 1.5}, {1.5, 8.5, 1.5}, {5.0, 8.5, 1.5}, {8.5, 8.5, 1.5},
 
-    {1.5, 1.5, 5.0}, {5.0, 1.5, 5.0}, {8.5, 1.5,  5.0},
-    {1.5, 5.0, 5.0}, {5.0, 5.0, 5.0}, {8.5, 5.0,  5.0},
-    {1.5, 8.5, 5.0}, {5.0, 8.5, 5.0}, {8.5, 8.5,  5.0},
+      {1.5, 1.5, 5.0}, {5.0, 1.5, 5.0}, {8.5, 1.5, 5.0}, {1.5, 5.0, 5.0}, {5.0, 5.0, 5.0},
+      {8.5, 5.0, 5.0}, {1.5, 8.5, 5.0}, {5.0, 8.5, 5.0}, {8.5, 8.5, 5.0},
 
-    {1.5, 1.5, 8.5}, {5.0, 1.5, 8.5}, {8.5, 1.5,  8.5},
-    {1.5, 5.0, 8.5}, {5.0, 5.0, 8.5}, {8.5, 5.0,  8.5},
-    {1.5, 8.5, 8.5}, {5.0, 8.5, 8.5}, {8.5, 8.5,  8.5}
-  };
-  
+      {1.5, 1.5, 8.5}, {5.0, 1.5, 8.5}, {8.5, 1.5, 8.5}, {1.5, 5.0, 8.5}, {5.0, 5.0, 8.5},
+      {8.5, 5.0, 8.5}, {1.5, 8.5, 8.5}, {5.0, 8.5, 8.5}, {8.5, 8.5, 8.5}};
+
   size_t id = 0;
   for (const auto position : particlePositions) {
-      ParticleType particle;
-      particle.setID(id);
-      particle.setR({position[0], position[1], position[2]});
+    ParticleType particle;
+    particle.setID(id);
+    particle.setR({position[0], position[1], position[2]});
 
-      autoPasContainer->addParticle(particle);
+    autoPasContainer->addParticle(particle);
 
-      ++id;
+    ++id;
   }
-
 
   for (auto particle = autoPasContainer->begin(autopas::IteratorBehavior::owned); particle.isValid(); ++particle) {
     auto position = particle->getR();
     if (position[0] < 2.5) {
       position[0] -= 3.0;
-    }
-    else if (position[0] > 7.5) {
+    } else if (position[0] > 7.5) {
       position[0] += 3.0;
     }
     if (position[1] < 2.5) {
       position[1] -= 3.0;
-    }
-    else if (position[1] > 7.5) {
+    } else if (position[1] > 7.5) {
       position[1] += 3.0;
     }
     if (position[2] < 2.5) {
       position[2] -= 3.0;
-    }
-    else if (position[2] > 7.5) {
+    } else if (position[2] > 7.5) {
       position[2] += 3.0;
     }
     particle->setR(position);

--- a/examples/md-flexible/tests/domainDecomposition/TestRegularGridDecomposition.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/TestRegularGridDecomposition.cpp
@@ -70,7 +70,7 @@ TEST_F(TestRegularGridDecomposition, testGetLocalDomain) {
 }
 
 TEST_F(TestRegularGridDecomposition, testExchangeHaloParticles) {
-  std::vector<std::string> arguments = {"md-flexible", "--yaml-filename", std::string(YAMLDIRECTORY) + "haloParticleTest.yaml"};
+  std::vector<std::string> arguments = {"md-flexible", "--yaml-filename", std::string(YAMLDIRECTORY) + "particleExchangeTest.yaml"};
 
   char *argv[3] = {arguments[0].data(), arguments[1].data(), arguments[2].data()};
 
@@ -112,46 +112,73 @@ TEST_F(TestRegularGridDecomposition, testExchangeHaloParticles) {
 
   EXPECT_NO_THROW(domainDecomposition.exchangeHaloParticles(autoPasContainer));
 
-  for (auto particle = autoPasContainer->begin(autopas::IteratorBehavior::halo); particle.isValid(); ++particle) {
-    std::cout << particle->getID() << ", " << autopas::utils::ArrayUtils::to_string(particle->getR()) << std::endl;
-  }
-
   const size_t haloParticleCount = autoPasContainer->getNumberOfParticles(autopas::IteratorBehavior::halo);
   EXPECT_EQ(haloParticleCount,98);
-  EXPECT_EQ(true,false);
 }
 
 TEST_F(TestRegularGridDecomposition, testExchangeMigratingParticles) {
-  std::vector<std::string> arguments = {"md-flexible", "--yaml-filename", std::string(YAMLDIRECTORY) + "cubeGrid.yaml"};
+  std::vector<std::string> arguments = {"md-flexible", "--yaml-filename", std::string(YAMLDIRECTORY) + "particleExchangeTest.yaml"};
 
   char *argv[3] = {arguments[0].data(), arguments[1].data(), arguments[2].data()};
+
   MDFlexConfig configuration(3, argv);
 
-  std::array<double, 3> globalBoxMin = {1.0, 1.0, 1.0};
-  std::array<double, 3> globalBoxMax = {10.0, 10.0, 10.0};
+  std::array<double, 3> localBoxMin = configuration.boxMin.value;
+  std::array<double, 3> localBoxMax = configuration.boxMax.value;
 
-  RegularGridDecomposition domainDecomposition(globalBoxMin, globalBoxMax, 0, 0);
-
-  std::array<double, 3> localBoxMin = domainDecomposition.getLocalBoxMin();
-  std::array<double, 3> localBoxMax = domainDecomposition.getLocalBoxMax();
-  for (int i = 0; i < localBoxMin.size(); ++i) {
-    configuration.boxMin.value[i] = localBoxMin[i];
-    configuration.boxMax.value[i] = localBoxMax[i];
-  }
+  RegularGridDecomposition domainDecomposition(configuration.boxMin.value, configuration.boxMax.value, configuration.cutoff.value, configuration.verletSkinRadius.value);
 
   auto autoPasContainer = std::make_shared<autopas::AutoPas<ParticleType>>(std::cout);
 
   initializeAutoPasContainer(autoPasContainer, configuration);
 
-  for (auto &particle : configuration.getParticles()) {
-    if (domainDecomposition.isInsideLocalDomain(particle.getR())) {
+  std::vector<std::vector<double>> particlePositions = {
+    {1.5, 1.5, 1.5}, {5.0, 1.5, 1.5}, {8.5, 1.5,  1.5},
+    {1.5, 5.0, 1.5}, {5.0, 5.0, 1.5}, {8.5, 5.0,  1.5},
+    {1.5, 8.5, 1.5}, {5.0, 8.5, 1.5}, {8.5, 8.5,  1.5},
+
+    {1.5, 1.5, 5.0}, {5.0, 1.5, 5.0}, {8.5, 1.5,  5.0},
+    {1.5, 5.0, 5.0}, {5.0, 5.0, 5.0}, {8.5, 5.0,  5.0},
+    {1.5, 8.5, 5.0}, {5.0, 8.5, 5.0}, {8.5, 8.5,  5.0},
+
+    {1.5, 1.5, 8.5}, {5.0, 1.5, 8.5}, {8.5, 1.5,  8.5},
+    {1.5, 5.0, 8.5}, {5.0, 5.0, 8.5}, {8.5, 5.0,  8.5},
+    {1.5, 8.5, 8.5}, {5.0, 8.5, 8.5}, {8.5, 8.5,  8.5}
+  };
+  
+  size_t id = 0;
+  for (const auto position : particlePositions) {
+      ParticleType particle;
+      particle.setID(id);
+      particle.setR({position[0], position[1], position[2]});
+
       autoPasContainer->addParticle(particle);
-    }
+
+      ++id;
   }
 
+
   for (auto particle = autoPasContainer->begin(autopas::IteratorBehavior::owned); particle.isValid(); ++particle) {
-    std::array<double, 3> deltaPosition({0.01, 0.0, 0.0});
-    particle->addR(deltaPosition);
+    auto position = particle->getR();
+    if (position[0] < 2.5) {
+      position[0] -= 3.0;
+    }
+    else if (position[0] > 7.5) {
+      position[0] += 3.0;
+    }
+    if (position[1] < 2.5) {
+      position[1] -= 3.0;
+    }
+    else if (position[1] > 7.5) {
+      position[1] += 3.0;
+    }
+    if (position[2] < 2.5) {
+      position[2] -= 3.0;
+    }
+    else if (position[2] > 7.5) {
+      position[2] += 3.0;
+    }
+    particle->setR(position);
   }
 
   EXPECT_NO_THROW(domainDecomposition.exchangeMigratingParticles(autoPasContainer));

--- a/examples/md-flexible/tests/yamlTestFiles/haloParticleTest.yaml
+++ b/examples/md-flexible/tests/yamlTestFiles/haloParticleTest.yaml
@@ -1,8 +1,0 @@
-#yaml input for an empty configuration
-#used in:
-#TestRegularGridDecomposition.testExchangeHaloParticles
-#YamlParser
-cutoff                    : 3
-verlet-skin-radius        : 0
-box-min                   : [0,0,0]
-box-max                   : [9,9,9]

--- a/examples/md-flexible/tests/yamlTestFiles/haloParticleTest.yaml
+++ b/examples/md-flexible/tests/yamlTestFiles/haloParticleTest.yaml
@@ -1,0 +1,8 @@
+#yaml input for an empty configuration
+#used in:
+#TestRegularGridDecomposition.testExchangeHaloParticles
+#YamlParser
+cutoff                    : 3
+verlet-skin-radius        : 0
+box-min                   : [0,0,0]
+box-max                   : [9,9,9]

--- a/examples/md-flexible/tests/yamlTestFiles/particleExchangeTest.yaml
+++ b/examples/md-flexible/tests/yamlTestFiles/particleExchangeTest.yaml
@@ -1,0 +1,9 @@
+#yaml input for an empty configuration
+#used in:
+#TestRegularGridDecomposition.testExchangeHaloParticles
+#TestRegularGridDecomposition.testExchangeMigratingParticles
+#YamlParser
+cutoff                    : 3
+verlet-skin-radius        : 0
+box-min                   : [0,0,0]
+box-max                   : [9,9,9]


### PR DESCRIPTION
# Description
Halo- and Migrating-Particle-Exchange have been fixed (2d -> 3D)
Created tests to properly test the particle exchange.

## Resolved Issues
default md-flexible run now has correct amount of halo particles

# How Has This Been Tested?
Manual test run on cluster with 27 ranks with fallingDrop scenario with 90000 iterations.
Ran all mdFlexTests