### PR TITLE
Include examples folder in formatting checks

### DIFF
--- a/.github/workflows/TestSuites.yaml
+++ b/.github/workflows/TestSuites.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: DoozyX/clang-format-lint-action@v0.12
         with:
-          source: 'src tests'
+          source: 'src tests examples'
           # exclude: 'none'
           extensions: 'h,cpp'
           clangFormatVersion: 9


### PR DESCRIPTION
# Description

- [x] Include examples folder in formatting checks

## Related Pull Requests

## Resolved Issues

# How Has This Been Tested?

`make clangformat && git status` yields no changes so currently everything is clean and the test should pass.

