### PR TITLE
add missing cmake variable

### DIFF
--- a/cmake/modules/autopas_mpi.cmake
+++ b/cmake/modules/autopas_mpi.cmake
@@ -14,5 +14,7 @@ endif ()
 # actual action
 if (AUTOPAS_INTERNODE_TUNING OR MD_FLEXIBLE_USE_MPI)
     find_package(MPI REQUIRED)
+    # set flag that will be used to include the macro with the same name
+    set(AUTOPAS_INCLUDE_MPI true)
     message(STATUS "MPI compiler found: ${MPI_CXX_COMPILER}")
 endif ()

--- a/examples/md-flexible/README.md
+++ b/examples/md-flexible/README.md
@@ -20,12 +20,13 @@ make md-flexible
 ```
 
 ### Compiling with MPI
-To use the MPI parallelization of md-flexible activate `AUTOPAS_INCLUDE_MPI` via `cmake`:
+To use the MPI parallelization of md-flexible activate `MD_FLEXIBLE_USE_MPI` via `cmake`:
 ```bash
-cmake -DAUTOPAS_INCLUDE_MPI=ON ..
+cmake -DMD_FLEXIBLE_USE_MPI=ON ..
 Using this option does not guarantee that MPI will be used. There are some additional requirements:
 * MPI is installed
 * mpirun is called with more than 1 process
+```
 
 ## Testing
 Simple tests can be run via:


### PR DESCRIPTION
# Description
Removes the requirement to use bote Cmake variables AUTOPAS_INCLUDE_MPI and MD_FLEXIBLE_USE_MPI to properly build MD-Flexible with MPI.

# How Has This Been Tested?
This has been tested by removing the build folder and by rebuilding only using the MD_FLEIXBLE_USE_MPI variable.

The build was successful, the fallingDrop scenario ran without issues on 4 ranks. All tests in mdFlexTests were successful
