### PR TITLE
Issue#667

### DIFF
--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -134,8 +134,8 @@ Simulation::Simulation(const MDFlexConfig &configuration,
 
   // Throw an error if there is not more than one configuration to test in the search space but more than one tuning
   // phase is requested
-  if (_autoPasContainer->getsearchSpaceIsTrivial() && _configuration.tuningPhases.value > 0) {
-    throw std::runtime_error("Search space must not be empty if multiple tuning phases are requested");
+  if (_autoPasContainer->searchSpaceIsTrivial() and _configuration.tuningPhases.value > 0) {
+    throw std::runtime_error("Search space must not be trivia if the simulation time is limited by the number tuning phases");
   }
 
   // @todo: the object generators should only generate particles relevant for the current rank's domain

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -134,7 +134,7 @@ Simulation::Simulation(const MDFlexConfig &configuration,
 
   // Throw an error if there is not more than one configuration to test in the search space but more than one tuning
   // phase is requested
-  if (_autoPasContainer->getsearchspaceistrivial() && _configuration.tuningPhases.value > 0) {
+  if (_autoPasContainer->getsearchSpaceIsTrivial() && _configuration.tuningPhases.value > 0) {
     throw std::runtime_error("Search space must not be empty if multiple tuning phases are requested");
   }
 

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -132,6 +132,11 @@ Simulation::Simulation(const MDFlexConfig &configuration,
   autopas::Logger::get()->set_level(_configuration.logLevel.value);
   _autoPasContainer->init();
 
+  // Throw an error if there is not more than one configuration to test in the search space but more than one tuning phase is requested 
+  if (_autoPasContainer->getsearchspaceistrivial() && _configuration.tuningPhases.value > 0){
+   throw std::runtime_error("Search space must not be empty if multiple tuning phases are requested");
+  }
+
   // @todo: the object generators should only generate particles relevant for the current rank's domain
   for (auto &particle : _configuration.getParticles()) {
     if (_domainDecomposition->isInsideLocalDomain(particle.getR())) {

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -135,7 +135,8 @@ Simulation::Simulation(const MDFlexConfig &configuration,
   // Throw an error if there is not more than one configuration to test in the search space but more than one tuning
   // phase is requested
   if (_autoPasContainer->searchSpaceIsTrivial() and _configuration.tuningPhases.value > 0) {
-    throw std::runtime_error("Search space must not be trivia if the simulation time is limited by the number tuning phases");
+    throw std::runtime_error(
+        "Search space must not be trivial if the simulation time is limited by the number tuning phases");
   }
 
   // @todo: the object generators should only generate particles relevant for the current rank's domain

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -132,9 +132,10 @@ Simulation::Simulation(const MDFlexConfig &configuration,
   autopas::Logger::get()->set_level(_configuration.logLevel.value);
   _autoPasContainer->init();
 
-  // Throw an error if there is not more than one configuration to test in the search space but more than one tuning phase is requested 
-  if (_autoPasContainer->getsearchspaceistrivial() && _configuration.tuningPhases.value > 0){
-   throw std::runtime_error("Search space must not be empty if multiple tuning phases are requested");
+  // Throw an error if there is not more than one configuration to test in the search space but more than one tuning
+  // phase is requested
+  if (_autoPasContainer->getsearchspaceistrivial() && _configuration.tuningPhases.value > 0) {
+    throw std::runtime_error("Search space must not be empty if multiple tuning phases are requested");
   }
 
   // @todo: the object generators should only generate particles relevant for the current rank's domain

--- a/src/autopas/AutoPasDecl.h
+++ b/src/autopas/AutoPasDecl.h
@@ -459,7 +459,7 @@ class AutoPas {
   [[nodiscard]] std::array<double, 3> getBoxMax() const;
 
   /**
-   * get the bool value indicating if the search space is 1
+   * get the bool value indicating if the search space is trivial (not more than one configuration to test).
    * @return bool indicating if search space is trivial.
    */
   [[nodiscard]] bool getsearchspaceistrivial();
@@ -771,20 +771,6 @@ class AutoPas {
   void setAllowedNewton3Options(const std::set<Newton3Option> &allowedNewton3Options) {
     AutoPas::_allowedNewton3Options = allowedNewton3Options;
   }
-
-
-//bool getsearchspaceistrivial() const {
-//return _autoTuner->getContainer();
-//return AutoTune::searchSpaceIsTrivial();
-//}
-
-
-
-
-
-
-
-
   /**
    * Getter for the currently selected configuration.
    * @return Configuration object currently used.

--- a/src/autopas/AutoPasDecl.h
+++ b/src/autopas/AutoPasDecl.h
@@ -462,7 +462,7 @@ class AutoPas {
    * get the bool value indicating if the search space is trivial (not more than one configuration to test).
    * @return bool indicating if search space is trivial.
    */
-  [[nodiscard]] bool getsearchspaceistrivial();
+  [[nodiscard]] bool getsearchSpaceIsTrivial();
 
   /**
    * Set coordinates of the lower corner of the domain.

--- a/src/autopas/AutoPasDecl.h
+++ b/src/autopas/AutoPasDecl.h
@@ -462,7 +462,7 @@ class AutoPas {
    * get the bool value indicating if the search space is trivial (not more than one configuration to test).
    * @return bool indicating if search space is trivial.
    */
-  [[nodiscard]] bool getsearchSpaceIsTrivial();
+  [[nodiscard]] bool searchSpaceIsTrivial();
 
   /**
    * Set coordinates of the lower corner of the domain.

--- a/src/autopas/AutoPasDecl.h
+++ b/src/autopas/AutoPasDecl.h
@@ -459,6 +459,12 @@ class AutoPas {
   [[nodiscard]] std::array<double, 3> getBoxMax() const;
 
   /**
+   * get the bool value indicating if the search space is 1
+   * @return bool indicating if search space is trivial.
+   */
+  [[nodiscard]] bool getsearchspaceistrivial();
+
+  /**
    * Set coordinates of the lower corner of the domain.
    * @param boxMin
    */
@@ -766,6 +772,19 @@ class AutoPas {
     AutoPas::_allowedNewton3Options = allowedNewton3Options;
   }
 
+
+//bool getsearchspaceistrivial() const {
+//return _autoTuner->getContainer();
+//return AutoTune::searchSpaceIsTrivial();
+//}
+
+
+
+
+
+
+
+
   /**
    * Getter for the currently selected configuration.
    * @return Configuration object currently used.
@@ -993,6 +1012,7 @@ class AutoPas {
    * This is useful when multiple instances of AutoPas exist, especially in an MPI context.
    */
   std::string _outputSuffix{""};
+
 
 };  // class AutoPas
 }  // namespace autopas

--- a/src/autopas/AutoPasDecl.h
+++ b/src/autopas/AutoPasDecl.h
@@ -999,6 +999,5 @@ class AutoPas {
    */
   std::string _outputSuffix{""};
 
-
 };  // class AutoPas
 }  // namespace autopas

--- a/src/autopas/AutoPasImpl.h
+++ b/src/autopas/AutoPasImpl.h
@@ -204,7 +204,7 @@ std::shared_ptr<const autopas::ParticleContainerInterface<Particle>> AutoPas<Par
 }
 
 template <class Particle>
-bool AutoPas<Particle>::getsearchspaceistrivial() {
+bool AutoPas<Particle>::getsearchSpaceIsTrivial() {
   return _autoTuner->searchSpaceIsTrivial();
 }
 

--- a/src/autopas/AutoPasImpl.h
+++ b/src/autopas/AutoPasImpl.h
@@ -203,4 +203,9 @@ std::shared_ptr<const autopas::ParticleContainerInterface<Particle>> AutoPas<Par
   return _autoTuner->getContainer();
 }
 
+template <class Particle>
+bool AutoPas<Particle>::getsearchspaceistrivial() {
+  return _autoTuner->searchSpaceIsTrivial();
+}
+
 }  // namespace autopas

--- a/src/autopas/AutoPasImpl.h
+++ b/src/autopas/AutoPasImpl.h
@@ -204,7 +204,7 @@ std::shared_ptr<const autopas::ParticleContainerInterface<Particle>> AutoPas<Par
 }
 
 template <class Particle>
-bool AutoPas<Particle>::getsearchSpaceIsTrivial() {
+bool AutoPas<Particle>::searchSpaceIsTrivial() {
   return _autoTuner->searchSpaceIsTrivial();
 }
 

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -354,7 +354,6 @@ void AutoTuner<Particle>::selectCurrentContainer() {
       conf.container, ContainerSelectorInfo(conf.cellSizeFactor, _verletSkin, _verletClusterSize, conf.loadEstimator));
 }
 
-
 template <class Particle>
 bool AutoTuner<Particle>::searchSpaceIsTrivial() {
   return _tuningStrategy->searchSpaceIsTrivial();

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -352,6 +352,10 @@ void AutoTuner<Particle>::selectCurrentContainer() {
       conf.container, ContainerSelectorInfo(conf.cellSizeFactor, _verletSkin, _verletClusterSize, conf.loadEstimator));
 }
 
+/**
+   * Access to the searchSpaceIsTrivial bool variable (true if search space size  is 1 or less).
+   * @return Smart pointer to the searchSpaceIsTrivial variable.
+   */
 template <class Particle>
 bool AutoTuner<Particle>::searchSpaceIsTrivial() {
   return _tuningStrategy->searchSpaceIsTrivial();

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -353,9 +353,9 @@ void AutoTuner<Particle>::selectCurrentContainer() {
 }
 
 /**
-   * Access to the searchSpaceIsTrivial bool variable (true if search space size  is 1 or less).
-   * @return Smart pointer to the searchSpaceIsTrivial variable.
-   */
+ * Access to the searchSpaceIsTrivial bool variable (true if search space size  is 1 or less).
+ * @return Smart pointer to the searchSpaceIsTrivial variable.
+ */
 template <class Particle>
 bool AutoTuner<Particle>::searchSpaceIsTrivial() {
   return _tuningStrategy->searchSpaceIsTrivial();

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -187,7 +187,6 @@ class AutoTuner {
    */
   bool searchSpaceIsTrivial();
 
-
  private:
   /**
    * Total number of collected samples. This is the sum of the sizes of all sample vectors.
@@ -239,7 +238,6 @@ class AutoTuner {
    * Initialize the container specified by the TuningStrategy.
    */
   void selectCurrentContainer();
-
 
   template <class PairwiseFunctor, DataLayoutOption::Value dataLayout, bool useNewton3, bool inTuningPhase>
   void iteratePairwiseTemplateHelper(PairwiseFunctor *f, bool doListRebuild, std::vector<Particle> &particleBuffer,

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -182,6 +182,12 @@ class AutoTuner {
    */
   [[nodiscard]] const Configuration &getCurrentConfig() const;
 
+  /**
+   * Initialize the container specified by the TuningStrategy.
+   */
+  bool searchSpaceIsTrivial();
+
+
  private:
   /**
    * Total number of collected samples. This is the sum of the sizes of all sample vectors.
@@ -233,6 +239,7 @@ class AutoTuner {
    * Initialize the container specified by the TuningStrategy.
    */
   void selectCurrentContainer();
+
 
   template <class PairwiseFunctor, DataLayoutOption::Value dataLayout, bool useNewton3, bool inTuningPhase>
   void iteratePairwiseTemplateHelper(PairwiseFunctor *f, bool doListRebuild, std::vector<Particle> &particleBuffer,
@@ -345,6 +352,12 @@ void AutoTuner<Particle>::selectCurrentContainer() {
   auto conf = _tuningStrategy->getCurrentConfiguration();
   _containerSelector.selectContainer(
       conf.container, ContainerSelectorInfo(conf.cellSizeFactor, _verletSkin, _verletClusterSize, conf.loadEstimator));
+}
+
+
+template <class Particle>
+bool AutoTuner<Particle>::searchSpaceIsTrivial() {
+  return _tuningStrategy->searchSpaceIsTrivial();
 }
 
 template <class Particle>


### PR DESCRIPTION
# Description

Give MDflexible access to autopas searchspaceistrivial() function through AutoTuner::searchSpaceIsTrivial() and AutoPas::getsearchSpaceIsTrivial(). Use this to throw an exception  in simulation.cpp when MD-flexible is ran with the invalid inputs of a single configuration but multiple tuning phases (nothing to tune for).

## Resolved Issues

- fixes #667

# How Has This Been Tested?

MD-flexible is ran with different inputs. Configurations resulting in a search space size of 1 and number of tuning phases >1. This throws an error. When the number of tuning phases is zero this does not throw an error. When the search space size is greater than 1 the simulation always runs. 