### PR TITLE
Removed content name in vtk writer and limited output to single rank

### DIFF
--- a/examples/md-flexible/src/ParallelVtkWriter.cpp
+++ b/examples/md-flexible/src/ParallelVtkWriter.cpp
@@ -253,14 +253,14 @@ void ParallelVtkWriter::createPvtuFile(const int &currentIteration) {
   timestepFile << "    </PPointData>\n";
   timestepFile << "    <PCellData/>\n";
   timestepFile << "    <PPoints>\n";
-  timestepFile << "      <PDataArray Name=\"points\" NumberOfComponents=\"3\" format=\"ascii\" type=\"Float32\"/>\n";
+  timestepFile << "      <PDataArray Name=\"positions\" NumberOfComponents=\"3\" format=\"ascii\" type=\"Float32\"/>\n";
   timestepFile << "    </PPoints>\n";
   timestepFile << "    <PCells>\n";
   timestepFile << "      <PDataArray Name=\"types\" NumberOfComponents=\"0\" format=\"ascii\" type=\"Float32\"/>\n";
   timestepFile << "    </PCells>\n";
 
   for (int i = 0; i < _numberOfRanks; ++i) {
-    timestepFile << "    <Piece Source=\"./data/" << _sessionName << "_particles_" << i << "_" << std::setfill('0')
+    timestepFile << "    <Piece Source=\"./data/" << _sessionName << "_" << i << "_" << std::setfill('0')
                  << std::setw(_maximumNumberOfDigitsInIteration) << currentIteration << ".vtu\"/>\n";
   }
 
@@ -318,7 +318,7 @@ void ParallelVtkWriter::createPvtsFile(const int &currentIteration, const Regula
     timestepFile << "    <Piece "
                  << "Extent=\"" << pieceExtent[0] << " " << pieceExtent[1] << " " << pieceExtent[2] << " "
                  << pieceExtent[3] << " " << pieceExtent[4] << " " << pieceExtent[5] << "\" "
-                 << "Source=\"./data/" << _sessionName << "_subdivision_" << i << "_" << std::setfill('0')
+                 << "Source=\"./data/" << _sessionName << "_" << i << "_" << std::setfill('0')
                  << std::setw(_maximumNumberOfDigitsInIteration) << currentIteration << ".vts\"/>\n";
   }
 

--- a/examples/md-flexible/src/ParallelVtkWriter.cpp
+++ b/examples/md-flexible/src/ParallelVtkWriter.cpp
@@ -62,7 +62,7 @@ void ParallelVtkWriter::recordParticleStates(const int &currentIteration,
   }
 
   std::ostringstream timestepFileName;
-  generateFilename("particles", "vtu", currentIteration, timestepFileName);
+  generateFilename("vtu", currentIteration, timestepFileName);
 
   std::ofstream timestepFile;
   timestepFile.open(timestepFileName.str(), std::ios::out | std::ios::binary);
@@ -142,7 +142,7 @@ void ParallelVtkWriter::recordDomainSubdivision(const int &currentIteration,
   }
 
   std::ostringstream timestepFileName;
-  generateFilename("subdivision", "vts", currentIteration, timestepFileName);
+  generateFilename("vts", currentIteration, timestepFileName);
 
   std::ofstream timestepFile;
   timestepFile.open(timestepFileName.str(), std::ios::out | std::ios::binary);
@@ -231,7 +231,7 @@ void ParallelVtkWriter::tryCreateSessionAndDataFolders(const std::string &name, 
 
 void ParallelVtkWriter::createPvtuFile(const int &currentIteration) {
   std::ostringstream filename;
-  filename << _sessionFolderPath << _sessionName << "_particles_" << std::setfill('0')
+  filename << _sessionFolderPath << _sessionName << "_" << std::setfill('0')
            << std::setw(_maximumNumberOfDigitsInIteration) << currentIteration << ".pvtu";
 
   std::ofstream timestepFile;
@@ -272,7 +272,7 @@ void ParallelVtkWriter::createPvtuFile(const int &currentIteration) {
 
 void ParallelVtkWriter::createPvtsFile(const int &currentIteration, const RegularGridDecomposition &decomposition) {
   std::ostringstream filename;
-  filename << _sessionFolderPath << _sessionName << "_subdivision_" << std::setfill('0')
+  filename << _sessionFolderPath << _sessionName << "_" << std::setfill('0')
            << std::setw(_maximumNumberOfDigitsInIteration) << currentIteration << ".pvts";
 
   std::ofstream timestepFile;
@@ -337,8 +337,8 @@ void ParallelVtkWriter::tryCreateFolder(const std::string &name, const std::stri
   }
 }
 
-void ParallelVtkWriter::generateFilename(const std::string &fileContent, const std::string &filetype,
-                                         const int &currentIteration, std::ostringstream &filenameStream) {
-  filenameStream << _dataFolderPath << _sessionName << "_" << fileContent << "_" << _mpiRank << "_" << std::setfill('0')
+void ParallelVtkWriter::generateFilename(const std::string &filetype, const int &currentIteration,
+                                         std::ostringstream &filenameStream) {
+  filenameStream << _dataFolderPath << _sessionName << "_" << _mpiRank << "_" << std::setfill('0')
                  << std::setw(_maximumNumberOfDigitsInIteration) << currentIteration << "." << filetype;
 }

--- a/examples/md-flexible/src/ParallelVtkWriter.h
+++ b/examples/md-flexible/src/ParallelVtkWriter.h
@@ -136,10 +136,8 @@ class ParallelVtkWriter {
   /**
    * Generates the file name for a given vtk file type.
    * @param currentIteration: The current iteration to record.
-   * @param fileContent: The type of data which will be recorded in this file.
    * @param filetype: The vtk file type extension. Pass the extension without the '.'.
    * @param filenameStream: The output string string for the filename.
    */
-  void generateFilename(const std::string &fileContent, const std::string &filetype, const int &currentIteration,
-                        std::ostringstream &filenameStream);
+  void generateFilename(const std::string &filetype, const int &currentIteration, std::ostringstream &filenameStream);
 };

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -490,11 +490,13 @@ void Simulation::logSimulationState() {
                                  AUTOPAS_MPI_SUM, AUTOPAS_MPI_COMM_WORLD);
   standardDeviationOfHomogeneity = std::sqrt(standardDeviationOfHomogeneity);
 
-  std::cout << "\n\n"
-            << "Total number of particles at the end of Simulation: " << totalNumberOfParticles << "\n"
-            << "Owned: " << ownedParticles << "\n"
-            << "Halo: " << haloParticles << "\n"
-            << "Standard Deviation of Homogeneity: " << standardDeviationOfHomogeneity << std::endl;
+  if (_domainDecomposition.getDomainIndex() == 0) {
+    std::cout << "\n\n"
+              << "Total number of particles at the end of Simulation: " << totalNumberOfParticles << "\n"
+              << "Owned: " << ownedParticles << "\n"
+              << "Halo: " << haloParticles << "\n"
+              << "Standard Deviation of Homogeneity: " << standardDeviationOfHomogeneity << std::endl;
+  }
 }
 
 void Simulation::logMeasurements() {

--- a/examples/md-flexible/src/configuration/MDFlexConfig.cpp
+++ b/examples/md-flexible/src/configuration/MDFlexConfig.cpp
@@ -73,7 +73,6 @@ void findWord(std::ifstream &file, const std::string &word) {
 bool checkpointWasCreatedWithEqualNumberOfRanks(const std::string filename, const size_t communicatorSize,
                                                 size_t &checkpointCommunicatorSize) {
   checkpointCommunicatorSize = 0;
-  std::cout << filename << std::endl;
   std::ifstream inputStream(filename);
   findWord(inputStream, "Piece");
   while (not inputStream.eof()) {


### PR DESCRIPTION
# Description
Removed unecessary content name in simulation record files.
Limited output of some simulation data to a single rank.

# How Has This Been Tested?
This has been tested by generating a new checkpoint and afterwards loading it.
Also the mdFlexTests have been executed.