### PR TITLE
Better Iterators for Octree

### DIFF
--- a/src/autopas/containers/octree/Octree.h
+++ b/src/autopas/containers/octree/Octree.h
@@ -250,9 +250,10 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
    */
   template <typename Lambda>
   void forEach(Lambda forEachLambda, IteratorBehavior behavior = IteratorBehavior::ownedOrHalo) {
-    for (auto iter = this->begin(behavior); iter.isValid(); ++iter) {
-      forEachLambda(*iter);
-    }
+    if (behavior & IteratorBehavior::owned) this->_cells[OWNED].forEach(forEachLambda);
+    if (behavior & IteratorBehavior::halo) this->_cells[HALO].forEach(forEachLambda);
+    if (not(behavior & IteratorBehavior::ownedOrHalo))
+      utils::ExceptionHandler::exception("Encountered invalid iterator behavior!");
   }
 
   /**
@@ -265,9 +266,10 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
    */
   template <typename Lambda, typename A>
   void reduce(Lambda reduceLambda, A &result, IteratorBehavior behavior = IteratorBehavior::ownedOrHalo) {
-    for (auto iter = this->begin(behavior); iter.isValid(); ++iter) {
-      reduceLambda(*iter, result);
-    }
+    if (behavior & IteratorBehavior::owned) this->_cells[OWNED].reduce(reduceLambda, result);
+    if (behavior & IteratorBehavior::halo) this->_cells[HALO].reduce(reduceLambda, result);
+    if (not(behavior & IteratorBehavior::ownedOrHalo))
+      utils::ExceptionHandler::exception("Encountered invalid iterator behavior!");
   }
 
   /**
@@ -276,9 +278,11 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
   template <typename Lambda>
   void forEachInRegion(Lambda forEachLambda, const std::array<double, 3> &lowerCorner,
                        const std::array<double, 3> &higherCorner, IteratorBehavior behavior) {
-    for (auto iter = this->getRegionIterator(lowerCorner, higherCorner, behavior); iter.isValid(); ++iter) {
-      forEachLambda(*iter);
-    }
+    if (behavior & IteratorBehavior::owned)
+      this->_cells[OWNED].forEachInRegion(forEachLambda, lowerCorner, higherCorner);
+    if (behavior & IteratorBehavior::halo) this->_cells[HALO].forEachInRegion(forEachLambda, lowerCorner, higherCorner);
+    if (not(behavior & IteratorBehavior::ownedOrHalo))
+      utils::ExceptionHandler::exception("Encountered invalid iterator behavior!");
   }
 
   /**
@@ -287,9 +291,12 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
   template <typename Lambda, typename A>
   void reduceInRegion(Lambda reduceLambda, A &result, const std::array<double, 3> &lowerCorner,
                       const std::array<double, 3> &higherCorner, IteratorBehavior behavior) {
-    for (auto iter = this->getRegionIterator(lowerCorner, higherCorner, behavior); iter.isValid(); ++iter) {
-      reduceLambda(*iter, result);
-    }
+    if (behavior & IteratorBehavior::owned)
+      this->_cells[OWNED].reduceInRegion(reduceLambda, result, lowerCorner, higherCorner);
+    if (behavior & IteratorBehavior::halo)
+      this->_cells[HALO].reduceInRegion(reduceLambda, result, lowerCorner, higherCorner);
+    if (not(behavior & IteratorBehavior::ownedOrHalo))
+      utils::ExceptionHandler::exception("Encountered invalid iterator behavior!");
   }
 
  private:

--- a/src/autopas/containers/octree/OctreeInnerNode.h
+++ b/src/autopas/containers/octree/OctreeInnerNode.h
@@ -201,6 +201,9 @@ class OctreeInnerNode : public OctreeNodeInterface<Particle> {
     return result;
   }
 
+  /**
+   * @copydoc LinkedCells::forEach()
+   */
   template <typename Lambda>
   void forEach(Lambda forEachLambda) {
     for (auto &child : _children) {
@@ -208,6 +211,9 @@ class OctreeInnerNode : public OctreeNodeInterface<Particle> {
     }
   }
 
+  /**
+   * @copydoc LinkedCells::reduce()
+   */
   template <typename Lambda, typename A>
   void reduce(Lambda reduceLambda, A &result) {
     for (auto &child : _children) {
@@ -215,6 +221,9 @@ class OctreeInnerNode : public OctreeNodeInterface<Particle> {
     }
   }
 
+  /**
+   * @copydoc LinkedCells::forEachInRegion()
+   */
   template <typename Lambda>
   void forEach(Lambda forEachLambda, const std::array<double, 3> &lowerCorner,
                const std::array<double, 3> &higherCorner, IteratorBehavior behavior) {
@@ -226,6 +235,9 @@ class OctreeInnerNode : public OctreeNodeInterface<Particle> {
     }
   }
 
+  /**
+   * @copydoc LinkedCells::reduceInRegion()
+   */
   template <typename Lambda, typename A>
   void reduce(Lambda reduceLambda, A &result, const std::array<double, 3> &lowerCorner,
               const std::array<double, 3> &higherCorner, IteratorBehavior behavior) {

--- a/src/autopas/containers/octree/OctreeInnerNode.h
+++ b/src/autopas/containers/octree/OctreeInnerNode.h
@@ -202,7 +202,7 @@ class OctreeInnerNode : public OctreeNodeInterface<Particle> {
   }
 
   /**
-   * @copydoc LinkedCells::forEach()
+   * @copydoc OctreeNodeWrapper::forEach()
    */
   template <typename Lambda>
   void forEach(Lambda forEachLambda) {
@@ -212,7 +212,7 @@ class OctreeInnerNode : public OctreeNodeInterface<Particle> {
   }
 
   /**
-   * @copydoc LinkedCells::reduce()
+   * @copydoc OctreeNodeWrapper::reduce()
    */
   template <typename Lambda, typename A>
   void reduce(Lambda reduceLambda, A &result) {
@@ -222,7 +222,14 @@ class OctreeInnerNode : public OctreeNodeInterface<Particle> {
   }
 
   /**
-   * @copydoc LinkedCells::forEachInRegion()
+   * Apply the forEach lambda to each particle in the region.
+   *
+   * @tparam Lambda Function type
+   * @param forEachLambda Function to apply
+   * @param lowerCorner Lower corner of region
+   * @param higherCorner Higher corner of region
+   * @param behavior Parameter is only there to reuse functionality already implemented in FullParticleCell, should be
+   * set to ownedOrHalo
    */
   template <typename Lambda>
   void forEach(Lambda forEachLambda, const std::array<double, 3> &lowerCorner,
@@ -236,7 +243,16 @@ class OctreeInnerNode : public OctreeNodeInterface<Particle> {
   }
 
   /**
-   * @copydoc LinkedCells::reduceInRegion()
+   * Apply the reduce lambda to each particle in the region.
+   *
+   * @tparam Lambda Function type
+   * @tparam A Initial value type
+   * @param reduceLambda Function to apply
+   * @param result Initial value
+   * @param lowerCorner Lower corner of region
+   * @param higherCorner Higher corner of region
+   * @param behavior Parameter is only there to reuse functionality already implemented in FullParticleCell, should be
+   * set to ownedOrHalo
    */
   template <typename Lambda, typename A>
   void reduce(Lambda reduceLambda, A &result, const std::array<double, 3> &lowerCorner,

--- a/src/autopas/containers/octree/OctreeLeafNode.h
+++ b/src/autopas/containers/octree/OctreeLeafNode.h
@@ -15,6 +15,9 @@
 #include "autopas/utils/ArrayMath.h"
 
 namespace autopas {
+template <typename Particle>
+class OctreeInnerNode;
+
 /**
  * An octree leaf node. This class utilizes the FullParticleCell to store the actual particles.
  *

--- a/src/autopas/containers/octree/OctreeNodeWrapper.h
+++ b/src/autopas/containers/octree/OctreeNodeWrapper.h
@@ -225,7 +225,10 @@ class OctreeNodeWrapper : public ParticleCell<Particle> {
   using const_iterator_t = internal::SingleCellIterator<Particle, OctreeNodeWrapper<Particle>, false>;
 
   /**
-   * @copydoc LinkedCells::forEach()
+   * Apply the forEach lambda to each particle.
+   *
+   * @tparam Lambda Function type
+   * @param forEachLambda Function to apply
    */
   template <typename Lambda>
   void forEach(Lambda forEachLambda) {
@@ -233,7 +236,12 @@ class OctreeNodeWrapper : public ParticleCell<Particle> {
   }
 
   /**
-   * @copydoc LinkedCells::reduce()
+   * Apply the reduce lambda to each particle.
+   *
+   * @tparam Lambda Function type
+   * @tparam A Initial value type
+   * @param reduceLambda Function to apply
+   * @param result Initial value
    */
   template <typename Lambda, typename A>
   void reduce(Lambda reduceLambda, A &result) {
@@ -241,7 +249,12 @@ class OctreeNodeWrapper : public ParticleCell<Particle> {
   }
 
   /**
-   * @copydoc LinkedCells::forEachInRegion()
+   * Apply the forEach lambda to each particle in the region.
+   *
+   * @tparam Lambda Function type
+   * @param forEachLambda Function to apply
+   * @param lowerCorner Lower corner of region
+   * @param higherCorner Higher corner of region
    */
   template <typename Lambda>
   void forEachInRegion(Lambda forEachLambda, const std::array<double, 3> &lowerCorner,
@@ -254,7 +267,14 @@ class OctreeNodeWrapper : public ParticleCell<Particle> {
   }
 
   /**
-   * @copydoc LinkedCells::reduceInRegion()
+   * Apply the reduce lambda to each particle in the region.
+   *
+   * @tparam Lambda Function type
+   * @tparam A Initial value type
+   * @param reduceLambda Function to apply
+   * @param result Initial value
+   * @param lowerCorner Lower corner of region
+   * @param higherCorner Higher corner of region
    */
   template <typename Lambda, typename A>
   void reduceInRegion(Lambda reduceLambda, A &result, const std::array<double, 3> &lowerCorner,

--- a/src/autopas/containers/octree/OctreeNodeWrapper.h
+++ b/src/autopas/containers/octree/OctreeNodeWrapper.h
@@ -246,7 +246,7 @@ class OctreeNodeWrapper : public ParticleCell<Particle> {
 
   template <typename Lambda, typename A>
   void reduceInRegion(Lambda reduceLambda, A &result, const std::array<double, 3> &lowerCorner,
-                       const std::array<double, 3> &higherCorner) {
+                      const std::array<double, 3> &higherCorner) {
     withStaticNodeType(_pointer, [&](auto nodePtr) {
       // The iterator behavior is set to ownedOrHalo to include all particles inside this subtree. The baseclass
       // (Octree) decides whether this instance of OctreeNodeWrapper should be included in the iteration or not.

--- a/src/autopas/containers/octree/OctreeNodeWrapper.h
+++ b/src/autopas/containers/octree/OctreeNodeWrapper.h
@@ -224,16 +224,25 @@ class OctreeNodeWrapper : public ParticleCell<Particle> {
    */
   using const_iterator_t = internal::SingleCellIterator<Particle, OctreeNodeWrapper<Particle>, false>;
 
+  /**
+   * @copydoc LinkedCells::forEach()
+   */
   template <typename Lambda>
   void forEach(Lambda forEachLambda) {
     withStaticNodeType(_pointer, [&](auto nodePtr) { nodePtr->forEach(forEachLambda); });
   }
 
+  /**
+   * @copydoc LinkedCells::reduce()
+   */
   template <typename Lambda, typename A>
   void reduce(Lambda reduceLambda, A &result) {
     withStaticNodeType(_pointer, [&](auto nodePtr) { nodePtr->reduce(reduceLambda, result); });
   }
 
+  /**
+   * @copydoc LinkedCells::forEachInRegion()
+   */
   template <typename Lambda>
   void forEachInRegion(Lambda forEachLambda, const std::array<double, 3> &lowerCorner,
                        const std::array<double, 3> &higherCorner) {
@@ -244,6 +253,9 @@ class OctreeNodeWrapper : public ParticleCell<Particle> {
     });
   }
 
+  /**
+   * @copydoc LinkedCells::reduceInRegion()
+   */
   template <typename Lambda, typename A>
   void reduceInRegion(Lambda reduceLambda, A &result, const std::array<double, 3> &lowerCorner,
                       const std::array<double, 3> &higherCorner) {

--- a/src/autopas/containers/octree/OctreeStaticNodeSelector.h
+++ b/src/autopas/containers/octree/OctreeStaticNodeSelector.h
@@ -8,9 +8,9 @@
 
 #include <memory>
 
-#include "autopas/containers/octree/OctreeNodeWrapper.h"
 #include "autopas/containers/octree/OctreeInnerNode.h"
 #include "autopas/containers/octree/OctreeLeafNode.h"
+#include "autopas/containers/octree/OctreeNodeWrapper.h"
 
 namespace autopas {
 template <typename Particle>

--- a/src/autopas/containers/octree/OctreeStaticNodeSelector.h
+++ b/src/autopas/containers/octree/OctreeStaticNodeSelector.h
@@ -1,0 +1,37 @@
+/**
+ * @file OctreeStaticNodeSelector.h
+ * @author Johannes Spies
+ * @date 01.12.2021
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "autopas/containers/octree/OctreeNodeWrapper.h"
+#include "autopas/containers/octree/OctreeInnerNode.h"
+#include "autopas/containers/octree/OctreeLeafNode.h"
+
+namespace autopas {
+template <typename Particle>
+class OctreeInnerNode;
+
+/**
+ * Will execute the passed function on the given root node.
+ *
+ * @tparam Particle
+ * @tparam FunctionType
+ * @param root
+ * @param function
+ * @return
+ */
+template <typename Particle, typename FunctionType>
+decltype(auto) withStaticNodeType(const std::unique_ptr<OctreeNodeInterface<Particle>> &root, FunctionType &&function) {
+  OctreeNodeInterface<Particle> *nodePtr = root.get();
+  if (nodePtr->hasChildren()) {
+    return function(dynamic_cast<OctreeInnerNode<Particle> *>(nodePtr));
+  } else {
+    return function(dynamic_cast<OctreeLeafNode<Particle> *>(nodePtr));
+  }
+}
+}  // namespace autopas


### PR DESCRIPTION
# Description

The `forEach` and `reduce` methods were only dummy functions in the `Octree` class. Now they are implemented using proper in-place iterators.
