### PR TITLE
Falling drop with reflective boundaries

### DIFF
--- a/examples/md-flexible/input/fallingDrop.yaml
+++ b/examples/md-flexible/input/fallingDrop.yaml
@@ -1,49 +1,25 @@
-# container                        :  [DirectSum, LinkedCells, VerletLists, VerletListsCells, VerletClusterLists, VarVerletListsAsBuild]
+container                        :  [LinkedCells, VerletLists, VerletClusterLists]
 verlet-rebuild-frequency         :  10
-verlet-skin-radius               :  0.3
+verlet-skin-radius               :  0.5
 verlet-cluster-size              :  4
 selector-strategy                :  Fastest-Absolute-Value
-# data-layout                      :  [AoS, SoA]
-# Traversals for Release paper:
-# traversal                        :  [ lc_c01, lc_c01_combined_soa, lc_c18, lc_c08, lc_c04_combined_SoA, lc_c04, lc_c04_HCP, lc_sliced, vl_list_iteration, vvl_as_built, vlc_c01, vlc_c18, vlc_sliced, vcl_cluster_iteration, vcl_c01_balanced, vcl_c06 ]
+data-layout                      :  [AoS, SoA]
+traversal                        :  [ lc_c01, lc_c18, lc_c08, lc_sliced_c02, vl_list_iteration, vcl_c01_balanced, vcl_c06 ] # Please see AllOptions.yaml for a comprehensive list of traversals
 tuning-strategy                  :  full-Search
-tuning-interval                  :  1000
+tuning-interval                  :  2500
 tuning-samples                   :  3
 tuning-max-evidence              :  10
-functor                          :  Lennard-Jones (12-6)
+functor                          :  Lennard-Jones
 newton3                          :  [disabled, enabled]
 cutoff                           :  3
-# box-min                          :  [0, 0, 0]
-# box-max                          :  [7.25, 7.25, 7.25]
+box-min                          :  [0, 0, 0]
+box-max                          :  [7.25, 7.25, 7.25]
 cell-size                        :  [1]
 deltaT                           :  0.0005
-iterations                       :  90000
-periodic-boundaries              :  true
+iterations                       :  15000
+boundary-type                    : [reflective,reflective,reflective]
 globalForce                      :  [0,0,-12]
 Objects:
-  # since md-flex currently has no reflecting boundaries we use walls of particles with infinite (or max double) mass.
-  # bottom wall
-  CubeGrid:
-    0:  
-      particles-per-dimension    :  [51, 31, 1]
-      particle-spacing           :  1
-      bottomLeftCorner           :  [0, 0, 0]
-      velocity                   :  [0, 0, 0]
-      particle-type              :  0
-      particle-epsilon           :  1
-      particle-sigma             :  1
-      particle-mass              :  1.79769e+308
-  # top wall
-#  CubeGrid:
-#    1:
-#      particles-per-dimension    :  [51, 31, 1]
-#      particle-spacing           :  1
-#      bottomLeftCorner           :  [1, 0, 40]
-#      velocity                   :  [0, 0, 0]
-#      particle-type              :  0
-#      particle-epsilon           :  1
-#      particle-sigma             :  1
-#      particle-mass              :  1.79769e+308
   # "water"
   CubeClosestPacked:
     0:  
@@ -51,7 +27,7 @@ Objects:
       bottomLeftCorner           :  [1, 1, 1]
       box-length                 :  [48, 28, 10]
       velocity                   :  [0, 0, 0]
-      particle-type              :  1
+      particle-type              :  0
       particle-epsilon           :  1
       particle-sigma             :  1
       particle-mass              :  1
@@ -61,7 +37,7 @@ Objects:
       radius                     :  6
       particle-spacing           :  1.122462048
       velocity                   :  [0, 0, 0]
-      particle-type              :  2
+      particle-type              :  1
       particle-epsilon           :  1
       particle-sigma             :  1
       particle-mass              :  1
@@ -72,7 +48,7 @@ Objects:
 #   thermostatInterval             :  10
 #   addBrownianMotion              :  false
 vtk-filename                     :  fallingDrop
-vtk-write-frequency              :  50
+vtk-write-frequency              :  1000
 no-flops                         :  false
 no-end-config                    :  true
-log-level                        :  debug
+log-level                        :  info

--- a/examples/md-flexible/input/fallingDrop.yaml
+++ b/examples/md-flexible/input/fallingDrop.yaml
@@ -1,6 +1,6 @@
 container                        :  [LinkedCells, VerletLists, VerletListsCells, VerletClusterLists]
 verlet-rebuild-frequency         :  10
-verlet-skin-radius               :  0.5
+verlet-skin-radius               :  1.0
 verlet-cluster-size              :  4
 selector-strategy                :  Fastest-Absolute-Value
 data-layout                      :  [AoS, SoA]

--- a/examples/md-flexible/input/fallingDrop.yaml
+++ b/examples/md-flexible/input/fallingDrop.yaml
@@ -1,10 +1,10 @@
-container                        :  [LinkedCells, VerletLists, VerletClusterLists]
+container                        :  [LinkedCells, VerletLists, VerletListsCells, VerletClusterLists]
 verlet-rebuild-frequency         :  10
 verlet-skin-radius               :  0.5
 verlet-cluster-size              :  4
 selector-strategy                :  Fastest-Absolute-Value
 data-layout                      :  [AoS, SoA]
-traversal                        :  [ lc_c01, lc_c18, lc_c08, lc_sliced_c02, vl_list_iteration, vcl_c01_balanced, vcl_c06 ] # Please see AllOptions.yaml for a comprehensive list of traversals
+traversal                        :  [ lc_c01, lc_c18, lc_c08, lc_sliced_c02, vl_list_iteration, vlc_c01, vlc_c18, vlc_sliced_c02, vcl_cluster_iteration, vcl_c01_balanced, vcl_c06 ] # Please see AllOptions.yaml for a comprehensive list of traversals
 tuning-strategy                  :  full-Search
 tuning-interval                  :  2500
 tuning-samples                   :  3


### PR DESCRIPTION
# Description

Changing fallingDrop.yaml to take advantage of reflective boundaries. In addition the default verlet-skin-radius was increased to limit the number of particles being lost (likely from moving too quickly past the reflective boundaries) and increase realism. 

Finally some changes to several other fields were made - these were from personal preference and I am happy to revert them to the original.


## Resolved Issues

- [x] fixes fallingDrop.yaml fudging reflective boundaries by using some highly massive particles.

# How Has This Been Tested?

Is only an input file.
