### PR TITLE
[CI] Abort old jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
         stage('abort old jobs') {
             agent { label 'master' }
             steps {
+                echo 'aborting old jobs'
                 milestone label: '', ordinal:  Integer.parseInt(env.BUILD_ID) - 1
                 milestone label: '', ordinal:  Integer.parseInt(env.BUILD_ID)
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ pipeline {
             agent { label 'master' }
             steps {
                 echo 'aborting old jobs'
+                // By passing the milestones, old builds are aborted.
                 milestone label: '', ordinal:  Integer.parseInt(env.BUILD_ID) - 1
                 milestone label: '', ordinal:  Integer.parseInt(env.BUILD_ID)
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,9 @@ pipeline {
             agent { label 'master' }
             steps {
                 echo 'aborting old jobs'
-                // By passing the milestones, old builds are aborted.
+                // We are using Nr. 3 from the doc (https://plugins.jenkins.io/pipeline-milestone-step/):
+                // - When a build passes a milestone, any older build that passed the previous milestone but not this one is aborted.
+                // E.g. build 4 passes 3 and 4, afterwards build 5 passes 4 and 5. Hence, build 4 passes milestone 4, but not 5 and is thus aborted.
                 milestone label: '', ordinal:  Integer.parseInt(env.BUILD_ID) - 1
                 milestone label: '', ordinal:  Integer.parseInt(env.BUILD_ID)
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,13 @@ pipeline {
         }
     }
     stages {
+        stage('abort old jobs') {
+            agent { label 'master' }
+            steps {
+                milestone label: '', ordinal:  Integer.parseInt(env.BUILD_ID) - 1
+                milestone label: '', ordinal:  Integer.parseInt(env.BUILD_ID)
+            }
+        }
         stage('setup') {
             steps {
                 echo 'Starting AutoPas Pipeline'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,5 @@
 pipeline {
-    agent {
-        node {
-            //cloud 'kubernetes'
-            label 'openshift-autoscale'
-        }
-    }
+    agent none
     stages {
         stage('abort old jobs') {
             agent { label 'master' }
@@ -14,231 +9,200 @@ pipeline {
                 milestone label: '', ordinal:  Integer.parseInt(env.BUILD_ID)
             }
         }
-        stage('setup') {
-            steps {
-                echo 'Starting AutoPas Pipeline'
+        stage("actual pipeline") {
+            agent {
+                node {
+                    //cloud 'kubernetes'
+                    label 'openshift-autoscale'
+                }
             }
-        }
-        stage("style check") {
-            parallel {
-// These stages are currently done via Github Actions. See AutoPas/.github/workflows
-//                 stage("build documentation") {
-//                     steps {
-//                         container('autopas-cmake-doxygen-make') {
-//                             dir("build-doxygen") {
-//                                 sh 'entrypoint.sh ccache -s'
-//                                 sh 'cmake ..'
-//                                 sh 'make doc_doxygen 2>DoxygenWarningLog.txt'
-//                             }
-//                         }
-//                         stash includes: 'build-doxygen/doc_doxygen/html/**', name: 'doxydocs'
-//
-//                         // get doxygen warnings
-//                         recordIssues filters: [excludeFile('.*README.*')], tools: [doxygen(id: 'docAutoPas', pattern: 'build-doxygen/DoxygenWarningLog.txt')], failedTotalAll: 1
-//                     }
-//                     post {
-//                         failure {
-//                             error "warnings in doxygen documentation"
-//                         }
-//                     }
-//                 }
-//                 stage("build md-flexible documentation") {
-//                     steps {
-//                         container('autopas-cmake-doxygen-make') {
-//                             dir("build-doxygen-md-flexible") {
-//                                 sh 'entrypoint.sh ccache -s'
-//                                 sh 'cmake ..'
-//                                 sh 'make doc_doxygen_md-flexible 2>DoxygenWarningLog.txt'
-//                             }
-//                         }
-//                         stash includes: 'build-doxygen-md-flexible/doc_doxygen_md-flexible/html/**', name: 'doxydocs_md-flexible'
-//
-//                         // get doxygen warnings
-//                         recordIssues filters: [excludeFile('.*README.*')], tools: [doxygen(id: 'docMdFlex', pattern: 'build-doxygen-md-flexible/DoxygenWarningLog.txt')], failedTotalAll: 1
-//                     }
-//                     post {
-//                         failure {
-//                             error "warnings in doxygen documentation for md-flexible"
-//                         }
-//                     }
-//                 }
-                stage ("clang and cmake format") {
+            stages {
+                stage('setup') {
                     steps {
-                        dir("format") {
-                            container('autopas-clang6-cmake-ninja-make') {
-                                sh "CC=clang CXX=clang++ cmake -G Ninja -DAUTOPAS_OPENMP=ON -DAUTOPAS_FORMATTING_TARGETS=ON .."
-                                sh "ninja clangformat"
-                                sh "ninja cmakeformat"
+                        echo 'Starting AutoPas Pipeline'
+                    }
+                }
+                stage("style check") {
+                    parallel {
+                        stage ("clang and cmake format") {
+                            steps {
+                                dir("format") {
+                                    container('autopas-clang6-cmake-ninja-make') {
+                                        sh "CC=clang CXX=clang++ cmake -G Ninja -DAUTOPAS_OPENMP=ON -DAUTOPAS_FORMATTING_TARGETS=ON .."
+                                        sh "ninja clangformat"
+                                        sh "ninja cmakeformat"
+                                    }
+                                    script {
+                                        // return 2 if files have been modified by clang-format, 0 otherwise
+                                        try {
+                                            // if files were modified, return 2
+                                            sh "git diff --quiet || exit 2"
+                                        } catch (Exception e) {
+                                            // change detected
+                                            echo 'clang or cmake format errors detected. please format the code properly. Affected files:'
+                                            sh "git status | grep modified"
+                                            sh "exit 1"
+                                        }
+                                    }
+                                }
                             }
-                            script {
-                                // return 2 if files have been modified by clang-format, 0 otherwise
-                                try {
-                                    // if files were modified, return 2
-                                    sh "git diff --quiet || exit 2"
-                                } catch (Exception e) {
-                                    // change detected
-                                    echo 'clang or cmake format errors detected. please format the code properly. Affected files:'
-                                    sh "git status | grep modified"
-                                    sh "exit 1"
+                        }
+                        stage ("custom checks") {
+                            steps {
+                                echo 'Testing src folder'
+                                dir("src") {
+                                    checkCustom()
+                                }
+                                echo 'Testing tests folder'
+                                dir("tests") {
+                                    checkCustom()
+                                }
+                                echo 'Testing examples folder'
+                                dir("examples") {
+                                    checkCustom()
                                 }
                             }
                         }
                     }
                 }
-                stage ("custom checks") {
-                    steps {
-                        echo 'Testing src folder'
-                        dir("src") {
-                            checkCustom()
-                        }
-                        echo 'Testing tests folder'
-                        dir("tests") {
-                            checkCustom()
-                        }
-                        echo 'Testing examples folder'
-                        dir("examples") {
-                            checkCustom()
-                        }
+                stage('build and test') {
+                    options {
+                        timeout(time: 8, unit: 'HOURS')
                     }
-                }
-            }
-        }
-        stage('build and test') {
-            options {
-                timeout(time: 8, unit: 'HOURS')
-            }
-            parallel {
-                stage("clang no-openmp") {
-                    steps {
-                        container('autopas-clang6-cmake-ninja-make') {
-                            dir("build") {
-                                sh "CC=clang CXX=clang++ cmake -G Ninja -DCCACHE=ON -DAUTOPAS_OPENMP=OFF .."
-                                sh "entrypoint.sh ninja -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
-                                sh 'env GTEST_OUTPUT="xml:$(pwd)/test.xml" ./tests/testAutopas/runTests'
-                            }
-                            dir("build/examples") {
-                                sh 'ctest -C checkExamples -j8 --verbose'
+                    parallel {
+                        stage("clang no-openmp") {
+                            steps {
+                                container('autopas-clang6-cmake-ninja-make') {
+                                    dir("build") {
+                                        sh "CC=clang CXX=clang++ cmake -G Ninja -DCCACHE=ON -DAUTOPAS_OPENMP=OFF .."
+                                        sh "entrypoint.sh ninja -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
+                                        sh 'env GTEST_OUTPUT="xml:$(pwd)/test.xml" ./tests/testAutopas/runTests'
+                                    }
+                                    dir("build/examples") {
+                                        sh 'ctest -C checkExamples -j8 --verbose'
+                                    }
+                                }
                             }
                         }
-                    }
-                }
-                // this is basically default
-                stage("gcc openmp") {
-                    steps {
-                        container('autopas-gcc7-cmake-make') {
-                            dir("build-openmp") {
-                                sh "cmake -DCCACHE=ON -DAUTOPAS_OPENMP=ON .."
-                                sh "entrypoint.sh make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
-                                sh './tests/testAutopas/runTests'
-                            }
-                            dir("build-openmp/examples") {
-                                sh 'ctest -C checkExamples -j8 --verbose'
-                            }
-                        }
-                    }
-                }
-                stage("gcc openmp address-sanitizer") {
-                    steps {
-                        container('autopas-gcc7-cmake-make') {
-                            dir("build-openmp-address-sanitizer") {
-                                sh "cmake -DCCACHE=ON -DAUTOPAS_OPENMP=ON -DCMAKE_BUILD_TYPE=Debug -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
-                                sh "entrypoint.sh make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
-                                sh './tests/testAutopas/runTests'
+                        // this is basically default
+                        stage("gcc openmp") {
+                            steps {
+                                container('autopas-gcc7-cmake-make') {
+                                    dir("build-openmp") {
+                                        sh "cmake -DCCACHE=ON -DAUTOPAS_OPENMP=ON .."
+                                        sh "entrypoint.sh make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
+                                        sh './tests/testAutopas/runTests'
+                                    }
+                                    dir("build-openmp/examples") {
+                                        sh 'ctest -C checkExamples -j8 --verbose'
+                                    }
+                                }
                             }
                         }
-                    }
-                }
-                stage("clang openmp") {
-                    steps {
-                        container('autopas-clang6-cmake-ninja-make') {
-                            dir("build-clang-ninja-openmp") {
-                                sh "CC=clang CXX=clang++ cmake -G Ninja -DCCACHE=ON -DAUTOPAS_OPENMP=ON .."
-                                sh "entrypoint.sh ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
-                                sh './tests/testAutopas/runTests'
-                            }
-                            dir("build-clang-ninja-openmp/examples") {
-                                sh 'ctest -C checkExamples -j8 --verbose'
+                        stage("gcc openmp address-sanitizer") {
+                            steps {
+                                container('autopas-gcc7-cmake-make') {
+                                    dir("build-openmp-address-sanitizer") {
+                                        sh "cmake -DCCACHE=ON -DAUTOPAS_OPENMP=ON -DCMAKE_BUILD_TYPE=Debug -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
+                                        sh "entrypoint.sh make -j 4 > buildlog.txt 2>&1 || (cat buildlog.txt && exit 1)"
+                                        sh './tests/testAutopas/runTests'
+                                    }
+                                }
                             }
                         }
-                    }
-                }
-                stage("clang ninja address sanitizer") {
-                    steps {
-                        container('autopas-clang6-cmake-ninja-make') {
-                            dir("build-clang-ninja-addresssanitizer-debug") {
-                                sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DCCACHE=ON -DCMAKE_BUILD_TYPE=Debug -DAUTOPAS_LOG_ALL=ON -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
-                                sh "entrypoint.sh ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
-                                sh './tests/testAutopas/runTests'
+                        stage("clang openmp") {
+                            steps {
+                                container('autopas-clang6-cmake-ninja-make') {
+                                    dir("build-clang-ninja-openmp") {
+                                        sh "CC=clang CXX=clang++ cmake -G Ninja -DCCACHE=ON -DAUTOPAS_OPENMP=ON .."
+                                        sh "entrypoint.sh ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
+                                        sh './tests/testAutopas/runTests'
+                                    }
+                                    dir("build-clang-ninja-openmp/examples") {
+                                        sh 'ctest -C checkExamples -j8 --verbose'
+                                    }
+                                }
                             }
                         }
-                    }
-                }
-                stage("clang ninja address sanitizer release") {
-                    steps {
-                        container('autopas-clang6-cmake-ninja-make') {
-                            dir("build-clang-ninja-addresssanitizer-release") {
-                                sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DCCACHE=ON -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_LOG_ALL=ON -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
-                                sh "entrypoint.sh ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
-                                sh './tests/testAutopas/runTests'
+                        stage("clang ninja address sanitizer") {
+                            steps {
+                                container('autopas-clang6-cmake-ninja-make') {
+                                    dir("build-clang-ninja-addresssanitizer-debug") {
+                                        sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DCCACHE=ON -DCMAKE_BUILD_TYPE=Debug -DAUTOPAS_LOG_ALL=ON -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
+                                        sh "entrypoint.sh ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
+                                        sh './tests/testAutopas/runTests'
+                                    }
+                                }
                             }
-                            dir("build-clang-ninja-addresssanitizer-release/examples") {
-                                sh 'ctest -C checkExamples -j8 --verbose'
+                        }
+                        stage("clang ninja address sanitizer release") {
+                            steps {
+                                container('autopas-clang6-cmake-ninja-make') {
+                                    dir("build-clang-ninja-addresssanitizer-release") {
+                                        sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DCCACHE=ON -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_LOG_ALL=ON -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=ON .."
+                                        sh "entrypoint.sh ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)"
+                                        sh './tests/testAutopas/runTests'
+                                    }
+                                    dir("build-clang-ninja-addresssanitizer-release/examples") {
+                                        sh 'ctest -C checkExamples -j8 --verbose'
+                                    }
+                                }
+                            }
+                        }
+                        stage("archer") {
+                            steps {
+                                container('autopas-llvm-archer') {
+                                    dir("build-archer") {
+                                        sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DAUTOPAS_ENABLE_THREAD_SANITIZER=ON -DAUTOPAS_OPENMP=ON -DCCACHE=ON -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_USE_VECTORIZATION=OFF .."
+                                        sh 'export TSAN_OPTIONS="ignore_noninstrumented_modules=1" && entrypoint.sh ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)'
+                                        sh 'export TSAN_OPTIONS="ignore_noninstrumented_modules=1" && ctest --verbose -j8'
+                                    }
+                                    dir("build-archer/examples") {
+                                        sh 'export TSAN_OPTIONS="ignore_noninstrumented_modules=1" && ctest -C checkExamples -j8 --verbose'
+                                    }
+                                }
                             }
                         }
                     }
+                    post {
+                        always {
+                            recordIssues qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]], tools: [clang(pattern: 'build*/buildlog_clang.txt'), gcc(pattern: 'build*/buildlog.txt')]
+                        }
+                    }
                 }
-                stage("archer") {
+                stage("generate reports") {
                     steps {
-                        container('autopas-llvm-archer') {
-                            dir("build-archer") {
-                                sh "CXXFLAGS=-Wno-pass-failed CC=clang CXX=clang++ cmake -G Ninja -DAUTOPAS_ENABLE_THREAD_SANITIZER=ON -DAUTOPAS_OPENMP=ON -DCCACHE=ON -DCMAKE_BUILD_TYPE=Release -DAUTOPAS_USE_VECTORIZATION=OFF .."
-                                sh 'export TSAN_OPTIONS="ignore_noninstrumented_modules=1" && entrypoint.sh ninja -j 4 > buildlog_clang.txt 2>&1 || (cat buildlog_clang.txt && exit 1)'
-                                sh 'export TSAN_OPTIONS="ignore_noninstrumented_modules=1" && ctest --verbose -j8'
+                        // get test results -- mainly to get number of tests
+                        junit 'build/test.xml'
+
+                        // generate coverage
+                        dir("coverage") {
+                            container('autopas-build-code-coverage') {
+                                sh "cmake -DAUTOPAS_CODE_COVERAGE=ON -DCCACHE=ON -DCMAKE_BUILD_TYPE=Debug .."
+                                sh "entrypoint.sh make AutoPas_cobertura -j 4"
                             }
-                            dir("build-archer/examples") {
-                                sh 'export TSAN_OPTIONS="ignore_noninstrumented_modules=1" && ctest -C checkExamples -j8 --verbose'
-                            }
+                            cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: 'coverage.xml', conditionalCoverageTargets: '70, 0, 0', failUnhealthy: false, failUnstable: false, lineCoverageTargets: '80, 0, 0', maxNumberOfBuilds: 0, methodCoverageTargets: '80, 0, 0', onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false
                         }
                     }
                 }
             }
             post {
-                always {
-                    recordIssues qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]], tools: [clang(pattern: 'build*/buildlog_clang.txt'), gcc(pattern: 'build*/buildlog.txt')]
+                changed {
+                    echo "change"
+                }
+                unstable {
+                    echo "unstable"
+                }
+                success {
+                    echo "success"
+                }
+                failure {
+                    echo "failure"
+                }
+                aborted {
+                    echo "aborted"
                 }
             }
-        }
-        stage("generate reports") {
-            steps {
-                // get test results -- mainly to get number of tests
-                junit 'build/test.xml'
-
-                // generate coverage
-                dir("coverage") {
-                    container('autopas-build-code-coverage') {
-                        sh "cmake -DAUTOPAS_CODE_COVERAGE=ON -DCCACHE=ON -DCMAKE_BUILD_TYPE=Debug .."
-                        sh "entrypoint.sh make AutoPas_cobertura -j 4"
-                    }
-                    cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: 'coverage.xml', conditionalCoverageTargets: '70, 0, 0', failUnhealthy: false, failUnstable: false, lineCoverageTargets: '80, 0, 0', maxNumberOfBuilds: 0, methodCoverageTargets: '80, 0, 0', onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false
-                }
-            }
-        }
-    }
-    post {
-        changed {
-            echo "change"
-        }
-        unstable {
-            echo "unstable"
-        }
-        success {
-            echo "success"
-        }
-        failure {
-            echo "failure"
-        }
-        aborted {
-            echo "aborted"
         }
     }
 }


### PR DESCRIPTION
# Description

Aborts an old job if a new job is scheduled.

Now old jobs will be aborted with a message like:
```
Superseded by AutoPas-Multibranch/PR-647#4
```
See:
https://vmbungartz21.in.tum.de/blue/organizations/jenkins/AutoPas-Multibranch/detail/PR-647/3/pipeline

## Resolved Issues

- [x] fixes #646 

# How Has This Been Tested?

- [x] Tested using Jenkins (see above)
- [x] Normal pipeline still works
- [x] Pipeline looks appropriate in gui
