### PR TITLE
Issue#691

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.associations": {
+        "typeindex": "cpp",
+        "typeinfo": "cpp"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "files.associations": {
         "typeindex": "cpp",
-        "typeinfo": "cpp"
+        "typeinfo": "cpp",
+        "array": "cpp"
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "files.associations": {
-        "typeindex": "cpp",
-        "typeinfo": "cpp",
-        "array": "cpp"
-    }
-}

--- a/examples/md-flexible/CMakeLists.txt
+++ b/examples/md-flexible/CMakeLists.txt
@@ -54,7 +54,7 @@ add_test(
         --particles-total 10
         --traversal c08,sliced
         --verlet-rebuild-frequency 5
-        --verlet-skin-radius 0
+        --verlet-skin-radius-per-timestep 0
         --boundary-type none
         --deltaT 0.
         --no-end-config
@@ -76,7 +76,7 @@ add_test(
         --particles-per-dimension 10
         --particle-spacing 1.1225
         --verlet-rebuild-frequency 4
-        --verlet-skin-radius 0.2
+        --verlet-skin-radius-per-timestep 0.05
         --boundary-type periodic
         --deltaT 0.005
         --no-end-config

--- a/examples/md-flexible/input/AllOptions.yaml
+++ b/examples/md-flexible/input/AllOptions.yaml
@@ -1,6 +1,6 @@
 container                        :  [DirectSum, LinkedCells, LinkedCellsReferences, VarVerletListsAsBuild, VerletClusterLists, VerletLists, VerletListsCells, PairwiseVerletLists]
 verlet-rebuild-frequency         :  20
-verlet-skin-radius               :  0.2
+verlet-skin-radius-per-timestep  :  0.01
 verlet-cluster-size              :  4
 selector-strategy                :  Fastest-Absolute-Value
 data-layout                      :  [AoS, SoA]

--- a/examples/md-flexible/input/explodingLiquid.yaml
+++ b/examples/md-flexible/input/explodingLiquid.yaml
@@ -3,7 +3,7 @@
 # data-layout                      :  [AoS, SoA]
 # newton3                          :  [disabled, enabled]
 verlet-rebuild-frequency         :  10
-verlet-skin-radius               :  0.2
+verlet-skin-radius-per-timestep  :  0.02
 verlet-cluster-size              :  4
 selector-strategy                :  Fastest-Mean-Value
 tuning-strategy                  :  predictive-tuning

--- a/examples/md-flexible/input/fallingDrop.yaml
+++ b/examples/md-flexible/input/fallingDrop.yaml
@@ -1,6 +1,6 @@
 container                        :  [LinkedCells, VerletLists, VerletListsCells, VerletClusterLists]
 verlet-rebuild-frequency         :  10
-verlet-skin-radius               :  1.0
+verlet-skin-radius-per-timestep  :  0.1
 verlet-cluster-size              :  4
 selector-strategy                :  Fastest-Absolute-Value
 data-layout                      :  [AoS, SoA]

--- a/examples/md-flexible/input/testTuning/MDFlex_Case2.yaml
+++ b/examples/md-flexible/input/testTuning/MDFlex_Case2.yaml
@@ -6,7 +6,7 @@ tuning-samples                   :  3
 tuning-max-evidence              :  40
 functor                          :  Lennard-Jones (12-6)
 cutoff                           :  2
-verlet-skin-radius               :  0.2
+verlet-skin-radius-per-timestep  :  0.02
 verlet-rebuild-frequency         :  10
 deltaT                           :  0
 cell-size                        :  [1.0,1.5,2.0]

--- a/examples/md-flexible/scripts/measurePerf.sh
+++ b/examples/md-flexible/scripts/measurePerf.sh
@@ -147,7 +147,7 @@ do
                             --traversal ${!t} \
                             --tuning-interval $(( ${thisReps} + 1 )) \
                             --verlet-rebuild-frequency ${VLRebuild[$iVL]} \
-                            --verlet-skin-radius ${VLSkin[$iVL]} \
+                            --verlet-skin-radius-per-timestep ${VLSkin[$iVL]} \
 
                         )
 

--- a/examples/md-flexible/scripts/strongscaling.sh
+++ b/examples/md-flexible/scripts/strongscaling.sh
@@ -27,7 +27,7 @@ do
     --particle-spacing                  .5 \
     --traversal                         sliced \
     --verlet-rebuild-frequency          20 \
-    --verlet-skin-radius                .2 \
+    --verlet-skin-radius-per-timestep   .01 \
     )
 
     if [ "${configPrinted}" = false ] ; then

--- a/examples/md-flexible/src/BoundaryConditions.h
+++ b/examples/md-flexible/src/BoundaryConditions.h
@@ -84,17 +84,17 @@ std::vector<Particle> identifyNewHaloParticles(autopas::AutoPas<Particle> &autoP
           // The search domain has to be enlarged by the skin as the position of the particles is not certain.
           if (direction[dim] == -1) {
             // just inside of boxMin
-            min[dim] = boxMin[dim] - autoPas.getVerletSkin();
-            max[dim] = boxMin[dim] + autoPas.getCutoff() + autoPas.getVerletSkin();
+            min[dim] = boxMin[dim] - autoPas.verletSkin();
+            max[dim] = boxMin[dim] + autoPas.getCutoff() + autoPas.verletSkin();
             needsShift = true;
           } else if (direction[dim] == 1) {
             // just inside of boxMax
-            min[dim] = boxMax[dim] - autoPas.getCutoff() - autoPas.getVerletSkin();
-            max[dim] = boxMax[dim] + autoPas.getVerletSkin();
+            min[dim] = boxMax[dim] - autoPas.getCutoff() - autoPas.verletSkin();
+            max[dim] = boxMax[dim] + autoPas.verletSkin();
             needsShift = true;
           } else {  // direction[dim] == 0
-            min[dim] = boxMin[dim] - autoPas.getVerletSkin();
-            max[dim] = boxMax[dim] + autoPas.getVerletSkin();
+            min[dim] = boxMin[dim] - autoPas.verletSkin();
+            max[dim] = boxMax[dim] + autoPas.verletSkin();
           }
           if (needsShift) {
             // particles left of min (direction == -1) need a shift by +boxLength. For right of max the opposite.

--- a/examples/md-flexible/src/BoundaryConditions.h
+++ b/examples/md-flexible/src/BoundaryConditions.h
@@ -84,17 +84,17 @@ std::vector<Particle> identifyNewHaloParticles(autopas::AutoPas<Particle> &autoP
           // The search domain has to be enlarged by the skin as the position of the particles is not certain.
           if (direction[dim] == -1) {
             // just inside of boxMin
-            min[dim] = boxMin[dim] - autoPas.verletSkin();
-            max[dim] = boxMin[dim] + autoPas.getCutoff() + autoPas.verletSkin();
+            min[dim] = boxMin[dim] - autoPas.getVerletSkin();
+            max[dim] = boxMin[dim] + autoPas.getCutoff() + autoPas.getVerletSkin();
             needsShift = true;
           } else if (direction[dim] == 1) {
             // just inside of boxMax
-            min[dim] = boxMax[dim] - autoPas.getCutoff() - autoPas.verletSkin();
-            max[dim] = boxMax[dim] + autoPas.verletSkin();
+            min[dim] = boxMax[dim] - autoPas.getCutoff() - autoPas.getVerletSkin();
+            max[dim] = boxMax[dim] + autoPas.getVerletSkin();
             needsShift = true;
           } else {  // direction[dim] == 0
-            min[dim] = boxMin[dim] - autoPas.verletSkin();
-            max[dim] = boxMax[dim] + autoPas.verletSkin();
+            min[dim] = boxMin[dim] - autoPas.getVerletSkin();
+            max[dim] = boxMax[dim] + autoPas.getVerletSkin();
           }
           if (needsShift) {
             // particles left of min (direction == -1) need a shift by +boxLength. For right of max the opposite.

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -124,7 +124,7 @@ Simulation::Simulation(const MDFlexConfig &configuration,
   _autoPasContainer->setMPITuningWeightForMaxDensity(_configuration.MPITuningWeightForMaxDensity.value);
   _autoPasContainer->setVerletClusterSize(_configuration.verletClusterSize.value);
   _autoPasContainer->setVerletRebuildFrequency(_configuration.verletRebuildFrequency.value);
-  _autoPasContainer->setVerletSkin(_configuration.verletSkinRadius.value);
+  _autoPasContainer->setVerletSkinPerTimestep(_configuration.verletSkinRadiusPerTimestep.value);
   _autoPasContainer->setAcquisitionFunction(_configuration.acquisitionFunctionOption.value);
   int rank{};
   autopas::AutoPas_MPI_Comm_rank(AUTOPAS_MPI_COMM_WORLD, &rank);

--- a/examples/md-flexible/src/configuration/CLIParser.cpp
+++ b/examples/md-flexible/src/configuration/CLIParser.cpp
@@ -409,7 +409,7 @@ MDFlexParser::exitCodes MDFlexParser::CLIParser::parseInput(int argc, char **arg
         try {
           config.verletSkinRadiusPerTimestep.value = stod(strArg);
         } catch (const exception &) {
-          cerr << "Error parsing verlet-skin-radius per timestep: " << optarg << endl;
+          cerr << "Error parsing verlet-skin-radius-per-timestep: " << optarg << endl;
           displayHelp = true;
         }
         break;

--- a/examples/md-flexible/src/configuration/CLIParser.cpp
+++ b/examples/md-flexible/src/configuration/CLIParser.cpp
@@ -36,7 +36,7 @@ MDFlexParser::exitCodes MDFlexParser::CLIParser::parseInput(int argc, char **arg
       config.generatorOption, config.iterations, config.tuningInterval, config.logLevel, config.logFileName,
       config.distributionMean, config.maxTuningPhasesWithoutTest, config.particlesPerDim, config.particlesTotal,
       config.relativeOptimumRange, config.relativeBlacklistRange, config.tuningPhases, config.verletClusterSize,
-      config.verletSkinRadius, config.particleSpacing, config.tuningSamples, config.traversalOptions,
+      config.verletSkinRadiusPerTimestep, config.particleSpacing, config.tuningSamples, config.traversalOptions,
       config.tuningStrategyOption, config.mpiStrategyOption, config.MPITuningMaxDifferenceForBucket,
       config.MPITuningWeightForMaxDensity, config.useThermostat, config.verletRebuildFrequency, config.vtkFileName,
       config.vtkWriteFrequency, config.selectorStrategy, config.yamlFilename, config.distributionStdDev,
@@ -405,11 +405,11 @@ MDFlexParser::exitCodes MDFlexParser::CLIParser::parseInput(int argc, char **arg
         }
         break;
       }
-      case decltype(config.verletSkinRadius)::getoptChar: {
+      case decltype(config.verletSkinRadiusPerTimestep)::getoptChar: {
         try {
-          config.verletSkinRadius.value = stod(strArg);
+          config.verletSkinRadiusPerTimestep.value = stod(strArg);
         } catch (const exception &) {
-          cerr << "Error parsing verlet-skin-radius: " << optarg << endl;
+          cerr << "Error parsing verlet-skin-radius per timestep: " << optarg << endl;
           displayHelp = true;
         }
         break;

--- a/examples/md-flexible/src/configuration/MDFlexConfig.cpp
+++ b/examples/md-flexible/src/configuration/MDFlexConfig.cpp
@@ -190,7 +190,7 @@ std::string MDFlexConfig::to_string() const {
 
   // since all containers are rebuilt only periodically print Verlet config always.
   os << setw(valueOffset) << left << verletRebuildFrequency.name << ":  " << verletRebuildFrequency.value << endl;
-  os << setw(valueOffset) << left << verletSkinRadius.name << ":  " << verletSkinRadius.value << endl;
+  os << setw(valueOffset) << left << verletSkinRadiusPerTimestep.name << ":  " << verletSkinRadiusPerTimestep.value << endl;
   if (passedContainerOptionsStr.find("luster") != std::string::npos) {
     os << setw(valueOffset) << left << verletClusterSize.name << ":  " << verletClusterSize.value << endl;
   }
@@ -321,7 +321,7 @@ std::string MDFlexConfig::to_string() const {
 }
 
 void MDFlexConfig::calcSimulationBox() {
-  const double interactionLength = cutoff.value + verletSkinRadius.value;
+  const double interactionLength = cutoff.value + verletSkinRadiusPerTimestep.value* verletRebuildFrequency.value;
 
   // helper function so that we can do the same for every object collection
   // resizes the domain to the maximal extents of all objects

--- a/examples/md-flexible/src/configuration/MDFlexConfig.cpp
+++ b/examples/md-flexible/src/configuration/MDFlexConfig.cpp
@@ -190,7 +190,8 @@ std::string MDFlexConfig::to_string() const {
 
   // since all containers are rebuilt only periodically print Verlet config always.
   os << setw(valueOffset) << left << verletRebuildFrequency.name << ":  " << verletRebuildFrequency.value << endl;
-  os << setw(valueOffset) << left << verletSkinRadiusPerTimestep.name << ":  " << verletSkinRadiusPerTimestep.value << endl;
+  os << setw(valueOffset) << left << verletSkinRadiusPerTimestep.name << ":  " << verletSkinRadiusPerTimestep.value
+     << endl;
   if (passedContainerOptionsStr.find("luster") != std::string::npos) {
     os << setw(valueOffset) << left << verletClusterSize.name << ":  " << verletClusterSize.value << endl;
   }
@@ -321,7 +322,7 @@ std::string MDFlexConfig::to_string() const {
 }
 
 void MDFlexConfig::calcSimulationBox() {
-  const double interactionLength = cutoff.value + verletSkinRadiusPerTimestep.value* verletRebuildFrequency.value;
+  const double interactionLength = cutoff.value + verletSkinRadiusPerTimestep.value * verletRebuildFrequency.value;
 
   // helper function so that we can do the same for every object collection
   // resizes the domain to the maximal extents of all objects

--- a/examples/md-flexible/src/configuration/MDFlexConfig.h
+++ b/examples/md-flexible/src/configuration/MDFlexConfig.h
@@ -346,7 +346,8 @@ class MDFlexConfig {
    */
   MDFlexOption<double, __LINE__> verletSkinRadiusPerTimestep{
       .2, "verlet-skin-radius-per-timestep", true,
-      "Skin added to the cutoff to form the interaction length. The total skin width is this number times verletRebuildFrequency."};
+      "Skin added to the cutoff to form the interaction length. The total skin width is this number times "
+      "verletRebuildFrequency."};
   /**
    * boxMin
    */

--- a/examples/md-flexible/src/configuration/MDFlexConfig.h
+++ b/examples/md-flexible/src/configuration/MDFlexConfig.h
@@ -344,8 +344,9 @@ class MDFlexConfig {
   /**
    * verletSkinRadiusPerTimeStep
    */
-  MDFlexOption<double, __LINE__> verletSkinRadiusPerTimestep{.2, "verlet-skin-radius-per-timestep", true,
-                                                  "Skin added to the cutoff to form the interaction length per time step."};
+  MDFlexOption<double, __LINE__> verletSkinRadiusPerTimestep{
+      .2, "verlet-skin-radius-per-timestep", true,
+      "Skin added to the cutoff to form the interaction length per time step."};
   /**
    * boxMin
    */

--- a/examples/md-flexible/src/configuration/MDFlexConfig.h
+++ b/examples/md-flexible/src/configuration/MDFlexConfig.h
@@ -342,10 +342,10 @@ class MDFlexConfig {
   MDFlexOption<unsigned int, __LINE__> verletRebuildFrequency{
       20, "verlet-rebuild-frequency", true, "Number of iterations after which containers are rebuilt."};
   /**
-   * verletSkinRadius
+   * verletSkinRadiusPerTimeStep
    */
-  MDFlexOption<double, __LINE__> verletSkinRadius{.2, "verlet-skin-radius", true,
-                                                  "Skin added to the cutoff to form the interaction length."};
+  MDFlexOption<double, __LINE__> verletSkinRadiusPerTimestep{.2, "verlet-skin-radius per timestep", true,
+                                                  "Skin added to the cutoff to form the interaction length per time step."};
   /**
    * boxMin
    */

--- a/examples/md-flexible/src/configuration/MDFlexConfig.h
+++ b/examples/md-flexible/src/configuration/MDFlexConfig.h
@@ -344,7 +344,7 @@ class MDFlexConfig {
   /**
    * verletSkinRadiusPerTimeStep
    */
-  MDFlexOption<double, __LINE__> verletSkinRadiusPerTimestep{.2, "verlet-skin-radius per timestep", true,
+  MDFlexOption<double, __LINE__> verletSkinRadiusPerTimestep{.2, "verlet-skin-radius-per-timestep", true,
                                                   "Skin added to the cutoff to form the interaction length per time step."};
   /**
    * boxMin

--- a/examples/md-flexible/src/configuration/MDFlexConfig.h
+++ b/examples/md-flexible/src/configuration/MDFlexConfig.h
@@ -346,7 +346,7 @@ class MDFlexConfig {
    */
   MDFlexOption<double, __LINE__> verletSkinRadiusPerTimestep{
       .2, "verlet-skin-radius-per-timestep", true,
-      "Skin added to the cutoff to form the interaction length per time step."};
+      "Skin added to the cutoff to form the interaction length. The total skin width is this number times verletRebuildFrequency."};
   /**
    * boxMin
    */

--- a/examples/md-flexible/src/configuration/YamlParser.cpp
+++ b/examples/md-flexible/src/configuration/YamlParser.cpp
@@ -210,8 +210,8 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
   if (node[config.verletRebuildFrequency.name]) {
     config.verletRebuildFrequency.value = node[config.verletRebuildFrequency.name].as<unsigned int>();
   }
-  if (node[config.verletSkinRadius.name]) {
-    config.verletSkinRadius.value = node[config.verletSkinRadius.name].as<double>();
+  if (node[config.verletSkinRadiusPerTimestep.name]) {
+    config.verletSkinRadiusPerTimestep.value = node[config.verletSkinRadiusPerTimestep.name].as<double>();
   }
   if (node[config.verletClusterSize.name]) {
     config.verletClusterSize.value = node[config.verletClusterSize.name].as<unsigned int>();

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -21,7 +21,7 @@ RegularGridDecomposition::RegularGridDecomposition(const MDFlexConfig &configura
       _cutoffWidth(configuration.cutoff.value),
       _skinWidthPerTimestep(configuration.verletSkinRadiusPerTimestep.value),
       _rebuildFrequency(configuration.verletRebuildFrequency.value),
-      _skinWidth(configuration.verletSkinRadiusPerTimestep.value*configuation.verletRebuildFrequency.value),
+      _skinWidth(configuration.verletSkinRadiusPerTimestep.value*configuration.verletRebuildFrequency.value),
       _globalBoxMin(configuration.boxMin.value),
       _globalBoxMax(configuration.boxMax.value),
       _boundaryType(configuration.boundaryOption.value),

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -21,7 +21,7 @@ RegularGridDecomposition::RegularGridDecomposition(const MDFlexConfig &configura
       _cutoffWidth(configuration.cutoff.value),
       _skinWidthPerTimestep(configuration.verletSkinRadiusPerTimestep.value),
       _rebuildFrequency(configuration.verletRebuildFrequency.value),
-      _skinWidth(configuration.verletSkinRadiusPerTimestep.value*configuration.verletRebuildFrequency.value),
+      _skinWidth(configuration.verletSkinRadiusPerTimestep.value * configuration.verletRebuildFrequency.value),
       _globalBoxMin(configuration.boxMin.value),
       _globalBoxMax(configuration.boxMax.value),
       _boundaryType(configuration.boundaryOption.value),

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -53,7 +53,7 @@ RegularGridDecomposition::RegularGridDecomposition(const MDFlexConfig &configura
     _allLoadBalancer = std::make_unique<ALL::ALL<double, double>>(ALL::TENSOR, _dimensionCount, 0);
     _allLoadBalancer->setCommunicator(_communicator);
 
-    const double minDomainSize = 2 * (_cutoffWidth + _skinWidthPerTimestep*_rebuildFrequency);
+    const double minDomainSize = 2 * (_cutoffWidth + _skinWidthPerTimestep * _rebuildFrequency);
     _allLoadBalancer->setMinDomainSize({minDomainSize, minDomainSize, minDomainSize});
     _allLoadBalancer->setup();
   }
@@ -164,10 +164,10 @@ void RegularGridDecomposition::exchangeHaloParticles(AutoPasType &autoPasContain
     collectHaloParticlesForLeftNeighbor(autoPasContainer, dimensionIndex, particlesForLeftNeighbor);
     collectHaloParticlesForRightNeighbor(autoPasContainer, dimensionIndex, particlesForRightNeighbor);
 
-    double leftHaloMin = _localBoxMin[dimensionIndex] - _skinWidthPerTimestep*_rebuildFrequency;
-    double leftHaloMax = _localBoxMin[dimensionIndex] + _cutoffWidth + _skinWidthPerTimestep*_rebuildFrequency;
-    double rightHaloMin = _localBoxMax[dimensionIndex] - _cutoffWidth - _skinWidthPerTimestep*_rebuildFrequency;
-    double rightHaloMax = _localBoxMax[dimensionIndex] + _skinWidthPerTimestep*_rebuildFrequency;
+    double leftHaloMin = _localBoxMin[dimensionIndex] - _skinWidthPerTimestep * _rebuildFrequency;
+    double leftHaloMax = _localBoxMin[dimensionIndex] + _cutoffWidth + _skinWidthPerTimestep * _rebuildFrequency;
+    double rightHaloMin = _localBoxMax[dimensionIndex] - _cutoffWidth - _skinWidthPerTimestep * _rebuildFrequency;
+    double rightHaloMax = _localBoxMax[dimensionIndex] + _skinWidthPerTimestep * _rebuildFrequency;
 
     for (const auto &particle : haloParticles) {
       std::array<double, _dimensionCount> position = particle.getR();
@@ -304,10 +304,11 @@ void RegularGridDecomposition::collectHaloParticlesForLeftNeighbor(AutoPasType &
                                                                    const size_t &direction,
                                                                    std::vector<ParticleType> &haloParticles) {
   // Calculate halo box for left neighbor
-  const std::array<double, _dimensionCount> boxMin = autopas::utils::ArrayMath::subScalar(_localBoxMin, _skinWidthPerTimestep*_rebuildFrequency);
+  const std::array<double, _dimensionCount> boxMin =
+      autopas::utils::ArrayMath::subScalar(_localBoxMin, _skinWidthPerTimestep * _rebuildFrequency);
   const std::array<double, _dimensionCount> boxMax = [&]() {
-    auto boxMax = autopas::utils::ArrayMath::addScalar(_localBoxMax, _skinWidthPerTimestep*_rebuildFrequency);
-    boxMax[direction] = _localBoxMin[direction] + _cutoffWidth + _skinWidthPerTimestep*_rebuildFrequency;
+    auto boxMax = autopas::utils::ArrayMath::addScalar(_localBoxMax, _skinWidthPerTimestep * _rebuildFrequency);
+    boxMax[direction] = _localBoxMin[direction] + _cutoffWidth + _skinWidthPerTimestep * _rebuildFrequency;
     return boxMax;
   }();
 
@@ -329,10 +330,11 @@ void RegularGridDecomposition::collectHaloParticlesForRightNeighbor(AutoPasType 
                                                                     const size_t &direction,
                                                                     std::vector<ParticleType> &haloParticles) {
   // Calculate left halo box of right neighbor
-  const std::array<double, _dimensionCount> boxMax = autopas::utils::ArrayMath::addScalar(_localBoxMax, _skinWidthPerTimestep*_rebuildFrequency);
+  const std::array<double, _dimensionCount> boxMax =
+      autopas::utils::ArrayMath::addScalar(_localBoxMax, _skinWidthPerTimestep * _rebuildFrequency);
   const std::array<double, _dimensionCount> boxMin = [&]() {
-    auto boxMin = autopas::utils::ArrayMath::subScalar(_localBoxMin, _skinWidthPerTimestep*_rebuildFrequency);
-    boxMin[direction] = _localBoxMax[direction] - _cutoffWidth - _skinWidthPerTimestep*_rebuildFrequency;
+    auto boxMin = autopas::utils::ArrayMath::subScalar(_localBoxMin, _skinWidthPerTimestep * _rebuildFrequency);
+    boxMin[direction] = _localBoxMax[direction] - _cutoffWidth - _skinWidthPerTimestep * _rebuildFrequency;
     return boxMin;
   }();
 
@@ -445,8 +447,9 @@ void RegularGridDecomposition::balanceWithInvertedPressureLoadBalancer(const dou
 
       // Calculate balanced positions and only shift by half the resulting distance to prevent localBox min to be larger
       // than localBoxMax.
-      balancedPosition = DomainTools::balanceAdjacentDomains(neighborPlaneWork, averageWorkInPlane[i], neighborBoundary,
-                                                             oldLocalBoxMax[i], 2 * (_cutoffWidth + _skinWidthPerTimestep*_rebuildFrequency));
+      balancedPosition = DomainTools::balanceAdjacentDomains(
+          neighborPlaneWork, averageWorkInPlane[i], neighborBoundary, oldLocalBoxMax[i],
+          2 * (_cutoffWidth + _skinWidthPerTimestep * _rebuildFrequency));
       _localBoxMin[i] += (balancedPosition - _localBoxMin[i]) / 2;
     }
 
@@ -459,9 +462,9 @@ void RegularGridDecomposition::balanceWithInvertedPressureLoadBalancer(const dou
 
       // Calculate balanced positions and only shift by half the resulting distance to prevent localBox min to be larger
       // than localBoxMax.
-      balancedPosition =
-          DomainTools::balanceAdjacentDomains(averageWorkInPlane[i], neighborPlaneWork, oldLocalBoxMin[i],
-                                              neighborBoundary, 2 * (_cutoffWidth + _skinWidthPerTimestep*_rebuildFrequency));
+      balancedPosition = DomainTools::balanceAdjacentDomains(
+          averageWorkInPlane[i], neighborPlaneWork, oldLocalBoxMin[i], neighborBoundary,
+          2 * (_cutoffWidth + _skinWidthPerTimestep * _rebuildFrequency));
       _localBoxMax[i] += (balancedPosition - _localBoxMax[i]) / 2;
     }
   }

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -272,7 +272,7 @@ void RegularGridDecomposition::reflectParticlesAtBoundaries(AutoPasType &autoPas
     if (_localBoxMin[dimensionIndex] == _globalBoxMin[dimensionIndex]) {
       reflSkinMin = _globalBoxMin;
       reflSkinMax = _globalBoxMax;
-      reflSkinMax[dimensionIndex] = _globalBoxMin[dimensionIndex] + autoPasContainer->verletSkin() / 2;
+      reflSkinMax[dimensionIndex] = _globalBoxMin[dimensionIndex] + autoPasContainer->getVerletSkin() / 2;
 
       reflect(false);
     }
@@ -280,7 +280,7 @@ void RegularGridDecomposition::reflectParticlesAtBoundaries(AutoPasType &autoPas
     if (_localBoxMax[dimensionIndex] == _globalBoxMax[dimensionIndex]) {
       reflSkinMin = _globalBoxMin;
       reflSkinMax = _globalBoxMax;
-      reflSkinMin[dimensionIndex] = _globalBoxMax[dimensionIndex] - autoPasContainer->verletSkin() / 2;
+      reflSkinMin[dimensionIndex] = _globalBoxMax[dimensionIndex] - autoPasContainer->getVerletSkin() / 2;
 
       reflect(true);
     }

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
@@ -161,10 +161,6 @@ class RegularGridDecomposition final : public DomainDecomposition {
    */
   unsigned int _rebuildFrequency;
   /**
-   * Stores the domain skin width.
-   */
-  double _skinWidth;
-  /**
    * The minimum coordinates of the global domain.
    */
   const std::array<double, _dimensionCount> _globalBoxMin;

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
@@ -24,17 +24,9 @@ class RegularGridDecomposition final : public DomainDecomposition {
  public:
   /**
    * Constructor.
-   * @param globalBoxMin: The minimum coordinates of the global domain.
-   * @param globalBoxMax: The maximum coordinates of the global domain.
-   * @param subdivideDimension: Decides if a dimension will be subdivided.
-   * @param cutoffWidth: The cutoff width for halo particles.
-   * @param skinWidthperTimestep: The skin width of an autopas container domain.
-   * @param RebuildFrequency: the rebuild frequency. 
-   * @param boundaryConditions: An array of boundary conditions in the x, y, and z directions.
+   * @param configuration: The configuration for definig the decomposition properties
    */
-  RegularGridDecomposition(const std::array<double, 3> &globalBoxMin, const std::array<double, 3> &globalBoxMax,
-                           const std::array<bool, 3> &subdivideDimension, double cutoffWidth, double skinWidthPerTimestep, 
-                           unsigned int rebuildFrequency, const std::array<options::BoundaryTypeOption, 3> &boundaryConditions);
+  explicit RegularGridDecomposition(const MDFlexConfig &configuration);
 
   /**
    * Destructor.
@@ -163,8 +155,15 @@ class RegularGridDecomposition final : public DomainDecomposition {
   /**
    * Stores the domain skin width.
    */
+  double _skinWidthPerTimestep;
+  /**
+   * Stores the domain skin width.
+   */
+  double _rebuildFrequency;
+  /**
+   * Stores the domain skin width.
+   */
   double _skinWidth;
-  
   /**
    * The minimum coordinates of the global domain.
    */
@@ -198,11 +197,7 @@ class RegularGridDecomposition final : public DomainDecomposition {
   std::array<int, 3> _decomposition{};
 
   /**
-   * Stores the domain skin width per timestep.
-   */
-  double _skinWidthPerTimestep;
-
-  /** Indicator to MPI to view all communication dimensions as periodic.
+   * Indicator to MPI to view all communication dimensions as periodic.
    * @note For usage in MPI functions, the const needs to be casted away.
    */
   const std::vector<int> _periods{_dimensionCount, 1};

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
@@ -34,7 +34,7 @@ class RegularGridDecomposition final : public DomainDecomposition {
    */
   RegularGridDecomposition(const std::array<double, 3> &globalBoxMin, const std::array<double, 3> &globalBoxMax,
                            const std::array<bool, 3> &subdivideDimension, double cutoffWidth, double skinWidthPerTimestep, 
-                           double rebuildFrequency, const std::array<options::BoundaryTypeOption, 3> &boundaryConditions);
+                           unsigned int rebuildFrequency, const std::array<options::BoundaryTypeOption, 3> &boundaryConditions);
 
   /**
    * Destructor.

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
@@ -153,13 +153,13 @@ class RegularGridDecomposition final : public DomainDecomposition {
   double _cutoffWidth;
 
   /**
-   * Stores the domain skin width.
+   * Stores the domain skin width per Timestep.
    */
   double _skinWidthPerTimestep;
   /**
-   * Stores the domain skin width.
+   * Stores the rebuild Frequency.
    */
-  double _rebuildFrequency;
+  unsigned int _rebuildFrequency;
   /**
    * Stores the domain skin width.
    */

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
@@ -29,6 +29,7 @@ class RegularGridDecomposition final : public DomainDecomposition {
    * @param subdivideDimension: Decides if a dimension will be subdivided.
    * @param cutoffWidth: The cutoff width for halo particles.
    * @param skinWidthperTimestep: The skin width of an autopas container domain.
+   * @param RebuildFrequency: the rebuild frequency. 
    * @param boundaryConditions: An array of boundary conditions in the x, y, and z directions.
    */
   RegularGridDecomposition(const std::array<double, 3> &globalBoxMin, const std::array<double, 3> &globalBoxMax,
@@ -163,6 +164,7 @@ class RegularGridDecomposition final : public DomainDecomposition {
    * Stores the domain skin width.
    */
   double _skinWidth;
+  
   /**
    * The minimum coordinates of the global domain.
    */
@@ -200,21 +202,7 @@ class RegularGridDecomposition final : public DomainDecomposition {
    */
   double _skinWidthPerTimestep;
 
-  /**
-   * Stores the domain skin width per timestep.
-   */
-  double _skinWidthPerTimestep;
-
-  /**
-<<<<<<< HEAD
-   * Stores the domain skin width per timestep.
-   */
-  double _skinWidthPerTimestep;
-
-  /**
-=======
->>>>>>> 72799a1a6012f6fb6787f3d177b24f6f3c1feb2c
-   * Indicator to MPI to view all communication dimensions as periodic.
+  /** Indicator to MPI to view all communication dimensions as periodic.
    * @note For usage in MPI functions, the const needs to be casted away.
    */
   const std::vector<int> _periods{_dimensionCount, 1};

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
@@ -24,9 +24,16 @@ class RegularGridDecomposition final : public DomainDecomposition {
  public:
   /**
    * Constructor.
-   * @param configuration: The configuration for definig the decomposition properties
+   * @param globalBoxMin: The minimum coordinates of the global domain.
+   * @param globalBoxMax: The maximum coordinates of the global domain.
+   * @param subdivideDimension: Decides if a dimension will be subdivided.
+   * @param cutoffWidth: The cutoff width for halo particles.
+   * @param skinWidthperTimestep: The skin width of an autopas container domain.
+   * @param boundaryConditions: An array of boundary conditions in the x, y, and z directions.
    */
-  explicit RegularGridDecomposition(const MDFlexConfig &configuration);
+  RegularGridDecomposition(const std::array<double, 3> &globalBoxMin, const std::array<double, 3> &globalBoxMax,
+                           const std::array<bool, 3> &subdivideDimension, double cutoffWidth, double skinWidthPerTimestep, 
+                           double rebuildFrequency, const std::array<options::BoundaryTypeOption, 3> &boundaryConditions);
 
   /**
    * Destructor.
@@ -187,6 +194,11 @@ class RegularGridDecomposition final : public DomainDecomposition {
    * Number of ranks per dimension.
    */
   std::array<int, 3> _decomposition{};
+
+  /**
+   * Stores the domain skin width per timestep.
+   */
+  double _skinWidthPerTimestep;
 
   /**
    * Indicator to MPI to view all communication dimensions as periodic.

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
@@ -201,6 +201,11 @@ class RegularGridDecomposition final : public DomainDecomposition {
   double _skinWidthPerTimestep;
 
   /**
+   * Stores the domain skin width per timestep.
+   */
+  double _skinWidthPerTimestep;
+
+  /**
    * Indicator to MPI to view all communication dimensions as periodic.
    * @note For usage in MPI functions, the const needs to be casted away.
    */

--- a/examples/md-flexible/tests/ThermostatTest.cpp
+++ b/examples/md-flexible/tests/ThermostatTest.cpp
@@ -13,7 +13,7 @@ void ThermostatTest::initContainer(AutoPasType &autopas, const Molecule &dummy, 
   constexpr double particleSpacing = 1.;
   constexpr double cutoff = 1.;
 
-  double minimalBoxLength = cutoff + autopas.verletSkin();
+  double minimalBoxLength = cutoff + autopas.geVerletSkin();
   std::array<double, 3> boxmax = {std::max(particlesPerDim[0] * particleSpacing, minimalBoxLength),
                                   std::max(particlesPerDim[1] * particleSpacing, minimalBoxLength),
                                   std::max(particlesPerDim[2] * particleSpacing, minimalBoxLength)};

--- a/examples/md-flexible/tests/ThermostatTest.cpp
+++ b/examples/md-flexible/tests/ThermostatTest.cpp
@@ -13,7 +13,7 @@ void ThermostatTest::initContainer(AutoPasType &autopas, const Molecule &dummy, 
   constexpr double particleSpacing = 1.;
   constexpr double cutoff = 1.;
 
-  double minimalBoxLength = cutoff + autopas.geVerletSkin();
+  double minimalBoxLength = cutoff + autopas.getVerletSkin();
   std::array<double, 3> boxmax = {std::max(particlesPerDim[0] * particleSpacing, minimalBoxLength),
                                   std::max(particlesPerDim[1] * particleSpacing, minimalBoxLength),
                                   std::max(particlesPerDim[2] * particleSpacing, minimalBoxLength)};

--- a/examples/md-flexible/tests/ThermostatTest.cpp
+++ b/examples/md-flexible/tests/ThermostatTest.cpp
@@ -13,7 +13,7 @@ void ThermostatTest::initContainer(AutoPasType &autopas, const Molecule &dummy, 
   constexpr double particleSpacing = 1.;
   constexpr double cutoff = 1.;
 
-  double minimalBoxLength = cutoff + autopas.getVerletSkin();
+  double minimalBoxLength = cutoff + autopas.verletSkin();
   std::array<double, 3> boxmax = {std::max(particlesPerDim[0] * particleSpacing, minimalBoxLength),
                                   std::max(particlesPerDim[1] * particleSpacing, minimalBoxLength),
                                   std::max(particlesPerDim[2] * particleSpacing, minimalBoxLength)};

--- a/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
@@ -92,7 +92,8 @@ void MixedBoundaryConditionTest::testFunction(const std::vector<std::array<doubl
   const auto &[expectedPositions, expectedHaloPositions, expectedVelocities] =
       setUpExpectations(particlePositions, particleVelocities, config.boxMin.value, config.boxMax.value,
                         config.verletSkinRadiusPerTimestep.value * config.verletRebuildFrequency.value / 2.,
-                        config.cutoff.value + config.verletSkinRadiusPerTimestep.value * config.verletRebuildFrequency, config.boundaryOption.value);
+                        config.cutoff.value + config.verletSkinRadiusPerTimestep.value * config.verletRebuildFrequency,
+                        config.boundaryOption.value);
 
   // particles need to be added at positions inside the domain
   // but also close to their designated positions so they end up in the correct MPI rank

--- a/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
@@ -90,8 +90,10 @@ void MixedBoundaryConditionTest::testFunction(const std::vector<std::array<doubl
   autoPasContainer->init();
 
   const auto &[expectedPositions, expectedHaloPositions, expectedVelocities] =
-      setUpExpectations(particlePositions, particleVelocities, boxMin, boxMax, autoPasContainer->getVerletSkin() / 2, cutoffWidth + autoPasContainer->getVerletSkin(),
-                        boundaryConditions);
+      setUpExpectations(particlePositions, particleVelocities, config.boxMin.value, config.boxMax.value,
+                        config.verletSkinRadiusPerTimestep.value*config.verletRebuildFrequency.value / 2., 
+                        config.cutoff.value + config.verletSkinRadiusPerTimestep.value,
+                        config.boundaryOption.value);
 
   // particles need to be added at positions inside the domain
   // but also close to their designated positions so they end up in the correct MPI rank

--- a/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
@@ -92,7 +92,7 @@ void MixedBoundaryConditionTest::testFunction(const std::vector<std::array<doubl
   const auto &[expectedPositions, expectedHaloPositions, expectedVelocities] =
       setUpExpectations(particlePositions, particleVelocities, config.boxMin.value, config.boxMax.value,
                         config.verletSkinRadiusPerTimestep.value * config.verletRebuildFrequency.value / 2.,
-                        config.cutoff.value + config.verletSkinRadiusPerTimestep.value, config.boundaryOption.value);
+                        config.cutoff.value + config.verletSkinRadiusPerTimestep.value * config.verletRebuildFrequency, config.boundaryOption.value);
 
   // particles need to be added at positions inside the domain
   // but also close to their designated positions so they end up in the correct MPI rank

--- a/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
@@ -89,11 +89,11 @@ void MixedBoundaryConditionTest::testFunction(const std::vector<std::array<doubl
   autoPasContainer->setVerletRebuildFrequency(config.verletRebuildFrequency.value);
   autoPasContainer->init();
 
-  const auto &[expectedPositions, expectedHaloPositions, expectedVelocities] =
-      setUpExpectations(particlePositions, particleVelocities, config.boxMin.value, config.boxMax.value,
-                        config.verletSkinRadiusPerTimestep.value * config.verletRebuildFrequency.value / 2.,
-                        config.cutoff.value + config.verletSkinRadiusPerTimestep.value * config.verletRebuildFrequency,
-                        config.boundaryOption.value);
+  const auto &[expectedPositions, expectedHaloPositions, expectedVelocities] = setUpExpectations(
+      particlePositions, particleVelocities, config.boxMin.value, config.boxMax.value,
+      config.verletSkinRadiusPerTimestep.value * config.verletRebuildFrequency.value / 2.,
+      config.cutoff.value + config.verletSkinRadiusPerTimestep.value * config.verletRebuildFrequency.value,
+      config.boundaryOption.value);
 
   // particles need to be added at positions inside the domain
   // but also close to their designated positions so they end up in the correct MPI rank

--- a/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
@@ -84,9 +84,9 @@ void MixedBoundaryConditionTest::testFunction(const std::vector<std::array<doubl
 
   autoPasContainer->setBoxMin(domainDecomposition.getLocalBoxMin());
   autoPasContainer->setBoxMax(domainDecomposition.getLocalBoxMax());
-  autoPasContainer->setCutoff(cutoffWidth);
-  autoPasContainer->setVerletSkinPerTimestep(skinWidthPerTimestep);
-  autoPasContainer->setVerletRebuildFrequency(rebuildFrequency);
+  autoPasContainer->setCutoff(config.cutoff.value);
+  autoPasContainer->setVerletSkinPerTimestep(config.verletSkinRadiusPerTimestep.value);
+  autoPasContainer->setVerletRebuildFrequency(config.verletRebuildFrequency.value);
   autoPasContainer->init();
 
   const auto &[expectedPositions, expectedHaloPositions, expectedVelocities] =

--- a/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
@@ -83,14 +83,13 @@ void MixedBoundaryConditionTest::testFunction(const std::vector<std::array<doubl
 
   autoPasContainer->setBoxMin(domainDecomposition.getLocalBoxMin());
   autoPasContainer->setBoxMax(domainDecomposition.getLocalBoxMax());
-  autoPasContainer->setCutoff(config.cutoff.value);
-  autoPasContainer->setVerletSkin(config.verletSkinRadius.value);
+  autoPasContainer->setCutoff(cutoffWidth);
+  autoPasContainer->setVerletSkinPerTimestep(skinWidthPerTimestep);
   autoPasContainer->init();
 
   const auto &[expectedPositions, expectedHaloPositions, expectedVelocities] =
-      setUpExpectations(particlePositions, particleVelocities, config.boxMin.value, config.boxMax.value,
-                        config.verletSkinRadius.value / 2., config.cutoff.value + config.verletSkinRadius.value,
-                        config.boundaryOption.value);
+      setUpExpectations(particlePositions, particleVelocities, boxMin, boxMax, autoPasContainer->verletSkin() / 2, cutoffWidth + autoPasContainer->verletSkin(),
+                        boundaryConditions);
 
   // particles need to be added at positions inside the domain
   // but also close to their designated positions so they end up in the correct MPI rank

--- a/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
@@ -72,8 +72,7 @@ void MixedBoundaryConditionTest::testFunction(const std::vector<std::array<doubl
   config.boxMin.value = {0., 0., 0.};
   config.boxMax.value = {5., 5., 5.};
   config.cutoff.value = 0.3;
-  config.verletSkinRadiusPerTimestep.value = 0.1;
-  config.verletRebuildFrequency.value=2;
+  config.verletSkinRadius.value = 0.2;
   config.subdivideDimension.value = {true, true, true};
   config.boundaryOption.value = boundaryConditions;
 

--- a/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
@@ -72,7 +72,8 @@ void MixedBoundaryConditionTest::testFunction(const std::vector<std::array<doubl
   config.boxMin.value = {0., 0., 0.};
   config.boxMax.value = {5., 5., 5.};
   config.cutoff.value = 0.3;
-  config.verletSkinRadius.value = 0.2;
+  config.verletSkinRadiusPerTimestep.value = 0.1;
+  config.verletRebuildFrequency.value=2;
   config.subdivideDimension.value = {true, true, true};
   config.boundaryOption.value = boundaryConditions;
 

--- a/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
@@ -88,7 +88,7 @@ void MixedBoundaryConditionTest::testFunction(const std::vector<std::array<doubl
   autoPasContainer->init();
 
   const auto &[expectedPositions, expectedHaloPositions, expectedVelocities] =
-      setUpExpectations(particlePositions, particleVelocities, boxMin, boxMax, autoPasContainer->verletSkin() / 2, cutoffWidth + autoPasContainer->verletSkin(),
+      setUpExpectations(particlePositions, particleVelocities, boxMin, boxMax, autoPasContainer->getVerletSkin() / 2, cutoffWidth + autoPasContainer->getVerletSkin(),
                         boundaryConditions);
 
   // particles need to be added at positions inside the domain

--- a/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
@@ -72,7 +72,8 @@ void MixedBoundaryConditionTest::testFunction(const std::vector<std::array<doubl
   config.boxMin.value = {0., 0., 0.};
   config.boxMax.value = {5., 5., 5.};
   config.cutoff.value = 0.3;
-  config.verletSkinRadius.value = 0.2;
+  config.verletSkinRadiusPerTimestep.value = 0.01;
+  config.verletRebuildFrequency.value = 20;
   config.subdivideDimension.value = {true, true, true};
   config.boundaryOption.value = boundaryConditions;
 
@@ -85,6 +86,7 @@ void MixedBoundaryConditionTest::testFunction(const std::vector<std::array<doubl
   autoPasContainer->setBoxMax(domainDecomposition.getLocalBoxMax());
   autoPasContainer->setCutoff(cutoffWidth);
   autoPasContainer->setVerletSkinPerTimestep(skinWidthPerTimestep);
+  autoPasContainer->setVerletRebuildFrequency(rebuildFrequency);
   autoPasContainer->init();
 
   const auto &[expectedPositions, expectedHaloPositions, expectedVelocities] =

--- a/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
@@ -91,9 +91,8 @@ void MixedBoundaryConditionTest::testFunction(const std::vector<std::array<doubl
 
   const auto &[expectedPositions, expectedHaloPositions, expectedVelocities] =
       setUpExpectations(particlePositions, particleVelocities, config.boxMin.value, config.boxMax.value,
-                        config.verletSkinRadiusPerTimestep.value*config.verletRebuildFrequency.value / 2., 
-                        config.cutoff.value + config.verletSkinRadiusPerTimestep.value,
-                        config.boundaryOption.value);
+                        config.verletSkinRadiusPerTimestep.value * config.verletRebuildFrequency.value / 2.,
+                        config.cutoff.value + config.verletSkinRadiusPerTimestep.value, config.boundaryOption.value);
 
   // particles need to be added at positions inside the domain
   // but also close to their designated positions so they end up in the correct MPI rank

--- a/examples/md-flexible/tests/domainDecomposition/ReflectiveBoundaryConditionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/ReflectiveBoundaryConditionTest.cpp
@@ -26,7 +26,8 @@ TEST_P(ReflectiveBoundaryConditionTest, simpleReflectionTest) {
   const std::array<double, 3> boxLength = autopas::utils::ArrayMath::sub(config.boxMax.value, config.boxMin.value);
   config.subdivideDimension.value = {true, true, true};
   config.cutoff.value = 0.3;
-  config.verletSkinRadius.value = 0.2;
+  config.verletSkinRadiusPerTimestep.value = 0.01;
+  config.verletRebuildFrequency.value = 20;
   config.boundaryOption.value = {options::BoundaryTypeOption::reflective, options::BoundaryTypeOption::reflective,
                                  options::BoundaryTypeOption::reflective};
 
@@ -38,6 +39,7 @@ TEST_P(ReflectiveBoundaryConditionTest, simpleReflectionTest) {
   autoPasContainer->setBoxMax(domainDecomposition.getLocalBoxMax());
   autoPasContainer->setCutoff(cutoffWidth);
   autoPasContainer->setVerletSkinPerTimestep(skinWidthPerTimestep);
+   autoPasContainer->setVerletRebuildFrequency(rebuildFrequency);
   autoPasContainer->init();
 
   // get particle properties

--- a/examples/md-flexible/tests/domainDecomposition/ReflectiveBoundaryConditionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/ReflectiveBoundaryConditionTest.cpp
@@ -36,8 +36,8 @@ TEST_P(ReflectiveBoundaryConditionTest, simpleReflectionTest) {
 
   autoPasContainer->setBoxMin(domainDecomposition.getLocalBoxMin());
   autoPasContainer->setBoxMax(domainDecomposition.getLocalBoxMax());
-  autoPasContainer->setCutoff(config.cutoff.value);
-  autoPasContainer->setVerletSkin(config.verletSkinRadius.value);
+  autoPasContainer->setCutoff(cutoffWidth);
+  autoPasContainer->setVerletSkinPerTimestep(skinWidthPerTimestep);
   autoPasContainer->init();
 
   // get particle properties

--- a/examples/md-flexible/tests/domainDecomposition/ReflectiveBoundaryConditionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/ReflectiveBoundaryConditionTest.cpp
@@ -37,9 +37,9 @@ TEST_P(ReflectiveBoundaryConditionTest, simpleReflectionTest) {
 
   autoPasContainer->setBoxMin(domainDecomposition.getLocalBoxMin());
   autoPasContainer->setBoxMax(domainDecomposition.getLocalBoxMax());
-  autoPasContainer->setCutoff(cutoffWidth);
-  autoPasContainer->setVerletSkinPerTimestep(skinWidthPerTimestep);
-   autoPasContainer->setVerletRebuildFrequency(rebuildFrequency);
+  autoPasContainer->setCutoff(config.cutoff.value);
+  autoPasContainer->setVerletSkinPerTimestep(config.verletSkinRadiusPerTimestep.value);
+  autoPasContainer->setVerletRebuildFrequency(config.verletRebuildFrequency.value);
   autoPasContainer->init();
 
   // get particle properties

--- a/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
@@ -31,8 +31,9 @@ auto initDomain() {
   configuration.boxMin.value = {0., 0., 0.};
   configuration.cutoff.value = 2.5;
   configuration.verletSkinRadiusPerTimestep.value = 0.5;
-  configuration.verletRebuildFrequency.value=2;
-  const double interactionLength = configuration.cutoff.value + configuration.verletSkinRadiusPerTimestep.value*configuration.verletRebuildFrequency.value;
+  configuration.verletRebuildFrequency.value = 2;
+  const double interactionLength = configuration.cutoff.value + configuration.verletSkinRadiusPerTimestep.value *
+                                                                    configuration.verletRebuildFrequency.value;
   // make sure evey rank gets exactly 3x3x3 cells
   const double localBoxLength = 3. * interactionLength;
   const double globalBoxLength = localBoxLength * numberOfProcesses;

--- a/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
@@ -30,8 +30,9 @@ auto initDomain() {
   MDFlexConfig configuration(0, nullptr);
   configuration.boxMin.value = {0., 0., 0.};
   configuration.cutoff.value = 2.5;
-  configuration.verletSkinRadius.value = 0.5;
-  const double interactionLength = configuration.cutoff.value + configuration.verletSkinRadius.value;
+  configuration.verletSkinRadiusPerTimestep.value = 0.5;
+  configuration.verletRebuildFrequency.value=2;
+  const double interactionLength = configuration.cutoff.value + configuration.verletSkinRadiusPerTimestep.value*configuration.verletRebuildFrequency.value;
   // make sure evey rank gets exactly 3x3x3 cells
   const double localBoxLength = 3. * interactionLength;
   const double globalBoxLength = localBoxLength * numberOfProcesses;
@@ -47,7 +48,8 @@ auto initDomain() {
   autoPasContainer->setBoxMin(localBoxMin);
   autoPasContainer->setBoxMax(localBoxMax);
   autoPasContainer->setCutoff(configuration.cutoff.value);
-  autoPasContainer->setVerletSkin(configuration.verletSkinRadius.value);
+  autoPasContainer->setVerletSkinPerTimestep(configuration.verletSkinRadiusPerTimestep.value);
+  autoPasContainer->setVerletRebuildFrequency(configuration.verletRebuildFrequency.value);
   autoPasContainer->setAllowedContainers({autopas::ContainerOption::directSum});
   autoPasContainer->setAllowedTraversals({autopas::TraversalOption::ds_sequential});
   autoPasContainer->init();

--- a/examples/md-flexible/tests/yamlTestFiles/MolSimBlatt2Task3.yaml
+++ b/examples/md-flexible/tests/yamlTestFiles/MolSimBlatt2Task3.yaml
@@ -10,7 +10,7 @@ log-level: debug
 #tuning-samples:                    #int option
 #tuning-max-evidence:               #int option
 #verlet-rebuild-frequency:          #int option
-#verlet-skin-radius                 #double option
+#verlet-skin-radius-per-timestep    #double option
 #no-flops:                          #boolean option
 #log-file:                          #string option
 vtk-filename:  MolSimBlatt2Task3

--- a/examples/md-flexible/tests/yamlTestFiles/particleExchangeTest.yaml
+++ b/examples/md-flexible/tests/yamlTestFiles/particleExchangeTest.yaml
@@ -3,7 +3,7 @@
 #TestRegularGridDecomposition.testExchangeHaloParticles
 #TestRegularGridDecomposition.testExchangeMigratingParticles
 #YamlParser
-cutoff                    : 3
-verlet-skin-radius        : 0
-box-min                   : [0,0,0]
-box-max                   : [9,9,9]
+cutoff                          : 3
+verlet-skin-radius-per-timestep : 0
+box-min                         : [0,0,0]
+box-max                         : [9,9,9]

--- a/examples/sph-mpi/sph-main-mpi.cpp
+++ b/examples/sph-mpi/sph-main-mpi.cpp
@@ -489,7 +489,7 @@ int main(int argc, char *argv[]) {
   sphSystem.setBoxMin(localBoxMin);
   sphSystem.setBoxMax(localBoxMax);
   sphSystem.setCutoff(cutoff);
-  sphSystem.setVerletSkinPerTimestepPerTimestep(skinToCutoffRatioPerTimestepPerTimestep * cutoff);
+  sphSystem.setVerletSkinPerTimestep(skinToCutoffRatioPerTimestepPerTimestep * cutoff);
   sphSystem.setVerletRebuildFrequency(rebuildFrequency);
 
   std::set<autopas::ContainerOption> allowedContainers{autopas::ContainerOption::linkedCells,

--- a/examples/sph-mpi/sph-main-mpi.cpp
+++ b/examples/sph-mpi/sph-main-mpi.cpp
@@ -489,7 +489,7 @@ int main(int argc, char *argv[]) {
   sphSystem.setBoxMin(localBoxMin);
   sphSystem.setBoxMax(localBoxMax);
   sphSystem.setCutoff(cutoff);
-  sphSystem.setVerletSkinPerTimestep(skinToCutoffRatio * cutoff);
+  sphSystem.setVerletSkinPerTimestep(skinToCutoffRatio * cutoff / rebuildFrequency);
   sphSystem.setVerletRebuildFrequency(rebuildFrequency);
 
   std::set<autopas::ContainerOption> allowedContainers{autopas::ContainerOption::linkedCells,

--- a/examples/sph-mpi/sph-main-mpi.cpp
+++ b/examples/sph-mpi/sph-main-mpi.cpp
@@ -475,7 +475,7 @@ int main(int argc, char *argv[]) {
   globalBoxMax[1] = globalBoxMax[2] = globalBoxMax[0] / 8.0;
   double cutoff = 0.03;               // 0.012*2.5=0.03; where 2.5 = kernel support radius
   unsigned int rebuildFrequency = 6;  // has to be multiple of 2
-  double skinToCutoffRatioPerTimestepPerTimestep = 0.1;
+  double skinToCutoffRatio = 0.1;
 
   std::array<double, 3> localBoxMin{}, localBoxMax{};
 

--- a/examples/sph-mpi/sph-main-mpi.cpp
+++ b/examples/sph-mpi/sph-main-mpi.cpp
@@ -270,7 +270,7 @@ void updateHaloParticles(AutoPasContainer &sphSystem, MPI_Comm &comm, const std:
   std::array<int, 3> diff{0, 0, 0};
   std::array<double, 3> shift{0, 0, 0};
   double cutoff = sphSystem.getCutoff();
-  double skin = sphSystem.getVerletSkin();
+  double skin= sphSystem.verletSkin();
   std::vector<double> buffer;
   for (diff[0] = -1; diff[0] < 2; diff[0]++) {
     for (diff[1] = -1; diff[1] < 2; diff[1]++) {
@@ -475,7 +475,7 @@ int main(int argc, char *argv[]) {
   globalBoxMax[1] = globalBoxMax[2] = globalBoxMax[0] / 8.0;
   double cutoff = 0.03;               // 0.012*2.5=0.03; where 2.5 = kernel support radius
   unsigned int rebuildFrequency = 6;  // has to be multiple of 2
-  double skinToCutoffRatio = 0.1;
+  double skinToCutoffRatioPerTimestep = 0.1;
 
   std::array<double, 3> localBoxMin{}, localBoxMax{};
 
@@ -489,7 +489,7 @@ int main(int argc, char *argv[]) {
   sphSystem.setBoxMin(localBoxMin);
   sphSystem.setBoxMax(localBoxMax);
   sphSystem.setCutoff(cutoff);
-  sphSystem.setVerletSkin(skinToCutoffRatio * cutoff);
+  sphSystem.setVerletSkinPerTimestep(skinToCutoffRatioPerTimestep * cutoff);
   sphSystem.setVerletRebuildFrequency(rebuildFrequency);
 
   std::set<autopas::ContainerOption> allowedContainers{autopas::ContainerOption::linkedCells,

--- a/examples/sph-mpi/sph-main-mpi.cpp
+++ b/examples/sph-mpi/sph-main-mpi.cpp
@@ -489,7 +489,7 @@ int main(int argc, char *argv[]) {
   sphSystem.setBoxMin(localBoxMin);
   sphSystem.setBoxMax(localBoxMax);
   sphSystem.setCutoff(cutoff);
-  sphSystem.setVerletSkinPerTimestep(skinToCutoffRatioPerTimestepPerTimestep * cutoff);
+  sphSystem.setVerletSkinPerTimestep(skinToCutoffRatio * cutoff);
   sphSystem.setVerletRebuildFrequency(rebuildFrequency);
 
   std::set<autopas::ContainerOption> allowedContainers{autopas::ContainerOption::linkedCells,

--- a/examples/sph-mpi/sph-main-mpi.cpp
+++ b/examples/sph-mpi/sph-main-mpi.cpp
@@ -270,7 +270,7 @@ void updateHaloParticles(AutoPasContainer &sphSystem, MPI_Comm &comm, const std:
   std::array<int, 3> diff{0, 0, 0};
   std::array<double, 3> shift{0, 0, 0};
   double cutoff = sphSystem.getCutoff();
-  double skin= sphSystem.verletSkin();
+  double skin= sphSystem.getVerletSkin();
   std::vector<double> buffer;
   for (diff[0] = -1; diff[0] < 2; diff[0]++) {
     for (diff[1] = -1; diff[1] < 2; diff[1]++) {

--- a/examples/sph-mpi/sph-main-mpi.cpp
+++ b/examples/sph-mpi/sph-main-mpi.cpp
@@ -270,7 +270,7 @@ void updateHaloParticles(AutoPasContainer &sphSystem, MPI_Comm &comm, const std:
   std::array<int, 3> diff{0, 0, 0};
   std::array<double, 3> shift{0, 0, 0};
   double cutoff = sphSystem.getCutoff();
-  double skin= sphSystem.getVerletSkin();
+  double skin = sphSystem.getVerletSkin();
   std::vector<double> buffer;
   for (diff[0] = -1; diff[0] < 2; diff[0]++) {
     for (diff[1] = -1; diff[1] < 2; diff[1]++) {

--- a/examples/sph/sph-main.cpp
+++ b/examples/sph/sph-main.cpp
@@ -294,7 +294,7 @@ int main() {
   boxMax[1] = boxMax[2] = boxMax[0] / 8.0;
   double cutoff = 0.03;               // 0.012*2.5=0.03; where 2.5 = kernel support radius
   unsigned int rebuildFrequency = 6;  // has to be multiple of two, as there are two functor calls per iteration.
-  double skinToCutoffRatio = 0.15;
+  double skinToCutoffRatioPerTimestep = 0.15;
 
   AutoPasContainer sphSystem;
   sphSystem.setNumSamples(
@@ -302,7 +302,7 @@ int main() {
   sphSystem.setBoxMin(boxMin);
   sphSystem.setBoxMax(boxMax);
   sphSystem.setCutoff(cutoff);
-  sphSystem.setVerletSkin(skinToCutoffRatio * cutoff);
+  sphSystem.setVerletSkinPerTimestep(skinToCutoffRatioPerTimestep * cutoff);
   sphSystem.setVerletRebuildFrequency(rebuildFrequency);
 
   // In case you want to use another tuning strategy, you can do that using:

--- a/examples/sph/sph-main.cpp
+++ b/examples/sph/sph-main.cpp
@@ -294,7 +294,7 @@ int main() {
   boxMax[1] = boxMax[2] = boxMax[0] / 8.0;
   double cutoff = 0.03;               // 0.012*2.5=0.03; where 2.5 = kernel support radius
   unsigned int rebuildFrequency = 6;  // has to be multiple of two, as there are two functor calls per iteration.
-  double skinToCutoffRatio= 0.15;
+  double skinToCutoffRatio = 0.15;
 
   AutoPasContainer sphSystem;
   sphSystem.setNumSamples(

--- a/examples/sph/sph-main.cpp
+++ b/examples/sph/sph-main.cpp
@@ -302,7 +302,7 @@ int main() {
   sphSystem.setBoxMin(boxMin);
   sphSystem.setBoxMax(boxMax);
   sphSystem.setCutoff(cutoff);
-  sphSystem.setVerletSkinPerTimestep(skinToCutoffRatio * cutoff);
+  sphSystem.setVerletSkinPerTimestep(skinToCutoffRatio * cutoff / rebuildFrequency);
   sphSystem.setVerletRebuildFrequency(rebuildFrequency);
 
   // In case you want to use another tuning strategy, you can do that using:

--- a/examples/sph/sph-main.cpp
+++ b/examples/sph/sph-main.cpp
@@ -294,7 +294,7 @@ int main() {
   boxMax[1] = boxMax[2] = boxMax[0] / 8.0;
   double cutoff = 0.03;               // 0.012*2.5=0.03; where 2.5 = kernel support radius
   unsigned int rebuildFrequency = 6;  // has to be multiple of two, as there are two functor calls per iteration.
-  double skinToCutoffRatioPerTimestep = 0.15;
+  double skinToCutoffRatio= 0.15;
 
   AutoPasContainer sphSystem;
   sphSystem.setNumSamples(
@@ -302,7 +302,7 @@ int main() {
   sphSystem.setBoxMin(boxMin);
   sphSystem.setBoxMax(boxMax);
   sphSystem.setCutoff(cutoff);
-  sphSystem.setVerletSkinPerTimestep(skinToCutoffRatioPerTimestep * cutoff);
+  sphSystem.setVerletSkinPerTimestep(skinToCutoffRatio * cutoff);
   sphSystem.setVerletRebuildFrequency(rebuildFrequency);
 
   // In case you want to use another tuning strategy, you can do that using:

--- a/examples/sphDiagramGeneration/sph-diagram-generation.cpp
+++ b/examples/sphDiagramGeneration/sph-diagram-generation.cpp
@@ -55,7 +55,7 @@ int main(int argc, char *argv[]) {
   enum FunctorType { densityFunctor, hydroForceFunctor } functorType = densityFunctor;
 
   double skinPerTimestep = 0.;
-  int rebuildFrequency = 10;
+  unsigned int rebuildFrequency = 10;
   bool useNewton3 = true;
   try {
     if (argc >= 9) {

--- a/examples/sphDiagramGeneration/sph-diagram-generation.cpp
+++ b/examples/sphDiagramGeneration/sph-diagram-generation.cpp
@@ -108,7 +108,7 @@ int main(int argc, char *argv[]) {
   autoPas.setBoxMin(boxMin);
   autoPas.setBoxMax(boxMax);
   autoPas.setCutoff(cutoff);
-  autoPas.setVerletSkinPerTimestep(skinPerTimestep * cutoff);
+  autoPas.setVerletSkinPerTimestep(skinPerTimestep * cutoff / rebuildFrequency);
   autoPas.setVerletRebuildFrequency(rebuildFrequency);
   autoPas.setAllowedContainers(containerOptions);
   autoPas.setAllowedNewton3Options({useNewton3 ? autopas::Newton3Option::enabled : autopas::Newton3Option::disabled});

--- a/examples/sphDiagramGeneration/sph-diagram-generation.cpp
+++ b/examples/sphDiagramGeneration/sph-diagram-generation.cpp
@@ -54,7 +54,7 @@ int main(int argc, char *argv[]) {
   int functorTypeInt = 0;
   enum FunctorType { densityFunctor, hydroForceFunctor } functorType = densityFunctor;
 
-  double skin = 0.;
+  double skinPerTimestep = 0.;
   int rebuildFrequency = 10;
   bool useNewton3 = true;
   try {
@@ -66,7 +66,7 @@ int main(int argc, char *argv[]) {
     }
     if (argc >= 7) {
       rebuildFrequency = std::stoi(argv[6]);
-      skin = std::stod(argv[5]);
+      skinPerTimestep = std::stod(argv[5]);
     }
     if (argc >= 5) {
       functorTypeInt = std::stoi(argv[4]);
@@ -86,7 +86,7 @@ int main(int argc, char *argv[]) {
     std::cerr
         << "ERROR parsing the input arguments: " << e.what() << std::endl
         << "sph-diagram-generation requires the following arguments:" << std::endl
-        << "numParticles numIterations containerType [functorType [skin rebuildFrequency [useNewton3 [boxSize]]]]:"
+        << "numParticles numIterations containerType [functorType [skinPerTimestep rebuildFrequency [useNewton3 [boxSize]]]]:"
         << std::endl
         << std::endl
         << "containerType should be either linked-cells, direct sum, verlet lists or verlet lists cells" << std::endl
@@ -107,7 +107,7 @@ int main(int argc, char *argv[]) {
   autoPas.setBoxMin(boxMin);
   autoPas.setBoxMax(boxMax);
   autoPas.setCutoff(cutoff);
-  autoPas.setVerletSkin(skin * cutoff);
+  autoPas.setVerletSkinPerTimestep(skinPerTimestep * cutoff);
   autoPas.setVerletRebuildFrequency(rebuildFrequency);
   autoPas.setAllowedContainers(containerOptions);
   autoPas.setAllowedNewton3Options({useNewton3 ? autopas::Newton3Option::enabled : autopas::Newton3Option::disabled});

--- a/examples/sphDiagramGeneration/sph-diagram-generation.cpp
+++ b/examples/sphDiagramGeneration/sph-diagram-generation.cpp
@@ -83,14 +83,15 @@ int main(int argc, char *argv[]) {
       throw std::runtime_error("too few arguments");
     }
   } catch (const std::exception &e) {
-    std::cerr
-        << "ERROR parsing the input arguments: " << e.what() << std::endl
-        << "sph-diagram-generation requires the following arguments:" << std::endl
-        << "numParticles numIterations containerType [functorType [skinPerTimestep rebuildFrequency [useNewton3 [boxSize]]]]:"
-        << std::endl
-        << std::endl
-        << "containerType should be either linked-cells, direct sum, verlet lists or verlet lists cells" << std::endl
-        << "functorType should be either 0 (density functor) or 1 (hydro force functor)" << std::endl;
+    std::cerr << "ERROR parsing the input arguments: " << e.what() << std::endl
+              << "sph-diagram-generation requires the following arguments:" << std::endl
+              << "numParticles numIterations containerType [functorType [skinPerTimestep rebuildFrequency [useNewton3 "
+                 "[boxSize]]]]:"
+              << std::endl
+              << std::endl
+              << "containerType should be either linked-cells, direct sum, verlet lists or verlet lists cells"
+              << std::endl
+              << "functorType should be either 0 (density functor) or 1 (hydro force functor)" << std::endl;
     exit(1);
   }
 

--- a/src/autopas/AutoPasDecl.h
+++ b/src/autopas/AutoPasDecl.h
@@ -542,7 +542,7 @@ class AutoPas {
 
   /**
    * Set length added to the cutoff for the Verlet lists' skin per timestep.
-   * @param verletSkinPerTimeStep
+   * @param verletSkinPerTimestep
    */
   void setVerletSkinPerTimestep(double verletSkinPerTimestep) {
     AutoPas::_verletSkinPerTimestep = verletSkinPerTimestep;

--- a/src/autopas/AutoPasDecl.h
+++ b/src/autopas/AutoPasDecl.h
@@ -536,7 +536,7 @@ class AutoPas {
 
   /**
    * Get length added to the cutoff for the Verlet lists' skin per timestep.
-   * @return
+   * @return _verletSkinPerTimestep
    */
   [[nodiscard]] double getVerletSkinPerTimestep() const { return _verletSkinPerTimestep; }
 
@@ -550,7 +550,7 @@ class AutoPas {
 
   /**
    * Get Verlet rebuild frequency.
-   * @return
+   * @return _verletRebuildFrequency
    */
   [[nodiscard]] unsigned int getVerletRebuildFrequency() const { return _verletRebuildFrequency; }
 

--- a/src/autopas/AutoPasDecl.h
+++ b/src/autopas/AutoPasDecl.h
@@ -870,17 +870,9 @@ class AutoPas {
    * Length added to the cutoff for the Verlet lists' skin per Timestep.
    */
   double _verletSkinPerTimestep{0.01};
-
-
-  /**
-   * Length added to the cutoff for the Verlet lists' skin.
-   */
-  //double _verletSkin{0};
   /**
    * Specifies after how many pair-wise traversals the neighbor lists are to be rebuild.
    */
-
-  
   unsigned int _verletRebuildFrequency{20};
   /**
    * Specifies the size of clusters for Verlet lists.

--- a/src/autopas/AutoPasDecl.h
+++ b/src/autopas/AutoPasDecl.h
@@ -432,6 +432,17 @@ class AutoPas {
       containerPtr->reduceInRegion(reduceLambda, result, lowerCorner, higherCorner, behavior);
     });
   }
+  /**
+   * Function to iterate over all pairs of particles in the container.
+   * This function only handles short-range interactions.
+   * @param _verletSkinPerTimestep 
+   * @param 
+   * @return _vereltSkin which is the length of the verlet skin at the time of rebuild
+   */
+  double verletSkin(){
+    double _verletSkin=AutoPas::_verletSkinPerTimestep*AutoPas::_verletRebuildFrequency;
+    return _verletSkin;
+  };
 
   /**
    * Returns the number of particles in this container.
@@ -528,13 +539,20 @@ class AutoPas {
    * Get length added to the cutoff for the Verlet lists' skin.
    * @return
    */
-  [[nodiscard]] double getVerletSkin() const { return _verletSkin; }
+ // [[nodiscard]] double getVerletSkin() const { return _verletSkin; }
+
+  
+  /**
+   * Get length added to the cutoff for the Verlet lists' skin per timestep.
+   * @return
+   */
+  [[nodiscard]] double getVerletSkinPerTimestep() const { return _verletSkinPerTimestep; }
 
   /**
-   * Set length added to the cutoff for the Verlet lists' skin.
-   * @param verletSkin
+   * Set length added to the cutoff for the Verlet lists' skin per timestep.
+   * @param verletSkinPerTimeStep
    */
-  void setVerletSkin(double verletSkin) { AutoPas::_verletSkin = verletSkin; }
+  void setVerletSkinPerTimestep(double verletSkinPerTimestep) { AutoPas::_verletSkinPerTimestep = verletSkinPerTimestep; }
 
   /**
    * Get Verlet rebuild frequency.
@@ -549,7 +567,6 @@ class AutoPas {
   void setVerletRebuildFrequency(unsigned int verletRebuildFrequency) {
     AutoPas::_verletRebuildFrequency = verletRebuildFrequency;
   }
-
   /**
    * Get Verlet cluster size.
    * @return
@@ -856,13 +873,21 @@ class AutoPas {
    * Cutoff radius to be used in this container.
    */
   double _cutoff{1.0};
+   /**
+   * Length added to the cutoff for the Verlet lists' skin per Timestep.
+   */
+  double _verletSkinPerTimestep{0.01};
+
+
   /**
    * Length added to the cutoff for the Verlet lists' skin.
    */
-  double _verletSkin{0.2};
+  //double _verletSkin{0};
   /**
    * Specifies after how many pair-wise traversals the neighbor lists are to be rebuild.
    */
+
+  
   unsigned int _verletRebuildFrequency{20};
   /**
    * Specifies the size of clusters for Verlet lists.

--- a/src/autopas/AutoPasDecl.h
+++ b/src/autopas/AutoPasDecl.h
@@ -436,8 +436,7 @@ class AutoPas {
    * Function to iterate over all pairs of particles in the container.
    * This function only handles short-range interactions.
    * @param _verletSkinPerTimestep
-   * @param
-   * @return _vereltSkin which is the length of the verlet skin at the time of rebuild
+   * @return _verletSkin
    */
   double getVerletSkin() {
     double _verletSkin = AutoPas::_verletSkinPerTimestep * AutoPas::_verletRebuildFrequency;

--- a/src/autopas/AutoPasDecl.h
+++ b/src/autopas/AutoPasDecl.h
@@ -439,7 +439,7 @@ class AutoPas {
    * @param 
    * @return _vereltSkin which is the length of the verlet skin at the time of rebuild
    */
-  double verletSkin(){
+  double getVerletSkin(){
     double _verletSkin=AutoPas::_verletSkinPerTimestep*AutoPas::_verletRebuildFrequency;
     return _verletSkin;
   };
@@ -534,13 +534,6 @@ class AutoPas {
     }
     AutoPas::_allowedCellSizeFactors = std::make_unique<NumberSetFinite<double>>(std::set<double>{cellSizeFactor});
   }
-
-  /**
-   * Get length added to the cutoff for the Verlet lists' skin.
-   * @return
-   */
- // [[nodiscard]] double getVerletSkin() const { return _verletSkin; }
-
   
   /**
    * Get length added to the cutoff for the Verlet lists' skin per timestep.

--- a/src/autopas/AutoPasDecl.h
+++ b/src/autopas/AutoPasDecl.h
@@ -435,12 +435,12 @@ class AutoPas {
   /**
    * Function to iterate over all pairs of particles in the container.
    * This function only handles short-range interactions.
-   * @param _verletSkinPerTimestep 
-   * @param 
+   * @param _verletSkinPerTimestep
+   * @param
    * @return _vereltSkin which is the length of the verlet skin at the time of rebuild
    */
-  double getVerletSkin(){
-    double _verletSkin=AutoPas::_verletSkinPerTimestep*AutoPas::_verletRebuildFrequency;
+  double getVerletSkin() {
+    double _verletSkin = AutoPas::_verletSkinPerTimestep * AutoPas::_verletRebuildFrequency;
     return _verletSkin;
   };
 
@@ -534,7 +534,7 @@ class AutoPas {
     }
     AutoPas::_allowedCellSizeFactors = std::make_unique<NumberSetFinite<double>>(std::set<double>{cellSizeFactor});
   }
-  
+
   /**
    * Get length added to the cutoff for the Verlet lists' skin per timestep.
    * @return
@@ -545,7 +545,9 @@ class AutoPas {
    * Set length added to the cutoff for the Verlet lists' skin per timestep.
    * @param verletSkinPerTimeStep
    */
-  void setVerletSkinPerTimestep(double verletSkinPerTimestep) { AutoPas::_verletSkinPerTimestep = verletSkinPerTimestep; }
+  void setVerletSkinPerTimestep(double verletSkinPerTimestep) {
+    AutoPas::_verletSkinPerTimestep = verletSkinPerTimestep;
+  }
 
   /**
    * Get Verlet rebuild frequency.
@@ -866,7 +868,7 @@ class AutoPas {
    * Cutoff radius to be used in this container.
    */
   double _cutoff{1.0};
-   /**
+  /**
    * Length added to the cutoff for the Verlet lists' skin per Timestep.
    */
   double _verletSkinPerTimestep{0.01};

--- a/src/autopas/AutoPasDecl.h
+++ b/src/autopas/AutoPasDecl.h
@@ -435,7 +435,6 @@ class AutoPas {
   /**
    * Function to iterate over all pairs of particles in the container.
    * This function only handles short-range interactions.
-   * @param _verletSkinPerTimestep
    * @return _verletSkin
    */
   double getVerletSkin() {

--- a/src/autopas/AutoPasImpl.h
+++ b/src/autopas/AutoPasImpl.h
@@ -73,9 +73,9 @@ void AutoPas<Particle>::init() {
       _relativeBlacklistRange, _evidenceFirstPrediction, _acquisitionFunctionOption, _extrapolationMethodOption,
       _outputSuffix, _mpiStrategyOption, _autopasMPICommunicator);
   _autoTuner = std::make_unique<autopas::AutoTuner<Particle>>(
-      _boxMin, _boxMax, _cutoff, _verletSkinPerTimestep, _verletRebuildFrequency,_verletClusterSize, std::move(tuningStrategy),
-      _mpiTuningMaxDifferenceForBucket, _mpiTuningWeightForMaxDensity, _selectorStrategy, _tuningInterval, _numSamples,
-      _verletRebuildFrequency, _outputSuffix);
+      _boxMin, _boxMax, _cutoff, _verletSkinPerTimestep, _verletRebuildFrequency, _verletClusterSize,
+      std::move(tuningStrategy), _mpiTuningMaxDifferenceForBucket, _mpiTuningWeightForMaxDensity, _selectorStrategy,
+      _tuningInterval, _numSamples, _verletRebuildFrequency, _outputSuffix);
   _logicHandler =
       std::make_unique<std::remove_reference_t<decltype(*_logicHandler)>>(*(_autoTuner.get()), _verletRebuildFrequency);
 }

--- a/src/autopas/AutoPasImpl.h
+++ b/src/autopas/AutoPasImpl.h
@@ -73,9 +73,9 @@ void AutoPas<Particle>::init() {
       _relativeBlacklistRange, _evidenceFirstPrediction, _acquisitionFunctionOption, _extrapolationMethodOption,
       _outputSuffix, _mpiStrategyOption, _autopasMPICommunicator);
   _autoTuner = std::make_unique<autopas::AutoTuner<Particle>>(
-      _boxMin, _boxMax, _cutoff, _verletSkinPerTimestep, _verletClusterSize,
-      std::move(tuningStrategy), _mpiTuningMaxDifferenceForBucket, _mpiTuningWeightForMaxDensity, _selectorStrategy,
-      _tuningInterval, _numSamples, _verletRebuildFrequency, _outputSuffix);
+      _boxMin, _boxMax, _cutoff, _verletSkinPerTimestep, _verletClusterSize, std::move(tuningStrategy),
+      _mpiTuningMaxDifferenceForBucket, _mpiTuningWeightForMaxDensity, _selectorStrategy, _tuningInterval, _numSamples,
+      _verletRebuildFrequency, _outputSuffix);
   _logicHandler =
       std::make_unique<std::remove_reference_t<decltype(*_logicHandler)>>(*(_autoTuner.get()), _verletRebuildFrequency);
 }

--- a/src/autopas/AutoPasImpl.h
+++ b/src/autopas/AutoPasImpl.h
@@ -73,7 +73,7 @@ void AutoPas<Particle>::init() {
       _relativeBlacklistRange, _evidenceFirstPrediction, _acquisitionFunctionOption, _extrapolationMethodOption,
       _outputSuffix, _mpiStrategyOption, _autopasMPICommunicator);
   _autoTuner = std::make_unique<autopas::AutoTuner<Particle>>(
-      _boxMin, _boxMax, _cutoff, _verletSkin, _verletClusterSize, std::move(tuningStrategy),
+      _boxMin, _boxMax, _cutoff, _verletSkinPerTimestep, _verletRebuildFrequency,_verletClusterSize, std::move(tuningStrategy),
       _mpiTuningMaxDifferenceForBucket, _mpiTuningWeightForMaxDensity, _selectorStrategy, _tuningInterval, _numSamples,
       _verletRebuildFrequency, _outputSuffix);
   _logicHandler =

--- a/src/autopas/AutoPasImpl.h
+++ b/src/autopas/AutoPasImpl.h
@@ -73,9 +73,9 @@ void AutoPas<Particle>::init() {
       _relativeBlacklistRange, _evidenceFirstPrediction, _acquisitionFunctionOption, _extrapolationMethodOption,
       _outputSuffix, _mpiStrategyOption, _autopasMPICommunicator);
   _autoTuner = std::make_unique<autopas::AutoTuner<Particle>>(
-      _boxMin, _boxMax, _cutoff, _verletSkinPerTimestep, _verletRebuildFrequency, _verletClusterSize,
+      _boxMin, _boxMax, _cutoff, _verletSkinPerTimestep, _verletClusterSize,
       std::move(tuningStrategy), _mpiTuningMaxDifferenceForBucket, _mpiTuningWeightForMaxDensity, _selectorStrategy,
-      _tuningInterval, _numSamples, _outputSuffix);
+      _tuningInterval, _numSamples, _verletRebuildFrequency, _outputSuffix);
   _logicHandler =
       std::make_unique<std::remove_reference_t<decltype(*_logicHandler)>>(*(_autoTuner.get()), _verletRebuildFrequency);
 }

--- a/src/autopas/AutoPasImpl.h
+++ b/src/autopas/AutoPasImpl.h
@@ -75,7 +75,7 @@ void AutoPas<Particle>::init() {
   _autoTuner = std::make_unique<autopas::AutoTuner<Particle>>(
       _boxMin, _boxMax, _cutoff, _verletSkinPerTimestep, _verletRebuildFrequency, _verletClusterSize,
       std::move(tuningStrategy), _mpiTuningMaxDifferenceForBucket, _mpiTuningWeightForMaxDensity, _selectorStrategy,
-      _tuningInterval, _numSamples, _verletRebuildFrequency, _outputSuffix);
+      _tuningInterval, _numSamples, _outputSuffix);
   _logicHandler =
       std::make_unique<std::remove_reference_t<decltype(*_logicHandler)>>(*(_autoTuner.get()), _verletRebuildFrequency);
 }

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -376,11 +376,11 @@ class LogicHandler {
     auto container = _autoTuner.getContainer();
     // check boxSize at least cutoff + skin
     for (unsigned int dim = 0; dim < 3; ++dim) {
-      if (container->getBoxMax()[dim] - container->getBoxMin()[dim] < container->getCutoff() + container->getSkin()) {
+      if (container->getBoxMax()[dim] - container->getBoxMin()[dim] < container->getCutoff() + container->getVerletSkin()) {
         autopas::utils::ExceptionHandler::exception(
             "Box (boxMin[{}]={} and boxMax[{}]={}) is too small.\nHas to be at least cutoff({}) + skin({}) = {}.", dim,
-            container->getBoxMin()[dim], dim, container->getBoxMax()[dim], container->getCutoff(), container->getSkin(),
-            container->getCutoff() + container->getSkin());
+            container->getBoxMin()[dim], dim, container->getBoxMax()[dim], container->getCutoff(), container->getVerletSkin(),
+            container->getCutoff() + container->getVerletSkin());
       }
     }
   }

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -376,11 +376,12 @@ class LogicHandler {
     auto container = _autoTuner.getContainer();
     // check boxSize at least cutoff + skin
     for (unsigned int dim = 0; dim < 3; ++dim) {
-      if (container->getBoxMax()[dim] - container->getBoxMin()[dim] < container->getCutoff() + container->getVerletSkin()) {
+      if (container->getBoxMax()[dim] - container->getBoxMin()[dim] <
+          container->getCutoff() + container->getVerletSkin()) {
         autopas::utils::ExceptionHandler::exception(
             "Box (boxMin[{}]={} and boxMax[{}]={}) is too small.\nHas to be at least cutoff({}) + skin({}) = {}.", dim,
-            container->getBoxMin()[dim], dim, container->getBoxMax()[dim], container->getCutoff(), container->getVerletSkin(),
-            container->getCutoff() + container->getVerletSkin());
+            container->getBoxMin()[dim], dim, container->getBoxMax()[dim], container->getCutoff(),
+            container->getVerletSkin(), container->getCutoff() + container->getVerletSkin());
       }
     }
   }

--- a/src/autopas/cells/ParticleCell.h
+++ b/src/autopas/cells/ParticleCell.h
@@ -73,7 +73,7 @@ class ParticleCell {
   virtual SingleCellIteratorWrapper<Particle, true> begin() = 0;
 
   /**
-   * @copydoc begin()
+   * @copydoc autopas::ParticleCell::begin()
    * @note const version
    */
   virtual SingleCellIteratorWrapper<Particle, false> begin() const = 0;

--- a/src/autopas/containers/CellBasedParticleContainer.h
+++ b/src/autopas/containers/CellBasedParticleContainer.h
@@ -110,9 +110,9 @@ class CellBasedParticleContainer : public ParticleContainerInterface<typename Pa
    */
   [[nodiscard]] double getInteractionLength() const override final { return _cutoff + _skinPerTimestep*_rebuildFrequency; }
   /**
-   * @copydoc autopas::ParticleContainerInterface::getSkin()
+   * @copydoc autopas::ParticleContainerInterface::getVerletSkin()
    */
-  [[nodiscard]] double getSkin() const override final { return _skinPerTimestep*_rebuildFrequency; }
+  [[nodiscard]] double getVerletSkin() const override final { return _skinPerTimestep*_rebuildFrequency; }
 
   /**
    * Deletes all particles from the container.
@@ -168,7 +168,7 @@ class CellBasedParticleContainer : public ParticleContainerInterface<typename Pa
   std::array<double, 3> _boxMax;
   double _cutoff;
   double _skinPerTimestep;
-  double _rebuildFrequency;
+  unsigned int _rebuildFrequency;
   
 };
 

--- a/src/autopas/containers/CellBasedParticleContainer.h
+++ b/src/autopas/containers/CellBasedParticleContainer.h
@@ -36,11 +36,7 @@ class CellBasedParticleContainer : public ParticleContainerInterface<typename Pa
    */
   CellBasedParticleContainer(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax,
                              const double cutoff, const double skin)
-      : _cells(),
-        _boxMin(boxMin),
-        _boxMax(boxMax),
-        _cutoff(cutoff),
-        _skin(skin) {}
+      : _cells(), _boxMin(boxMin), _boxMax(boxMax), _cutoff(cutoff), _skin(skin) {}
 
   /**
    * Destructor of CellBasedParticleContainer.
@@ -95,9 +91,7 @@ class CellBasedParticleContainer : public ParticleContainerInterface<typename Pa
   /**
    * @copydoc autopas::ParticleContainerInterface::getInteractionLength()
    */
-  [[nodiscard]] double getInteractionLength() const override final {
-    return _cutoff + _skin;
-  }
+  [[nodiscard]] double getInteractionLength() const override final { return _cutoff + _skin; }
   /**
    * Returns the total verlet Skin length
    * @return _skinPerTimestep * _rebuildFrequency

--- a/src/autopas/containers/CellBasedParticleContainer.h
+++ b/src/autopas/containers/CellBasedParticleContainer.h
@@ -35,7 +35,7 @@ class CellBasedParticleContainer : public ParticleContainerInterface<typename Pa
    * @param skinPerTimestep
    */
   CellBasedParticleContainer(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax,
-                             const double cutoff, const double skinPerTimestep, const double rebuildFrequency)
+                             const double cutoff, const double skinPerTimestep, const unsigned int rebuildFrequency)
       : _cells(), _boxMin(boxMin), _boxMax(boxMax), _cutoff(cutoff), _skinPerTimestep(skinPerTimestep), 
       _rebuildFrequency(rebuildFrequency){}
 

--- a/src/autopas/containers/CellBasedParticleContainer.h
+++ b/src/autopas/containers/CellBasedParticleContainer.h
@@ -32,17 +32,15 @@ class CellBasedParticleContainer : public ParticleContainerInterface<typename Pa
    * @param boxMin
    * @param boxMax
    * @param cutoff
-   * @param skinPerTimestep
-   * @param rebuildFrequency
+   * @param skin
    */
   CellBasedParticleContainer(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax,
-                             const double cutoff, const double skinPerTimestep, const unsigned int rebuildFrequency)
+                             const double cutoff, const double skin)
       : _cells(),
         _boxMin(boxMin),
         _boxMax(boxMax),
         _cutoff(cutoff),
-        _skinPerTimestep(skinPerTimestep),
-        _rebuildFrequency(rebuildFrequency) {}
+        _skin(skin) {}
 
   /**
    * Destructor of CellBasedParticleContainer.
@@ -95,32 +93,16 @@ class CellBasedParticleContainer : public ParticleContainerInterface<typename Pa
   void setCutoff(double cutoff) override final { _cutoff = cutoff; }
 
   /**
-   * @copydoc autopas::ParticleContainerInterface::getSkinPerTimestep()
-   */
-  [[nodiscard]] double getSkinPerTimestep() const override final { return _skinPerTimestep; }
-  /**
-   * @copydoc autopas::ParticleContainerInterface::setSkinPerTimestep()
-   */
-  void setSkinPerTimestep(double skinPerTimestep) override final { _skinPerTimestep = skinPerTimestep; }
-  /**
-   * @copydoc autopas::ParticleContainerInterface::setRebuildFrequency()
-   */
-  void setRebuildFrequency(unsigned int rebuildFrequency) override final { _rebuildFrequency = rebuildFrequency; }
-  /**
-   * @copydoc autopas::ParticleContainerInterface::getRebuildFrequency()
-   */
-  [[nodiscard]] unsigned int getRebuildFrequency() const override final { return _rebuildFrequency; }
-  /**
    * @copydoc autopas::ParticleContainerInterface::getInteractionLength()
    */
   [[nodiscard]] double getInteractionLength() const override final {
-    return _cutoff + _skinPerTimestep * _rebuildFrequency;
+    return _cutoff + _skin;
   }
   /**
    * Returns the total verlet Skin length
    * @return _skinPerTimestep * _rebuildFrequency
    */
-  [[nodiscard]] double getVerletSkin() const override final { return _skinPerTimestep * _rebuildFrequency; }
+  [[nodiscard]] double getVerletSkin() const override final { return _skin; }
 
   /**
    * Deletes all particles from the container.
@@ -175,8 +157,7 @@ class CellBasedParticleContainer : public ParticleContainerInterface<typename Pa
   std::array<double, 3> _boxMin;
   std::array<double, 3> _boxMax;
   double _cutoff;
-  double _skinPerTimestep;
-  unsigned int _rebuildFrequency;
+  double _skin;
 };
 
 }  // namespace autopas

--- a/src/autopas/containers/CellBasedParticleContainer.h
+++ b/src/autopas/containers/CellBasedParticleContainer.h
@@ -100,11 +100,11 @@ class CellBasedParticleContainer : public ParticleContainerInterface<typename Pa
   /**
    * @copydoc autopas::ParticleContainerInterface::setRebuildFrequency()
    */
-  void setRebuildFrequency(double rebuildFrequency) override final { _rebuildFrequency = rebuildFrequency; }
+  void setRebuildFrequency(unsigned int rebuildFrequency) override final { _rebuildFrequency = rebuildFrequency; }
    /**
    * @copydoc autopas::ParticleContainerInterface::getRebuildFrequency()
    */
-  [[nodiscard]] double getRebuildFrequency() const override final { return _rebuildFrequency; }
+  [[nodiscard]] unsigned int getRebuildFrequency() const override final { return _rebuildFrequency; }
   /**
    * @copydoc autopas::ParticleContainerInterface::getInteractionLength()
    */

--- a/src/autopas/containers/CellBasedParticleContainer.h
+++ b/src/autopas/containers/CellBasedParticleContainer.h
@@ -32,11 +32,12 @@ class CellBasedParticleContainer : public ParticleContainerInterface<typename Pa
    * @param boxMin
    * @param boxMax
    * @param cutoff
-   * @param skin
+   * @param skinPerTimestep
    */
   CellBasedParticleContainer(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax,
-                             const double cutoff, const double skin)
-      : _cells(), _boxMin(boxMin), _boxMax(boxMax), _cutoff(cutoff), _skin(skin) {}
+                             const double cutoff, const double skinPerTimestep, const double rebuildFrequency)
+      : _cells(), _boxMin(boxMin), _boxMax(boxMax), _cutoff(cutoff), _skinPerTimestep(skinPerTimestep), 
+      _rebuildFrequency(rebuildFrequency){}
 
   /**
    * Destructor of CellBasedParticleContainer.
@@ -89,19 +90,29 @@ class CellBasedParticleContainer : public ParticleContainerInterface<typename Pa
   void setCutoff(double cutoff) override final { _cutoff = cutoff; }
 
   /**
-   * @copydoc autopas::ParticleContainerInterface::getSkin()
+   * @copydoc autopas::ParticleContainerInterface::getSkinPerTimestep()
    */
-  [[nodiscard]] double getSkin() const override final { return _skin; }
-
+  [[nodiscard]] double getSkinPerTimestep() const override final { return _skinPerTimestep; }
   /**
-   * @copydoc autopas::ParticleContainerInterface::setSkin()
+   * @copydoc autopas::ParticleContainerInterface::setSkinPerTimestep()
    */
-  void setSkin(double skin) override final { _skin = skin; }
-
+  void setSkinPerTimestep(double skinPerTimestep) override final { _skinPerTimestep = skinPerTimestep; }
+  /**
+   * @copydoc autopas::ParticleContainerInterface::setRebuildFrequency()
+   */
+  void setRebuildFrequency(double rebuildFrequency) override final { _rebuildFrequency = rebuildFrequency; }
+   /**
+   * @copydoc autopas::ParticleContainerInterface::getRebuildFrequency()
+   */
+  [[nodiscard]] double getRebuildFrequency() const override final { return _rebuildFrequency; }
   /**
    * @copydoc autopas::ParticleContainerInterface::getInteractionLength()
    */
-  [[nodiscard]] double getInteractionLength() const override final { return _cutoff + _skin; }
+  [[nodiscard]] double getInteractionLength() const override final { return _cutoff + _skinPerTimestep*_rebuildFrequency; }
+  /**
+   * @copydoc autopas::ParticleContainerInterface::getSkin()
+   */
+  [[nodiscard]] double getSkin() const override final { return _skinPerTimestep*_rebuildFrequency; }
 
   /**
    * Deletes all particles from the container.
@@ -156,7 +167,9 @@ class CellBasedParticleContainer : public ParticleContainerInterface<typename Pa
   std::array<double, 3> _boxMin;
   std::array<double, 3> _boxMax;
   double _cutoff;
-  double _skin;
+  double _skinPerTimestep;
+  double _rebuildFrequency;
+  
 };
 
 }  // namespace autopas

--- a/src/autopas/containers/CellBasedParticleContainer.h
+++ b/src/autopas/containers/CellBasedParticleContainer.h
@@ -33,6 +33,7 @@ class CellBasedParticleContainer : public ParticleContainerInterface<typename Pa
    * @param boxMax
    * @param cutoff
    * @param skinPerTimestep
+   * @param rebuildFrequency
    */
   CellBasedParticleContainer(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax,
                              const double cutoff, const double skinPerTimestep, const unsigned int rebuildFrequency)

--- a/src/autopas/containers/CellBasedParticleContainer.h
+++ b/src/autopas/containers/CellBasedParticleContainer.h
@@ -116,7 +116,8 @@ class CellBasedParticleContainer : public ParticleContainerInterface<typename Pa
     return _cutoff + _skinPerTimestep * _rebuildFrequency;
   }
   /**
-   * @copydoc autopas::ParticleContainerInterface::getVerletSkin()
+   * Returns the total verlet Skin length
+   * @return _skinPerTimestep * _rebuildFrequency
    */
   [[nodiscard]] double getVerletSkin() const override final { return _skinPerTimestep * _rebuildFrequency; }
 

--- a/src/autopas/containers/CellBasedParticleContainer.h
+++ b/src/autopas/containers/CellBasedParticleContainer.h
@@ -36,8 +36,12 @@ class CellBasedParticleContainer : public ParticleContainerInterface<typename Pa
    */
   CellBasedParticleContainer(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax,
                              const double cutoff, const double skinPerTimestep, const unsigned int rebuildFrequency)
-      : _cells(), _boxMin(boxMin), _boxMax(boxMax), _cutoff(cutoff), _skinPerTimestep(skinPerTimestep), 
-      _rebuildFrequency(rebuildFrequency){}
+      : _cells(),
+        _boxMin(boxMin),
+        _boxMax(boxMax),
+        _cutoff(cutoff),
+        _skinPerTimestep(skinPerTimestep),
+        _rebuildFrequency(rebuildFrequency) {}
 
   /**
    * Destructor of CellBasedParticleContainer.
@@ -101,18 +105,20 @@ class CellBasedParticleContainer : public ParticleContainerInterface<typename Pa
    * @copydoc autopas::ParticleContainerInterface::setRebuildFrequency()
    */
   void setRebuildFrequency(unsigned int rebuildFrequency) override final { _rebuildFrequency = rebuildFrequency; }
-   /**
+  /**
    * @copydoc autopas::ParticleContainerInterface::getRebuildFrequency()
    */
   [[nodiscard]] unsigned int getRebuildFrequency() const override final { return _rebuildFrequency; }
   /**
    * @copydoc autopas::ParticleContainerInterface::getInteractionLength()
    */
-  [[nodiscard]] double getInteractionLength() const override final { return _cutoff + _skinPerTimestep*_rebuildFrequency; }
+  [[nodiscard]] double getInteractionLength() const override final {
+    return _cutoff + _skinPerTimestep * _rebuildFrequency;
+  }
   /**
    * @copydoc autopas::ParticleContainerInterface::getVerletSkin()
    */
-  [[nodiscard]] double getVerletSkin() const override final { return _skinPerTimestep*_rebuildFrequency; }
+  [[nodiscard]] double getVerletSkin() const override final { return _skinPerTimestep * _rebuildFrequency; }
 
   /**
    * Deletes all particles from the container.
@@ -169,7 +175,6 @@ class CellBasedParticleContainer : public ParticleContainerInterface<typename Pa
   double _cutoff;
   double _skinPerTimestep;
   unsigned int _rebuildFrequency;
-  
 };
 
 }  // namespace autopas

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -267,7 +267,7 @@ class ParticleContainerInterface {
    * Return the skin of the container.
    * @return skin radius.
    */
-  [[nodiscard]] virtual double getSkin() const = 0;
+  [[nodiscard]] virtual double getVerletSkin() const = 0;
 
   /**
    * Set the skin of the container.

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -179,14 +179,14 @@ class ParticleContainerInterface {
       IteratorBehavior behavior = autopas::IteratorBehavior::ownedOrHalo) = 0;
 
   /**
-   * @copydoc begin()
+   * @copydoc autopas::ParticleContainerInterface::begin()
    * @note const version
    */
   [[nodiscard]] virtual ParticleIteratorWrapper<ParticleType, false> begin(
       IteratorBehavior behavior = autopas::IteratorBehavior::ownedOrHalo) const = 0;
 
   /**
-   * @copydoc begin()
+   * @copydoc autopas::ParticleContainerInterface::begin()
    * @note cbegin will guarantee to return a const_iterator.
    */
   [[nodiscard]] virtual ParticleIteratorWrapper<ParticleType, false> cbegin(
@@ -207,7 +207,7 @@ class ParticleContainerInterface {
       IteratorBehavior behavior) = 0;
 
   /**
-   * @copydoc getRegionIterator()
+   * @copydoc autopas::ParticleContainerInterface::getRegionIterator()
    * @note const version
    */
   [[nodiscard]] virtual ParticleIteratorWrapper<ParticleType, false> getRegionIterator(

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -264,16 +264,33 @@ class ParticleContainerInterface {
   virtual void setCutoff(double cutoff) = 0;
 
   /**
-   * Return the skin of the container.
-   * @return skin radius.
+   * Return the skin per timestep of the container.
+   * @return skin radius per Timestep.
    */
-  [[nodiscard]] virtual double getVerletSkinPerTimestep() const = 0;
+  [[nodiscard]] virtual double getSkinPerTimestep() const = 0;
 
   /**
    * Set the skin of the container per Timestep.
    * @param skinPerTimestep
    */
-  virtual void setVerletSkinPerTimestep(double skinPerTimestep) = 0;
+  virtual void setSkinPerTimestep(double skinPerTimestep) = 0;
+
+  /**
+   * Return the rebulild frequency of the container.
+   * @return rebuild Frequency.
+   */
+  [[nodiscard]] virtual unsigned int getRebuildFrequency() const = 0;
+
+  /**
+   * Set the skin of the container per Timestep.
+   * @param rebuildFrequency
+   */
+  virtual void setRebuildFrequency(unsigned int rebuildFrequency) = 0;
+  
+  /**
+   * @copydoc autopas::ParticleContainerInterface::getVerletSkin()
+   */
+  [[nodiscard]] virtual double getVerletSkin() const =0;
 
   /**
    * Return the interaction length (cutoff+skin) of the container.

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -267,13 +267,13 @@ class ParticleContainerInterface {
    * Return the skin of the container.
    * @return skin radius.
    */
-  [[nodiscard]] virtual double getVerletSkin() const = 0;
+  [[nodiscard]] virtual double getVerletSkinPerTimestep() const = 0;
 
   /**
-   * Set the skin of the container.
-   * @param skin
+   * Set the skin of the container per Timestep.
+   * @param skinPerTimestep
    */
-  virtual void setSkin(double skin) = 0;
+  virtual void setVerletSkinPerTimestep(double skinPerTimestep) = 0;
 
   /**
    * Return the interaction length (cutoff+skin) of the container.

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -286,11 +286,11 @@ class ParticleContainerInterface {
    * @param rebuildFrequency
    */
   virtual void setRebuildFrequency(unsigned int rebuildFrequency) = 0;
-  
+
   /**
    * @copydoc autopas::ParticleContainerInterface::getVerletSkin()
    */
-  [[nodiscard]] virtual double getVerletSkin() const =0;
+  [[nodiscard]] virtual double getVerletSkin() const = 0;
 
   /**
    * Return the interaction length (cutoff+skin) of the container.

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -277,7 +277,7 @@ class ParticleContainerInterface {
 
   /**
    * Return the rebulild frequency of the container.
-   * @return rebuild Frequency.
+   * @return rebuildFrequency.
    */
   [[nodiscard]] virtual unsigned int getRebuildFrequency() const = 0;
 

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -288,7 +288,8 @@ class ParticleContainerInterface {
   virtual void setRebuildFrequency(unsigned int rebuildFrequency) = 0;
 
   /**
-   * @copydoc autopas::ParticleContainerInterface::getVerletSkin()
+   * Return the verletSkin of the container verletSkinPerTimestep*rebuildFrequency
+   * @return verletSkin 
    */
   [[nodiscard]] virtual double getVerletSkin() const = 0;
 

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -264,30 +264,6 @@ class ParticleContainerInterface {
   virtual void setCutoff(double cutoff) = 0;
 
   /**
-   * Return the skin per timestep of the container.
-   * @return skin radius per Timestep.
-   */
-  [[nodiscard]] virtual double getSkinPerTimestep() const = 0;
-
-  /**
-   * Set the skin of the container per Timestep.
-   * @param skinPerTimestep
-   */
-  virtual void setSkinPerTimestep(double skinPerTimestep) = 0;
-
-  /**
-   * Return the rebulild frequency of the container.
-   * @return rebuildFrequency.
-   */
-  [[nodiscard]] virtual unsigned int getRebuildFrequency() const = 0;
-
-  /**
-   * Set the skin of the container per Timestep.
-   * @param rebuildFrequency
-   */
-  virtual void setRebuildFrequency(unsigned int rebuildFrequency) = 0;
-
-  /**
    * Return the verletSkin of the container verletSkinPerTimestep*rebuildFrequency
    * @return verletSkin
    */

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -289,7 +289,7 @@ class ParticleContainerInterface {
 
   /**
    * Return the verletSkin of the container verletSkinPerTimestep*rebuildFrequency
-   * @return verletSkin 
+   * @return verletSkin
    */
   [[nodiscard]] virtual double getVerletSkin() const = 0;
 

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -83,7 +83,7 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
   bool updateHaloParticle(const ParticleType &haloParticle) override {
     ParticleType pCopy = haloParticle;
     pCopy.setOwnershipState(OwnershipState::halo);
-    return internal::checkParticleInCellAndUpdateByIDAndPosition(getHaloCell(), pCopy, this->getSkin());
+    return internal::checkParticleInCellAndUpdateByIDAndPosition(getHaloCell(), pCopy, this->getVerletSkin());
   }
 
   void deleteHaloParticles() override { getHaloCell().clear(); }

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -53,7 +53,7 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
    * @param cutoff
    * @param skinpPerTimestep
    */
-  DirectSum(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, double cutoff, double skinPerTimestep, double vertletRebuildFrequency)
+  DirectSum(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, double cutoff, double skinPerTimestep, unsigned int vertletRebuildFrequency)
       : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep, vertletRebuildFrequency), _cellBorderFlagManager() {
     this->_cells.resize(2);
   }

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -51,10 +51,10 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
    * @param boxMin
    * @param boxMax
    * @param cutoff
-   * @param skin
+   * @param skinpPerTimestep
    */
-  DirectSum(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, double cutoff, double skin)
-      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skin), _cellBorderFlagManager() {
+  DirectSum(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, double cutoff, double skinPerTimestep, double vertletRebuildFrequency)
+      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep, vertletRebuildFrequency), _cellBorderFlagManager() {
     this->_cells.resize(2);
   }
 

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -55,8 +55,8 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
    * @param vertletRebuildFrequency
    */
   DirectSum(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, double cutoff,
-            double skinPerTimestep, unsigned int vertletRebuildFrequency)
-      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep, vertletRebuildFrequency),
+            double skinPerTimestep, unsigned int verletRebuildFrequency)
+      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep*verletRebuildFrequency),
         _cellBorderFlagManager() {
     this->_cells.resize(2);
   }
@@ -296,6 +296,7 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
   ParticleCell &getCell() { return this->_cells.at(0); };
 
   ParticleCell &getHaloCell() { return this->_cells.at(1); };
+
 };
 
 }  // namespace autopas

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -51,7 +51,8 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
    * @param boxMin
    * @param boxMax
    * @param cutoff
-   * @param skinpPerTimestep
+   * @param skinPerTimestep
+   * @param vertletRebuildFrequency
    */
   DirectSum(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, double cutoff,
             double skinPerTimestep, unsigned int vertletRebuildFrequency)

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -52,7 +52,7 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
    * @param boxMax
    * @param cutoff
    * @param skinPerTimestep
-   * @param vertletRebuildFrequency
+   * @param verletRebuildFrequency
    */
   DirectSum(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, double cutoff,
             double skinPerTimestep, unsigned int verletRebuildFrequency)

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -53,8 +53,10 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
    * @param cutoff
    * @param skinpPerTimestep
    */
-  DirectSum(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, double cutoff, double skinPerTimestep, unsigned int vertletRebuildFrequency)
-      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep, vertletRebuildFrequency), _cellBorderFlagManager() {
+  DirectSum(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, double cutoff,
+            double skinPerTimestep, unsigned int vertletRebuildFrequency)
+      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep, vertletRebuildFrequency),
+        _cellBorderFlagManager() {
     this->_cells.resize(2);
   }
 

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -56,7 +56,7 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
    */
   DirectSum(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, double cutoff,
             double skinPerTimestep, unsigned int verletRebuildFrequency)
-      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep*verletRebuildFrequency),
+      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep * verletRebuildFrequency),
         _cellBorderFlagManager() {
     this->_cells.resize(2);
   }
@@ -296,7 +296,6 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
   ParticleCell &getCell() { return this->_cells.at(0); };
 
   ParticleCell &getHaloCell() { return this->_cells.at(1); };
-
 };
 
 }  // namespace autopas

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -63,8 +63,8 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
   LinkedCells(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
               const double skinPerTimestep, const unsigned int rebuildFrequency, const double cellSizeFactor = 1.0,
               LoadEstimatorOption loadEstimator = LoadEstimatorOption::squaredParticlesPerCell)
-      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep, rebuildFrequency),
-        _cellBlock(this->_cells, boxMin, boxMax, cutoff + skinPerTimestep * rebuildFrequency, cellSizeFactor),
+      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep*rebuildFrequency),
+        _cellBlock(this->_cells, boxMin, boxMax, cutoff + skinPerTimestep*rebuildFrequency, cellSizeFactor),
         _loadEstimator(loadEstimator) {}
 
   [[nodiscard]] ContainerOption getContainerType() const override { return ContainerOption::linkedCells; }
@@ -428,6 +428,7 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
    */
   autopas::LoadEstimatorOption _loadEstimator;
   // ThreeDimensionalCellHandler
+
 };
 
 }  // namespace autopas

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -63,8 +63,8 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
   LinkedCells(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
               const double skinPerTimestep, const unsigned int rebuildFrequency, const double cellSizeFactor = 1.0,
               LoadEstimatorOption loadEstimator = LoadEstimatorOption::squaredParticlesPerCell)
-      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep,rebuildFrequency),
-        _cellBlock(this->_cells, boxMin, boxMax, cutoff + skinPerTimestep*rebuildFrequency, cellSizeFactor),
+      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep, rebuildFrequency),
+        _cellBlock(this->_cells, boxMin, boxMax, cutoff + skinPerTimestep * rebuildFrequency, cellSizeFactor),
         _loadEstimator(loadEstimator) {}
 
   [[nodiscard]] ContainerOption getContainerType() const override { return ContainerOption::linkedCells; }

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -60,7 +60,7 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
    * By default all applicable traversals are allowed.
    */
   LinkedCells(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
-              const double skinPerTimestep, const double rebuildFrequency, const double cellSizeFactor = 1.0,
+              const double skinPerTimestep, const unsigned int rebuildFrequency, const double cellSizeFactor = 1.0,
               LoadEstimatorOption loadEstimator = LoadEstimatorOption::squaredParticlesPerCell)
       : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep,rebuildFrequency),
         _cellBlock(this->_cells, boxMin, boxMax, cutoff + skinPerTimestep*rebuildFrequency, cellSizeFactor),

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -406,7 +406,7 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
   internal::CellBlock3D<ParticleCell> &getCellBlock() { return _cellBlock; }
 
   /**
-   * @copydoc getCellBlock()
+   * @copydoc autopas::LinkedCells::getCellBlock()
    * @note const version
    */
   const internal::CellBlock3D<ParticleCell> &getCellBlock() const { return _cellBlock; }

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -55,6 +55,7 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
    * @param boxMax
    * @param cutoff
    * @param skinPerTimestep
+   * @param rebuildFrequency
    * @param cellSizeFactor cell size factor relative to cutoff
    * @param loadEstimator the load estimation algorithm for balanced traversals.
    * By default all applicable traversals are allowed.

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -85,7 +85,7 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
   bool updateHaloParticle(const ParticleType &haloParticle) override {
     ParticleType pCopy = haloParticle;
     pCopy.setOwnershipState(OwnershipState::halo);
-    auto cells = _cellBlock.getNearbyHaloCells(pCopy.getR(), this->getSkin());
+    auto cells = _cellBlock.getNearbyHaloCells(pCopy.getR(), this->getVerletSkin());
     for (auto cellptr : cells) {
       bool updated = internal::checkParticleInCellAndUpdateByID(*cellptr, pCopy);
       if (updated) {
@@ -269,9 +269,9 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
                                                                               IteratorBehavior behavior) override {
     // We increase the search region by skin, as particles can move over cell borders.
     auto startIndex3D =
-        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getSkin()));
+        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getVerletSkin()));
     auto stopIndex3D =
-        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::addScalar(higherCorner, this->getSkin()));
+        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::addScalar(higherCorner, this->getVerletSkin()));
 
     size_t numCellsOfInterest = (stopIndex3D[0] - startIndex3D[0] + 1) * (stopIndex3D[1] - startIndex3D[1] + 1) *
                                 (stopIndex3D[2] - startIndex3D[2] + 1);
@@ -297,9 +297,9 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
       IteratorBehavior behavior) const override {
     // We increase the search region by skin, as particles can move over cell borders.
     auto startIndex3D =
-        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getSkin()));
+        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getVerletSkin()));
     auto stopIndex3D =
-        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::addScalar(higherCorner, this->getSkin()));
+        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::addScalar(higherCorner, this->getVerletSkin()));
 
     size_t numCellsOfInterest = (stopIndex3D[0] - startIndex3D[0] + 1) * (stopIndex3D[1] - startIndex3D[1] + 1) *
                                 (stopIndex3D[2] - startIndex3D[2] + 1);
@@ -332,9 +332,9 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
   void forEachInRegion(Lambda forEachLambda, const std::array<double, 3> &lowerCorner,
                        const std::array<double, 3> &higherCorner, IteratorBehavior behavior) {
     auto startIndex3D =
-        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getSkin()));
+        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getVerletSkin()));
     auto stopIndex3D =
-        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::addScalar(higherCorner, this->getSkin()));
+        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::addScalar(higherCorner, this->getVerletSkin()));
 
     size_t numCellsOfInterest = (stopIndex3D[0] - startIndex3D[0] + 1) * (stopIndex3D[1] - startIndex3D[1] + 1) *
                                 (stopIndex3D[2] - startIndex3D[2] + 1);
@@ -372,9 +372,9 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
   void reduceInRegion(Lambda reduceLambda, A &result, const std::array<double, 3> &lowerCorner,
                       const std::array<double, 3> &higherCorner, IteratorBehavior behavior) {
     auto startIndex3D =
-        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getSkin()));
+        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getVerletSkin()));
     auto stopIndex3D =
-        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::addScalar(higherCorner, this->getSkin()));
+        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::addScalar(higherCorner, this->getVerletSkin()));
 
     size_t numCellsOfInterest = (stopIndex3D[0] - startIndex3D[0] + 1) * (stopIndex3D[1] - startIndex3D[1] + 1) *
                                 (stopIndex3D[2] - startIndex3D[2] + 1);

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -54,16 +54,16 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
    * @param boxMin
    * @param boxMax
    * @param cutoff
-   * @param skin
+   * @param skinPerTimestep
    * @param cellSizeFactor cell size factor relative to cutoff
    * @param loadEstimator the load estimation algorithm for balanced traversals.
    * By default all applicable traversals are allowed.
    */
   LinkedCells(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
-              const double skin, const double cellSizeFactor = 1.0,
+              const double skinPerTimestep, const double rebuildFrequency, const double cellSizeFactor = 1.0,
               LoadEstimatorOption loadEstimator = LoadEstimatorOption::squaredParticlesPerCell)
-      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skin),
-        _cellBlock(this->_cells, boxMin, boxMax, cutoff + skin, cellSizeFactor),
+      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep,rebuildFrequency),
+        _cellBlock(this->_cells, boxMin, boxMax, cutoff + skinPerTimestep*rebuildFrequency, cellSizeFactor),
         _loadEstimator(loadEstimator) {}
 
   [[nodiscard]] ContainerOption getContainerType() const override { return ContainerOption::linkedCells; }

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -63,8 +63,8 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
   LinkedCells(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
               const double skinPerTimestep, const unsigned int rebuildFrequency, const double cellSizeFactor = 1.0,
               LoadEstimatorOption loadEstimator = LoadEstimatorOption::squaredParticlesPerCell)
-      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep*rebuildFrequency),
-        _cellBlock(this->_cells, boxMin, boxMax, cutoff + skinPerTimestep*rebuildFrequency, cellSizeFactor),
+      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep * rebuildFrequency),
+        _cellBlock(this->_cells, boxMin, boxMax, cutoff + skinPerTimestep * rebuildFrequency, cellSizeFactor),
         _loadEstimator(loadEstimator) {}
 
   [[nodiscard]] ContainerOption getContainerType() const override { return ContainerOption::linkedCells; }
@@ -428,7 +428,6 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
    */
   autopas::LoadEstimatorOption _loadEstimator;
   // ThreeDimensionalCellHandler
-
 };
 
 }  // namespace autopas

--- a/src/autopas/containers/linkedCells/LinkedCellsReferences.h
+++ b/src/autopas/containers/linkedCells/LinkedCellsReferences.h
@@ -58,7 +58,7 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
    * By default all applicable traversals are allowed.
    */
   LinkedCellsReferences(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
-                        const double skinPerTimestep, const double rebuildFrequency, const double cellSizeFactor = 1.0,
+                        const double skinPerTimestep, const unsigned int rebuildFrequency, const double cellSizeFactor = 1.0,
                         LoadEstimatorOption loadEstimator = LoadEstimatorOption::squaredParticlesPerCell)
       : CellBasedParticleContainer<ReferenceCell>(boxMin, boxMax, cutoff, skinPerTimestep, rebuildFrequency),
         _cellBlock(this->_cells, boxMin, boxMax, cutoff + skinPerTimestep*rebuildFrequency, cellSizeFactor),

--- a/src/autopas/containers/linkedCells/LinkedCellsReferences.h
+++ b/src/autopas/containers/linkedCells/LinkedCellsReferences.h
@@ -62,8 +62,8 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
                         const double skinPerTimestep, const unsigned int rebuildFrequency,
                         const double cellSizeFactor = 1.0,
                         LoadEstimatorOption loadEstimator = LoadEstimatorOption::squaredParticlesPerCell)
-      : CellBasedParticleContainer<ReferenceCell>(boxMin, boxMax, cutoff, skinPerTimestep*rebuildFrequency),
-        _cellBlock(this->_cells, boxMin, boxMax, cutoff + skinPerTimestep*rebuildFrequency, cellSizeFactor),
+      : CellBasedParticleContainer<ReferenceCell>(boxMin, boxMax, cutoff, skinPerTimestep * rebuildFrequency),
+        _cellBlock(this->_cells, boxMin, boxMax, cutoff + skinPerTimestep * rebuildFrequency, cellSizeFactor),
         _loadEstimator(loadEstimator) {}
 
   /**
@@ -473,7 +473,6 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
    * Workaround for adding particles in parallel -> https://github.com/AutoPas/AutoPas/issues/555
    */
   AutoPasLock addParticleLock;
-  
 };
 
 }  // namespace autopas

--- a/src/autopas/containers/linkedCells/LinkedCellsReferences.h
+++ b/src/autopas/containers/linkedCells/LinkedCellsReferences.h
@@ -62,8 +62,8 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
                         const double skinPerTimestep, const unsigned int rebuildFrequency,
                         const double cellSizeFactor = 1.0,
                         LoadEstimatorOption loadEstimator = LoadEstimatorOption::squaredParticlesPerCell)
-      : CellBasedParticleContainer<ReferenceCell>(boxMin, boxMax, cutoff, skinPerTimestep, rebuildFrequency),
-        _cellBlock(this->_cells, boxMin, boxMax, cutoff + skinPerTimestep * rebuildFrequency, cellSizeFactor),
+      : CellBasedParticleContainer<ReferenceCell>(boxMin, boxMax, cutoff, skinPerTimestep*rebuildFrequency),
+        _cellBlock(this->_cells, boxMin, boxMax, cutoff + skinPerTimestep*rebuildFrequency, cellSizeFactor),
         _loadEstimator(loadEstimator) {}
 
   /**
@@ -473,6 +473,7 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
    * Workaround for adding particles in parallel -> https://github.com/AutoPas/AutoPas/issues/555
    */
   AutoPasLock addParticleLock;
+  
 };
 
 }  // namespace autopas

--- a/src/autopas/containers/linkedCells/LinkedCellsReferences.h
+++ b/src/autopas/containers/linkedCells/LinkedCellsReferences.h
@@ -103,7 +103,7 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
   bool updateHaloParticle(const ParticleType &haloParticle) override {
     ParticleType pCopy = haloParticle;
     pCopy.setOwnershipState(OwnershipState::halo);
-    auto cells = _cellBlock.getNearbyHaloCells(pCopy.getR(), this->getSkin());
+    auto cells = _cellBlock.getNearbyHaloCells(pCopy.getR(), this->getVerletSkin());
     for (auto cellptr : cells) {
       bool updated = internal::checkParticleInCellAndUpdateByID(*cellptr, pCopy);
       if (updated) {
@@ -313,9 +313,9 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
                                                                 IteratorBehavior behavior) override {
     // We increase the search region by skin, as particles can move over cell borders.
     auto startIndex3D =
-        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getSkin()));
+        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getVerletSkin()));
     auto stopIndex3D =
-        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::addScalar(higherCorner, this->getSkin()));
+        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::addScalar(higherCorner, this->getVerletSkin()));
 
     size_t numCellsOfInterest = (stopIndex3D[0] - startIndex3D[0] + 1) * (stopIndex3D[1] - startIndex3D[1] + 1) *
                                 (stopIndex3D[2] - startIndex3D[2] + 1);
@@ -341,9 +341,9 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
                                                                  IteratorBehavior behavior) const override {
     // We increase the search region by skin, as particles can move over cell borders.
     auto startIndex3D =
-        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getSkin()));
+        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getVerletSkin()));
     auto stopIndex3D =
-        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::addScalar(higherCorner, this->getSkin()));
+        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::addScalar(higherCorner, this->getVerletSkin()));
 
     size_t numCellsOfInterest = (stopIndex3D[0] - startIndex3D[0] + 1) * (stopIndex3D[1] - startIndex3D[1] + 1) *
                                 (stopIndex3D[2] - startIndex3D[2] + 1);
@@ -372,9 +372,9 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
                        const std::array<double, 3> &higherCorner, IteratorBehavior behavior) {
     // We increase the search region by skin, as particles can move over cell borders.
     auto startIndex3D =
-        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getSkin()));
+        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getVerletSkin()));
     auto stopIndex3D =
-        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::addScalar(higherCorner, this->getSkin()));
+        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::addScalar(higherCorner, this->getVerletSkin()));
 
     size_t numCellsOfInterest = (stopIndex3D[0] - startIndex3D[0] + 1) * (stopIndex3D[1] - startIndex3D[1] + 1) *
                                 (stopIndex3D[2] - startIndex3D[2] + 1);
@@ -405,9 +405,9 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
                       const std::array<double, 3> &higherCorner, IteratorBehavior behavior) {
     // We increase the search region by skin, as particles can move over cell borders.
     auto startIndex3D =
-        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getSkin()));
+        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::subScalar(lowerCorner, this->getVerletSkin()));
     auto stopIndex3D =
-        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::addScalar(higherCorner, this->getSkin()));
+        this->_cellBlock.get3DIndexOfPosition(utils::ArrayMath::addScalar(higherCorner, this->getVerletSkin()));
 
     size_t numCellsOfInterest = (stopIndex3D[0] - startIndex3D[0] + 1) * (stopIndex3D[1] - startIndex3D[1] + 1) *
                                 (stopIndex3D[2] - startIndex3D[2] + 1);

--- a/src/autopas/containers/linkedCells/LinkedCellsReferences.h
+++ b/src/autopas/containers/linkedCells/LinkedCellsReferences.h
@@ -53,6 +53,7 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
    * @param boxMax
    * @param cutoff
    * @param skinPerTimestep
+   * @param rebuildFrequency
    * @param cellSizeFactor cell size factor relative to cutoff
    * @param loadEstimator the load estimation algorithm for balanced traversals.
    * By default all applicable traversals are allowed.

--- a/src/autopas/containers/linkedCells/LinkedCellsReferences.h
+++ b/src/autopas/containers/linkedCells/LinkedCellsReferences.h
@@ -52,16 +52,16 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
    * @param boxMin
    * @param boxMax
    * @param cutoff
-   * @param skin
+   * @param skinPerTimestep
    * @param cellSizeFactor cell size factor relative to cutoff
    * @param loadEstimator the load estimation algorithm for balanced traversals.
    * By default all applicable traversals are allowed.
    */
   LinkedCellsReferences(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
-                        const double skin, const double cellSizeFactor = 1.0,
+                        const double skinPerTimestep, const double rebuildFrequency, const double cellSizeFactor = 1.0,
                         LoadEstimatorOption loadEstimator = LoadEstimatorOption::squaredParticlesPerCell)
-      : CellBasedParticleContainer<ReferenceCell>(boxMin, boxMax, cutoff, skin),
-        _cellBlock(this->_cells, boxMin, boxMax, cutoff + skin, cellSizeFactor),
+      : CellBasedParticleContainer<ReferenceCell>(boxMin, boxMax, cutoff, skinPerTimestep, rebuildFrequency),
+        _cellBlock(this->_cells, boxMin, boxMax, cutoff + skinPerTimestep*rebuildFrequency, cellSizeFactor),
         _loadEstimator(loadEstimator) {}
 
   /**

--- a/src/autopas/containers/linkedCells/LinkedCellsReferences.h
+++ b/src/autopas/containers/linkedCells/LinkedCellsReferences.h
@@ -59,10 +59,11 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
    * By default all applicable traversals are allowed.
    */
   LinkedCellsReferences(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
-                        const double skinPerTimestep, const unsigned int rebuildFrequency, const double cellSizeFactor = 1.0,
+                        const double skinPerTimestep, const unsigned int rebuildFrequency,
+                        const double cellSizeFactor = 1.0,
                         LoadEstimatorOption loadEstimator = LoadEstimatorOption::squaredParticlesPerCell)
       : CellBasedParticleContainer<ReferenceCell>(boxMin, boxMax, cutoff, skinPerTimestep, rebuildFrequency),
-        _cellBlock(this->_cells, boxMin, boxMax, cutoff + skinPerTimestep*rebuildFrequency, cellSizeFactor),
+        _cellBlock(this->_cells, boxMin, boxMax, cutoff + skinPerTimestep * rebuildFrequency, cellSizeFactor),
         _loadEstimator(loadEstimator) {}
 
   /**

--- a/src/autopas/containers/octree/Octree.h
+++ b/src/autopas/containers/octree/Octree.h
@@ -63,7 +63,7 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
    */
   Octree(std::array<double, 3> boxMin, std::array<double, 3> boxMax, const double cutoff, const double skinPerTimestep,
          const unsigned int rebuildFrequency, const double cellSizeFactor)
-      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep, rebuildFrequency) {
+      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep*rebuildFrequency) {
     // @todo Obtain this from a configuration, reported in https://github.com/AutoPas/AutoPas/issues/624
     int unsigned treeSplitThreshold = 16;
 
@@ -306,6 +306,8 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
    * A logger that can be called to log the octree data structure.
    */
   OctreeLogger<Particle> logger;
+
+  double skin;
 };
 
 }  // namespace autopas

--- a/src/autopas/containers/octree/Octree.h
+++ b/src/autopas/containers/octree/Octree.h
@@ -162,7 +162,7 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
   bool updateHaloParticle(const ParticleType &haloParticle) override {
     ParticleType pCopy = haloParticle;
     pCopy.setOwnershipState(OwnershipState::halo);
-    return internal::checkParticleInCellAndUpdateByIDAndPosition(this->_cells[CellTypes::HALO], pCopy, this->getSkin());
+    return internal::checkParticleInCellAndUpdateByIDAndPosition(this->_cells[CellTypes::HALO], pCopy, this->getVerletSkin());
   }
 
   void rebuildNeighborLists(TraversalInterface *traversal) override {}

--- a/src/autopas/containers/octree/Octree.h
+++ b/src/autopas/containers/octree/Octree.h
@@ -58,7 +58,7 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
    * @param boxMax The maximum coordinate of the enclosing box
    * @param cutoff The cutoff radius
    * @param skinPerTimestep The skin radius per timestep
-   * @param rebuildFrequency The Rebuild Frequency 
+   * @param rebuildFrequency The Rebuild Frequency
    * @param cellSizeFactor The cell size factor
    */
   Octree(std::array<double, 3> boxMin, std::array<double, 3> boxMax, const double cutoff, const double skinPerTimestep,
@@ -163,7 +163,8 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
   bool updateHaloParticle(const ParticleType &haloParticle) override {
     ParticleType pCopy = haloParticle;
     pCopy.setOwnershipState(OwnershipState::halo);
-    return internal::checkParticleInCellAndUpdateByIDAndPosition(this->_cells[CellTypes::HALO], pCopy, this->getVerletSkin());
+    return internal::checkParticleInCellAndUpdateByIDAndPosition(this->_cells[CellTypes::HALO], pCopy,
+                                                                 this->getVerletSkin());
   }
 
   void rebuildNeighborLists(TraversalInterface *traversal) override {}

--- a/src/autopas/containers/octree/Octree.h
+++ b/src/autopas/containers/octree/Octree.h
@@ -57,12 +57,12 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
    * @param boxMin The minimum coordinate of the enclosing box
    * @param boxMax The maximum coordinate of the enclosing box
    * @param cutoff The cutoff radius
-   * @param skin The skin radius
+   * @param skinPerTimestep The skin radius per timestep
    * @param cellSizeFactor The cell size factor
    */
-  Octree(std::array<double, 3> boxMin, std::array<double, 3> boxMax, const double cutoff, const double skin,
-         const double cellSizeFactor)
-      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skin) {
+  Octree(std::array<double, 3> boxMin, std::array<double, 3> boxMax, const double cutoff, const double skinPerTimestep,
+         const unsigned int rebuildFrequency, const double cellSizeFactor)
+      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep, rebuildFrequency) {
     // @todo Obtain this from a configuration, reported in https://github.com/AutoPas/AutoPas/issues/624
     int unsigned treeSplitThreshold = 16;
 

--- a/src/autopas/containers/octree/Octree.h
+++ b/src/autopas/containers/octree/Octree.h
@@ -58,6 +58,7 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
    * @param boxMax The maximum coordinate of the enclosing box
    * @param cutoff The cutoff radius
    * @param skinPerTimestep The skin radius per timestep
+   * @param rebuildFrequency The Rebuild Frequency 
    * @param cellSizeFactor The cell size factor
    */
   Octree(std::array<double, 3> boxMin, std::array<double, 3> boxMax, const double cutoff, const double skinPerTimestep,

--- a/src/autopas/containers/octree/Octree.h
+++ b/src/autopas/containers/octree/Octree.h
@@ -63,7 +63,7 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
    */
   Octree(std::array<double, 3> boxMin, std::array<double, 3> boxMax, const double cutoff, const double skinPerTimestep,
          const unsigned int rebuildFrequency, const double cellSizeFactor)
-      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep*rebuildFrequency) {
+      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep * rebuildFrequency) {
     // @todo Obtain this from a configuration, reported in https://github.com/AutoPas/AutoPas/issues/624
     int unsigned treeSplitThreshold = 16;
 

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -690,7 +690,9 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
 
   [[nodiscard]] double getVerletSkin() const override { return _skinPerTimestep*_rebuildFrequency; }
 
-  void setSkin(double skinPerTimestep) override { _skinPerTimestep = skinPerTimestep; }
+  [[nodiscard]] double getSkinPerTimestep() const override { return _skinPerTimestep*_rebuildFrequency; }
+
+  void setSkinPerTimestep(double skinPerTimestep) override { _skinPerTimestep = skinPerTimestep; }
 
   [[nodiscard]] double getInteractionLength() const override { return _cutoff + _skinPerTimestep*_rebuildFrequency; }
 

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -695,7 +695,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
   /**
    * Set the verlet skin length per timestep for the container.
    * @param skinPerTimestep
-   */  
+   */
   void setSkinPerTimestep(double skinPerTimestep) { _skinPerTimestep = skinPerTimestep; }
 
   /**
@@ -707,7 +707,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
   /**
    * Set the rebuild Frequency value for the container.
    * @param rebuildFrequency
-   */  
+   */
   void setRebuildFrequency(unsigned int rebuildFrequency) { _rebuildFrequency = rebuildFrequency; }
 
   [[nodiscard]] double getInteractionLength() const override { return _cutoff + _skinPerTimestep * _rebuildFrequency; }

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -65,6 +65,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
    * @param boxMax The upper corner of the domain.
    * @param cutoff The cutoff radius of the interaction.
    * @param skinPerTimestep The skin radius per Timestep.
+   * @param rebuildFrequency The rebuild Frequency.
    * @param clusterSize Number of particles per cluster.
    * @param loadEstimator load estimation algorithm for balanced traversals.
    */

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -169,8 +169,8 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
     pCopy.setOwnershipState(OwnershipState::halo);
 
     // this might be called from a parallel region so force this iterator to be sequential
-    for (auto it = getRegionIterator(utils::ArrayMath::subScalar(pCopy.getR(), this->getSkin() / 2),
-                                     utils::ArrayMath::addScalar(pCopy.getR(), this->getSkin() / 2),
+    for (auto it = getRegionIterator(utils::ArrayMath::subScalar(pCopy.getR(), this->getVerletSkin() / 2),
+                                     utils::ArrayMath::addScalar(pCopy.getR(), this->getVerletSkin() / 2),
                                      IteratorBehavior::halo | IteratorBehavior::forceSequential);
          it.isValid(); ++it) {
       if (pCopy.getID() == it->getID()) {
@@ -687,7 +687,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
 
   void setCutoff(double cutoff) override { _cutoff = cutoff; }
 
-  [[nodiscard]] double getSkin() const override { return _skin; }
+  [[nodiscard]] double getVerletSkin() const override { return _skin; }
 
   void setSkin(double skin) override { _skin = skin; }
 

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -692,10 +692,22 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
 
   [[nodiscard]] double getVerletSkin() const override { return _skinPerTimestep * _rebuildFrequency; }
 
+  /**
+   * Set the verlet skin length per timestep for the container.
+   * @param skinPerTimestep
+   */  
   void setSkinPerTimestep(double skinPerTimestep) { _skinPerTimestep = skinPerTimestep; }
 
+  /**
+   * Get the rebuild Frequency value for the container.
+   * @return rebuildFrequency
+   */
   [[nodiscard]] unsigned int getRebuildFrequency() { return _rebuildFrequency; }
 
+  /**
+   * Set the rebuild Frequency value for the container.
+   * @param rebuildFrequency
+   */  
   void setRebuildFrequency(unsigned int rebuildFrequency) { _rebuildFrequency = rebuildFrequency; }
 
   [[nodiscard]] double getInteractionLength() const override { return _cutoff + _skinPerTimestep * _rebuildFrequency; }

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -694,6 +694,10 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
 
   void setSkinPerTimestep(double skinPerTimestep) override { _skinPerTimestep = skinPerTimestep; }
 
+  [[nodiscard]] unsigned int getRebuildFrequency() const override { return _rebuildFrequency; }
+
+  void setRebuildFrequency(unsigned int rebuildFrequency) override { _rebuildFrequency = rebuildFrequency; }
+
   [[nodiscard]] double getInteractionLength() const override { return _cutoff + _skinPerTimestep*_rebuildFrequency; }
 
   void deleteAllParticles() override {

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -692,13 +692,13 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
 
   [[nodiscard]] double getVerletSkin() const override { return _skinPerTimestep * _rebuildFrequency; }
 
-  [[nodiscard]] double getSkinPerTimestep() const override { return _skinPerTimestep * _rebuildFrequency; }
+  [[nodiscard]] double getSkinPerTimestep() { return _skinPerTimestep * _rebuildFrequency; }
 
-  void setSkinPerTimestep(double skinPerTimestep) override { _skinPerTimestep = skinPerTimestep; }
+  void setSkinPerTimestep(double skinPerTimestep) { _skinPerTimestep = skinPerTimestep; }
 
-  [[nodiscard]] unsigned int getRebuildFrequency() const override { return _rebuildFrequency; }
+  [[nodiscard]] unsigned int getRebuildFrequency() { return _rebuildFrequency; }
 
-  void setRebuildFrequency(unsigned int rebuildFrequency) override { _rebuildFrequency = rebuildFrequency; }
+  void setRebuildFrequency(unsigned int rebuildFrequency) { _rebuildFrequency = rebuildFrequency; }
 
   [[nodiscard]] double getInteractionLength() const override { return _cutoff + _skinPerTimestep * _rebuildFrequency; }
 

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -69,8 +69,9 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
    * @param clusterSize Number of particles per cluster.
    * @param loadEstimator load estimation algorithm for balanced traversals.
    */
-  VerletClusterLists(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, double cutoff, double skinPerTimestep,
-                     unsigned int rebuildFrequency, size_t clusterSize, LoadEstimatorOption loadEstimator = LoadEstimatorOption::none)
+  VerletClusterLists(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, double cutoff,
+                     double skinPerTimestep, unsigned int rebuildFrequency, size_t clusterSize,
+                     LoadEstimatorOption loadEstimator = LoadEstimatorOption::none)
       : ParticleContainerInterface<Particle>(),
         _clusterSize{clusterSize},
         _numClusters{0},
@@ -78,8 +79,8 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
         _particlesToAdd(autopas_get_max_threads()),
         _boxMin{boxMin},
         _boxMax{boxMax},
-        _haloBoxMin{utils::ArrayMath::subScalar(boxMin, cutoff + skinPerTimestep*rebuildFrequency)},
-        _haloBoxMax{utils::ArrayMath::addScalar(boxMax, cutoff + skinPerTimestep*rebuildFrequency)},
+        _haloBoxMin{utils::ArrayMath::subScalar(boxMin, cutoff + skinPerTimestep * rebuildFrequency)},
+        _haloBoxMax{utils::ArrayMath::addScalar(boxMax, cutoff + skinPerTimestep * rebuildFrequency)},
         _cutoff{cutoff},
         _skinPerTimestep{skinPerTimestep},
         _rebuildFrequency{rebuildFrequency},
@@ -689,9 +690,9 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
 
   void setCutoff(double cutoff) override { _cutoff = cutoff; }
 
-  [[nodiscard]] double getVerletSkin() const override { return _skinPerTimestep*_rebuildFrequency; }
+  [[nodiscard]] double getVerletSkin() const override { return _skinPerTimestep * _rebuildFrequency; }
 
-  [[nodiscard]] double getSkinPerTimestep() const override { return _skinPerTimestep*_rebuildFrequency; }
+  [[nodiscard]] double getSkinPerTimestep() const override { return _skinPerTimestep * _rebuildFrequency; }
 
   void setSkinPerTimestep(double skinPerTimestep) override { _skinPerTimestep = skinPerTimestep; }
 
@@ -699,7 +700,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
 
   void setRebuildFrequency(unsigned int rebuildFrequency) override { _rebuildFrequency = rebuildFrequency; }
 
-  [[nodiscard]] double getInteractionLength() const override { return _cutoff + _skinPerTimestep*_rebuildFrequency; }
+  [[nodiscard]] double getInteractionLength() const override { return _cutoff + _skinPerTimestep * _rebuildFrequency; }
 
   void deleteAllParticles() override {
     _isValid = ValidityState::invalid;

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -81,7 +81,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
         _haloBoxMax{utils::ArrayMath::addScalar(boxMax, cutoff + skinPerTimestep*rebuildFrequency)},
         _cutoff{cutoff},
         _skinPerTimestep{skinPerTimestep},
-        _rebuildFrequency{rebuildFrequency}
+        _rebuildFrequency{rebuildFrequency},
         _loadEstimator(loadEstimator) {
     // always have at least one tower.
     _towers.push_back(internal::ClusterTower<Particle>(_clusterSize));
@@ -1053,7 +1053,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
   /**
    * rebuidFrequency.
    */
-  double _rebuildFrequency{};
+  unsigned int _rebuildFrequency{};
   /**
    * Enum to specify the validity of this container.
    */

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -692,8 +692,6 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
 
   [[nodiscard]] double getVerletSkin() const override { return _skinPerTimestep * _rebuildFrequency; }
 
-  [[nodiscard]] double getSkinPerTimestep() { return _skinPerTimestep * _rebuildFrequency; }
-
   void setSkinPerTimestep(double skinPerTimestep) { _skinPerTimestep = skinPerTimestep; }
 
   [[nodiscard]] unsigned int getRebuildFrequency() { return _rebuildFrequency; }

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -114,7 +114,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
   bool updateHaloParticle(const Particle &particle) override {
     Particle pCopy = particle;
     pCopy.setOwnershipState(OwnershipState::halo);
-    auto cells = _linkedCells.getCellBlock().getNearbyHaloCells(pCopy.getR(), this->getSkin());
+    auto cells = _linkedCells.getCellBlock().getNearbyHaloCells(pCopy.getR(), this->getVerletSkin());
     for (auto cellptr : cells) {
       bool updated = internal::checkParticleInCellAndUpdateByID(*cellptr, pCopy);
       if (updated) {
@@ -244,9 +244,9 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
   void setCutoff(double cutoff) override final { _linkedCells.setCutoff(cutoff); }
 
   /**
-   * @copydoc autopas::ParticleContainerInterface::getSkin()
+   * @copydoc autopas::ParticleContainerInterface::getVerletSkin()
    */
-  [[nodiscard]] double getSkin() const override final { return _linkedCells.getSkin(); }
+  [[nodiscard]] double getVerletSkin() const override final { return _linkedCells.getVerletSkin(); }
 
   /**
    * @copydoc autopas::ParticleContainerInterface::setSkin()

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -30,15 +30,15 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    * @param boxMin the lower corner of the domain
    * @param boxMax the upper corner of the domain
    * @param cutoff the cutoff radius of the interaction
-   * @param skin the skin radius
+   * @param skinPerTimestep the skin radius per timestep
    * @param applicableTraversals all applicable traversals
    * @param cellSizeFactor cell size factor relative to cutoff. Verlet lists are only implemented for values >= 1.0
    * (smaller values are set to 1.0).
    */
   VerletListsLinkedBase(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
-                        const double skin, const std::set<TraversalOption> &applicableTraversals,
+                        const double skinPerTimestep,const double rebuildFrequency, const std::set<TraversalOption> &applicableTraversals,
                         const double cellSizeFactor)
-      : _linkedCells(boxMin, boxMax, cutoff, skin, std::max(1.0, cellSizeFactor)) {
+      : _linkedCells(boxMin, boxMax, cutoff, skinPerTimestep,rebuildFrequency, std::max(1.0, cellSizeFactor)) {
     if (cellSizeFactor < 1.0) {
       AutoPasLog(debug, "VerletListsLinkedBase: CellSizeFactor smaller 1 detected. Set to 1.");
     }

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -261,7 +261,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
   void setSkinPerTimestep(double skinPerTimestep) { _linkedCells.setSkinPerTimestep(skinPerTimestep); }
 
   /**
-   * @copydoc autopas::ParticleContainerInterface::getSkinPerTimestep()
+   * @copydoc autopas::ParticleContainerInterface::getRebuildFrequency()
    */
   [[nodiscard]] unsigned int getRebuildFrequency() { return _linkedCells.getRebuildFrequency(); }
 

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -37,7 +37,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    * (smaller values are set to 1.0).
    */
   VerletListsLinkedBase(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
-                        const double skinPerTimestep,const double rebuildFrequency, const std::set<TraversalOption> &applicableTraversals,
+                        const double skinPerTimestep,const unsigned int rebuildFrequency, const std::set<TraversalOption> &applicableTraversals,
                         const double cellSizeFactor)
       : _linkedCells(boxMin, boxMax, cutoff, skinPerTimestep,rebuildFrequency, std::max(1.0, cellSizeFactor)) {
     if (cellSizeFactor < 1.0) {

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -26,7 +26,8 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
  public:
   /**
    * Constructor of the VerletListsLinkedBase class.
-   * The neighbor lists are build using a search radius of cutoff + skin.LinkedParticleCell::ParticleType *rebuildFrequency
+   * The neighbor lists are build using a search radius of cutoff + skin.LinkedParticleCell::ParticleType
+   * *rebuildFrequency
    * @param boxMin the lower corner of the domain
    * @param boxMax the upper corner of the domain
    * @param cutoff the cutoff radius of the interaction
@@ -37,9 +38,9 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    * (smaller values are set to 1.0).
    */
   VerletListsLinkedBase(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
-                        const double skinPerTimestep,const unsigned int rebuildFrequency, const std::set<TraversalOption> &applicableTraversals,
-                        const double cellSizeFactor)
-      : _linkedCells(boxMin, boxMax, cutoff, skinPerTimestep,rebuildFrequency, std::max(1.0, cellSizeFactor)) {
+                        const double skinPerTimestep, const unsigned int rebuildFrequency,
+                        const std::set<TraversalOption> &applicableTraversals, const double cellSizeFactor)
+      : _linkedCells(boxMin, boxMax, cutoff, skinPerTimestep, rebuildFrequency, std::max(1.0, cellSizeFactor)) {
     if (cellSizeFactor < 1.0) {
       AutoPasLog(debug, "VerletListsLinkedBase: CellSizeFactor smaller 1 detected. Set to 1.");
     }
@@ -249,7 +250,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    */
   [[nodiscard]] double getVerletSkin() const override final { return _linkedCells.getVerletSkin(); }
 
-    /**
+  /**
    * @copydoc autopas::ParticleContainerInterface::getSkinPerTimestep()
    */
   [[nodiscard]] double getSkinPerTimestep() const override final { return _linkedCells.getSkinPerTimestep(); }
@@ -267,7 +268,9 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
   /**SkinPer
    * @copydoc autopas::ParticleContainerInterface::setSkinPerTimestep()
    */
-  void setRebuildFrequency(unsigned int rebuildFrequency) override final { _linkedCells.setRebuildFrequency(rebuildFrequency);} 
+  void setRebuildFrequency(unsigned int rebuildFrequency) override final {
+    _linkedCells.setRebuildFrequency(rebuildFrequency);
+  }
 
   /**
    * @copydoc autopas::ParticleContainerInterface::getInteractionLength()

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -31,7 +31,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    * @param boxMax the upper corner of the domain
    * @param cutoff the cutoff radius of the interaction
    * @param skinPerTimestep the skin radius per timestep
-   * @param rebuildFrequency
+   * @param rebuildFrequency the rebuild frequency.
    * @param applicableTraversals all applicable traversals
    * @param cellSizeFactor cell size factor relative to cutoff. Verlet lists are only implemented for values >= 1.0
    * (smaller values are set to 1.0).

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -268,9 +268,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
   /**
    * @copydoc autopas::ParticleContainerInterface::setRebuildFrequency()
    */
-  void setRebuildFrequency(unsigned int rebuildFrequency) {
-    _linkedCells.setRebuildFrequency(rebuildFrequency);
-  }
+  void setRebuildFrequency(unsigned int rebuildFrequency) { _linkedCells.setRebuildFrequency(rebuildFrequency); }
 
   /**
    * @copydoc autopas::ParticleContainerInterface::getInteractionLength()

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -26,11 +26,12 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
  public:
   /**
    * Constructor of the VerletListsLinkedBase class.
-   * The neighbor lists are build using a search radius of cutoff + skin.LinkedParticleCell::ParticleType
+   * The neighbor lists are build using a search radius of cutoff + skin.LinkedParticleCell::ParticleType *rebuildFrequency
    * @param boxMin the lower corner of the domain
    * @param boxMax the upper corner of the domain
    * @param cutoff the cutoff radius of the interaction
    * @param skinPerTimestep the skin radius per timestep
+   * @param rebuildFrequency
    * @param applicableTraversals all applicable traversals
    * @param cellSizeFactor cell size factor relative to cutoff. Verlet lists are only implemented for values >= 1.0
    * (smaller values are set to 1.0).
@@ -249,9 +250,9 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
   [[nodiscard]] double getVerletSkin() const override final { return _linkedCells.getVerletSkin(); }
 
   /**
-   * @copydoc autopas::ParticleContainerInterface::setSkin()
+   * @copydoc autopas::ParticleContainerInterface::setSkinPerTimestep()
    */
-  void setSkin(double skin) override final { _linkedCells.setSkin(skin); }
+  void setSkinPerTimestep(double skinPerTimestep) override final { _linkedCells.setSkinPerTimestep(skinPerTimestep); }
 
   /**
    * @copydoc autopas::ParticleContainerInterface::getInteractionLength()

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -249,7 +249,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    * @copydoc autopas::ParticleContainerInterface::getVerletSkin()
    */
   [[nodiscard]] double getVerletSkin() const override final { return _linkedCells.getVerletSkin(); }
-  
+
   /**
    * @copydoc autopas::ParticleContainerInterface::getInteractionLength()
    */

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -249,27 +249,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    * @copydoc autopas::ParticleContainerInterface::getVerletSkin()
    */
   [[nodiscard]] double getVerletSkin() const override final { return _linkedCells.getVerletSkin(); }
-
-  /**
-   * @copydoc autopas::ParticleContainerInterface::getSkinPerTimestep()
-   */
-  [[nodiscard]] double getSkinPerTimestep() { return _linkedCells.getSkinPerTimestep(); }
-
-  /**
-   * @copydoc autopas::ParticleContainerInterface::setSkinPerTimestep()
-   */
-  void setSkinPerTimestep(double skinPerTimestep) { _linkedCells.setSkinPerTimestep(skinPerTimestep); }
-
-  /**
-   * @copydoc autopas::ParticleContainerInterface::getRebuildFrequency()
-   */
-  [[nodiscard]] unsigned int getRebuildFrequency() { return _linkedCells.getRebuildFrequency(); }
-
-  /**
-   * @copydoc autopas::ParticleContainerInterface::setRebuildFrequency()
-   */
-  void setRebuildFrequency(unsigned int rebuildFrequency) { _linkedCells.setRebuildFrequency(rebuildFrequency); }
-
+  
   /**
    * @copydoc autopas::ParticleContainerInterface::getInteractionLength()
    */

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -265,8 +265,8 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    */
   [[nodiscard]] unsigned int getRebuildFrequency() const override final { return _linkedCells.getRebuildFrequency(); }
 
-  /**SkinPer
-   * @copydoc autopas::ParticleContainerInterface::setSkinPerTimestep()
+  /**
+   * @copydoc autopas::ParticleContainerInterface::setRebuildFrequency()
    */
   void setRebuildFrequency(unsigned int rebuildFrequency) override final {
     _linkedCells.setRebuildFrequency(rebuildFrequency);

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -249,10 +249,25 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    */
   [[nodiscard]] double getVerletSkin() const override final { return _linkedCells.getVerletSkin(); }
 
+    /**
+   * @copydoc autopas::ParticleContainerInterface::getSkinPerTimestep()
+   */
+  [[nodiscard]] double getSkinPerTimestep() const override final { return _linkedCells.getSkinPerTimestep(); }
+
   /**
    * @copydoc autopas::ParticleContainerInterface::setSkinPerTimestep()
    */
   void setSkinPerTimestep(double skinPerTimestep) override final { _linkedCells.setSkinPerTimestep(skinPerTimestep); }
+
+  /**
+   * @copydoc autopas::ParticleContainerInterface::getSkinPerTimestep()
+   */
+  [[nodiscard]] unsigned int getRebuildFrequency() const override final { return _linkedCells.getRebuildFrequency(); }
+
+  /**SkinPer
+   * @copydoc autopas::ParticleContainerInterface::setSkinPerTimestep()
+   */
+  void setRebuildFrequency(unsigned int rebuildFrequency) override final { _linkedCells.setRebuildFrequency(rebuildFrequency);} 
 
   /**
    * @copydoc autopas::ParticleContainerInterface::getInteractionLength()

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -253,22 +253,22 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
   /**
    * @copydoc autopas::ParticleContainerInterface::getSkinPerTimestep()
    */
-  [[nodiscard]] double getSkinPerTimestep() const override final { return _linkedCells.getSkinPerTimestep(); }
+  [[nodiscard]] double getSkinPerTimestep() { return _linkedCells.getSkinPerTimestep(); }
 
   /**
    * @copydoc autopas::ParticleContainerInterface::setSkinPerTimestep()
    */
-  void setSkinPerTimestep(double skinPerTimestep) override final { _linkedCells.setSkinPerTimestep(skinPerTimestep); }
+  void setSkinPerTimestep(double skinPerTimestep) { _linkedCells.setSkinPerTimestep(skinPerTimestep); }
 
   /**
    * @copydoc autopas::ParticleContainerInterface::getSkinPerTimestep()
    */
-  [[nodiscard]] unsigned int getRebuildFrequency() const override final { return _linkedCells.getRebuildFrequency(); }
+  [[nodiscard]] unsigned int getRebuildFrequency() { return _linkedCells.getRebuildFrequency(); }
 
   /**
    * @copydoc autopas::ParticleContainerInterface::setRebuildFrequency()
    */
-  void setRebuildFrequency(unsigned int rebuildFrequency) override final {
+  void setRebuildFrequency(unsigned int rebuildFrequency) {
     _linkedCells.setRebuildFrequency(rebuildFrequency);
   }
 

--- a/src/autopas/containers/verletListsCellBased/varVerletLists/VarVerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/varVerletLists/VarVerletLists.h
@@ -23,16 +23,16 @@ class VarVerletLists : public VerletListsLinkedBase<Particle> {
  public:
   /**
    * Constructor of the Variable VerletLists class.
-   * The neighbor lists are build using a search radius of cutoff + skin.
+   * The neighbor lists are build using a search radius of cutoff + skin*rebuildfrequency.
    * @param boxMin The lower corner of the domain.
    * @param boxMax The upper corner of the domain.
    * @param cutoff The cutoff radius of the interaction.
-   * @param skin The skin radius.
+   * @param skinPertimestep The skin radius per Timestep.
    * @param cellSizeFactor cell size factor relative to cutoff
    */
   VarVerletLists(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
-                 const double skin, const double cellSizeFactor = 1.0)
-      : VerletListsLinkedBase<Particle>(boxMin, boxMax, cutoff, skin,
+                 const double skinPerTimestep, const unsigned int rebuildFrequency, const double cellSizeFactor = 1.0)
+      : VerletListsLinkedBase<Particle>(boxMin, boxMax, cutoff, skinPerTimestep, rebuildFrequency,
                                         compatibleTraversals::allVarVLAsBuildCompatibleTraversals(), cellSizeFactor),
         _neighborList{} {}
 

--- a/src/autopas/containers/verletListsCellBased/varVerletLists/VarVerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/varVerletLists/VarVerletLists.h
@@ -28,6 +28,7 @@ class VarVerletLists : public VerletListsLinkedBase<Particle> {
    * @param boxMax The upper corner of the domain.
    * @param cutoff The cutoff radius of the interaction.
    * @param skinPertimestep The skin radius per Timestep.
+   * @param rebuildFrquency The rebuild Frequency.
    * @param cellSizeFactor cell size factor relative to cutoff
    */
   VarVerletLists(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,

--- a/src/autopas/containers/verletListsCellBased/varVerletLists/VarVerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/varVerletLists/VarVerletLists.h
@@ -27,8 +27,8 @@ class VarVerletLists : public VerletListsLinkedBase<Particle> {
    * @param boxMin The lower corner of the domain.
    * @param boxMax The upper corner of the domain.
    * @param cutoff The cutoff radius of the interaction.
-   * @param skinPertimestep The skin radius per Timestep.
-   * @param rebuildFrquency The rebuild Frequency.
+   * @param skinPerTimestep The skin radius per Timestep.
+   * @param rebuildFrequency The rebuild Frequency.
    * @param cellSizeFactor cell size factor relative to cutoff
    */
   VarVerletLists(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -54,7 +54,7 @@ class VerletLists : public VerletListsLinkedBase<Particle> {
    * @param boxMin The lower corner of the domain.
    * @param boxMax The upper corner of the domain.
    * @param cutoff The cutoff radius of the interaction.
-   * @param skinPerTimestep The skin radius.
+   * @param skinPerTimestep The skin radius per timestep.
    * @param rebuildFrequency rebuild fequency.
    * @param buildVerletListType Specifies how the verlet list should be build, see BuildVerletListType
    * @param cellSizeFactor cell size factor ralative to cutoff

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -55,6 +55,7 @@ class VerletLists : public VerletListsLinkedBase<Particle> {
    * @param boxMax The upper corner of the domain.
    * @param cutoff The cutoff radius of the interaction.
    * @param skinPerTimestep The skin radius.
+   * @param rebuildFrequency rebuild fequency.
    * @param buildVerletListType Specifies how the verlet list should be build, see BuildVerletListType
    * @param cellSizeFactor cell size factor ralative to cutoff
    */
@@ -118,7 +119,7 @@ class VerletLists : public VerletListsLinkedBase<Particle> {
   virtual void updateVerletListsAoS(bool useNewton3) {
     generateAoSNeighborLists();
     typename VerletListHelpers<Particle>::VerletListGeneratorFunctor f(_aosNeighborLists,
-                                                                       this->getCutoff() + this->getSkin());
+                                                                       this->getCutoff() + this->getVerletSkin());
 
     /// @todo autotune traversal
     switch (_buildVerletListType) {

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -50,7 +50,7 @@ class VerletLists : public VerletListsLinkedBase<Particle> {
 
   /**
    * Constructor of the VerletLists class.
-   * The neighbor lists are build using a search radius of cutoff + skin.
+   * The neighbor lists are build using a search radius of cutoff + skinPerTimestep*rebuildFrequency.
    * @param boxMin The lower corner of the domain.
    * @param boxMax The upper corner of the domain.
    * @param cutoff The cutoff radius of the interaction.
@@ -59,7 +59,7 @@ class VerletLists : public VerletListsLinkedBase<Particle> {
    * @param cellSizeFactor cell size factor ralative to cutoff
    */
   VerletLists(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
-              const double skinPerTimestep, const double rebuildFrequency, const BuildVerletListType buildVerletListType = BuildVerletListType::VerletSoA,
+              const double skinPerTimestep, const unsigned int rebuildFrequency, const BuildVerletListType buildVerletListType = BuildVerletListType::VerletSoA,
               const double cellSizeFactor = 1.0)
       : VerletListsLinkedBase<Particle>(boxMin, boxMax, cutoff, skinPerTimestep,rebuildFrequency, compatibleTraversals::allVLCompatibleTraversals(),
                                         cellSizeFactor),

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -54,14 +54,14 @@ class VerletLists : public VerletListsLinkedBase<Particle> {
    * @param boxMin The lower corner of the domain.
    * @param boxMax The upper corner of the domain.
    * @param cutoff The cutoff radius of the interaction.
-   * @param skin The skin radius.
+   * @param skinPerTimestep The skin radius.
    * @param buildVerletListType Specifies how the verlet list should be build, see BuildVerletListType
    * @param cellSizeFactor cell size factor ralative to cutoff
    */
   VerletLists(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
-              const double skin, const BuildVerletListType buildVerletListType = BuildVerletListType::VerletSoA,
+              const double skinPerTimestep, const double rebuildFrequency, const BuildVerletListType buildVerletListType = BuildVerletListType::VerletSoA,
               const double cellSizeFactor = 1.0)
-      : VerletListsLinkedBase<Particle>(boxMin, boxMax, cutoff, skin, compatibleTraversals::allVLCompatibleTraversals(),
+      : VerletListsLinkedBase<Particle>(boxMin, boxMax, cutoff, skinPerTimestep,rebuildFrequency, compatibleTraversals::allVLCompatibleTraversals(),
                                         cellSizeFactor),
         _soaListIsValid(false),
         _buildVerletListType(buildVerletListType) {}

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -60,10 +60,11 @@ class VerletLists : public VerletListsLinkedBase<Particle> {
    * @param cellSizeFactor cell size factor ralative to cutoff
    */
   VerletLists(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
-              const double skinPerTimestep, const unsigned int rebuildFrequency, const BuildVerletListType buildVerletListType = BuildVerletListType::VerletSoA,
+              const double skinPerTimestep, const unsigned int rebuildFrequency,
+              const BuildVerletListType buildVerletListType = BuildVerletListType::VerletSoA,
               const double cellSizeFactor = 1.0)
-      : VerletListsLinkedBase<Particle>(boxMin, boxMax, cutoff, skinPerTimestep,rebuildFrequency, compatibleTraversals::allVLCompatibleTraversals(),
-                                        cellSizeFactor),
+      : VerletListsLinkedBase<Particle>(boxMin, boxMax, cutoff, skinPerTimestep, rebuildFrequency,
+                                        compatibleTraversals::allVLCompatibleTraversals(), cellSizeFactor),
         _soaListIsValid(false),
         _buildVerletListType(buildVerletListType) {}
 

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
@@ -50,11 +50,11 @@ class VerletListsCells : public VerletListsLinkedBase<Particle> {
    * @param buildType data layout of the particles which are used to generate the neighbor lists
    */
   VerletListsCells(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
-                   const double skinPerTimestep = 0, const unsigned int rebuildFrequency, const double cellSizeFactor = 1.0,
+                   const double skinPerTimestep = 0, const unsigned int rebuildFrequency = 2, const double cellSizeFactor = 1.0,
                    const LoadEstimatorOption loadEstimator = LoadEstimatorOption::squaredParticlesPerCell,
                    typename VerletListsCellsHelpers<Particle>::VLCBuildType::Value buildType =
                        VerletListsCellsHelpers<Particle>::VLCBuildType::soaBuild)
-      : VerletListsLinkedBase<Particle>(boxMin, boxMax, cutoff, skinPerTimestep,rebuildFrequency
+      : VerletListsLinkedBase<Particle>(boxMin, boxMax, cutoff, skinPerTimestep,rebuildFrequency,
                                         compatibleTraversals::allVLCCompatibleTraversals(), cellSizeFactor),
         _loadEstimator(loadEstimator),
         _buildType(buildType) {}

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
@@ -118,7 +118,7 @@ class VerletListsCells : public VerletListsLinkedBase<Particle> {
     this->_verletBuiltNewton3 = traversal->getUseNewton3();
 
     _neighborList.buildAoSNeighborList(this->_linkedCells, this->_verletBuiltNewton3, this->getCutoff(),
-                                       this->getSkin(), this->getInteractionLength(), TraversalOption::lc_c18,
+                                       this->getVerletSkin(), this->getInteractionLength(), TraversalOption::lc_c18,
                                        _buildType);
 
     if (traversal->getDataLayout() == DataLayoutOption::soa) {

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
@@ -51,11 +51,12 @@ class VerletListsCells : public VerletListsLinkedBase<Particle> {
    * @param buildType data layout of the particles which are used to generate the neighbor lists
    */
   VerletListsCells(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
-                   const double skinPerTimestep = 0, const unsigned int rebuildFrequency = 2, const double cellSizeFactor = 1.0,
+                   const double skinPerTimestep = 0, const unsigned int rebuildFrequency = 2,
+                   const double cellSizeFactor = 1.0,
                    const LoadEstimatorOption loadEstimator = LoadEstimatorOption::squaredParticlesPerCell,
                    typename VerletListsCellsHelpers<Particle>::VLCBuildType::Value buildType =
                        VerletListsCellsHelpers<Particle>::VLCBuildType::soaBuild)
-      : VerletListsLinkedBase<Particle>(boxMin, boxMax, cutoff, skinPerTimestep,rebuildFrequency,
+      : VerletListsLinkedBase<Particle>(boxMin, boxMax, cutoff, skinPerTimestep, rebuildFrequency,
                                         compatibleTraversals::allVLCCompatibleTraversals(), cellSizeFactor),
         _loadEstimator(loadEstimator),
         _buildType(buildType) {}

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
@@ -27,7 +27,7 @@ namespace autopas {
  * to calculate pairwise interactions of particles.
  * It is optimized for a constant, i.e. particle independent, cutoff radius of
  * the interaction.
- * Cells are created using a cell size of at least cutoff + skin radius.
+ * Cells are created using a cell size of at least cutoff + skinPerTimestep*rebuildFrequency.
  * @tparam Particle
  * @tparam NeighborList The neighbor list used by this container.
  */
@@ -40,21 +40,21 @@ class VerletListsCells : public VerletListsLinkedBase<Particle> {
  public:
   /**
    * Constructor of the VerletListsCells class.
-   * The neighbor lists are build using a search radius of cutoff + skin.
+   * The neighbor lists are build using a search radius of cutoff + skin*rebuildfrequency.
    * @param boxMin the lower corner of the domain
    * @param boxMax the upper corner of the domain
    * @param cutoff the cutoff radius of the interaction
-   * @param skinPerTimestep the skin radius
+   * @param skinPerTimestep the skin radius per Timestep
    * @param cellSizeFactor cell size factor relative to cutoff
    * @param loadEstimator load estimation algorithm for balanced traversals
    * @param buildType data layout of the particles which are used to generate the neighbor lists
    */
   VerletListsCells(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
-                   const double skinPerTimestep = 0, const double rebuildFrequency, const double cellSizeFactor = 1.0,
+                   const double skinPerTimestep = 0, const unsigned int rebuildFrequency, const double cellSizeFactor = 1.0,
                    const LoadEstimatorOption loadEstimator = LoadEstimatorOption::squaredParticlesPerCell,
                    typename VerletListsCellsHelpers<Particle>::VLCBuildType::Value buildType =
                        VerletListsCellsHelpers<Particle>::VLCBuildType::soaBuild)
-      : VerletListsLinkedBase<Particle>(boxMin, boxMax, cutoff, skin,
+      : VerletListsLinkedBase<Particle>(boxMin, boxMax, cutoff, skinPerTimestep,rebuildFrequency
                                         compatibleTraversals::allVLCCompatibleTraversals(), cellSizeFactor),
         _loadEstimator(loadEstimator),
         _buildType(buildType) {}

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
@@ -44,13 +44,13 @@ class VerletListsCells : public VerletListsLinkedBase<Particle> {
    * @param boxMin the lower corner of the domain
    * @param boxMax the upper corner of the domain
    * @param cutoff the cutoff radius of the interaction
-   * @param skin the skin radius
+   * @param skinPerTimestep the skin radius
    * @param cellSizeFactor cell size factor relative to cutoff
    * @param loadEstimator load estimation algorithm for balanced traversals
    * @param buildType data layout of the particles which are used to generate the neighbor lists
    */
   VerletListsCells(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
-                   const double skin = 0, const double cellSizeFactor = 1.0,
+                   const double skinPerTimestep = 0, const double rebuildFrequency, const double cellSizeFactor = 1.0,
                    const LoadEstimatorOption loadEstimator = LoadEstimatorOption::squaredParticlesPerCell,
                    typename VerletListsCellsHelpers<Particle>::VLCBuildType::Value buildType =
                        VerletListsCellsHelpers<Particle>::VLCBuildType::soaBuild)

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
@@ -44,6 +44,7 @@ class VerletListsCells : public VerletListsLinkedBase<Particle> {
    * @param boxMin the lower corner of the domain
    * @param boxMax the upper corner of the domain
    * @param cutoff the cutoff radius of the interaction
+   * @param rebuildFrequency the rebuild Frequency
    * @param skinPerTimestep the skin radius per Timestep
    * @param cellSizeFactor cell size factor relative to cutoff
    * @param loadEstimator load estimation algorithm for balanced traversals

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -52,8 +52,7 @@ class AutoTuner {
    * @param boxMin Lower corner of the container.
    * @param boxMax Upper corner of the container.
    * @param cutoff Cutoff radius to be used in this container.
-   * @param verletSkinPerTimestep Length added to the cutoff for the Verlet lists' skin.
-   * @param verletRebuildFrequency The frequency of the rebuilds.
+   * @param verletSkinPerTimestep Length added to the cutoff for the Verlet lists' skin per Timestep.
    * @param verletClusterSize Number of particles in a cluster to use in verlet list.
    * @param tuningStrategy Object implementing the modelling and exploration of a search space.
    * @param MPITuningMaxDifferenceForBucket For MPI-tuning: Maximum of the relative difference in the comparison metric
@@ -77,7 +76,7 @@ class AutoTuner {
         _iterationsSinceTuning(tuningInterval),  // init to max so that tuning happens in first iteration
         _containerSelector(boxMin, boxMax, cutoff),
         _verletSkinPerTimestep(verletSkinPerTimestep),
-        _verletRebuildFrequency(verletRebuildFrequency),
+        _rebuildFrequency(rebuildFrequency),
         _verletClusterSize(verletClusterSize),
         _mpiTuningMaxDifferenceForBucket(MPITuningMaxDifferenceForBucket),
         _mpiTuningWeightForMaxDensity(MPITuningWeightForMaxDensity),
@@ -294,7 +293,7 @@ class AutoTuner {
   /**
    * The rebuild frequency this instance of AutoPas uses.
    */
-  unsigned int _verletRebuildFrequency;
+  unsigned int _rebuildFrequency;
 
   /**
    * How many times each configuration should be tested.
@@ -357,7 +356,7 @@ template <class Particle>
 void AutoTuner<Particle>::selectCurrentContainer() {
   auto conf = _tuningStrategy->getCurrentConfiguration();
   _containerSelector.selectContainer(
-      conf.container, ContainerSelectorInfo(conf.cellSizeFactor, _verletSkinPerTimestep, _verletRebuildFrequency, _verletClusterSize, conf.loadEstimator));
+      conf.container, ContainerSelectorInfo(conf.cellSizeFactor, _verletSkinPerTimestep, _rebuildFrequency, _verletClusterSize, conf.loadEstimator));
 }
 
 /**
@@ -696,7 +695,7 @@ bool AutoTuner<Particle>::configApplicable(const Configuration &conf, PairwiseFu
   }
 
   _containerSelector.selectContainer(
-      conf.container, ContainerSelectorInfo(conf.cellSizeFactor, _verletSkinPerTimestep, _verletRebuildFrequency,_verletClusterSize, conf.loadEstimator));
+      conf.container, ContainerSelectorInfo(conf.cellSizeFactor, _verletSkinPerTimestep, _rebuildFrequency,_verletClusterSize, conf.loadEstimator));
   auto traversalInfo = _containerSelector.getCurrentContainer()->getTraversalSelectorInfo();
 
   auto containerPtr = getContainer();

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -65,11 +65,11 @@ class AutoTuner {
    * @param rebuildFrequency The rebuild frequency this AutoPas instance uses.
    * @param outputSuffix Suffix for all output files produced by this class.
    */
-  AutoTuner(std::array<double, 3> boxMin, std::array<double, 3> boxMax, double cutoff, double verletSkinPerTimestep, unsigned int verletRebuildFrequency,
-            unsigned int verletClusterSize, std::unique_ptr<TuningStrategyInterface> tuningStrategy,
-            double MPITuningMaxDifferenceForBucket, double MPITuningWeightForMaxDensity,
-            SelectorStrategyOption selectorStrategy, unsigned int tuningInterval, unsigned int maxSamples,
-            unsigned int rebuildFrequency, const std::string &outputSuffix = "")
+  AutoTuner(std::array<double, 3> boxMin, std::array<double, 3> boxMax, double cutoff, double verletSkinPerTimestep,
+            unsigned int verletRebuildFrequency, unsigned int verletClusterSize,
+            std::unique_ptr<TuningStrategyInterface> tuningStrategy, double MPITuningMaxDifferenceForBucket,
+            double MPITuningWeightForMaxDensity, SelectorStrategyOption selectorStrategy, unsigned int tuningInterval,
+            unsigned int maxSamples, unsigned int rebuildFrequency, const std::string &outputSuffix = "")
       : _selectorStrategy(selectorStrategy),
         _tuningStrategy(std::move(tuningStrategy)),
         _tuningInterval(tuningInterval),
@@ -280,12 +280,12 @@ class AutoTuner {
    */
   ContainerSelector<Particle> _containerSelector;
 
-   /**
+  /**
    * The skin length per timestep this instance of AutoPas uses.
    */
   double _verletSkinPerTimestep;
 
- /**
+  /**
    * The cluster size this instance of AutoPas uses.
    */
   unsigned int _verletClusterSize;
@@ -356,7 +356,8 @@ template <class Particle>
 void AutoTuner<Particle>::selectCurrentContainer() {
   auto conf = _tuningStrategy->getCurrentConfiguration();
   _containerSelector.selectContainer(
-      conf.container, ContainerSelectorInfo(conf.cellSizeFactor, _verletSkinPerTimestep, _rebuildFrequency, _verletClusterSize, conf.loadEstimator));
+      conf.container, ContainerSelectorInfo(conf.cellSizeFactor, _verletSkinPerTimestep, _rebuildFrequency,
+                                            _verletClusterSize, conf.loadEstimator));
 }
 
 /**
@@ -695,7 +696,8 @@ bool AutoTuner<Particle>::configApplicable(const Configuration &conf, PairwiseFu
   }
 
   _containerSelector.selectContainer(
-      conf.container, ContainerSelectorInfo(conf.cellSizeFactor, _verletSkinPerTimestep, _rebuildFrequency,_verletClusterSize, conf.loadEstimator));
+      conf.container, ContainerSelectorInfo(conf.cellSizeFactor, _verletSkinPerTimestep, _rebuildFrequency,
+                                            _verletClusterSize, conf.loadEstimator));
   auto traversalInfo = _containerSelector.getCurrentContainer()->getTraversalSelectorInfo();
 
   auto containerPtr = getContainer();

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -53,6 +53,7 @@ class AutoTuner {
    * @param boxMax Upper corner of the container.
    * @param cutoff Cutoff radius to be used in this container.
    * @param verletSkinPerTimestep Length added to the cutoff for the Verlet lists' skin per Timestep.
+   * @param verletRebuildFrequency The Rebuild Frequency of the verlet lists. 
    * @param verletClusterSize Number of particles in a cluster to use in verlet list.
    * @param tuningStrategy Object implementing the modelling and exploration of a search space.
    * @param MPITuningMaxDifferenceForBucket For MPI-tuning: Maximum of the relative difference in the comparison metric

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -52,7 +52,7 @@ class AutoTuner {
    * @param boxMin Lower corner of the container.
    * @param boxMax Upper corner of the container.
    * @param cutoff Cutoff radius to be used in this container.
-   * @param verletSkin Length added to the cutoff for the Verlet lists' skin.
+   * @param verletSkinPerTimestep Length added to the cutoff for the Verlet lists' skin.
    * @param verletClusterSize Number of particles in a cluster to use in verlet list.
    * @param tuningStrategy Object implementing the modelling and exploration of a search space.
    * @param MPITuningMaxDifferenceForBucket For MPI-tuning: Maximum of the relative difference in the comparison metric
@@ -65,7 +65,7 @@ class AutoTuner {
    * @param rebuildFrequency The rebuild frequency this AutoPas instance uses.
    * @param outputSuffix Suffix for all output files produced by this class.
    */
-  AutoTuner(std::array<double, 3> boxMin, std::array<double, 3> boxMax, double cutoff, double verletSkin,
+  AutoTuner(std::array<double, 3> boxMin, std::array<double, 3> boxMax, double cutoff, double verletSkinPerTimestep,
             unsigned int verletClusterSize, std::unique_ptr<TuningStrategyInterface> tuningStrategy,
             double MPITuningMaxDifferenceForBucket, double MPITuningWeightForMaxDensity,
             SelectorStrategyOption selectorStrategy, unsigned int tuningInterval, unsigned int maxSamples,
@@ -75,7 +75,7 @@ class AutoTuner {
         _tuningInterval(tuningInterval),
         _iterationsSinceTuning(tuningInterval),  // init to max so that tuning happens in first iteration
         _containerSelector(boxMin, boxMax, cutoff),
-        _verletSkin(verletSkin),
+        _verletSkinPerTimestep(verletSkinPerTimestep),
         _verletClusterSize(verletClusterSize),
         _mpiTuningMaxDifferenceForBucket(MPITuningMaxDifferenceForBucket),
         _mpiTuningWeightForMaxDensity(MPITuningWeightForMaxDensity),
@@ -280,7 +280,7 @@ class AutoTuner {
    */
   ContainerSelector<Particle> _containerSelector;
 
-  double _verletSkin;
+  double _verletSkinPerTimestep;
   unsigned int _verletClusterSize;
 
   /**
@@ -349,7 +349,7 @@ template <class Particle>
 void AutoTuner<Particle>::selectCurrentContainer() {
   auto conf = _tuningStrategy->getCurrentConfiguration();
   _containerSelector.selectContainer(
-      conf.container, ContainerSelectorInfo(conf.cellSizeFactor, _verletSkin, _verletClusterSize, conf.loadEstimator));
+      conf.container, ContainerSelectorInfo(conf.cellSizeFactor, _verletSkinPerTimestep, _verletClusterSize, conf.loadEstimator));
 }
 
 /**
@@ -688,7 +688,7 @@ bool AutoTuner<Particle>::configApplicable(const Configuration &conf, PairwiseFu
   }
 
   _containerSelector.selectContainer(
-      conf.container, ContainerSelectorInfo(conf.cellSizeFactor, _verletSkin, _verletClusterSize, conf.loadEstimator));
+      conf.container, ContainerSelectorInfo(conf.cellSizeFactor, _verletSkinPerTimestep, _verletClusterSize, conf.loadEstimator));
   auto traversalInfo = _containerSelector.getCurrentContainer()->getTraversalSelectorInfo();
 
   auto containerPtr = getContainer();

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -52,7 +52,7 @@ class AutoTuner {
    * @param boxMin Lower corner of the container.
    * @param boxMax Upper corner of the container.
    * @param cutoff Cutoff radius to be used in this container.
-   * @param verletSkin Length added to the cutoff for the Verlet lists' skin.
+   * @param verletSkinPerTimestep Length added to the cutoff for the Verlet lists' skin.
    * @param verletClusterSize Number of particles in a cluster to use in verlet list.
    * @param tuningStrategy Object implementing the modelling and exploration of a search space.
    * @param MPITuningMaxDifferenceForBucket For MPI-tuning: Maximum of the relative difference in the comparison metric
@@ -65,7 +65,7 @@ class AutoTuner {
    * @param rebuildFrequency The rebuild frequency this AutoPas instance uses.
    * @param outputSuffix Suffix for all output files produced by this class.
    */
-  AutoTuner(std::array<double, 3> boxMin, std::array<double, 3> boxMax, double cutoff, double verletSkin,
+  AutoTuner(std::array<double, 3> boxMin, std::array<double, 3> boxMax, double cutoff, double verletSkinPerTimestep,
             unsigned int verletClusterSize, std::unique_ptr<TuningStrategyInterface> tuningStrategy,
             double MPITuningMaxDifferenceForBucket, double MPITuningWeightForMaxDensity,
             SelectorStrategyOption selectorStrategy, unsigned int tuningInterval, unsigned int maxSamples,
@@ -75,7 +75,7 @@ class AutoTuner {
         _tuningInterval(tuningInterval),
         _iterationsSinceTuning(tuningInterval),  // init to max so that tuning happens in first iteration
         _containerSelector(boxMin, boxMax, cutoff),
-        _verletSkin(verletSkin),
+        _verletSkinPerTimestep(verletSkinPerTimestep),
         _verletClusterSize(verletClusterSize),
         _mpiTuningMaxDifferenceForBucket(MPITuningMaxDifferenceForBucket),
         _mpiTuningWeightForMaxDensity(MPITuningWeightForMaxDensity),
@@ -280,7 +280,7 @@ class AutoTuner {
    */
   ContainerSelector<Particle> _containerSelector;
 
-  double _verletSkin;
+  double _verletSkinPerTimestep;
   unsigned int _verletClusterSize;
 
   /**
@@ -349,7 +349,7 @@ template <class Particle>
 void AutoTuner<Particle>::selectCurrentContainer() {
   auto conf = _tuningStrategy->getCurrentConfiguration();
   _containerSelector.selectContainer(
-      conf.container, ContainerSelectorInfo(conf.cellSizeFactor, _verletSkin, _verletClusterSize, conf.loadEstimator));
+      conf.container, ContainerSelectorInfo(conf.cellSizeFactor, _verletSkinPerTimestep,_rebuildFrequency, _verletClusterSize, conf.loadEstimator));
 }
 
 /**
@@ -688,7 +688,7 @@ bool AutoTuner<Particle>::configApplicable(const Configuration &conf, PairwiseFu
   }
 
   _containerSelector.selectContainer(
-      conf.container, ContainerSelectorInfo(conf.cellSizeFactor, _verletSkin, _verletClusterSize, conf.loadEstimator));
+      conf.container, ContainerSelectorInfo(conf.cellSizeFactor, _verletSkinPerTimestep,_rebuildFrequency, _verletClusterSize, conf.loadEstimator));
   auto traversalInfo = _containerSelector.getCurrentContainer()->getTraversalSelectorInfo();
 
   auto containerPtr = getContainer();

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -53,7 +53,7 @@ class AutoTuner {
    * @param boxMax Upper corner of the container.
    * @param cutoff Cutoff radius to be used in this container.
    * @param verletSkinPerTimestep Length added to the cutoff for the Verlet lists' skin per Timestep.
-   * @param rebuildFrequency The Rebuild Frequency of the verlet lists. 
+   * @param rebuildFrequency The Rebuild Frequency of the verlet lists.
    * @param verletClusterSize Number of particles in a cluster to use in verlet list.
    * @param tuningStrategy Object implementing the modelling and exploration of a search space.
    * @param MPITuningMaxDifferenceForBucket For MPI-tuning: Maximum of the relative difference in the comparison metric

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -349,7 +349,8 @@ template <class Particle>
 void AutoTuner<Particle>::selectCurrentContainer() {
   auto conf = _tuningStrategy->getCurrentConfiguration();
   _containerSelector.selectContainer(
-      conf.container, ContainerSelectorInfo(conf.cellSizeFactor, _verletSkinPerTimestep,_rebuildFrequency, _verletClusterSize, conf.loadEstimator));
+      conf.container, ContainerSelectorInfo(conf.cellSizeFactor, _verletSkinPerTimestep, _rebuildFrequency,
+                                            _verletClusterSize, conf.loadEstimator));
 }
 
 /**
@@ -688,7 +689,8 @@ bool AutoTuner<Particle>::configApplicable(const Configuration &conf, PairwiseFu
   }
 
   _containerSelector.selectContainer(
-      conf.container, ContainerSelectorInfo(conf.cellSizeFactor, _verletSkinPerTimestep,_rebuildFrequency, _verletClusterSize, conf.loadEstimator));
+      conf.container, ContainerSelectorInfo(conf.cellSizeFactor, _verletSkinPerTimestep, _rebuildFrequency,
+                                            _verletClusterSize, conf.loadEstimator));
   auto traversalInfo = _containerSelector.getCurrentContainer()->getTraversalSelectorInfo();
 
   auto containerPtr = getContainer();

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -53,7 +53,7 @@ class AutoTuner {
    * @param boxMax Upper corner of the container.
    * @param cutoff Cutoff radius to be used in this container.
    * @param verletSkinPerTimestep Length added to the cutoff for the Verlet lists' skin per Timestep.
-   * @param verletRebuildFrequency The Rebuild Frequency of the verlet lists. 
+   * @param rebuildFrequency The Rebuild Frequency of the verlet lists. 
    * @param verletClusterSize Number of particles in a cluster to use in verlet list.
    * @param tuningStrategy Object implementing the modelling and exploration of a search space.
    * @param MPITuningMaxDifferenceForBucket For MPI-tuning: Maximum of the relative difference in the comparison metric
@@ -63,14 +63,13 @@ class AutoTuner {
    * @param selectorStrategy Strategy for the configuration selection.
    * @param tuningInterval Number of time steps after which the auto-tuner shall reevaluate all selections.
    * @param maxSamples Number of samples that shall be collected for each combination.
-   * @param rebuildFrequency The rebuild frequency this AutoPas instance uses.
    * @param outputSuffix Suffix for all output files produced by this class.
    */
   AutoTuner(std::array<double, 3> boxMin, std::array<double, 3> boxMax, double cutoff, double verletSkinPerTimestep,
-            unsigned int verletRebuildFrequency, unsigned int verletClusterSize,
+            unsigned int rebuildFrequency, unsigned int verletClusterSize,
             std::unique_ptr<TuningStrategyInterface> tuningStrategy, double MPITuningMaxDifferenceForBucket,
             double MPITuningWeightForMaxDensity, SelectorStrategyOption selectorStrategy, unsigned int tuningInterval,
-            unsigned int maxSamples, unsigned int rebuildFrequency, const std::string &outputSuffix = "")
+            unsigned int maxSamples, const std::string &outputSuffix = "")
       : _selectorStrategy(selectorStrategy),
         _tuningStrategy(std::move(tuningStrategy)),
         _tuningInterval(tuningInterval),

--- a/src/autopas/selectors/ContainerSelector.h
+++ b/src/autopas/selectors/ContainerSelector.h
@@ -132,7 +132,8 @@ std::unique_ptr<autopas::ParticleContainerInterface<Particle>> ContainerSelector
     case ContainerOption::verletClusterLists: {
       container =
           std::make_unique<VerletClusterLists<Particle>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep,
-                                                         containerInfo.verletClusterSize, containerInfo.loadEstimator);
+                                                        containerInfo.verletRebuildFrequency,
+                                                        containerInfo.verletClusterSize, containerInfo.loadEstimator);
       break;
     }
     case ContainerOption::varVerletListsAsBuild: {

--- a/src/autopas/selectors/ContainerSelector.h
+++ b/src/autopas/selectors/ContainerSelector.h
@@ -138,19 +138,20 @@ std::unique_ptr<autopas::ParticleContainerInterface<Particle>> ContainerSelector
     }
     case ContainerOption::varVerletListsAsBuild: {
       container = std::make_unique<VarVerletLists<Particle, VerletNeighborListAsBuild<Particle>>>(
-          _boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep, containerInfo.cellSizeFactor);
+          _boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep, containerInfo.verletRebuildFrequency, containerInfo.cellSizeFactor);
       break;
     }
 
     case ContainerOption::pairwiseVerletLists: {
       container = std::make_unique<VerletListsCells<Particle, VLCCellPairNeighborList<Particle>>>(
-          _boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep, containerInfo.cellSizeFactor,
+          _boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep, containerInfo.verletRebuildFrequency,
+          containerInfo.cellSizeFactor,
           containerInfo.loadEstimator, VerletListsCellsHelpers<Particle>::VLCBuildType::Value::soaBuild);
       break;
     }
     case ContainerOption::octree: {
       container = std::make_unique<Octree<Particle>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep,
-                                                     containerInfo.cellSizeFactor);
+                                                    containerInfo.verletRebuildFrequency, containerInfo.cellSizeFactor);
       break;
     }
     default: {

--- a/src/autopas/selectors/ContainerSelector.h
+++ b/src/autopas/selectors/ContainerSelector.h
@@ -101,57 +101,59 @@ std::unique_ptr<autopas::ParticleContainerInterface<Particle>> ContainerSelector
   switch (containerChoice) {
     case ContainerOption::directSum: {
       container = std::make_unique<DirectSum<Particle>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep,
-                                                       containerInfo.verletRebuildFrequency);
+                                                        containerInfo.verletRebuildFrequency);
       break;
     }
 
     case ContainerOption::linkedCells: {
-      container = std::make_unique<LinkedCells<Particle>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep, 
-                                                        containerInfo.verletRebuildFrequency,containerInfo.cellSizeFactor, 
-                                                        containerInfo.loadEstimator);
+      container = std::make_unique<LinkedCells<Particle>>(
+          _boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep, containerInfo.verletRebuildFrequency,
+          containerInfo.cellSizeFactor, containerInfo.loadEstimator);
       break;
     }
     case ContainerOption::linkedCellsReferences: {
-      container = std::make_unique<LinkedCellsReferences<Particle>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep,
-                                                                    containerInfo.verletRebuildFrequency,containerInfo.cellSizeFactor);
+      container = std::make_unique<LinkedCellsReferences<Particle>>(
+          _boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep, containerInfo.verletRebuildFrequency,
+          containerInfo.cellSizeFactor);
       break;
     }
     case ContainerOption::verletLists: {
-      container = std::make_unique<VerletLists<Particle>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep,
-                                                          containerInfo.verletRebuildFrequency,
-                                                          VerletLists<Particle>::BuildVerletListType::VerletSoA,
-                                                          containerInfo.cellSizeFactor);
+      container = std::make_unique<VerletLists<Particle>>(
+          _boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep, containerInfo.verletRebuildFrequency,
+          VerletLists<Particle>::BuildVerletListType::VerletSoA, containerInfo.cellSizeFactor);
       break;
     }
     case ContainerOption::verletListsCells: {
       container = std::make_unique<VerletListsCells<Particle, VLCAllCellsNeighborList<Particle>>>(
-          _boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep,containerInfo.verletRebuildFrequency,
-           containerInfo.cellSizeFactor, containerInfo.loadEstimator, VerletListsCellsHelpers<Particle>::VLCBuildType::Value::soaBuild);
+          _boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep, containerInfo.verletRebuildFrequency,
+          containerInfo.cellSizeFactor, containerInfo.loadEstimator,
+          VerletListsCellsHelpers<Particle>::VLCBuildType::Value::soaBuild);
       break;
     }
     case ContainerOption::verletClusterLists: {
-      container =
-          std::make_unique<VerletClusterLists<Particle>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep,
-                                                        containerInfo.verletRebuildFrequency,
-                                                        containerInfo.verletClusterSize, containerInfo.loadEstimator);
+      container = std::make_unique<VerletClusterLists<Particle>>(
+          _boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep, containerInfo.verletRebuildFrequency,
+          containerInfo.verletClusterSize, containerInfo.loadEstimator);
       break;
     }
     case ContainerOption::varVerletListsAsBuild: {
       container = std::make_unique<VarVerletLists<Particle, VerletNeighborListAsBuild<Particle>>>(
-          _boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep, containerInfo.verletRebuildFrequency, containerInfo.cellSizeFactor);
+          _boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep, containerInfo.verletRebuildFrequency,
+          containerInfo.cellSizeFactor);
       break;
     }
 
     case ContainerOption::pairwiseVerletLists: {
       container = std::make_unique<VerletListsCells<Particle, VLCCellPairNeighborList<Particle>>>(
           _boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep, containerInfo.verletRebuildFrequency,
-          containerInfo.cellSizeFactor,
-          containerInfo.loadEstimator, VerletListsCellsHelpers<Particle>::VLCBuildType::Value::soaBuild);
+          containerInfo.cellSizeFactor, containerInfo.loadEstimator,
+          VerletListsCellsHelpers<Particle>::VLCBuildType::Value::soaBuild);
       break;
     }
     case ContainerOption::octree: {
-      container = std::make_unique<Octree<Particle>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep,
-                                                    containerInfo.verletRebuildFrequency, containerInfo.cellSizeFactor);
+      container =
+          std::make_unique<Octree<Particle>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep,
+                                             containerInfo.verletRebuildFrequency, containerInfo.cellSizeFactor);
       break;
     }
     default: {

--- a/src/autopas/selectors/ContainerSelector.h
+++ b/src/autopas/selectors/ContainerSelector.h
@@ -100,52 +100,55 @@ std::unique_ptr<autopas::ParticleContainerInterface<Particle>> ContainerSelector
   std::unique_ptr<autopas::ParticleContainerInterface<Particle>> container;
   switch (containerChoice) {
     case ContainerOption::directSum: {
-      container = std::make_unique<DirectSum<Particle>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin);
+      container = std::make_unique<DirectSum<Particle>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep,
+                                                       containerInfo.verletRebuildFrequency);
       break;
     }
 
     case ContainerOption::linkedCells: {
-      container = std::make_unique<LinkedCells<Particle>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin,
-                                                          containerInfo.cellSizeFactor, containerInfo.loadEstimator);
+      container = std::make_unique<LinkedCells<Particle>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep, 
+                                                        containerInfo.verletRebuildFrequency,containerInfo.cellSizeFactor, 
+                                                        containerInfo.loadEstimator);
       break;
     }
     case ContainerOption::linkedCellsReferences: {
-      container = std::make_unique<LinkedCellsReferences<Particle>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin,
-                                                                    containerInfo.cellSizeFactor);
+      container = std::make_unique<LinkedCellsReferences<Particle>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep,
+                                                                    containerInfo.verletRebuildFrequency,containerInfo.cellSizeFactor);
       break;
     }
     case ContainerOption::verletLists: {
-      container = std::make_unique<VerletLists<Particle>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin,
+      container = std::make_unique<VerletLists<Particle>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep,
+                                                          containerInfo.verletRebuildFrequency,
                                                           VerletLists<Particle>::BuildVerletListType::VerletSoA,
                                                           containerInfo.cellSizeFactor);
       break;
     }
     case ContainerOption::verletListsCells: {
       container = std::make_unique<VerletListsCells<Particle, VLCAllCellsNeighborList<Particle>>>(
-          _boxMin, _boxMax, _cutoff, containerInfo.verletSkin, containerInfo.cellSizeFactor,
-          containerInfo.loadEstimator, VerletListsCellsHelpers<Particle>::VLCBuildType::Value::soaBuild);
+          _boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep,containerInfo.verletRebuildFrequency,
+           containerInfo.cellSizeFactor, containerInfo.loadEstimator, VerletListsCellsHelpers<Particle>::VLCBuildType::Value::soaBuild);
       break;
     }
     case ContainerOption::verletClusterLists: {
       container =
-          std::make_unique<VerletClusterLists<Particle>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin,
+          std::make_unique<VerletClusterLists<Particle>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep,
                                                          containerInfo.verletClusterSize, containerInfo.loadEstimator);
       break;
     }
     case ContainerOption::varVerletListsAsBuild: {
       container = std::make_unique<VarVerletLists<Particle, VerletNeighborListAsBuild<Particle>>>(
-          _boxMin, _boxMax, _cutoff, containerInfo.verletSkin, containerInfo.cellSizeFactor);
+          _boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep, containerInfo.cellSizeFactor);
       break;
     }
 
     case ContainerOption::pairwiseVerletLists: {
       container = std::make_unique<VerletListsCells<Particle, VLCCellPairNeighborList<Particle>>>(
-          _boxMin, _boxMax, _cutoff, containerInfo.verletSkin, containerInfo.cellSizeFactor,
+          _boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep, containerInfo.cellSizeFactor,
           containerInfo.loadEstimator, VerletListsCellsHelpers<Particle>::VLCBuildType::Value::soaBuild);
       break;
     }
     case ContainerOption::octree: {
-      container = std::make_unique<Octree<Particle>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin,
+      container = std::make_unique<Octree<Particle>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep,
                                                      containerInfo.cellSizeFactor);
       break;
     }

--- a/src/autopas/selectors/ContainerSelectorInfo.h
+++ b/src/autopas/selectors/ContainerSelectorInfo.h
@@ -30,7 +30,7 @@ class ContainerSelectorInfo {
    * Constructor.
    * @param cellSizeFactor Cell size factor to be used in this container (only relevant for LinkedCells, VerletLists and
    * VerletListsCells).
-   * @param verletSkinPerTimestep Length added to the cutoff for the verlet lists' skin per timestep.
+   * @param verletSkinPerTimestep Length added to the cutoff for the verlet lists' skin per timestep inbetween rebuilding lists.
    * @param verletRebuildFrequency rebuild frequency.
    * @param verletClusterSize Size of verlet Clusters
    * @param loadEstimator load estimation algorithm for balanced traversals.

--- a/src/autopas/selectors/ContainerSelectorInfo.h
+++ b/src/autopas/selectors/ContainerSelectorInfo.h
@@ -20,20 +20,21 @@ class ContainerSelectorInfo {
    * Default Constructor.
    */
   ContainerSelectorInfo()
-      : cellSizeFactor(1.), verletSkin(0.), verletClusterSize(64), loadEstimator(autopas::LoadEstimatorOption::none) {}
+      : cellSizeFactor(1.), verletSkinPerTimestep(0.),verletRebuildFrequency(0.), verletClusterSize(64), loadEstimator(autopas::LoadEstimatorOption::none) {}
 
   /**
    * Constructor.
    * @param cellSizeFactor Cell size factor to be used in this container (only relevant for LinkedCells, VerletLists and
    * VerletListsCells).
-   * @param verletSkin Length added to the cutoff for the verlet lists' skin.
+   * @param verletSkinPerTimestep Length added to the cutoff for the verlet lists' skin per timestep.
    * @param verletClusterSize Size of verlet Clusters
    * @param loadEstimator load estimation algorithm for balanced traversals.
    */
-  explicit ContainerSelectorInfo(double cellSizeFactor, double verletSkin, unsigned int verletClusterSize,
+  explicit ContainerSelectorInfo(double cellSizeFactor, double verletSkinPerTimestep, unsigned int verletClusterSize,
                                  autopas::LoadEstimatorOption loadEstimator)
       : cellSizeFactor(cellSizeFactor),
-        verletSkin(verletSkin),
+        verletSkinPerTimestep(verletSkinPerTimestep),
+        verletRebuildFrequency(verletRebuildFrequency),
         verletClusterSize(verletClusterSize),
         loadEstimator(loadEstimator) {}
 
@@ -43,7 +44,7 @@ class ContainerSelectorInfo {
    * @return True iff all member equal
    */
   bool operator==(const ContainerSelectorInfo &other) const {
-    return cellSizeFactor == other.cellSizeFactor and verletSkin == other.verletSkin and
+    return cellSizeFactor == other.cellSizeFactor and verletSkinPerTimestep == other.verletSkinperTimestep and
            verletClusterSize == other.verletClusterSize and loadEstimator == other.loadEstimator;
   }
 
@@ -63,8 +64,8 @@ class ContainerSelectorInfo {
    * @return
    */
   bool operator<(const ContainerSelectorInfo &other) {
-    return std::tie(cellSizeFactor, verletSkin, verletClusterSize, loadEstimator) <
-           std::tie(other.cellSizeFactor, other.verletSkin, other.verletClusterSize, other.loadEstimator);
+    return std::tie(cellSizeFactor, verletSkinPerTimestep, verletClusterSize, loadEstimator) <
+           std::tie(other.cellSizeFactor, other.verletSkinPerTimestep, other.verletClusterSize, other.loadEstimator);
   }
 
   /**
@@ -74,13 +75,15 @@ class ContainerSelectorInfo {
   /**
    * Length added to the cutoff for the verlet lists' skin.
    */
-  double verletSkin;
-
+  double verletSkinPerTimestep;
+  /**
+   * Length added to the cutoff for the verlet lists' skin.
+   */
+  double verletRebuildFrequency;
   /**
    * Size of Verlet Clusters
    */
   unsigned int verletClusterSize;
-
   /**
    * Load estimator for balanced sliced traversals.
    */

--- a/src/autopas/selectors/ContainerSelectorInfo.h
+++ b/src/autopas/selectors/ContainerSelectorInfo.h
@@ -20,7 +20,11 @@ class ContainerSelectorInfo {
    * Default Constructor.
    */
   ContainerSelectorInfo()
-      : cellSizeFactor(1.), verletSkinPerTimestep(0.),verletRebuildFrequency(0.), verletClusterSize(64), loadEstimator(autopas::LoadEstimatorOption::none) {}
+      : cellSizeFactor(1.),
+        verletSkinPerTimestep(0.),
+        verletRebuildFrequency(0.),
+        verletClusterSize(64),
+        loadEstimator(autopas::LoadEstimatorOption::none) {}
 
   /**
    * Constructor.
@@ -31,7 +35,8 @@ class ContainerSelectorInfo {
    * @param verletClusterSize Size of verlet Clusters
    * @param loadEstimator load estimation algorithm for balanced traversals.
    */
-  explicit ContainerSelectorInfo(double cellSizeFactor, double verletSkinPerTimestep, unsigned int verletRebuildFrequency, unsigned int verletClusterSize,
+  explicit ContainerSelectorInfo(double cellSizeFactor, double verletSkinPerTimestep,
+                                 unsigned int verletRebuildFrequency, unsigned int verletClusterSize,
                                  autopas::LoadEstimatorOption loadEstimator)
       : cellSizeFactor(cellSizeFactor),
         verletSkinPerTimestep(verletSkinPerTimestep),
@@ -58,15 +63,16 @@ class ContainerSelectorInfo {
 
   /**
    * Comparison operator for ContainerSelectorInfo objects.
-   * Configurations are compared member wise in the order: _cellSizeFactor, _verletSkinPerTimestep, _verlerRebuildFrequency,
-   * loadEstimator
+   * Configurations are compared member wise in the order: _cellSizeFactor, _verletSkinPerTimestep,
+   * _verlerRebuildFrequency, loadEstimator
    *
    * @param other
    * @return
    */
   bool operator<(const ContainerSelectorInfo &other) {
-    return std::tie(cellSizeFactor, verletSkinPerTimestep, verletRebuildFrequency,verletClusterSize, loadEstimator) <
-           std::tie(other.cellSizeFactor, other.verletSkinPerTimestep,other.verletRebuildFrequency, other.verletClusterSize, other.loadEstimator);
+    return std::tie(cellSizeFactor, verletSkinPerTimestep, verletRebuildFrequency, verletClusterSize, loadEstimator) <
+           std::tie(other.cellSizeFactor, other.verletSkinPerTimestep, other.verletRebuildFrequency,
+                    other.verletClusterSize, other.loadEstimator);
   }
 
   /**

--- a/src/autopas/selectors/ContainerSelectorInfo.h
+++ b/src/autopas/selectors/ContainerSelectorInfo.h
@@ -30,7 +30,7 @@ class ContainerSelectorInfo {
    * @param verletClusterSize Size of verlet Clusters
    * @param loadEstimator load estimation algorithm for balanced traversals.
    */
-  explicit ContainerSelectorInfo(double cellSizeFactor, double verletSkinPerTimestep, unsigned int verletClusterSize,
+  explicit ContainerSelectorInfo(double cellSizeFactor, double verletSkinPerTimestep, unsigned int verletRebuildFrequency, unsigned int verletClusterSize,
                                  autopas::LoadEstimatorOption loadEstimator)
       : cellSizeFactor(cellSizeFactor),
         verletSkinPerTimestep(verletSkinPerTimestep),
@@ -57,15 +57,15 @@ class ContainerSelectorInfo {
 
   /**
    * Comparison operator for ContainerSelectorInfo objects.
-   * Configurations are compared member wise in the order: _cellSizeFactor, _verletSkin, _verlerRebuildFrequency,
+   * Configurations are compared member wise in the order: _cellSizeFactor, _verletSkinPerTimestep, _verlerRebuildFrequency,
    * loadEstimator
    *
    * @param other
    * @return
    */
   bool operator<(const ContainerSelectorInfo &other) {
-    return std::tie(cellSizeFactor, verletSkinPerTimestep, verletClusterSize, loadEstimator) <
-           std::tie(other.cellSizeFactor, other.verletSkinPerTimestep, other.verletClusterSize, other.loadEstimator);
+    return std::tie(cellSizeFactor, verletSkinPerTimestep, verletRebuildFrequency,verletClusterSize, loadEstimator) <
+           std::tie(other.cellSizeFactor, other.verletSkinPerTimestep,other.verletRebuildFrequency, other.verletClusterSize, other.loadEstimator);
   }
 
   /**
@@ -77,7 +77,7 @@ class ContainerSelectorInfo {
    */
   double verletSkinPerTimestep;
   /**
-   * Length added to the cutoff for the verlet lists' skin.
+   * The rebuild frequency.
    */
   double verletRebuildFrequency;
   /**

--- a/src/autopas/selectors/ContainerSelectorInfo.h
+++ b/src/autopas/selectors/ContainerSelectorInfo.h
@@ -80,7 +80,7 @@ class ContainerSelectorInfo {
    */
   double cellSizeFactor;
   /**
-   * Length added to the cutoff for the verlet lists' skin per timestep.
+   * Length added to the cutoff for the verlet lists' skin per timestep inbetween rebuilding lists.
    */
   double verletSkinPerTimestep;
   /**

--- a/src/autopas/selectors/ContainerSelectorInfo.h
+++ b/src/autopas/selectors/ContainerSelectorInfo.h
@@ -30,7 +30,8 @@ class ContainerSelectorInfo {
    * Constructor.
    * @param cellSizeFactor Cell size factor to be used in this container (only relevant for LinkedCells, VerletLists and
    * VerletListsCells).
-   * @param verletSkinPerTimestep Length added to the cutoff for the verlet lists' skin per timestep inbetween rebuilding lists.
+   * @param verletSkinPerTimestep Length added to the cutoff for the verlet lists' skin per timestep inbetween
+   * rebuilding lists.
    * @param verletRebuildFrequency rebuild frequency.
    * @param verletClusterSize Size of verlet Clusters
    * @param loadEstimator load estimation algorithm for balanced traversals.

--- a/src/autopas/selectors/ContainerSelectorInfo.h
+++ b/src/autopas/selectors/ContainerSelectorInfo.h
@@ -27,6 +27,7 @@ class ContainerSelectorInfo {
    * @param cellSizeFactor Cell size factor to be used in this container (only relevant for LinkedCells, VerletLists and
    * VerletListsCells).
    * @param verletSkinPerTimestep Length added to the cutoff for the verlet lists' skin per timestep.
+   * @param verletRebuildFrequency rebuild frequency.
    * @param verletClusterSize Size of verlet Clusters
    * @param loadEstimator load estimation algorithm for balanced traversals.
    */
@@ -44,7 +45,7 @@ class ContainerSelectorInfo {
    * @return True iff all member equal
    */
   bool operator==(const ContainerSelectorInfo &other) const {
-    return cellSizeFactor == other.cellSizeFactor and verletSkinPerTimestep == other.verletSkinperTimestep and
+    return cellSizeFactor == other.cellSizeFactor and verletSkinPerTimestep == other.verletSkinPerTimestep and
            verletClusterSize == other.verletClusterSize and loadEstimator == other.loadEstimator;
   }
 
@@ -73,7 +74,7 @@ class ContainerSelectorInfo {
    */
   double cellSizeFactor;
   /**
-   * Length added to the cutoff for the verlet lists' skin.
+   * Length added to the cutoff for the verlet lists' skin per timestep.
    */
   double verletSkinPerTimestep;
   /**

--- a/src/autopas/utils/SoAStorage.h
+++ b/src/autopas/utils/SoAStorage.h
@@ -44,7 +44,7 @@ class SoAStorage {
   }
 
   /**
-   * @copydoc get()
+   * @copydoc autopas::utils::SoAStorage<SoAArraysType>::get()
    * @note const variant
    */
   template <size_t soaAttribute>

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
@@ -15,7 +15,7 @@ extern template class autopas::AutoPas<Molecule>;
 extern template bool autopas::AutoPas<Molecule>::iteratePairwise(autopas::LJFunctor<Molecule, true, false> *);
 
 constexpr double cutoff = 1.1;
-//constexpr double skin = 0.2;
+//constexpr double skinPerTimestep = 0.2;
 constexpr std::array<double, 3> boxMin{0., 0., 0.};
 constexpr std::array<double, 3> boxMax{10., 10., 10.};
 

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
@@ -15,7 +15,7 @@ extern template class autopas::AutoPas<Molecule>;
 extern template bool autopas::AutoPas<Molecule>::iteratePairwise(autopas::LJFunctor<Molecule, true, false> *);
 
 constexpr double cutoff = 1.1;
-constexpr double skin = 0.2;
+//constexpr double skin = 0.2;
 constexpr std::array<double, 3> boxMin{0., 0., 0.};
 constexpr std::array<double, 3> boxMax{10., 10., 10.};
 
@@ -26,9 +26,12 @@ void defaultInit(AutoPasT &autoPas) {
   autoPas.setBoxMin(boxMin);
   autoPas.setBoxMax(boxMax);
   autoPas.setCutoff(cutoff);
-  autoPas.setVerletSkin(skin);
+  autoPas.setVerletSkinPerTimestep(skinPerTimestep);
   autoPas.setVerletRebuildFrequency(3);
   autoPas.setNumSamples(3);
+
+  //double skin = autoPas.verletSkin();
+
   // init autopas
   autoPas.init();
 }
@@ -46,7 +49,7 @@ void defaultInit(AutoPasT &autoPas1, AutoPasT &autoPas2, size_t direction) {
 
   for (auto &aP : {&autoPas1, &autoPas2}) {
     aP->setCutoff(cutoff);
-    aP->setVerletSkin(skin);
+    aP->setVerletSkinPerTimestep(skinPerTimestep);
     aP->setVerletRebuildFrequency(2);
     aP->setNumSamples(2);
     // init autopas
@@ -335,7 +338,7 @@ void testSimulationLoop(testingTuple options) {
 
   doAssertions(autoPas, &functor, numParticles, __LINE__);
 
-  moveParticlesAndResetF({skin / 6, 0., 0.});
+  moveParticlesAndResetF({autoPas.verletSkin() / 6, 0., 0.});
   addParticlePair({9.99, 1., 5.});
 
   // do second simulation loop
@@ -343,7 +346,7 @@ void testSimulationLoop(testingTuple options) {
 
   doAssertions(autoPas, &functor, numParticles, __LINE__);
 
-  moveParticlesAndResetF({-skin / 6, 0., 0.});
+  moveParticlesAndResetF({-autoPas.verletSkin() / 6, 0., 0.});
   addParticlePair({9.99, 7., 5.});
   deleteIDs({2, 3});
 
@@ -353,7 +356,7 @@ void testSimulationLoop(testingTuple options) {
   doAssertions(autoPas, &functor, numParticles, __LINE__);
 
   // update positions a bit (outside of domain!) + reset F
-  moveParticlesAndResetF({skin / 6, 0., 0.});
+  moveParticlesAndResetF({autoPas.verletSkin() / 6, 0., 0.});
 
   // do fourth simulation loop, tests rebuilding of container.
   doSimulationLoop(autoPas, &functor);
@@ -488,7 +491,7 @@ TEST_P(AutoPasInterface1ContainersTest, testResize) {
   autoPas.setBoxMin({0, 0, 0});
   autoPas.setBoxMax({10, 10, 10});
   autoPas.setCutoff(1);
-  autoPas.setVerletSkin(0.1);
+  autoPas.setVerletSkinPerTimestep(0.1);
 
   const auto &containerOp = GetParam();
   autoPas.setAllowedContainers({containerOp});
@@ -583,7 +586,7 @@ void testSimulationLoop(autopas::ContainerOption containerOption1, autopas::Cont
 
   // update positions a bit (outside of domain!) + reset F
   {
-    std::array<double, 3> moveVec{skin / 3., 0., 0.};
+    std::array<double, 3> moveVec{autoPas.verletSkin() / 3., 0., 0.};
     for (auto *aP : {&autoPas1, &autoPas2}) {
       for (auto iter = aP->begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
         iter->setR(autopas::utils::ArrayMath::add(iter->getR(), moveVec));
@@ -599,7 +602,7 @@ void testSimulationLoop(autopas::ContainerOption containerOption1, autopas::Cont
 
   // update positions a bit (outside of domain!) + reset F
   {
-    std::array<double, 3> moveVec{-skin / 3., 0., 0.};
+    std::array<double, 3> moveVec{-autoPas.verletSkin() / 3., 0., 0.};
     for (auto *aP : {&autoPas1, &autoPas2}) {
       for (auto iter = aP->begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
         iter->setR(autopas::utils::ArrayMath::add(iter->getR(), moveVec));
@@ -615,7 +618,7 @@ void testSimulationLoop(autopas::ContainerOption containerOption1, autopas::Cont
 
   // update positions a bit (outside of domain!) + reset F
   {
-    std::array<double, 3> moveVec{skin / 3., 0., 0.};
+    std::array<double, 3> moveVec{autoPas.verletSkin() / 3., 0., 0.};
     for (auto *aP : {&autoPas1, &autoPas2}) {
       for (auto iter = aP->begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
         iter->setR(autopas::utils::ArrayMath::add(iter->getR(), moveVec));

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
@@ -30,8 +30,6 @@ void defaultInit(AutoPasT &autoPas) {
   autoPas.setVerletRebuildFrequency(3);
   autoPas.setNumSamples(3);
 
-  //double skin = autoPas.verletSkin();
-
   // init autopas
   autoPas.init();
 }
@@ -338,7 +336,7 @@ void testSimulationLoop(testingTuple options) {
 
   doAssertions(autoPas, &functor, numParticles, __LINE__);
 
-  moveParticlesAndResetF({autoPas.verletSkin() / 6, 0., 0.});
+  moveParticlesAndResetF({autoPas.getVerletSkin() / 6, 0., 0.});
   addParticlePair({9.99, 1., 5.});
 
   // do second simulation loop
@@ -346,7 +344,7 @@ void testSimulationLoop(testingTuple options) {
 
   doAssertions(autoPas, &functor, numParticles, __LINE__);
 
-  moveParticlesAndResetF({-autoPas.verletSkin() / 6, 0., 0.});
+  moveParticlesAndResetF({-autoPas.getVerletSkin() / 6, 0., 0.});
   addParticlePair({9.99, 7., 5.});
   deleteIDs({2, 3});
 
@@ -356,7 +354,7 @@ void testSimulationLoop(testingTuple options) {
   doAssertions(autoPas, &functor, numParticles, __LINE__);
 
   // update positions a bit (outside of domain!) + reset F
-  moveParticlesAndResetF({autoPas.verletSkin() / 6, 0., 0.});
+  moveParticlesAndResetF({autoPas.getVerletSkin() / 6, 0., 0.});
 
   // do fourth simulation loop, tests rebuilding of container.
   doSimulationLoop(autoPas, &functor);
@@ -586,7 +584,7 @@ void testSimulationLoop(autopas::ContainerOption containerOption1, autopas::Cont
 
   // update positions a bit (outside of domain!) + reset F
   {
-    std::array<double, 3> moveVec{autoPas.verletSkin() / 3., 0., 0.};
+    std::array<double, 3> moveVec{autoPas.getVerletSkin() / 3., 0., 0.};
     for (auto *aP : {&autoPas1, &autoPas2}) {
       for (auto iter = aP->begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
         iter->setR(autopas::utils::ArrayMath::add(iter->getR(), moveVec));
@@ -602,7 +600,7 @@ void testSimulationLoop(autopas::ContainerOption containerOption1, autopas::Cont
 
   // update positions a bit (outside of domain!) + reset F
   {
-    std::array<double, 3> moveVec{-autoPas.verletSkin() / 3., 0., 0.};
+    std::array<double, 3> moveVec{-autoPas.getVerletSkin() / 3., 0., 0.};
     for (auto *aP : {&autoPas1, &autoPas2}) {
       for (auto iter = aP->begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
         iter->setR(autopas::utils::ArrayMath::add(iter->getR(), moveVec));
@@ -618,7 +616,7 @@ void testSimulationLoop(autopas::ContainerOption containerOption1, autopas::Cont
 
   // update positions a bit (outside of domain!) + reset F
   {
-    std::array<double, 3> moveVec{autoPas.verletSkin() / 3., 0., 0.};
+    std::array<double, 3> moveVec{autoPas.getVerletSkin() / 3., 0., 0.};
     for (auto *aP : {&autoPas1, &autoPas2}) {
       for (auto iter = aP->begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
         iter->setR(autopas::utils::ArrayMath::add(iter->getR(), moveVec));

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
@@ -26,7 +26,7 @@ void defaultInit(AutoPasT &autoPas) {
   autoPas.setBoxMin(boxMin);
   autoPas.setBoxMax(boxMax);
   autoPas.setCutoff(cutoff);
-  autoPas.setVerletSkinPerTimestepPerTimestep(skinPerTimestepPerTimestep);
+  autoPas.setVerletSkinPerTimestep(skinPerTimestep);
   autoPas.setVerletRebuildFrequency(3);
   autoPas.setNumSamples(3);
 
@@ -47,7 +47,7 @@ void defaultInit(AutoPasT &autoPas1, AutoPasT &autoPas2, size_t direction) {
 
   for (auto &aP : {&autoPas1, &autoPas2}) {
     aP->setCutoff(cutoff);
-    aP->setVerletSkinPerTimestepPerTimestep(skinPerTimestepPerTimestep);
+    aP->setVerletSkinPerTimestep(skinPerTimestep);
     aP->setVerletRebuildFrequency(2);
     aP->setNumSamples(2);
     // init autopas

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
@@ -15,7 +15,8 @@ extern template class autopas::AutoPas<Molecule>;
 extern template bool autopas::AutoPas<Molecule>::iteratePairwise(autopas::LJFunctor<Molecule, true, false> *);
 
 constexpr double cutoff = 1.1;
-//constexpr double skinPerTimestep = 0.2;
+constexpr double skinPerTimestep = 0.2;
+constexpr unsigned int rebuildFrequency = 3;
 constexpr std::array<double, 3> boxMin{0., 0., 0.};
 constexpr std::array<double, 3> boxMax{10., 10., 10.};
 
@@ -27,7 +28,7 @@ void defaultInit(AutoPasT &autoPas) {
   autoPas.setBoxMax(boxMax);
   autoPas.setCutoff(cutoff);
   autoPas.setVerletSkinPerTimestep(skinPerTimestep);
-  autoPas.setVerletRebuildFrequency(3);
+  autoPas.setVerletRebuildFrequency(rebuildFrequency);
   autoPas.setNumSamples(3);
 
   // init autopas
@@ -584,7 +585,7 @@ void testSimulationLoop(autopas::ContainerOption containerOption1, autopas::Cont
 
   // update positions a bit (outside of domain!) + reset F
   {
-    std::array<double, 3> moveVec{autoPas.getVerletSkin() / 3., 0., 0.};
+    std::array<double, 3> moveVec{skinPerTimestep*rebuildFrequency / 3., 0., 0.};
     for (auto *aP : {&autoPas1, &autoPas2}) {
       for (auto iter = aP->begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
         iter->setR(autopas::utils::ArrayMath::add(iter->getR(), moveVec));
@@ -600,7 +601,7 @@ void testSimulationLoop(autopas::ContainerOption containerOption1, autopas::Cont
 
   // update positions a bit (outside of domain!) + reset F
   {
-    std::array<double, 3> moveVec{-autoPas.getVerletSkin() / 3., 0., 0.};
+    std::array<double, 3> moveVec{-skinPerTimestep*rebuildFrequency / 3., 0., 0.};
     for (auto *aP : {&autoPas1, &autoPas2}) {
       for (auto iter = aP->begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
         iter->setR(autopas::utils::ArrayMath::add(iter->getR(), moveVec));
@@ -616,7 +617,7 @@ void testSimulationLoop(autopas::ContainerOption containerOption1, autopas::Cont
 
   // update positions a bit (outside of domain!) + reset F
   {
-    std::array<double, 3> moveVec{autoPas.getVerletSkin() / 3., 0., 0.};
+    std::array<double, 3> moveVec{skinPerTimestep*rebuildFrequency / 3., 0., 0.};
     for (auto *aP : {&autoPas1, &autoPas2}) {
       for (auto iter = aP->begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
         iter->setR(autopas::utils::ArrayMath::add(iter->getR(), moveVec));

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp
@@ -585,7 +585,7 @@ void testSimulationLoop(autopas::ContainerOption containerOption1, autopas::Cont
 
   // update positions a bit (outside of domain!) + reset F
   {
-    std::array<double, 3> moveVec{skinPerTimestep*rebuildFrequency / 3., 0., 0.};
+    std::array<double, 3> moveVec{skinPerTimestep * rebuildFrequency / 3., 0., 0.};
     for (auto *aP : {&autoPas1, &autoPas2}) {
       for (auto iter = aP->begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
         iter->setR(autopas::utils::ArrayMath::add(iter->getR(), moveVec));
@@ -601,7 +601,7 @@ void testSimulationLoop(autopas::ContainerOption containerOption1, autopas::Cont
 
   // update positions a bit (outside of domain!) + reset F
   {
-    std::array<double, 3> moveVec{-skinPerTimestep*rebuildFrequency / 3., 0., 0.};
+    std::array<double, 3> moveVec{-skinPerTimestep * rebuildFrequency / 3., 0., 0.};
     for (auto *aP : {&autoPas1, &autoPas2}) {
       for (auto iter = aP->begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
         iter->setR(autopas::utils::ArrayMath::add(iter->getR(), moveVec));
@@ -617,7 +617,7 @@ void testSimulationLoop(autopas::ContainerOption containerOption1, autopas::Cont
 
   // update positions a bit (outside of domain!) + reset F
   {
-    std::array<double, 3> moveVec{skinPerTimestep*rebuildFrequency / 3., 0., 0.};
+    std::array<double, 3> moveVec{skinPerTimestep * rebuildFrequency / 3., 0., 0.};
     for (auto *aP : {&autoPas1, &autoPas2}) {
       for (auto iter = aP->begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
         iter->setR(autopas::utils::ArrayMath::add(iter->getR(), moveVec));

--- a/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
@@ -37,8 +37,9 @@ INSTANTIATE_TEST_SUITE_P(
           // container factory
           autopas::ContainerSelector<Particle> containerSelector({0., 0., 0.}, {10., 10., 10.}, 1.);
           autopas::ContainerSelectorInfo containerInfo(
-              Newton3OnOffTest::getCellSizeFactor(), Newton3OnOffTest::getVerletSkinPerTimestep(),Newton3OnOffTest::getRebuildFrequency(),
-              Newton3OnOffTest::getClusterSize(), autopas::LoadEstimatorOption::none);
+              Newton3OnOffTest::getCellSizeFactor(), Newton3OnOffTest::getVerletSkinPerTimestep(),
+              Newton3OnOffTest::getRebuildFrequency(), Newton3OnOffTest::getClusterSize(),
+              autopas::LoadEstimatorOption::none);
 
           // generate for all containers
           for (auto containerOption : autopas::ContainerOption::getAllOptions()) {
@@ -81,8 +82,8 @@ void Newton3OnOffTest::countFunctorCalls(autopas::ContainerOption containerOptio
                                          autopas::TraversalOption traversalOption,
                                          autopas::DataLayoutOption dataLayout) {
   autopas::ContainerSelector<Particle> containerSelector(getBoxMin(), getBoxMax(), getCutoff());
-  autopas::ContainerSelectorInfo containerInfo(getCellSizeFactor(), getVerletSkinPerTimestep(),getRebuildFrequency(), getClusterSize(),
-                                               autopas::LoadEstimatorOption::none);
+  autopas::ContainerSelectorInfo containerInfo(getCellSizeFactor(), getVerletSkinPerTimestep(), getRebuildFrequency(),
+                                               getClusterSize(), autopas::LoadEstimatorOption::none);
 
   containerSelector.selectContainer(containerOption, containerInfo);
 

--- a/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
@@ -37,7 +37,7 @@ INSTANTIATE_TEST_SUITE_P(
           // container factory
           autopas::ContainerSelector<Particle> containerSelector({0., 0., 0.}, {10., 10., 10.}, 1.);
           autopas::ContainerSelectorInfo containerInfo(
-              Newton3OnOffTest::getCellSizeFactor(), Newton3OnOffTest::getVerletSkin(),
+              Newton3OnOffTest::getCellSizeFactor(), Newton3OnOffTest::getVerletSkinPerTimestep(),Newton3OnOffTest::getRebuildFrequency(),
               Newton3OnOffTest::getClusterSize(), autopas::LoadEstimatorOption::none);
 
           // generate for all containers
@@ -81,7 +81,7 @@ void Newton3OnOffTest::countFunctorCalls(autopas::ContainerOption containerOptio
                                          autopas::TraversalOption traversalOption,
                                          autopas::DataLayoutOption dataLayout) {
   autopas::ContainerSelector<Particle> containerSelector(getBoxMin(), getBoxMax(), getCutoff());
-  autopas::ContainerSelectorInfo containerInfo(getCellSizeFactor(), getVerletSkin(), getClusterSize(),
+  autopas::ContainerSelectorInfo containerInfo(getCellSizeFactor(), getVerletSkinPerTimestep(),getRebuildFrequency(), getClusterSize(),
                                                autopas::LoadEstimatorOption::none);
 
   containerSelector.selectContainer(containerOption, containerInfo);

--- a/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.h
+++ b/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.h
@@ -37,7 +37,7 @@ class Newton3OnOffTest
   static double getCutoff() { return 1.0; }
   static double getCellSizeFactor() { return 1.0; }
   static double getVerletSkinPerTimestep() { return 0.0; }
-  static unsigned int getRebuildFrequency(){return 20;}
+  static unsigned int getRebuildFrequency() { return 20; }
   static int getClusterSize() { return 4; }
 
   void countFunctorCalls(autopas::ContainerOption containerOption, autopas::TraversalOption traversalOption,

--- a/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.h
+++ b/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.h
@@ -36,7 +36,8 @@ class Newton3OnOffTest
 
   static double getCutoff() { return 1.0; }
   static double getCellSizeFactor() { return 1.0; }
-  static double getVerletSkin() { return 0.0; }
+  static double getVerletSkinPerTimestep() { return 0.0; }
+  static unsigned int getRebuildFrequency(){return 20;}
   static int getClusterSize() { return 4; }
 
   void countFunctorCalls(autopas::ContainerOption containerOption, autopas::TraversalOption traversalOption,

--- a/tests/testAutopas/tests/containers/AllContainersTests.h
+++ b/tests/testAutopas/tests/containers/AllContainersTests.h
@@ -19,11 +19,12 @@ class AllContainersTestsBase : public AutoPasTestBase {
   auto getInitializedContainer(autopas::ContainerOption containerOptionToTest) {
     double cutoff = 1;
     double skinPerTimestep = 0.01;
-    unsigned int rebuildFrequency=20;
+    unsigned int rebuildFrequency = 20;
     double cellSizeFactor = 1;
 
     autopas::ContainerSelector<Particle> selector{boxMin, boxMax, cutoff};
-    autopas::ContainerSelectorInfo selectorInfo{cellSizeFactor, skinPerTimestep,rebuildFrequency, 32, autopas::LoadEstimatorOption::none};
+    autopas::ContainerSelectorInfo selectorInfo{cellSizeFactor, skinPerTimestep, rebuildFrequency, 32,
+                                                autopas::LoadEstimatorOption::none};
     selector.selectContainer(containerOptionToTest, selectorInfo);
     return selector.getCurrentContainer();
   }

--- a/tests/testAutopas/tests/containers/AllContainersTests.h
+++ b/tests/testAutopas/tests/containers/AllContainersTests.h
@@ -18,11 +18,12 @@ class AllContainersTestsBase : public AutoPasTestBase {
   template <class ParticleType = autopas::Particle>
   auto getInitializedContainer(autopas::ContainerOption containerOptionToTest) {
     double cutoff = 1;
-    double skin = 0.2;
+    double skinPerTimestep = 0.01;
+    unsigned int rebuildFrequency=20;
     double cellSizeFactor = 1;
 
     autopas::ContainerSelector<Particle> selector{boxMin, boxMax, cutoff};
-    autopas::ContainerSelectorInfo selectorInfo{cellSizeFactor, skin, 32, autopas::LoadEstimatorOption::none};
+    autopas::ContainerSelectorInfo selectorInfo{cellSizeFactor, skinPerTimestep,rebuildFrequency, 32, autopas::LoadEstimatorOption::none};
     selector.selectContainer(containerOptionToTest, selectorInfo);
     return selector.getCurrentContainer();
   }

--- a/tests/testAutopas/tests/containers/TraversalComparison.cpp
+++ b/tests/testAutopas/tests/containers/TraversalComparison.cpp
@@ -101,9 +101,10 @@ std::tuple<std::vector<std::array<double, 3>>, TraversalComparison::Globals> Tra
     DeletionPosition particleDeletionPosition) {
   // Construct container
   autopas::ContainerSelector<Molecule> selector{_boxMin, boxMax, _cutoff};
-  constexpr double skin = _cutoff * 0.1;
+  constexpr double skinPerTimestep = _cutoff * 0.01;
+  constexpr unsigned int rebuildFrequency= 10;
   selector.selectContainer(
-      containerOption, autopas::ContainerSelectorInfo{cellSizeFactor, skin, 32, autopas::LoadEstimatorOption::none});
+      containerOption, autopas::ContainerSelectorInfo{cellSizeFactor, skinPerTimestep,rebuildFrequency, 32, autopas::LoadEstimatorOption::none});
   auto container = selector.getCurrentContainer();
   autopas::LJFunctor<Molecule, true /*applyShift*/, false /*useMixing*/, autopas::FunctorN3Modes::Both,
                      globals /*calculateGlobals*/>
@@ -135,7 +136,7 @@ std::tuple<std::vector<std::array<double, 3>>, TraversalComparison::Globals> Tra
   container->rebuildNeighborLists(traversal.get());
 
   if (doSlightShift) {
-    executeShift(container, skin / 2, numMolecules + numHaloMolecules);
+    executeShift(container, skinPerTimestep*rebuildFrequency / 2, numMolecules + numHaloMolecules);
   }
 
   if (particleDeletionPosition & DeletionPosition::afterLists) {

--- a/tests/testAutopas/tests/containers/TraversalComparison.cpp
+++ b/tests/testAutopas/tests/containers/TraversalComparison.cpp
@@ -102,9 +102,10 @@ std::tuple<std::vector<std::array<double, 3>>, TraversalComparison::Globals> Tra
   // Construct container
   autopas::ContainerSelector<Molecule> selector{_boxMin, boxMax, _cutoff};
   constexpr double skinPerTimestep = _cutoff * 0.01;
-  constexpr unsigned int rebuildFrequency= 10;
-  selector.selectContainer(
-      containerOption, autopas::ContainerSelectorInfo{cellSizeFactor, skinPerTimestep,rebuildFrequency, 32, autopas::LoadEstimatorOption::none});
+  constexpr unsigned int rebuildFrequency = 10;
+  selector.selectContainer(containerOption,
+                           autopas::ContainerSelectorInfo{cellSizeFactor, skinPerTimestep, rebuildFrequency, 32,
+                                                          autopas::LoadEstimatorOption::none});
   auto container = selector.getCurrentContainer();
   autopas::LJFunctor<Molecule, true /*applyShift*/, false /*useMixing*/, autopas::FunctorN3Modes::Both,
                      globals /*calculateGlobals*/>
@@ -136,7 +137,7 @@ std::tuple<std::vector<std::array<double, 3>>, TraversalComparison::Globals> Tra
   container->rebuildNeighborLists(traversal.get());
 
   if (doSlightShift) {
-    executeShift(container, skinPerTimestep*rebuildFrequency / 2, numMolecules + numHaloMolecules);
+    executeShift(container, skinPerTimestep * rebuildFrequency / 2, numMolecules + numHaloMolecules);
   }
 
   if (particleDeletionPosition & DeletionPosition::afterLists) {

--- a/tests/testAutopas/tests/containers/TraversalComparison.cpp
+++ b/tests/testAutopas/tests/containers/TraversalComparison.cpp
@@ -101,8 +101,8 @@ std::tuple<std::vector<std::array<double, 3>>, TraversalComparison::Globals> Tra
     DeletionPosition particleDeletionPosition) {
   // Construct container
   autopas::ContainerSelector<Molecule> selector{_boxMin, boxMax, _cutoff};
-  constexpr double skinPerTimestep = _cutoff * 0.01;
-  constexpr unsigned int rebuildFrequency = 10;
+  constexpr double skinPerTimestep = _cutoff * 0.1;
+  constexpr unsigned int rebuildFrequency = 1;
   selector.selectContainer(containerOption,
                            autopas::ContainerSelectorInfo{cellSizeFactor, skinPerTimestep, rebuildFrequency, 32,
                                                           autopas::LoadEstimatorOption::none});

--- a/tests/testAutopas/tests/containers/directSum/DirectSumContainerTest.cpp
+++ b/tests/testAutopas/tests/containers/directSum/DirectSumContainerTest.cpp
@@ -9,7 +9,7 @@
 INSTANTIATE_TEST_SUITE_P(Generated, DirectSumContainerTest, testing::Bool());
 
 TEST_P(DirectSumContainerTest, testUpdateContainerCloseToBoundary) {
-  autopas::DirectSum<autopas::Particle> directSum({0., 0., 0.}, {10., 10., 10.}, 1., 0.);
+  autopas::DirectSum<autopas::Particle> directSum({0., 0., 0.}, {10., 10., 10.}, 1., 0. ,0);
   int id = 1;
   for (double x : {0., 5., 9.999}) {
     for (double y : {0., 5., 9.999}) {

--- a/tests/testAutopas/tests/containers/directSum/DirectSumContainerTest.cpp
+++ b/tests/testAutopas/tests/containers/directSum/DirectSumContainerTest.cpp
@@ -9,7 +9,7 @@
 INSTANTIATE_TEST_SUITE_P(Generated, DirectSumContainerTest, testing::Bool());
 
 TEST_P(DirectSumContainerTest, testUpdateContainerCloseToBoundary) {
-  autopas::DirectSum<autopas::Particle> directSum({0., 0., 0.}, {10., 10., 10.}, 1., 0. ,0);
+  autopas::DirectSum<autopas::Particle> directSum({0., 0., 0.}, {10., 10., 10.}, 1., 0., 0);
   int id = 1;
   for (double x : {0., 5., 9.999}) {
     for (double y : {0., 5., 9.999}) {

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.cpp
@@ -26,7 +26,7 @@ void testTraversal(autopas::TraversalOption traversalOption, autopas::LoadEstima
   const std::array<double, 3> linkedCellsBoxMin = {0., 0., 0.};
 
   TraversalTest::CountFunctor functor(cutoff);
-  autopas::LinkedCells<Particle> linkedCells(linkedCellsBoxMin, linkedCellsBoxMax, cutoff, 0.0, 1.0 / cutoff,
+  autopas::LinkedCells<Particle> linkedCells(linkedCellsBoxMin, linkedCellsBoxMax, cutoff, 0.0, 1, 1.0 / cutoff,
                                              loadEstimatorOption);
 
   autopasTools::generators::GridGenerator::fillWithParticles(linkedCells, edgeLength);

--- a/tests/testAutopas/tests/containers/octree/OctreeTests.cpp
+++ b/tests/testAutopas/tests/containers/octree/OctreeTests.cpp
@@ -466,8 +466,8 @@ std::pair<OctreeTest::Vector3DList, std::vector<std::tuple<unsigned long, unsign
 OctreeTest::calculateForcesAndPairs(autopas::ContainerOption containerOption, autopas::TraversalOption traversalOption,
                                     autopas::DataLayoutOption dataLayoutOption, autopas::Newton3Option newton3Option,
                                     size_t numParticles, size_t numHaloParticles, std::array<double, 3> boxMin,
-                                    std::array<double, 3> boxMax, double cellSizeFactor, double cutoff, double skin,
-                                    double interactionLength, Vector3DList particlePositions,
+                                    std::array<double, 3> boxMax, double cellSizeFactor, double cutoff, double skinPerTimestep,
+                                    unsigned int rebuildFrequency, double interactionLength, Vector3DList particlePositions,
                                     Vector3DList haloParticlePositions) {
   using namespace autopas;
 
@@ -478,7 +478,7 @@ OctreeTest::calculateForcesAndPairs(autopas::ContainerOption containerOption, au
   // Construct container
   ContainerSelector<Molecule> selector{boxMin, boxMax, cutoff};
   selector.selectContainer(
-      containerOption, autopas::ContainerSelectorInfo{cellSizeFactor, skin, 32, autopas::LoadEstimatorOption::none});
+      containerOption, autopas::ContainerSelectorInfo{cellSizeFactor, skinPerTimestep, rebuildFrequency, 32, autopas::LoadEstimatorOption::none});
   auto container = selector.getCurrentContainer();
 
   // Create a functor that is able to calculate forces
@@ -590,8 +590,9 @@ TEST_P(OctreeTest, testCustomParticleDistribution) {
 
   std::array<double, 3> _boxMin{0, 0, 0};
   double _cutoff{1.};
-  double skin = _cutoff * 0.1;
-  double interactionLength = _cutoff + skin;
+  double skinPerTimestep = _cutoff * 0.01;
+  unsigned int rebuildFrequency= 10;
+  double interactionLength = _cutoff + skinPerTimestep*rebuildFrequency;
 
   // Obtain a starting configuration
   auto containerOption = ContainerOption::octree;
@@ -629,17 +630,17 @@ TEST_P(OctreeTest, testCustomParticleDistribution) {
   // Calculate the forces using the octree
   auto [calculatedForces, calculatedPairs] = calculateForcesAndPairs(
       containerOption, traversalOption, dataLayoutOption, newton3Option, numParticles, numHaloParticles, _boxMin,
-      boxMax, cellSizeFactor, _cutoff, skin, interactionLength, particlePositions, haloParticlePositions);
+      boxMax, cellSizeFactor, _cutoff, skinPerTimestep,rebuildFrequency, interactionLength, particlePositions, haloParticlePositions);
 
   // Calculate the forces using the reference implementation
   auto [referenceForces, referencePairs] = calculateForcesAndPairs(
       autopas::ContainerOption::linkedCells, autopas::TraversalOption::lc_c08, autopas::DataLayoutOption::aos,
-      autopas::Newton3Option::enabled, numParticles, numHaloParticles, _boxMin, boxMax, cellSizeFactor, _cutoff, skin,
-      interactionLength, particlePositions, haloParticlePositions);
+      autopas::Newton3Option::enabled, numParticles, numHaloParticles, _boxMin, boxMax, cellSizeFactor, _cutoff, skinPerTimestep,
+      rebuildFrequency,interactionLength, particlePositions, haloParticlePositions);
 
   // Calculate which pairs are in the set difference between the reference pairs and the calculated pairs
   // std::sort(calculatedPairs.begin(), calculatedPairs.end());
-  // std::sort(referencePairs.begin(), referencePairs.end());
+  // std::sort(referencePairs.begin(), referencePairs.end()); 
   std::vector<std::tuple<long unsigned, long unsigned, double>> diff = onlyFromRef(referencePairs, calculatedPairs);
   // std::set_difference(referencePairs.begin(), referencePairs.end(), calculatedPairs.begin(), calculatedPairs.end(),
   //                     std::inserter(diff, diff.begin()));

--- a/tests/testAutopas/tests/containers/octree/OctreeTests.cpp
+++ b/tests/testAutopas/tests/containers/octree/OctreeTests.cpp
@@ -591,8 +591,8 @@ TEST_P(OctreeTest, testCustomParticleDistribution) {
 
   std::array<double, 3> _boxMin{0, 0, 0};
   double _cutoff{1.};
-  double skinPerTimestep = _cutoff * 0.01;
-  unsigned int rebuildFrequency = 10;
+  double skinPerTimestep = _cutoff * 0.1;
+  unsigned int rebuildFrequency = 1;
   double interactionLength = _cutoff + skinPerTimestep * rebuildFrequency;
 
   // Obtain a starting configuration

--- a/tests/testAutopas/tests/containers/octree/OctreeTests.cpp
+++ b/tests/testAutopas/tests/containers/octree/OctreeTests.cpp
@@ -466,9 +466,9 @@ std::pair<OctreeTest::Vector3DList, std::vector<std::tuple<unsigned long, unsign
 OctreeTest::calculateForcesAndPairs(autopas::ContainerOption containerOption, autopas::TraversalOption traversalOption,
                                     autopas::DataLayoutOption dataLayoutOption, autopas::Newton3Option newton3Option,
                                     size_t numParticles, size_t numHaloParticles, std::array<double, 3> boxMin,
-                                    std::array<double, 3> boxMax, double cellSizeFactor, double cutoff, double skinPerTimestep,
-                                    unsigned int rebuildFrequency, double interactionLength, Vector3DList particlePositions,
-                                    Vector3DList haloParticlePositions) {
+                                    std::array<double, 3> boxMax, double cellSizeFactor, double cutoff,
+                                    double skinPerTimestep, unsigned int rebuildFrequency, double interactionLength,
+                                    Vector3DList particlePositions, Vector3DList haloParticlePositions) {
   using namespace autopas;
 
   double _cutoffsquare = cutoff * cutoff;
@@ -477,8 +477,9 @@ OctreeTest::calculateForcesAndPairs(autopas::ContainerOption containerOption, au
 
   // Construct container
   ContainerSelector<Molecule> selector{boxMin, boxMax, cutoff};
-  selector.selectContainer(
-      containerOption, autopas::ContainerSelectorInfo{cellSizeFactor, skinPerTimestep, rebuildFrequency, 32, autopas::LoadEstimatorOption::none});
+  selector.selectContainer(containerOption,
+                           autopas::ContainerSelectorInfo{cellSizeFactor, skinPerTimestep, rebuildFrequency, 32,
+                                                          autopas::LoadEstimatorOption::none});
   auto container = selector.getCurrentContainer();
 
   // Create a functor that is able to calculate forces
@@ -591,8 +592,8 @@ TEST_P(OctreeTest, testCustomParticleDistribution) {
   std::array<double, 3> _boxMin{0, 0, 0};
   double _cutoff{1.};
   double skinPerTimestep = _cutoff * 0.01;
-  unsigned int rebuildFrequency= 10;
-  double interactionLength = _cutoff + skinPerTimestep*rebuildFrequency;
+  unsigned int rebuildFrequency = 10;
+  double interactionLength = _cutoff + skinPerTimestep * rebuildFrequency;
 
   // Obtain a starting configuration
   auto containerOption = ContainerOption::octree;
@@ -628,19 +629,20 @@ TEST_P(OctreeTest, testCustomParticleDistribution) {
   }
 
   // Calculate the forces using the octree
-  auto [calculatedForces, calculatedPairs] = calculateForcesAndPairs(
-      containerOption, traversalOption, dataLayoutOption, newton3Option, numParticles, numHaloParticles, _boxMin,
-      boxMax, cellSizeFactor, _cutoff, skinPerTimestep,rebuildFrequency, interactionLength, particlePositions, haloParticlePositions);
+  auto [calculatedForces, calculatedPairs] =
+      calculateForcesAndPairs(containerOption, traversalOption, dataLayoutOption, newton3Option, numParticles,
+                              numHaloParticles, _boxMin, boxMax, cellSizeFactor, _cutoff, skinPerTimestep,
+                              rebuildFrequency, interactionLength, particlePositions, haloParticlePositions);
 
   // Calculate the forces using the reference implementation
   auto [referenceForces, referencePairs] = calculateForcesAndPairs(
       autopas::ContainerOption::linkedCells, autopas::TraversalOption::lc_c08, autopas::DataLayoutOption::aos,
-      autopas::Newton3Option::enabled, numParticles, numHaloParticles, _boxMin, boxMax, cellSizeFactor, _cutoff, skinPerTimestep,
-      rebuildFrequency,interactionLength, particlePositions, haloParticlePositions);
+      autopas::Newton3Option::enabled, numParticles, numHaloParticles, _boxMin, boxMax, cellSizeFactor, _cutoff,
+      skinPerTimestep, rebuildFrequency, interactionLength, particlePositions, haloParticlePositions);
 
   // Calculate which pairs are in the set difference between the reference pairs and the calculated pairs
   // std::sort(calculatedPairs.begin(), calculatedPairs.end());
-  // std::sort(referencePairs.begin(), referencePairs.end()); 
+  // std::sort(referencePairs.begin(), referencePairs.end());
   std::vector<std::tuple<long unsigned, long unsigned, double>> diff = onlyFromRef(referencePairs, calculatedPairs);
   // std::set_difference(referencePairs.begin(), referencePairs.end(), calculatedPairs.begin(), calculatedPairs.end(),
   //                     std::inserter(diff, diff.begin()));

--- a/tests/testAutopas/tests/containers/octree/OctreeTests.cpp
+++ b/tests/testAutopas/tests/containers/octree/OctreeTests.cpp
@@ -27,7 +27,7 @@ TEST_F(OctreeTest, testDummy) {
   using namespace autopas;
 
   std::array<double, 3> min = {0, 0, 0}, max = {2, 2, 2};
-  Octree<ParticleFP64> tree(min, max, 0.001f, 0.1f, 1.0f);
+  Octree<ParticleFP64> tree(min, max, 0.001f, 0.01f, 10, 1.0f);
 }
 
 /**

--- a/tests/testAutopas/tests/containers/octree/OctreeTests.h
+++ b/tests/testAutopas/tests/containers/octree/OctreeTests.h
@@ -32,7 +32,7 @@ class OctreeTest : public AutoPasTestBase, public ::testing::WithParamInterface<
       autopas::ContainerOption containerOption, autopas::TraversalOption traversalOption,
       autopas::DataLayoutOption dataLayoutOption, autopas::Newton3Option newton3Option, size_t numParticles,
       size_t numHaloParticles, std::array<double, 3> boxMin, std::array<double, 3> boxMax, double cellSizeFactor,
-      double cutoff, double skin, double interactionLength, Vector3DList particlePositions,
+      double cutoff, double skinPerTimestep, unsigned int rebuildFrequency, double interactionLength, Vector3DList particlePositions,
       Vector3DList haloParticlePositions);
 
   MockFunctor<Molecule> mockFunctor;

--- a/tests/testAutopas/tests/containers/octree/OctreeTests.h
+++ b/tests/testAutopas/tests/containers/octree/OctreeTests.h
@@ -32,8 +32,8 @@ class OctreeTest : public AutoPasTestBase, public ::testing::WithParamInterface<
       autopas::ContainerOption containerOption, autopas::TraversalOption traversalOption,
       autopas::DataLayoutOption dataLayoutOption, autopas::Newton3Option newton3Option, size_t numParticles,
       size_t numHaloParticles, std::array<double, 3> boxMin, std::array<double, 3> boxMax, double cellSizeFactor,
-      double cutoff, double skinPerTimestep, unsigned int rebuildFrequency, double interactionLength, Vector3DList particlePositions,
-      Vector3DList haloParticlePositions);
+      double cutoff, double skinPerTimestep, unsigned int rebuildFrequency, double interactionLength,
+      Vector3DList particlePositions, Vector3DList haloParticlePositions);
 
   MockFunctor<Molecule> mockFunctor;
 };

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
@@ -18,18 +18,20 @@ TEST_F(VerletClusterListsTest, VerletListConstructor) {
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
-  double skin = 0.2;
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency =20;
   size_t clusterSize = 4;
-  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skin, clusterSize);
+  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skinPerTimestep,rebuildFrequency, clusterSize);
 }
 
 TEST_F(VerletClusterListsTest, testVerletListBuild) {
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
-  double skin = 0.2;
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency =20;
   size_t clusterSize = 4;
-  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skin, clusterSize);
+  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skinPerTimestep,rebuildFrequency, clusterSize);
 
   std::array<double, 3> r = {2, 2, 2};
   Particle p(r, {0., 0., 0.}, 0);
@@ -50,10 +52,11 @@ TEST_F(VerletClusterListsTest, testAddParticlesAndBuildTwice) {
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
-  double skin = 0.2;
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency =20;
   unsigned long numParticles = 271;
   size_t clusterSize = 4;
-  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skin, clusterSize);
+  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skinPerTimestep,rebuildFrequency, clusterSize);
 
   autopasTools::generators::RandomGenerator::fillWithParticles(
       verletLists, autopas::Particle{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
@@ -71,10 +74,11 @@ TEST_F(VerletClusterListsTest, testIterator) {
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
-  double skin = 0.2;
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency =20;
   unsigned long numParticles = 271;
   size_t clusterSize = 4;
-  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skin, clusterSize);
+  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skinPerTimestep,rebuildFrequency, clusterSize);
 
   autopasTools::generators::RandomGenerator::fillWithParticles(
       verletLists, autopas::Particle{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
@@ -121,10 +125,11 @@ TEST_F(VerletClusterListsTest, testNeighborListsValidAfterMovingLessThanHalfSkin
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double cutoffSqr = cutoff * cutoff;
-  double skin = 0.2;
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency =20;
   unsigned long numParticles = 271;
   size_t clusterSize = 4;
-  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skin, clusterSize);
+  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skinPerTimestep,rebuildFrequency, clusterSize);
 
   autopasTools::generators::RandomGenerator::fillWithParticles(
       verletLists, autopas::Particle{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
@@ -153,7 +158,7 @@ TEST_F(VerletClusterListsTest, testNeighborListsValidAfterMovingLessThanHalfSkin
     // generate some different directions
     std::array<double, 3> direction = {(double)(i % 2), (double)(i % 3),
                                        (double)(i % numParticles) / (double)numParticles};
-    auto offset = autopas::utils::ArrayMath::mulScalar(autopas::utils::ArrayMath::normalize(direction), skin / 2.1);
+    auto offset = autopas::utils::ArrayMath::mulScalar(autopas::utils::ArrayMath::normalize(direction), skinPerTimestep*rebuildFrequency / 2.1);
     particle.addR(offset);
     // Upper corner is excluded
     constexpr double smallValue = 0.000001;
@@ -195,10 +200,11 @@ TEST_F(VerletClusterListsTest, testNewton3NeighborList) {
   std::array<double, 3> min = {0, 0, 0};
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
-  double skin = 0.1;
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency =10;
   int numParticles = 2431;
   size_t clusterSize = 4;
-  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skin, clusterSize);
+  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skinPerTimestep,rebuildFrequency, clusterSize);
 
   autopasTools::generators::RandomGenerator::fillWithParticles(
       verletLists, autopas::Particle{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
@@ -231,10 +237,11 @@ TEST_F(VerletClusterListsTest, testVerletListColoringTraversalNewton3NoDataRace)
   std::array<double, 3> min = {0, 0, 0};
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
-  double skin = 0.1;
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency =10;
   int numParticles = 5000;
   size_t clusterSize = 4;
-  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skin, clusterSize);
+  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skinPerTimestep,rebuildFrequency, clusterSize);
 
   autopasTools::generators::RandomGenerator::fillWithParticles(verletLists, autopas::Particle{}, min, max,
                                                                numParticles);

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
@@ -19,9 +19,9 @@ TEST_F(VerletClusterListsTest, VerletListConstructor) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency =20;
+  unsigned int rebuildFrequency = 20;
   size_t clusterSize = 4;
-  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skinPerTimestep,rebuildFrequency, clusterSize);
+  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skinPerTimestep, rebuildFrequency, clusterSize);
 }
 
 TEST_F(VerletClusterListsTest, testVerletListBuild) {
@@ -29,9 +29,9 @@ TEST_F(VerletClusterListsTest, testVerletListBuild) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency =20;
+  unsigned int rebuildFrequency = 20;
   size_t clusterSize = 4;
-  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skinPerTimestep,rebuildFrequency, clusterSize);
+  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skinPerTimestep, rebuildFrequency, clusterSize);
 
   std::array<double, 3> r = {2, 2, 2};
   Particle p(r, {0., 0., 0.}, 0);
@@ -53,10 +53,10 @@ TEST_F(VerletClusterListsTest, testAddParticlesAndBuildTwice) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency =20;
+  unsigned int rebuildFrequency = 20;
   unsigned long numParticles = 271;
   size_t clusterSize = 4;
-  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skinPerTimestep,rebuildFrequency, clusterSize);
+  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skinPerTimestep, rebuildFrequency, clusterSize);
 
   autopasTools::generators::RandomGenerator::fillWithParticles(
       verletLists, autopas::Particle{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
@@ -75,10 +75,10 @@ TEST_F(VerletClusterListsTest, testIterator) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency =20;
+  unsigned int rebuildFrequency = 20;
   unsigned long numParticles = 271;
   size_t clusterSize = 4;
-  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skinPerTimestep,rebuildFrequency, clusterSize);
+  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skinPerTimestep, rebuildFrequency, clusterSize);
 
   autopasTools::generators::RandomGenerator::fillWithParticles(
       verletLists, autopas::Particle{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
@@ -126,10 +126,10 @@ TEST_F(VerletClusterListsTest, testNeighborListsValidAfterMovingLessThanHalfSkin
   double cutoff = 1.;
   double cutoffSqr = cutoff * cutoff;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency =20;
+  unsigned int rebuildFrequency = 20;
   unsigned long numParticles = 271;
   size_t clusterSize = 4;
-  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skinPerTimestep,rebuildFrequency, clusterSize);
+  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skinPerTimestep, rebuildFrequency, clusterSize);
 
   autopasTools::generators::RandomGenerator::fillWithParticles(
       verletLists, autopas::Particle{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
@@ -158,7 +158,8 @@ TEST_F(VerletClusterListsTest, testNeighborListsValidAfterMovingLessThanHalfSkin
     // generate some different directions
     std::array<double, 3> direction = {(double)(i % 2), (double)(i % 3),
                                        (double)(i % numParticles) / (double)numParticles};
-    auto offset = autopas::utils::ArrayMath::mulScalar(autopas::utils::ArrayMath::normalize(direction), skinPerTimestep*rebuildFrequency / 2.1);
+    auto offset = autopas::utils::ArrayMath::mulScalar(autopas::utils::ArrayMath::normalize(direction),
+                                                       skinPerTimestep * rebuildFrequency / 2.1);
     particle.addR(offset);
     // Upper corner is excluded
     constexpr double smallValue = 0.000001;
@@ -201,10 +202,10 @@ TEST_F(VerletClusterListsTest, testNewton3NeighborList) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency =10;
+  unsigned int rebuildFrequency = 10;
   int numParticles = 2431;
   size_t clusterSize = 4;
-  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skinPerTimestep,rebuildFrequency, clusterSize);
+  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skinPerTimestep, rebuildFrequency, clusterSize);
 
   autopasTools::generators::RandomGenerator::fillWithParticles(
       verletLists, autopas::Particle{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
@@ -238,10 +239,10 @@ TEST_F(VerletClusterListsTest, testVerletListColoringTraversalNewton3NoDataRace)
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency =10;
+  unsigned int rebuildFrequency = 10;
   int numParticles = 5000;
   size_t clusterSize = 4;
-  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skinPerTimestep,rebuildFrequency, clusterSize);
+  autopas::VerletClusterLists<Particle> verletLists(min, max, cutoff, skinPerTimestep, rebuildFrequency, clusterSize);
 
   autopasTools::generators::RandomGenerator::fillWithParticles(verletLists, autopas::Particle{}, min, max,
                                                                numParticles);

--- a/tests/testAutopas/tests/containers/verletListsCellBased/varVerletLists/VarVerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/varVerletLists/VarVerletListsTest.cpp
@@ -25,8 +25,9 @@ TEST_F(VarVerletListsTest, VerletListConstructor) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency =20;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skinPerTimestep,rebuildFrequency);
+  unsigned int rebuildFrequency = 20;
+  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(
+      min, max, cutoff, skinPerTimestep, rebuildFrequency);
 }
 
 TEST_F(VarVerletListsTest, testAddParticleNumParticle) {
@@ -34,8 +35,9 @@ TEST_F(VarVerletListsTest, testAddParticleNumParticle) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency =20;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skinPerTimestep, rebuildFrequency);
+  unsigned int rebuildFrequency = 20;
+  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(
+      min, max, cutoff, skinPerTimestep, rebuildFrequency);
   EXPECT_EQ(verletLists.getNumberOfParticles(), 0);
 
   std::array<double, 3> r = {2, 2, 2};
@@ -54,8 +56,9 @@ TEST_F(VarVerletListsTest, testDeleteAllParticles) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency =20;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skinPerTimestep, rebuildFrequency);
+  unsigned int rebuildFrequency = 20;
+  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(
+      min, max, cutoff, skinPerTimestep, rebuildFrequency);
   EXPECT_EQ(verletLists.getNumberOfParticles(), 0);
 
   std::array<double, 3> r = {2, 2, 2};
@@ -76,8 +79,9 @@ TEST_F(VarVerletListsTest, testVerletListBuild) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency =20;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skinPerTimestep,rebuildFrequency);
+  unsigned int rebuildFrequency = 20;
+  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(
+      min, max, cutoff, skinPerTimestep, rebuildFrequency);
 
   std::array<double, 3> r = {2, 2, 2};
   Particle p(r, {0., 0., 0.}, 0);
@@ -103,8 +107,9 @@ TEST_F(VarVerletListsTest, testVerletList) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency =20;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skinPerTimestep, rebuildFrequency);
+  unsigned int rebuildFrequency = 20;
+  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(
+      min, max, cutoff, skinPerTimestep, rebuildFrequency);
 
   std::array<double, 3> r = {2, 2, 2};
   Particle p(r, {0., 0., 0.}, 0);
@@ -130,8 +135,9 @@ TEST_F(VarVerletListsTest, testVerletListInSkin) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency =20;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skinPerTimestep, rebuildFrequency);
+  unsigned int rebuildFrequency = 20;
+  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(
+      min, max, cutoff, skinPerTimestep, rebuildFrequency);
 
   std::array<double, 3> r = {1.4, 2, 2};
   Particle p(r, {0., 0., 0.}, 0);
@@ -158,8 +164,9 @@ TEST_F(VarVerletListsTest, testVerletListBuildTwice) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency =20;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skinPerTimestep,rebuildFrequency);
+  unsigned int rebuildFrequency = 20;
+  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(
+      min, max, cutoff, skinPerTimestep, rebuildFrequency);
 
   std::array<double, 3> r = {2, 2, 2};
   Particle p(r, {0., 0., 0.}, 0);
@@ -187,8 +194,9 @@ TEST_F(VarVerletListsTest, testVerletListBuildFarAway) {
   std::array<double, 3> max = {5, 5, 5};
   double cutoff = 1.;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency =20;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skinPerTimestep,rebuildFrequency);
+  unsigned int rebuildFrequency = 20;
+  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(
+      min, max, cutoff, skinPerTimestep, rebuildFrequency);
 
   std::array<double, 3> r = {2, 2, 2};
   Particle p(r, {0., 0., 0.}, 0);
@@ -217,8 +225,9 @@ TEST_F(VarVerletListsTest, testVerletListBuildHalo) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency =20;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skinPerTimestep, rebuildFrequency);
+  unsigned int rebuildFrequency = 20;
+  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(
+      min, max, cutoff, skinPerTimestep, rebuildFrequency);
 
   std::array<double, 3> r = {0.9, 0.9, 0.9};
   Particle p(r, {0., 0., 0.}, 0);

--- a/tests/testAutopas/tests/containers/verletListsCellBased/varVerletLists/VarVerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/varVerletLists/VarVerletListsTest.cpp
@@ -24,16 +24,18 @@ TEST_F(VarVerletListsTest, VerletListConstructor) {
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
-  double skin = 0.2;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skin);
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency =20;
+  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skinPerTimestep,rebuildFrequency);
 }
 
 TEST_F(VarVerletListsTest, testAddParticleNumParticle) {
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
-  double skin = 0.2;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skin);
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency =20;
+  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skinPerTimestep, rebuildFrequency);
   EXPECT_EQ(verletLists.getNumberOfParticles(), 0);
 
   std::array<double, 3> r = {2, 2, 2};
@@ -51,8 +53,9 @@ TEST_F(VarVerletListsTest, testDeleteAllParticles) {
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
-  double skin = 0.2;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skin);
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency =20;
+  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skinPerTimestep, rebuildFrequency);
   EXPECT_EQ(verletLists.getNumberOfParticles(), 0);
 
   std::array<double, 3> r = {2, 2, 2};
@@ -72,8 +75,9 @@ TEST_F(VarVerletListsTest, testVerletListBuild) {
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
-  double skin = 0.2;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skin);
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency =20;
+  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skinPerTimestep,rebuildFrequency);
 
   std::array<double, 3> r = {2, 2, 2};
   Particle p(r, {0., 0., 0.}, 0);
@@ -98,8 +102,9 @@ TEST_F(VarVerletListsTest, testVerletList) {
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
-  double skin = 0.2;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skin);
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency =20;
+  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skinPerTimestep, rebuildFrequency);
 
   std::array<double, 3> r = {2, 2, 2};
   Particle p(r, {0., 0., 0.}, 0);
@@ -124,8 +129,9 @@ TEST_F(VarVerletListsTest, testVerletListInSkin) {
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
-  double skin = 0.2;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skin);
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency =20;
+  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skinPerTimestep, rebuildFrequency);
 
   std::array<double, 3> r = {1.4, 2, 2};
   Particle p(r, {0., 0., 0.}, 0);
@@ -151,8 +157,9 @@ TEST_F(VarVerletListsTest, testVerletListBuildTwice) {
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
-  double skin = 0.2;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skin);
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency =20;
+  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skinPerTimestep,rebuildFrequency);
 
   std::array<double, 3> r = {2, 2, 2};
   Particle p(r, {0., 0., 0.}, 0);
@@ -179,8 +186,9 @@ TEST_F(VarVerletListsTest, testVerletListBuildFarAway) {
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {5, 5, 5};
   double cutoff = 1.;
-  double skin = 0.2;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skin);
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency =20;
+  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skinPerTimestep,rebuildFrequency);
 
   std::array<double, 3> r = {2, 2, 2};
   Particle p(r, {0., 0., 0.}, 0);
@@ -208,8 +216,9 @@ TEST_F(VarVerletListsTest, testVerletListBuildHalo) {
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
-  double skin = 0.2;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skin);
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency =20;
+  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skinPerTimestep, rebuildFrequency);
 
   std::array<double, 3> r = {0.9, 0.9, 0.9};
   Particle p(r, {0., 0., 0.}, 0);

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.cpp
@@ -22,10 +22,11 @@ TEST_P(VerletListsTest, testVerletListBuildAndIterate) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency =20;
+  unsigned int rebuildFrequency = 20;
   const double cellSizeFactor = GetParam();
-  autopas::VerletLists<Particle> verletLists(
-      min, max, cutoff, skinPerTimestep,rebuildFrequency, autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA, cellSizeFactor);
+  autopas::VerletLists<Particle> verletLists(min, max, cutoff, skinPerTimestep, rebuildFrequency,
+                                             autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA,
+                                             cellSizeFactor);
 
   std::array<double, 3> r = {2, 2, 2};
   Particle p(r, {0., 0., 0.}, 0);
@@ -57,10 +58,11 @@ TEST_P(VerletListsTest, testVerletListInSkin) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency =20;
+  unsigned int rebuildFrequency = 20;
   const double cellSizeFactor = GetParam();
-  autopas::VerletLists<Particle> verletLists(
-      min, max, cutoff, skinPerTimestep,rebuildFrequency, autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA, cellSizeFactor);
+  autopas::VerletLists<Particle> verletLists(min, max, cutoff, skinPerTimestep, rebuildFrequency,
+                                             autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA,
+                                             cellSizeFactor);
 
   std::array<double, 3> r = {1.4, 2, 2};
   Particle p(r, {0., 0., 0.}, 0);
@@ -92,10 +94,11 @@ TEST_P(VerletListsTest, testVerletListBuildTwice) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency =20;
+  unsigned int rebuildFrequency = 20;
   const double cellSizeFactor = GetParam();
-  autopas::VerletLists<Particle> verletLists(
-      min, max, cutoff, skinPerTimestep,rebuildFrequency, autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA, cellSizeFactor);
+  autopas::VerletLists<Particle> verletLists(min, max, cutoff, skinPerTimestep, rebuildFrequency,
+                                             autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA,
+                                             cellSizeFactor);
 
   std::array<double, 3> r = {2, 2, 2};
   Particle p(r, {0., 0., 0.}, 0);
@@ -128,10 +131,11 @@ TEST_P(VerletListsTest, testVerletListBuildFarAway) {
   std::array<double, 3> max = {5, 5, 5};
   double cutoff = 1.;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency =20;
+  unsigned int rebuildFrequency = 20;
   const double cellSizeFactor = GetParam();
-  autopas::VerletLists<Particle> verletLists(
-      min, max, cutoff, skinPerTimestep, rebuildFrequency, autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA, cellSizeFactor);
+  autopas::VerletLists<Particle> verletLists(min, max, cutoff, skinPerTimestep, rebuildFrequency,
+                                             autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA,
+                                             cellSizeFactor);
 
   std::array<double, 3> r = {2, 2, 2};
   Particle p(r, {0., 0., 0.}, 0);
@@ -168,10 +172,11 @@ TEST_P(VerletListsTest, testVerletListBuildHalo) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency =20;
+  unsigned int rebuildFrequency = 20;
   const double cellSizeFactor = GetParam();
-  autopas::VerletLists<Particle> verletLists(
-      min, max, cutoff, skinPerTimestep,rebuildFrequency, autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA, cellSizeFactor);
+  autopas::VerletLists<Particle> verletLists(min, max, cutoff, skinPerTimestep, rebuildFrequency,
+                                             autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA,
+                                             cellSizeFactor);
 
   std::array<double, 3> r = {0.9, 0.9, 0.9};
   Particle p(r, {0., 0., 0.}, 0);
@@ -266,9 +271,9 @@ TEST_P(VerletListsTest, testUpdateHaloParticle) {
 TEST_P(VerletListsTest, LoadExtractSoA) {
   const double cutoff = 2.;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency =30;
+  unsigned int rebuildFrequency = 30;
   const double cellSizeFactor = GetParam();
-  autopas::VerletLists<Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, cutoff, skinPerTimestep,rebuildFrequency,
+  autopas::VerletLists<Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, cutoff, skinPerTimestep, rebuildFrequency,
                                              autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA,
                                              cellSizeFactor);
 
@@ -279,7 +284,7 @@ TEST_P(VerletListsTest, LoadExtractSoA) {
 
   autopas::VLListIterationTraversal<FPCell, MFunctor, autopas::DataLayoutOption::soa, false> verletTraversal(
       &mockFunctor);
-  const size_t dimWithHalo = 10 / ((cutoff + skinPerTimestep*rebuildFrequency) * cellSizeFactor) + 2ul;
+  const size_t dimWithHalo = 10 / ((cutoff + skinPerTimestep * rebuildFrequency) * cellSizeFactor) + 2ul;
   const size_t numCells = dimWithHalo * dimWithHalo * dimWithHalo;
   EXPECT_CALL(mockFunctor, SoALoader(testing::An<autopas::FullParticleCell<Particle> &>(), _, _)).Times(numCells);
   EXPECT_CALL(mockFunctor, SoAExtractor(testing::An<autopas::FullParticleCell<Particle> &>(), _, _)).Times(numCells);
@@ -295,9 +300,9 @@ TEST_P(VerletListsTest, LoadExtractSoA) {
 TEST_P(VerletListsTest, LoadExtractSoALJ) {
   const double cutoff = 2.;
   const double cellSizeFactor = GetParam();
-  autopas::VerletLists<Molecule> verletLists({0., 0., 0.}, {10., 10., 10.}, cutoff, 0.01 /*skin*/, 30 /*rebuildFrequency*/,
-                                             autopas::VerletLists<Molecule>::BuildVerletListType::VerletSoA,
-                                             cellSizeFactor);
+  autopas::VerletLists<Molecule> verletLists(
+      {0., 0., 0.}, {10., 10., 10.}, cutoff, 0.01 /*skin*/, 30 /*rebuildFrequency*/,
+      autopas::VerletLists<Molecule>::BuildVerletListType::VerletSoA, cellSizeFactor);
 
   Molecule p({-.1, 10.1, -.1}, {0., 0., 0.}, 1, 0);
   verletLists.addHaloParticle(p);

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.cpp
@@ -214,7 +214,7 @@ bool moveUpdateAndExpectEqual(Container &container, Particle &particle, std::arr
 
 TEST_P(VerletListsTest, testUpdateHaloParticle) {
   const double cellSizeFactor = GetParam();
-  autopas::VerletLists<Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3,
+  autopas::VerletLists<Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.01, 30,
                                              autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA,
                                              cellSizeFactor);
 
@@ -295,7 +295,7 @@ TEST_P(VerletListsTest, LoadExtractSoA) {
 TEST_P(VerletListsTest, LoadExtractSoALJ) {
   const double cutoff = 2.;
   const double cellSizeFactor = GetParam();
-  autopas::VerletLists<Molecule> verletLists({0., 0., 0.}, {10., 10., 10.}, cutoff, 0.01 /*skin*/, 30 /*rebuildFrequency*/
+  autopas::VerletLists<Molecule> verletLists({0., 0., 0.}, {10., 10., 10.}, cutoff, 0.01 /*skin*/, 30 /*rebuildFrequency*/,
                                              autopas::VerletLists<Molecule>::BuildVerletListType::VerletSoA,
                                              cellSizeFactor);
 
@@ -313,11 +313,11 @@ TEST_P(VerletListsTest, LoadExtractSoALJ) {
 TEST_P(VerletListsTest, SoAvsAoSLJ) {
   const double cutoff = 2.;
   const double cellSizeFactor = GetParam();
-  autopas::VerletLists<Molecule> verletLists1({0., 0., 0.}, {10., 10., 10.}, cutoff, 0.3,
+  autopas::VerletLists<Molecule> verletLists1({0., 0., 0.}, {10., 10., 10.}, cutoff, 0.01, 30,
                                               autopas::VerletLists<Molecule>::BuildVerletListType::VerletSoA,
                                               cellSizeFactor);
 
-  autopas::VerletLists<Molecule> verletLists2({0., 0., 0.}, {10., 10., 10.}, cutoff, 0.3,
+  autopas::VerletLists<Molecule> verletLists2({0., 0., 0.}, {10., 10., 10.}, cutoff, 0.01, 30,
                                               autopas::VerletLists<Molecule>::BuildVerletListType::VerletSoA,
                                               cellSizeFactor);
 

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.cpp
@@ -21,10 +21,11 @@ TEST_P(VerletListsTest, testVerletListBuildAndIterate) {
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
-  double skin = 0.2;
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency =20;
   const double cellSizeFactor = GetParam();
   autopas::VerletLists<Particle> verletLists(
-      min, max, cutoff, skin, autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA, cellSizeFactor);
+      min, max, cutoff, skinPerTimestep,rebuildFrequency, autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA, cellSizeFactor);
 
   std::array<double, 3> r = {2, 2, 2};
   Particle p(r, {0., 0., 0.}, 0);
@@ -55,10 +56,11 @@ TEST_P(VerletListsTest, testVerletListInSkin) {
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
-  double skin = 0.2;
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency =20;
   const double cellSizeFactor = GetParam();
   autopas::VerletLists<Particle> verletLists(
-      min, max, cutoff, skin, autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA, cellSizeFactor);
+      min, max, cutoff, skinPerTimestep,rebuildFrequency, autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA, cellSizeFactor);
 
   std::array<double, 3> r = {1.4, 2, 2};
   Particle p(r, {0., 0., 0.}, 0);
@@ -89,10 +91,11 @@ TEST_P(VerletListsTest, testVerletListBuildTwice) {
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
-  double skin = 0.2;
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency =20;
   const double cellSizeFactor = GetParam();
   autopas::VerletLists<Particle> verletLists(
-      min, max, cutoff, skin, autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA, cellSizeFactor);
+      min, max, cutoff, skinPerTimestep,rebuildFrequency, autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA, cellSizeFactor);
 
   std::array<double, 3> r = {2, 2, 2};
   Particle p(r, {0., 0., 0.}, 0);
@@ -124,10 +127,11 @@ TEST_P(VerletListsTest, testVerletListBuildFarAway) {
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {5, 5, 5};
   double cutoff = 1.;
-  double skin = 0.2;
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency =20;
   const double cellSizeFactor = GetParam();
   autopas::VerletLists<Particle> verletLists(
-      min, max, cutoff, skin, autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA, cellSizeFactor);
+      min, max, cutoff, skinPerTimestep, rebuildFrequency, autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA, cellSizeFactor);
 
   std::array<double, 3> r = {2, 2, 2};
   Particle p(r, {0., 0., 0.}, 0);
@@ -163,10 +167,11 @@ TEST_P(VerletListsTest, testVerletListBuildHalo) {
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
-  double skin = 0.2;
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency =20;
   const double cellSizeFactor = GetParam();
   autopas::VerletLists<Particle> verletLists(
-      min, max, cutoff, skin, autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA, cellSizeFactor);
+      min, max, cutoff, skinPerTimestep,rebuildFrequency, autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA, cellSizeFactor);
 
   std::array<double, 3> r = {0.9, 0.9, 0.9};
   Particle p(r, {0., 0., 0.}, 0);
@@ -260,9 +265,10 @@ TEST_P(VerletListsTest, testUpdateHaloParticle) {
 
 TEST_P(VerletListsTest, LoadExtractSoA) {
   const double cutoff = 2.;
-  const double skin = 0.3;
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency =30;
   const double cellSizeFactor = GetParam();
-  autopas::VerletLists<Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, cutoff, skin,
+  autopas::VerletLists<Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, cutoff, skinPerTimestep,rebuildFrequency,
                                              autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA,
                                              cellSizeFactor);
 
@@ -273,7 +279,7 @@ TEST_P(VerletListsTest, LoadExtractSoA) {
 
   autopas::VLListIterationTraversal<FPCell, MFunctor, autopas::DataLayoutOption::soa, false> verletTraversal(
       &mockFunctor);
-  const size_t dimWithHalo = 10 / ((cutoff + skin) * cellSizeFactor) + 2ul;
+  const size_t dimWithHalo = 10 / ((cutoff + skinPerTimestep*rebuildFrequency) * cellSizeFactor) + 2ul;
   const size_t numCells = dimWithHalo * dimWithHalo * dimWithHalo;
   EXPECT_CALL(mockFunctor, SoALoader(testing::An<autopas::FullParticleCell<Particle> &>(), _, _)).Times(numCells);
   EXPECT_CALL(mockFunctor, SoAExtractor(testing::An<autopas::FullParticleCell<Particle> &>(), _, _)).Times(numCells);
@@ -289,7 +295,7 @@ TEST_P(VerletListsTest, LoadExtractSoA) {
 TEST_P(VerletListsTest, LoadExtractSoALJ) {
   const double cutoff = 2.;
   const double cellSizeFactor = GetParam();
-  autopas::VerletLists<Molecule> verletLists({0., 0., 0.}, {10., 10., 10.}, cutoff, 0.3 /*skin*/,
+  autopas::VerletLists<Molecule> verletLists({0., 0., 0.}, {10., 10., 10.}, cutoff, 0.01 /*skin*/, 30 /*rebuildFrequency*/
                                              autopas::VerletLists<Molecule>::BuildVerletListType::VerletSoA,
                                              cellSizeFactor);
 

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/PairwiseVerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/PairwiseVerletListsTest.cpp
@@ -21,7 +21,8 @@ TEST_P(PairwiseVerletListsTest, testTwoParticles) {
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
-  double skin = 0.2;
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency=20;
   auto params = GetParam();
   double cellSizeFactor = std::get<0>(params);
   bool useNewton3 = std::get<1>(params);
@@ -29,7 +30,7 @@ TEST_P(PairwiseVerletListsTest, testTwoParticles) {
   const autopas::LoadEstimatorOption loadEstimator = autopas::LoadEstimatorOption::none;
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, useNewton3)).Times(AtLeast(1));
   autopas::VerletListsCells<Particle, autopas::VLCCellPairNeighborList<Particle>> verletLists(
-      min, max, cutoff, skin, cellSizeFactor, loadEstimator, buildType);
+      min, max, cutoff, skinPerTimestep, rebuildFrequency, cellSizeFactor, loadEstimator, buildType);
 
   std::array<double, 3> r = {2, 2, 2};
   Particle p(r, {0., 0., 0.}, 0);
@@ -86,7 +87,8 @@ TEST_P(PairwiseVerletListsTest, testThreeParticlesOneFar) {
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {5, 5, 5};
   double cutoff = 1.;
-  double skin = 0.2;
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency=20;
   auto params = GetParam();
   double cellSizeFactor = std::get<0>(params);
   bool useNewton3 = std::get<1>(params);
@@ -96,7 +98,7 @@ TEST_P(PairwiseVerletListsTest, testThreeParticlesOneFar) {
   EXPECT_CALL(emptyFunctorOther, AoSFunctor(_, _, useNewton3)).Times(AtLeast(1));
 
   autopas::VerletListsCells<Particle, autopas::VLCCellPairNeighborList<Particle>> verletLists(
-      min, max, cutoff, skin, cellSizeFactor, loadEstimator, buildType);
+      min, max, cutoff, skinPerTimestep, rebuildFrequency, cellSizeFactor, loadEstimator, buildType);
 
   std::array<double, 3> r = {2.5, 2.5, 2.5};
   Particle p(r, {0., 0., 0.}, 0);
@@ -157,7 +159,8 @@ TEST_P(PairwiseVerletListsTest, testThreeParticlesClose) {
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {5, 5, 5};
   double cutoff = 1.;
-  double skin = 0.2;
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency= 20;
   auto params = GetParam();
   double cellSizeFactor = std::get<0>(params);
   bool useNewton3 = std::get<1>(params);
@@ -166,7 +169,7 @@ TEST_P(PairwiseVerletListsTest, testThreeParticlesClose) {
 
   EXPECT_CALL(mock, AoSFunctor(_, _, useNewton3)).Times(AtLeast(1));
   autopas::VerletListsCells<Particle, autopas::VLCCellPairNeighborList<Particle>> verletLists(
-      min, max, cutoff, skin, cellSizeFactor, loadEstimator, buildType);
+      min, max, cutoff, skinPerTimestep, rebuildFrequency, cellSizeFactor, loadEstimator, buildType);
 
   std::array<double, 3> r = {2.5, 2.5, 2.5};
   Particle p(r, {0., 0., 0.}, 0);
@@ -228,14 +231,15 @@ TEST_P(PairwiseVerletListsTest, testOneParticle) {
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {5, 5, 5};
   double cutoff = 1.;
-  double skin = 0.2;
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency =20;
   auto params = GetParam();
   double cellSizeFactor = std::get<0>(params);
   bool useNewton3 = std::get<1>(params);
   auto buildType = std::get<2>(params);
   const autopas::LoadEstimatorOption loadEstimator = autopas::LoadEstimatorOption::none;
   autopas::VerletListsCells<Particle, autopas::VLCCellPairNeighborList<Particle>> verletLists(
-      min, max, cutoff, skin, cellSizeFactor, loadEstimator, buildType);
+      min, max, cutoff, skinPerTimestep, rebuildFrequency, cellSizeFactor, loadEstimator, buildType);
 
   std::array<double, 3> r = {2.5, 2.5, 2.5};
   Particle p(r, {0., 0., 0.}, 0);
@@ -296,9 +300,9 @@ TEST_P(PairwiseVerletListsTest, SoAvsAoSLJ) {
   std::array<double, 3> min = {0, 0, 0};
   std::array<double, 3> max = {10, 10, 10};
   autopas::VerletListsCells<Molecule, autopas::VLCCellPairNeighborList<Molecule>> verletLists1(
-      min, max, cutoff, 0.3, cellSizeFactor, loadEstimator, buildType);
+      min, max, cutoff, 0.01,30, cellSizeFactor, loadEstimator, buildType);
   autopas::VerletListsCells<Molecule, autopas::VLCCellPairNeighborList<Molecule>> verletLists2(
-      min, max, cutoff, 0.3, cellSizeFactor, loadEstimator, buildType);
+      min, max, cutoff, 0.01,30, cellSizeFactor, loadEstimator, buildType);
 
   Molecule defaultParticle({0., 0., 0.}, {0., 0., 0.}, 0, 0);
   autopasTools::generators::RandomGenerator::fillWithParticles(verletLists1, defaultParticle, verletLists1.getBoxMin(),

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/PairwiseVerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/PairwiseVerletListsTest.cpp
@@ -22,7 +22,7 @@ TEST_P(PairwiseVerletListsTest, testTwoParticles) {
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency=20;
+  unsigned int rebuildFrequency = 20;
   auto params = GetParam();
   double cellSizeFactor = std::get<0>(params);
   bool useNewton3 = std::get<1>(params);
@@ -88,7 +88,7 @@ TEST_P(PairwiseVerletListsTest, testThreeParticlesOneFar) {
   std::array<double, 3> max = {5, 5, 5};
   double cutoff = 1.;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency=20;
+  unsigned int rebuildFrequency = 20;
   auto params = GetParam();
   double cellSizeFactor = std::get<0>(params);
   bool useNewton3 = std::get<1>(params);
@@ -160,7 +160,7 @@ TEST_P(PairwiseVerletListsTest, testThreeParticlesClose) {
   std::array<double, 3> max = {5, 5, 5};
   double cutoff = 1.;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency= 20;
+  unsigned int rebuildFrequency = 20;
   auto params = GetParam();
   double cellSizeFactor = std::get<0>(params);
   bool useNewton3 = std::get<1>(params);
@@ -232,7 +232,7 @@ TEST_P(PairwiseVerletListsTest, testOneParticle) {
   std::array<double, 3> max = {5, 5, 5};
   double cutoff = 1.;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency =20;
+  unsigned int rebuildFrequency = 20;
   auto params = GetParam();
   double cellSizeFactor = std::get<0>(params);
   bool useNewton3 = std::get<1>(params);
@@ -300,9 +300,9 @@ TEST_P(PairwiseVerletListsTest, SoAvsAoSLJ) {
   std::array<double, 3> min = {0, 0, 0};
   std::array<double, 3> max = {10, 10, 10};
   autopas::VerletListsCells<Molecule, autopas::VLCCellPairNeighborList<Molecule>> verletLists1(
-      min, max, cutoff, 0.01,30, cellSizeFactor, loadEstimator, buildType);
+      min, max, cutoff, 0.01, 30, cellSizeFactor, loadEstimator, buildType);
   autopas::VerletListsCells<Molecule, autopas::VLCCellPairNeighborList<Molecule>> verletLists2(
-      min, max, cutoff, 0.01,30, cellSizeFactor, loadEstimator, buildType);
+      min, max, cutoff, 0.01, 30, cellSizeFactor, loadEstimator, buildType);
 
   Molecule defaultParticle({0., 0., 0.}, {0., 0., 0.}, 0, 0);
   autopasTools::generators::RandomGenerator::fillWithParticles(verletLists1, defaultParticle, verletLists1.getBoxMin(),

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/VerletListsCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/VerletListsCellsTest.cpp
@@ -25,7 +25,7 @@ void applyFunctor(MockFunctor<Particle> &functor, const double cellSizefactor,
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
   double skinPerTimestep = 0.01;
-  unsigned int rebuildFrequency =20;
+  unsigned int rebuildFrequency = 20;
   const autopas::LoadEstimatorOption loadEstimator = autopas::LoadEstimatorOption::none;
   autopas::VerletListsCells<Particle, autopas::VLCAllCellsNeighborList<Particle>> verletLists(
       min, max, cutoff, skinPerTimestep, rebuildFrequency, cellSizefactor, loadEstimator, buildType);
@@ -76,9 +76,9 @@ void soaTest(const double cellSizeFactor,
   }
 
   autopas::VerletListsCells<Molecule, autopas::VLCCellPairNeighborList<Molecule>> verletLists1(
-      min, max, cutoff, 0.01,30, cellSizeFactor, loadEstimator, buildType);
+      min, max, cutoff, 0.01, 30, cellSizeFactor, loadEstimator, buildType);
   autopas::VerletListsCells<Molecule, autopas::VLCCellPairNeighborList<Molecule>> verletLists2(
-      min, max, cutoff, 0.01,30, cellSizeFactor, loadEstimator, buildType);
+      min, max, cutoff, 0.01, 30, cellSizeFactor, loadEstimator, buildType);
 
   Molecule defaultParticle({0., 0., 0.}, {0., 0., 0.}, 0, 0);
   autopasTools::generators::RandomGenerator::fillWithParticles(verletLists1, defaultParticle, verletLists1.getBoxMin(),

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/VerletListsCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/VerletListsCellsTest.cpp
@@ -76,9 +76,9 @@ void soaTest(const double cellSizeFactor,
   }
 
   autopas::VerletListsCells<Molecule, autopas::VLCCellPairNeighborList<Molecule>> verletLists1(
-      min, max, cutoff, 0.3, cellSizeFactor, loadEstimator, buildType);
+      min, max, cutoff, 0.01,30, cellSizeFactor, loadEstimator, buildType);
   autopas::VerletListsCells<Molecule, autopas::VLCCellPairNeighborList<Molecule>> verletLists2(
-      min, max, cutoff, 0.3, cellSizeFactor, loadEstimator, buildType);
+      min, max, cutoff, 0.01,30, cellSizeFactor, loadEstimator, buildType);
 
   Molecule defaultParticle({0., 0., 0.}, {0., 0., 0.}, 0, 0);
   autopasTools::generators::RandomGenerator::fillWithParticles(verletLists1, defaultParticle, verletLists1.getBoxMin(),

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/VerletListsCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/VerletListsCellsTest.cpp
@@ -24,10 +24,11 @@ void applyFunctor(MockFunctor<Particle> &functor, const double cellSizefactor,
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
-  double skin = 0.2;
+  double skinPerTimestep = 0.01;
+  unsigned int rebuildFrequency =20;
   const autopas::LoadEstimatorOption loadEstimator = autopas::LoadEstimatorOption::none;
   autopas::VerletListsCells<Particle, autopas::VLCAllCellsNeighborList<Particle>> verletLists(
-      min, max, cutoff, skin, cellSizefactor, loadEstimator, buildType);
+      min, max, cutoff, skinPerTimestep, rebuildFrequency, cellSizefactor, loadEstimator, buildType);
 
   std::array<double, 3> r = {2, 2, 2};
   Particle p(r, {0., 0., 0.}, 0);

--- a/tests/testAutopas/tests/forEach/ContainerForEachTest.cpp
+++ b/tests/testAutopas/tests/forEach/ContainerForEachTest.cpp
@@ -28,9 +28,9 @@ auto ContainerForEachTest::defaultInit(AutoPasT &autoPas, autopas::ContainerOpti
   autoPas.init();
 
   auto haloBoxMin =
-      autopas::utils::ArrayMath::subScalar(autoPas.getBoxMin(), autoPas.verletSkin() + autoPas.getCutoff());
+      autopas::utils::ArrayMath::subScalar(autoPas.getBoxMin(), autoPas.getVerletSkin() + autoPas.getCutoff());
   auto haloBoxMax =
-      autopas::utils::ArrayMath::addScalar(autoPas.getBoxMax(), autoPas.verletSkin() + autoPas.getCutoff());
+      autopas::utils::ArrayMath::addScalar(autoPas.getBoxMax(), autoPas.getVerletSkin() + autoPas.getCutoff());
 
   return std::make_tuple(haloBoxMin, haloBoxMax);
 }

--- a/tests/testAutopas/tests/forEach/ContainerForEachTest.cpp
+++ b/tests/testAutopas/tests/forEach/ContainerForEachTest.cpp
@@ -18,7 +18,7 @@ auto ContainerForEachTest::defaultInit(AutoPasT &autoPas, autopas::ContainerOpti
   autoPas.setBoxMin({0., 0., 0.});
   autoPas.setBoxMax({10., 10., 10.});
   autoPas.setCutoff(1);
-  autoPas.setVerletSkinPerTimestep(0.2);
+  autoPas.setVerletSkinPerTimestep(0.1);
   autoPas.setVerletRebuildFrequency(2);
   autoPas.setNumSamples(2);
   autoPas.setAllowedContainers(std::set<autopas::ContainerOption>{containerOption});

--- a/tests/testAutopas/tests/forEach/ContainerForEachTest.cpp
+++ b/tests/testAutopas/tests/forEach/ContainerForEachTest.cpp
@@ -18,7 +18,7 @@ auto ContainerForEachTest::defaultInit(AutoPasT &autoPas, autopas::ContainerOpti
   autoPas.setBoxMin({0., 0., 0.});
   autoPas.setBoxMax({10., 10., 10.});
   autoPas.setCutoff(1);
-  autoPas.setVerletSkin(0.2);
+  autoPas.setVerletSkinPerTimestep(0.2);
   autoPas.setVerletRebuildFrequency(2);
   autoPas.setNumSamples(2);
   autoPas.setAllowedContainers(std::set<autopas::ContainerOption>{containerOption});
@@ -28,9 +28,9 @@ auto ContainerForEachTest::defaultInit(AutoPasT &autoPas, autopas::ContainerOpti
   autoPas.init();
 
   auto haloBoxMin =
-      autopas::utils::ArrayMath::subScalar(autoPas.getBoxMin(), autoPas.getVerletSkin() + autoPas.getCutoff());
+      autopas::utils::ArrayMath::subScalar(autoPas.getBoxMin(), autoPas.verletSkin() + autoPas.getCutoff());
   auto haloBoxMax =
-      autopas::utils::ArrayMath::addScalar(autoPas.getBoxMax(), autoPas.getVerletSkin() + autoPas.getCutoff());
+      autopas::utils::ArrayMath::addScalar(autoPas.getBoxMax(), autoPas.verletSkin() + autoPas.getCutoff());
 
   return std::make_tuple(haloBoxMin, haloBoxMax);
 }

--- a/tests/testAutopas/tests/forEach/ContainerReduceTest.cpp
+++ b/tests/testAutopas/tests/forEach/ContainerReduceTest.cpp
@@ -28,9 +28,9 @@ auto ContainerReduceTest::defaultInit(AutoPasT &autoPas, autopas::ContainerOptio
   autoPas.init();
 
   auto haloBoxMin =
-      autopas::utils::ArrayMath::subScalar(autoPas.getBoxMin(), autoPas.verletSkin() + autoPas.getCutoff());
+      autopas::utils::ArrayMath::subScalar(autoPas.getBoxMin(), autoPas.getVerletSkin() + autoPas.getCutoff());
   auto haloBoxMax =
-      autopas::utils::ArrayMath::addScalar(autoPas.getBoxMax(), autoPas.verletSkin() + autoPas.getCutoff());
+      autopas::utils::ArrayMath::addScalar(autoPas.getBoxMax(), autoPas.getVerletSkin() + autoPas.getCutoff());
 
   return std::make_tuple(haloBoxMin, haloBoxMax);
 }

--- a/tests/testAutopas/tests/forEach/ContainerReduceTest.cpp
+++ b/tests/testAutopas/tests/forEach/ContainerReduceTest.cpp
@@ -18,7 +18,7 @@ auto ContainerReduceTest::defaultInit(AutoPasT &autoPas, autopas::ContainerOptio
   autoPas.setBoxMin({0., 0., 0.});
   autoPas.setBoxMax({10., 10., 10.});
   autoPas.setCutoff(1);
-  autoPas.setVerletSkin(0.2);
+  autoPas.setVerletSkinPerTimestep(0.2);
   autoPas.setVerletRebuildFrequency(2);
   autoPas.setNumSamples(2);
   autoPas.setAllowedContainers(std::set<autopas::ContainerOption>{containerOption});
@@ -28,9 +28,9 @@ auto ContainerReduceTest::defaultInit(AutoPasT &autoPas, autopas::ContainerOptio
   autoPas.init();
 
   auto haloBoxMin =
-      autopas::utils::ArrayMath::subScalar(autoPas.getBoxMin(), autoPas.getVerletSkin() + autoPas.getCutoff());
+      autopas::utils::ArrayMath::subScalar(autoPas.getBoxMin(), autoPas.verletSkin() + autoPas.getCutoff());
   auto haloBoxMax =
-      autopas::utils::ArrayMath::addScalar(autoPas.getBoxMax(), autoPas.getVerletSkin() + autoPas.getCutoff());
+      autopas::utils::ArrayMath::addScalar(autoPas.getBoxMax(), autoPas.verletSkin() + autoPas.getCutoff());
 
   return std::make_tuple(haloBoxMin, haloBoxMax);
 }

--- a/tests/testAutopas/tests/iterators/IteratorTestHelper.h
+++ b/tests/testAutopas/tests/iterators/IteratorTestHelper.h
@@ -190,9 +190,8 @@ void provideIterator(AutoPasT &autoPas, autopas::IteratorBehavior behavior, bool
       };
       fun(autoPasRef, getIter);
     } else {
-      auto getIter = [&]() -> typename AutoPasT::iterator_t {
-        return autoPas.getRegionIterator(haloBoxMin, haloBoxMax, behavior);
-      };
+      auto getIter = [&]() ->
+          typename AutoPasT::iterator_t { return autoPas.getRegionIterator(haloBoxMin, haloBoxMax, behavior); };
       fun(autoPas, getIter);
     }
   } else {
@@ -243,14 +242,12 @@ void provideRegionIterator(AutoPasT &autoPas, autopas::IteratorBehavior behavior
                            const std::array<double, 3> &boxMax, F fun) {
   if constexpr (useConstIterator) {
     const auto &autoPasRef = autoPas;
-    auto getIter = [&]() -> typename AutoPasT::const_iterator_t {
-      return autoPasRef.getRegionIterator(boxMin, boxMax, behavior);
-    };
+    auto getIter = [&]() ->
+        typename AutoPasT::const_iterator_t { return autoPasRef.getRegionIterator(boxMin, boxMax, behavior); };
     fun(autoPasRef, getIter);
   } else {
-    auto getIter = [&]() -> typename AutoPasT::iterator_t {
-      return autoPas.getRegionIterator(boxMin, boxMax, behavior);
-    };
+    auto getIter = [&]() ->
+        typename AutoPasT::iterator_t { return autoPas.getRegionIterator(boxMin, boxMax, behavior); };
     fun(autoPas, getIter);
   }
 }

--- a/tests/testAutopas/tests/iterators/IteratorTestHelper.h
+++ b/tests/testAutopas/tests/iterators/IteratorTestHelper.h
@@ -190,8 +190,9 @@ void provideIterator(AutoPasT &autoPas, autopas::IteratorBehavior behavior, bool
       };
       fun(autoPasRef, getIter);
     } else {
-      auto getIter = [&]() ->
-          typename AutoPasT::iterator_t { return autoPas.getRegionIterator(haloBoxMin, haloBoxMax, behavior); };
+      auto getIter = [&]() -> typename AutoPasT::iterator_t {
+        return autoPas.getRegionIterator(haloBoxMin, haloBoxMax, behavior);
+      };
       fun(autoPas, getIter);
     }
   } else {
@@ -242,12 +243,14 @@ void provideRegionIterator(AutoPasT &autoPas, autopas::IteratorBehavior behavior
                            const std::array<double, 3> &boxMax, F fun) {
   if constexpr (useConstIterator) {
     const auto &autoPasRef = autoPas;
-    auto getIter = [&]() ->
-        typename AutoPasT::const_iterator_t { return autoPasRef.getRegionIterator(boxMin, boxMax, behavior); };
+    auto getIter = [&]() -> typename AutoPasT::const_iterator_t {
+      return autoPasRef.getRegionIterator(boxMin, boxMax, behavior);
+    };
     fun(autoPasRef, getIter);
   } else {
-    auto getIter = [&]() ->
-        typename AutoPasT::iterator_t { return autoPas.getRegionIterator(boxMin, boxMax, behavior); };
+    auto getIter = [&]() -> typename AutoPasT::iterator_t {
+      return autoPas.getRegionIterator(boxMin, boxMax, behavior);
+    };
     fun(autoPas, getIter);
   }
 }

--- a/tests/testAutopas/tests/iterators/ParticleIteratorInterfaceTest.cpp
+++ b/tests/testAutopas/tests/iterators/ParticleIteratorInterfaceTest.cpp
@@ -25,7 +25,7 @@ auto ParticleIteratorInterfaceTest::defaultInit(AutoPasT &autoPas, autopas::Cont
   autoPas.setBoxMin({0., 0., 0.});
   autoPas.setBoxMax({10., 10., 10.});
   autoPas.setCutoff(1);
-  autoPas.setVerletSkin(0.2);
+  autoPas.setVerletSkinPerTimestep(0.2);
   autoPas.setVerletRebuildFrequency(2);
   autoPas.setNumSamples(2);
   autoPas.setAllowedContainers(std::set<autopas::ContainerOption>{containerOption});
@@ -35,9 +35,9 @@ auto ParticleIteratorInterfaceTest::defaultInit(AutoPasT &autoPas, autopas::Cont
   autoPas.init();
 
   auto haloBoxMin =
-      autopas::utils::ArrayMath::subScalar(autoPas.getBoxMin(), autoPas.getVerletSkin() + autoPas.getCutoff());
+      autopas::utils::ArrayMath::subScalar(autoPas.getBoxMin(), autoPas.verletSkin() + autoPas.getCutoff());
   auto haloBoxMax =
-      autopas::utils::ArrayMath::addScalar(autoPas.getBoxMax(), autoPas.getVerletSkin() + autoPas.getCutoff());
+      autopas::utils::ArrayMath::addScalar(autoPas.getBoxMax(), autoPas.verletSkin() + autoPas.getCutoff());
 
   return std::make_tuple(haloBoxMin, haloBoxMax);
 }

--- a/tests/testAutopas/tests/iterators/ParticleIteratorInterfaceTest.cpp
+++ b/tests/testAutopas/tests/iterators/ParticleIteratorInterfaceTest.cpp
@@ -35,9 +35,9 @@ auto ParticleIteratorInterfaceTest::defaultInit(AutoPasT &autoPas, autopas::Cont
   autoPas.init();
 
   auto haloBoxMin =
-      autopas::utils::ArrayMath::subScalar(autoPas.getBoxMin(), autoPas.verletSkin() + autoPas.getCutoff());
+      autopas::utils::ArrayMath::subScalar(autoPas.getBoxMin(), autoPas.getVerletSkin() + autoPas.getCutoff());
   auto haloBoxMax =
-      autopas::utils::ArrayMath::addScalar(autoPas.getBoxMax(), autoPas.verletSkin() + autoPas.getCutoff());
+      autopas::utils::ArrayMath::addScalar(autoPas.getBoxMax(), autoPas.getVerletSkin() + autoPas.getCutoff());
 
   return std::make_tuple(haloBoxMin, haloBoxMax);
 }

--- a/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
@@ -28,9 +28,9 @@ auto RegionParticleIteratorTest::defaultInit(AutoPasT &autoPas, autopas::Contain
   autoPas.init();
 
   auto haloBoxMin =
-      autopas::utils::ArrayMath::subScalar(autoPas.getBoxMin(), autoPas.verletSkin() + autoPas.getCutoff());
+      autopas::utils::ArrayMath::subScalar(autoPas.getBoxMin(), autoPas.getVerletSkin() + autoPas.getCutoff());
   auto haloBoxMax =
-      autopas::utils::ArrayMath::addScalar(autoPas.getBoxMax(), autoPas.verletSkin() + autoPas.getCutoff());
+      autopas::utils::ArrayMath::addScalar(autoPas.getBoxMax(), autoPas.getVerletSkin() + autoPas.getCutoff());
 
   return std::make_tuple(haloBoxMin, haloBoxMax);
 }

--- a/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
@@ -18,7 +18,7 @@ auto RegionParticleIteratorTest::defaultInit(AutoPasT &autoPas, autopas::Contain
   autoPas.setBoxMin({0., 0., 0.});
   autoPas.setBoxMax({10., 10., 10.});
   autoPas.setCutoff(1);
-  autoPas.setVerletSkin(0.2);
+  autoPas.setVerletSkinPerTimestep(0.2);
   autoPas.setVerletRebuildFrequency(2);
   autoPas.setNumSamples(2);
   autoPas.setAllowedContainers(std::set<autopas::ContainerOption>{containerOption});
@@ -28,9 +28,9 @@ auto RegionParticleIteratorTest::defaultInit(AutoPasT &autoPas, autopas::Contain
   autoPas.init();
 
   auto haloBoxMin =
-      autopas::utils::ArrayMath::subScalar(autoPas.getBoxMin(), autoPas.getVerletSkin() + autoPas.getCutoff());
+      autopas::utils::ArrayMath::subScalar(autoPas.getBoxMin(), autoPas.verletSkin() + autoPas.getCutoff());
   auto haloBoxMax =
-      autopas::utils::ArrayMath::addScalar(autoPas.getBoxMax(), autoPas.getVerletSkin() + autoPas.getCutoff());
+      autopas::utils::ArrayMath::addScalar(autoPas.getBoxMax(), autoPas.verletSkin() + autoPas.getCutoff());
 
   return std::make_tuple(haloBoxMin, haloBoxMax);
 }

--- a/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
@@ -18,7 +18,7 @@ auto RegionParticleIteratorTest::defaultInit(AutoPasT &autoPas, autopas::Contain
   autoPas.setBoxMin({0., 0., 0.});
   autoPas.setBoxMax({10., 10., 10.});
   autoPas.setCutoff(1);
-  autoPas.setVerletSkinPerTimestep(0.2);
+  autoPas.setVerletSkinPerTimestep(0.1);
   autoPas.setVerletRebuildFrequency(2);
   autoPas.setNumSamples(2);
   autoPas.setAllowedContainers(std::set<autopas::ContainerOption>{containerOption});

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorAVXTest.h
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorAVXTest.h
@@ -91,8 +91,9 @@ class LJFunctorAVXTest : public AutoPasTestBase, public ::testing::WithParamInte
 
   constexpr static double _cutoff{6.};
   constexpr static double _skinPerTimestep{0.1};
-  constexpr static unsigned int _rebuildFrequency {20};
-  constexpr static double _interactionLengthSquare{(_cutoff + _skinPerTimestep*_rebuildFrequency) * (_cutoff + _skinPerTimestep*_rebuildFrequency)};
+  constexpr static unsigned int _rebuildFrequency{20};
+  constexpr static double _interactionLengthSquare{(_cutoff + _skinPerTimestep * _rebuildFrequency) *
+                                                   (_cutoff + _skinPerTimestep * _rebuildFrequency)};
   constexpr static double _epsilon{1.};
   constexpr static double _sigma{1.};
   const std::array<double, 3> _lowCorner{0., 0., 0.};

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorAVXTest.h
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorAVXTest.h
@@ -90,8 +90,9 @@ class LJFunctorAVXTest : public AutoPasTestBase, public ::testing::WithParamInte
   bool particleEqual(Particle &p1, Particle &p2);
 
   constexpr static double _cutoff{6.};
-  constexpr static double _skin{2.};
-  constexpr static double _interactionLengthSquare{(_cutoff + _skin) * (_cutoff + _skin)};
+  constexpr static double _skinPerTimestep{0.1};
+  constexpr static unsigned int _rebuildFrequency {20.};
+  constexpr static double _interactionLengthSquare{(_cutoff + _skin) * (_cutoff + _skinPerTimestep*_rebuildFrequency)};
   constexpr static double _epsilon{1.};
   constexpr static double _sigma{1.};
   const std::array<double, 3> _lowCorner{0., 0., 0.};

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorAVXTest.h
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorAVXTest.h
@@ -91,8 +91,8 @@ class LJFunctorAVXTest : public AutoPasTestBase, public ::testing::WithParamInte
 
   constexpr static double _cutoff{6.};
   constexpr static double _skinPerTimestep{0.1};
-  constexpr static unsigned int _rebuildFrequency {20.};
-  constexpr static double _interactionLengthSquare{(_cutoff + _skin) * (_cutoff + _skinPerTimestep*_rebuildFrequency)};
+  constexpr static unsigned int _rebuildFrequency {20};
+  constexpr static double _interactionLengthSquare{(_cutoff + _skinPerTimestep*_rebuildFrequency) * (_cutoff + _skinPerTimestep*_rebuildFrequency)};
   constexpr static double _epsilon{1.};
   constexpr static double _sigma{1.};
   const std::array<double, 3> _lowCorner{0., 0., 0.};

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorSVETest.h
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorSVETest.h
@@ -90,9 +90,8 @@ class LJFunctorSVETest : public AutoPasTestBase, public ::testing::WithParamInte
   bool particleEqual(Particle &p1, Particle &p2);
 
   constexpr static double _cutoff{6.};
-  constexpr static double _skinPerTimestep{0.1};
-  constexpr static unsigned int _rebuildFrequency{20.};
-  constexpr static double _interactionLengthSquare{(_cutoff + _skinPerTimestep * _rebuildFrequency) * (_cutoff + _skinPerTimestep * _rebuildFrequency)};
+  constexpr static double _skin{2.};
+  constexpr static double _interactionLengthSquare{(_cutoff + _skin) * (_cutoff + _skin)};
   constexpr static double _epsilon{1.};
   constexpr static double _sigma{1.};
   const std::array<double, 3> _lowCorner{0., 0., 0.};

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorSVETest.h
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorSVETest.h
@@ -92,7 +92,7 @@ class LJFunctorSVETest : public AutoPasTestBase, public ::testing::WithParamInte
   constexpr static double _cutoff{6.};
   constexpr static double _skinPerTimestep{0.1};
   constexpr static unsigned int _rebuildFrequency{20.};
-  constexpr static double _interactionLengthSquare{(_cutoff + _skin) * (_cutoff + _skinPerTimestep)};
+  constexpr static double _interactionLengthSquare{(_cutoff + _skinPerTimestep * _rebuildFrequency) * (_cutoff + _skinPerTimestep * _rebuildFrequency)};
   constexpr static double _epsilon{1.};
   constexpr static double _sigma{1.};
   const std::array<double, 3> _lowCorner{0., 0., 0.};

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorSVETest.h
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorSVETest.h
@@ -90,8 +90,9 @@ class LJFunctorSVETest : public AutoPasTestBase, public ::testing::WithParamInte
   bool particleEqual(Particle &p1, Particle &p2);
 
   constexpr static double _cutoff{6.};
-  constexpr static double _skin{2.};
-  constexpr static double _interactionLengthSquare{(_cutoff + _skin) * (_cutoff + _skin)};
+  constexpr static double _skinPerTimestep{0.1};
+  constexpr static unsigned int _rebuildFrequency{20.};
+  constexpr static double _interactionLengthSquare{(_cutoff + _skin) * (_cutoff + _skinPerTimestep)};
   constexpr static double _epsilon{1.};
   constexpr static double _sigma{1.};
   const std::array<double, 3> _lowCorner{0., 0., 0.};

--- a/tests/testAutopas/tests/selectors/AutoTunerTest.cpp
+++ b/tests/testAutopas/tests/selectors/AutoTunerTest.cpp
@@ -48,10 +48,10 @@ TEST_F(AutoTunerTest, testAllConfigurations) {
       autopas::ContainerOption::getAllOptions(), std::set<double>({cellSizeFactor}),
       autopas::TraversalOption::getAllOptions(), autopas::LoadEstimatorOption::getAllOptions(),
       autopas::DataLayoutOption::getAllOptions(), autopas::Newton3Option::getAllOptions());
-  autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkinPerTimestep, 
-                                         verletClusterSize, std::move(tuningStrategy), mpiTuningMaxDifferenceForBucket,
+  autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkinPerTimestep, verletClusterSize,
+                                         std::move(tuningStrategy), mpiTuningMaxDifferenceForBucket,
                                          mpiTuningWeightForMaxDensity, autopas::SelectorStrategyOption::fastestAbs, 100,
-                                         maxSamples,verletRebuildFrequency);
+                                         maxSamples, verletRebuildFrequency);
 
   autopas::Logger::get()->set_level(autopas::Logger::LogLevel::off);
   //  autopas::Logger::get()->set_level(autopas::Logger::LogLevel::debug);
@@ -311,10 +311,10 @@ TEST_F(AutoTunerTest, testForceRetuneBetweenPhases) {
   auto configsList = {_confLc_c01, _confLc_c04, _confLc_c08};
 
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
-  autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkinPerTimestep, 
-                                         verletClusterSize, std::move(tuningStrategy), mpiTuningMaxDifferenceForBucket,
+  autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkinPerTimestep, verletClusterSize,
+                                         std::move(tuningStrategy), mpiTuningMaxDifferenceForBucket,
                                          mpiTuningWeightForMaxDensity, autopas::SelectorStrategyOption::fastestAbs, 100,
-                                         maxSamples,verletRebuildFrequency);
+                                         maxSamples, verletRebuildFrequency);
 
   size_t numExpectedTuningIterations = configsList.size() * maxSamples;
   MockFunctor<Molecule> functor;
@@ -370,10 +370,10 @@ TEST_F(AutoTunerTest, testForceRetuneInPhase) {
   auto configsList = {confLc_c01, confLc_c04, confLc_c08};
 
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
-  autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkinPerTimestep, 
-                                         verletClusterSize, std::move(tuningStrategy), mpiTuningMaxDifferenceForBucket,
+  autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkinPerTimestep, verletClusterSize,
+                                         std::move(tuningStrategy), mpiTuningMaxDifferenceForBucket,
                                          mpiTuningWeightForMaxDensity, autopas::SelectorStrategyOption::fastestAbs, 100,
-                                         maxSamples,verletRebuildFrequency);
+                                         maxSamples, verletRebuildFrequency);
 
   size_t numExpectedTuningIterations = configsList.size() * maxSamples;
   MockFunctor<Molecule> functor;
@@ -420,8 +420,8 @@ TEST_F(AutoTunerTest, testNoConfig) {
   auto exp1 = []() {
     std::set<autopas::Configuration> configsList = {};
     auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
-    autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.05, 0, 64, std::move(tuningStrategy), 0.3,
-                                           0.0, autopas::SelectorStrategyOption::fastestAbs, 1000, 3,20);
+    autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.05, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+                                           autopas::SelectorStrategyOption::fastestAbs, 1000, 3, 20);
   };
 
   EXPECT_THROW(exp1(), autopas::utils::ExceptionHandler::AutoPasException) << "Constructor with given configs";
@@ -435,8 +435,8 @@ TEST_F(AutoTunerTest, testNoConfig) {
     std::set<autopas::DataLayoutOption> dl = {};
     std::set<autopas::Newton3Option> n3 = {};
     auto tuningStrategy = std::make_unique<autopas::FullSearch>(co, csf, tr, le, dl, n3);
-    autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 1, 0, 64, std::move(tuningStrategy), 0.3,
-                                           0.0, autopas::SelectorStrategyOption::fastestAbs, 1000, 3, 20);
+    autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 1, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+                                           autopas::SelectorStrategyOption::fastestAbs, 1000, 3, 20);
   };
 
   EXPECT_THROW(exp2(), autopas::utils::ExceptionHandler::AutoPasException) << "Constructor which generates configs";
@@ -525,7 +525,7 @@ TEST_F(AutoTunerTest, testLastConfigThrownOut) {
   auto configsList = {confN3, confNoN3};
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
   autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 1, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
-                                     autopas::SelectorStrategyOption::fastestAbs, 1000, 3,20);
+                                     autopas::SelectorStrategyOption::fastestAbs, 1000, 3, 20);
 
   EXPECT_EQ(confN3, tuner.getCurrentConfig());
 
@@ -560,8 +560,8 @@ TEST_F(AutoTunerTest, testBuildNotBuildTimeEstimation) {
 
   auto configsList = {confA, confB};
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
-  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 1, 0, 64, std::move(tuningStrategy),
-                                     0.3, 0.0, autopas::SelectorStrategyOption::fastestAbs, 1000, 3, rebuildFrequency);
+  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 1, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+                                     autopas::SelectorStrategyOption::fastestAbs, 1000, 3, rebuildFrequency);
 
   MockFunctor<Molecule> functor;
   EXPECT_CALL(functor, isRelevantForTuning()).WillRepeatedly(::testing::Return(true));

--- a/tests/testAutopas/tests/selectors/AutoTunerTest.cpp
+++ b/tests/testAutopas/tests/selectors/AutoTunerTest.cpp
@@ -48,10 +48,10 @@ TEST_F(AutoTunerTest, testAllConfigurations) {
       autopas::ContainerOption::getAllOptions(), std::set<double>({cellSizeFactor}),
       autopas::TraversalOption::getAllOptions(), autopas::LoadEstimatorOption::getAllOptions(),
       autopas::DataLayoutOption::getAllOptions(), autopas::Newton3Option::getAllOptions());
-  autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkinPerTimestep, verletRebuildFrequency,
+  autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkinPerTimestep, 
                                          verletClusterSize, std::move(tuningStrategy), mpiTuningMaxDifferenceForBucket,
                                          mpiTuningWeightForMaxDensity, autopas::SelectorStrategyOption::fastestAbs, 100,
-                                         maxSamples);
+                                         maxSamples,verletRebuildFrequency);
 
   autopas::Logger::get()->set_level(autopas::Logger::LogLevel::off);
   //  autopas::Logger::get()->set_level(autopas::Logger::LogLevel::debug);
@@ -167,8 +167,8 @@ TEST_F(AutoTunerTest, testWillRebuildDDL) {
                   autopas::LoadEstimatorOption::none, autopas::DataLayoutOption::aos, autopas::Newton3Option::disabled);
 
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configs);
-  autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.05, 20, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
-                                         autopas::SelectorStrategyOption::fastestAbs, 1000, 2);
+  autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.05, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+                                         autopas::SelectorStrategyOption::fastestAbs, 1000, 2, 20);
 
   EXPECT_EQ(*(configs.begin()), autoTuner.getCurrentConfig());
 
@@ -221,8 +221,8 @@ TEST_F(AutoTunerTest, testWillRebuildDDLOneConfigKicked) {
                   autopas::LoadEstimatorOption::none, autopas::DataLayoutOption::aos, autopas::Newton3Option::enabled);
 
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configs);
-  autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.05, 20, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
-                                         autopas::SelectorStrategyOption::fastestAbs, 1000, 2);
+  autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.05, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+                                         autopas::SelectorStrategyOption::fastestAbs, 1000, 2, 20);
 
   EXPECT_EQ(*(configs.begin()), autoTuner.getCurrentConfig());
 
@@ -263,8 +263,8 @@ TEST_F(AutoTunerTest, testWillRebuildDL) {
                   autopas::LoadEstimatorOption::none, autopas::DataLayoutOption::aos, autopas::Newton3Option::disabled);
 
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configs);
-  autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.05, 20, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
-                                         autopas::SelectorStrategyOption::fastestAbs, 1000, 2);
+  autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.05, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+                                         autopas::SelectorStrategyOption::fastestAbs, 1000, 2, 20);
 
   EXPECT_EQ(*(configs.begin()), autoTuner.getCurrentConfig());
 
@@ -311,10 +311,10 @@ TEST_F(AutoTunerTest, testForceRetuneBetweenPhases) {
   auto configsList = {_confLc_c01, _confLc_c04, _confLc_c08};
 
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
-  autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkinPerTimestep, verletRebuildFrequency,
+  autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkinPerTimestep, 
                                          verletClusterSize, std::move(tuningStrategy), mpiTuningMaxDifferenceForBucket,
                                          mpiTuningWeightForMaxDensity, autopas::SelectorStrategyOption::fastestAbs, 100,
-                                         maxSamples);
+                                         maxSamples,verletRebuildFrequency);
 
   size_t numExpectedTuningIterations = configsList.size() * maxSamples;
   MockFunctor<Molecule> functor;
@@ -370,10 +370,10 @@ TEST_F(AutoTunerTest, testForceRetuneInPhase) {
   auto configsList = {confLc_c01, confLc_c04, confLc_c08};
 
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
-  autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkinPerTimestep, verletRebuildFrequency,
+  autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkinPerTimestep, 
                                          verletClusterSize, std::move(tuningStrategy), mpiTuningMaxDifferenceForBucket,
                                          mpiTuningWeightForMaxDensity, autopas::SelectorStrategyOption::fastestAbs, 100,
-                                         maxSamples);
+                                         maxSamples,verletRebuildFrequency);
 
   size_t numExpectedTuningIterations = configsList.size() * maxSamples;
   MockFunctor<Molecule> functor;
@@ -420,8 +420,8 @@ TEST_F(AutoTunerTest, testNoConfig) {
   auto exp1 = []() {
     std::set<autopas::Configuration> configsList = {};
     auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
-    autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.05, 20, 0, 64, std::move(tuningStrategy), 0.3,
-                                           0.0, autopas::SelectorStrategyOption::fastestAbs, 1000, 3);
+    autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.05, 0, 64, std::move(tuningStrategy), 0.3,
+                                           0.0, autopas::SelectorStrategyOption::fastestAbs, 1000, 3,20);
   };
 
   EXPECT_THROW(exp1(), autopas::utils::ExceptionHandler::AutoPasException) << "Constructor with given configs";
@@ -435,8 +435,8 @@ TEST_F(AutoTunerTest, testNoConfig) {
     std::set<autopas::DataLayoutOption> dl = {};
     std::set<autopas::Newton3Option> n3 = {};
     auto tuningStrategy = std::make_unique<autopas::FullSearch>(co, csf, tr, le, dl, n3);
-    autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.05, 20, 0, 64, std::move(tuningStrategy), 0.3,
-                                           0.0, autopas::SelectorStrategyOption::fastestAbs, 1000, 3);
+    autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.05, 0, 64, std::move(tuningStrategy), 0.3,
+                                           0.0, autopas::SelectorStrategyOption::fastestAbs, 1000, 3,20);
   };
 
   EXPECT_THROW(exp2(), autopas::utils::ExceptionHandler::AutoPasException) << "Constructor which generates configs";
@@ -449,8 +449,8 @@ TEST_F(AutoTunerTest, testOneConfig) {
   auto configsList = {_confLc_c08};
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
   size_t maxSamples = 3;
-  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 0.05, 20, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
-                                     autopas::SelectorStrategyOption::fastestAbs, 1000, maxSamples);
+  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 0.05, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+                                     autopas::SelectorStrategyOption::fastestAbs, 1000, maxSamples, 20);
 
   EXPECT_EQ(_confLc_c08, tuner.getCurrentConfig());
 
@@ -488,8 +488,8 @@ TEST_F(AutoTunerTest, testConfigSecondInvalid) {
 
   auto configsList = {confNoN3, confN3};
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
-  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 0.05, 20, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
-                                     autopas::SelectorStrategyOption::fastestAbs, 1000, 3);
+  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 0.05, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+                                     autopas::SelectorStrategyOption::fastestAbs, 1000, 3, 20);
 
   EXPECT_EQ(confNoN3, tuner.getCurrentConfig());
 
@@ -524,8 +524,8 @@ TEST_F(AutoTunerTest, testLastConfigThrownOut) {
 
   auto configsList = {confN3, confNoN3};
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
-  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 0.05, 20, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
-                                     autopas::SelectorStrategyOption::fastestAbs, 1000, 3);
+  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 0.05, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+                                     autopas::SelectorStrategyOption::fastestAbs, 1000, 3,20);
 
   EXPECT_EQ(confN3, tuner.getCurrentConfig());
 
@@ -560,8 +560,8 @@ TEST_F(AutoTunerTest, testBuildNotBuildTimeEstimation) {
 
   auto configsList = {confA, confB};
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
-  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 0.05, rebuildFrequency, 0, 64, std::move(tuningStrategy),
-                                     0.3, 0.0, autopas::SelectorStrategyOption::fastestAbs, 1000, 3);
+  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 0.05, 0, 64, std::move(tuningStrategy),
+                                     0.3, 0.0, autopas::SelectorStrategyOption::fastestAbs, 1000, 3, rebuildFrequency);
 
   MockFunctor<Molecule> functor;
   EXPECT_CALL(functor, isRelevantForTuning()).WillRepeatedly(::testing::Return(true));

--- a/tests/testAutopas/tests/selectors/AutoTunerTest.cpp
+++ b/tests/testAutopas/tests/selectors/AutoTunerTest.cpp
@@ -24,7 +24,8 @@ TEST_F(AutoTunerTest, testAllConfigurations) {
   // bBoxMax[1] = autopas::autopas_get_max_threads() * 2;
   const double cutoff = 1;
   const double cellSizeFactor = 1;
-  const double verletSkin = 0;
+  const double verletSkinPerTimestep = 0;
+  const unsigned verletRebuildFrequency =2;
   const unsigned int verletClusterSize = 64;
   const double mpiTuningMaxDifferenceForBucket = 0.3;
   const double mpiTuningWeightForMaxDensity = 0.0;
@@ -47,7 +48,7 @@ TEST_F(AutoTunerTest, testAllConfigurations) {
       autopas::ContainerOption::getAllOptions(), std::set<double>({cellSizeFactor}),
       autopas::TraversalOption::getAllOptions(), autopas::LoadEstimatorOption::getAllOptions(),
       autopas::DataLayoutOption::getAllOptions(), autopas::Newton3Option::getAllOptions());
-  autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkin, verletClusterSize,
+  autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkinPerTimestep,verletRebuildFrequency, verletClusterSize,
                                          std::move(tuningStrategy), mpiTuningMaxDifferenceForBucket,
                                          mpiTuningWeightForMaxDensity, autopas::SelectorStrategyOption::fastestAbs, 100,
                                          maxSamples, 20);
@@ -300,7 +301,8 @@ TEST_F(AutoTunerTest, testWillRebuildDL) {
 TEST_F(AutoTunerTest, testForceRetuneBetweenPhases) {
   std::array<double, 3> bBoxMin = {0, 0, 0}, bBoxMax = {2, 4, 2};
   const double cutoff = 1;
-  const double verletSkin = 0;
+  const double verletSkinPerTimestep = 0;
+  const unsigned int verletRebuildFrequency =2;
   const unsigned int verletClusterSize = 4;
   const double mpiTuningMaxDifferenceForBucket = 0.3;
   const double mpiTuningWeightForMaxDensity = 0.0;
@@ -309,7 +311,7 @@ TEST_F(AutoTunerTest, testForceRetuneBetweenPhases) {
   auto configsList = {_confLc_c01, _confLc_c04, _confLc_c08};
 
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
-  autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkin, verletClusterSize,
+  autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkinPerTimestep,verletRebuildFrequency, verletClusterSize,
                                          std::move(tuningStrategy), mpiTuningMaxDifferenceForBucket,
                                          mpiTuningWeightForMaxDensity, autopas::SelectorStrategyOption::fastestAbs, 100,
                                          maxSamples, 20);
@@ -348,7 +350,8 @@ TEST_F(AutoTunerTest, testForceRetuneInPhase) {
   std::array<double, 3> bBoxMin = {0, 0, 0}, bBoxMax = {2, 4, 2};
   const double cutoff = 1;
   const double cellSizeFactor = 1;
-  const double verletSkin = 0;
+  const double verletSkinPerTimestep = 0;
+  const unsigned int verletRebuildFrequency=2;
   const unsigned int verletClusterSize = 4;
   const double mpiTuningMaxDifferenceForBucket = 0.3;
   const double mpiTuningWeightForMaxDensity = 0.0;
@@ -367,7 +370,7 @@ TEST_F(AutoTunerTest, testForceRetuneInPhase) {
   auto configsList = {confLc_c01, confLc_c04, confLc_c08};
 
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
-  autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkin, verletClusterSize,
+  autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkinPerTimestep, verletRebuildFrequency,verletClusterSize,
                                          std::move(tuningStrategy), mpiTuningMaxDifferenceForBucket,
                                          mpiTuningWeightForMaxDensity, autopas::SelectorStrategyOption::fastestAbs, 100,
                                          maxSamples, 20);

--- a/tests/testAutopas/tests/selectors/AutoTunerTest.cpp
+++ b/tests/testAutopas/tests/selectors/AutoTunerTest.cpp
@@ -167,7 +167,7 @@ TEST_F(AutoTunerTest, testWillRebuildDDL) {
                   autopas::LoadEstimatorOption::none, autopas::DataLayoutOption::aos, autopas::Newton3Option::disabled);
 
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configs);
-  autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.05, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+  autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 1, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
                                          autopas::SelectorStrategyOption::fastestAbs, 1000, 2, 20);
 
   EXPECT_EQ(*(configs.begin()), autoTuner.getCurrentConfig());
@@ -221,7 +221,7 @@ TEST_F(AutoTunerTest, testWillRebuildDDLOneConfigKicked) {
                   autopas::LoadEstimatorOption::none, autopas::DataLayoutOption::aos, autopas::Newton3Option::enabled);
 
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configs);
-  autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.05, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+  autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 1, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
                                          autopas::SelectorStrategyOption::fastestAbs, 1000, 2, 20);
 
   EXPECT_EQ(*(configs.begin()), autoTuner.getCurrentConfig());
@@ -263,7 +263,7 @@ TEST_F(AutoTunerTest, testWillRebuildDL) {
                   autopas::LoadEstimatorOption::none, autopas::DataLayoutOption::aos, autopas::Newton3Option::disabled);
 
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configs);
-  autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.05, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+  autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 1, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
                                          autopas::SelectorStrategyOption::fastestAbs, 1000, 2, 20);
 
   EXPECT_EQ(*(configs.begin()), autoTuner.getCurrentConfig());
@@ -435,8 +435,8 @@ TEST_F(AutoTunerTest, testNoConfig) {
     std::set<autopas::DataLayoutOption> dl = {};
     std::set<autopas::Newton3Option> n3 = {};
     auto tuningStrategy = std::make_unique<autopas::FullSearch>(co, csf, tr, le, dl, n3);
-    autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.05, 0, 64, std::move(tuningStrategy), 0.3,
-                                           0.0, autopas::SelectorStrategyOption::fastestAbs, 1000, 3,20);
+    autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 1, 0, 64, std::move(tuningStrategy), 0.3,
+                                           0.0, autopas::SelectorStrategyOption::fastestAbs, 1000, 3, 20);
   };
 
   EXPECT_THROW(exp2(), autopas::utils::ExceptionHandler::AutoPasException) << "Constructor which generates configs";
@@ -449,7 +449,7 @@ TEST_F(AutoTunerTest, testOneConfig) {
   auto configsList = {_confLc_c08};
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
   size_t maxSamples = 3;
-  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 0.05, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 1, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
                                      autopas::SelectorStrategyOption::fastestAbs, 1000, maxSamples, 20);
 
   EXPECT_EQ(_confLc_c08, tuner.getCurrentConfig());
@@ -488,7 +488,7 @@ TEST_F(AutoTunerTest, testConfigSecondInvalid) {
 
   auto configsList = {confNoN3, confN3};
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
-  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 0.05, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 1, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
                                      autopas::SelectorStrategyOption::fastestAbs, 1000, 3, 20);
 
   EXPECT_EQ(confNoN3, tuner.getCurrentConfig());
@@ -524,7 +524,7 @@ TEST_F(AutoTunerTest, testLastConfigThrownOut) {
 
   auto configsList = {confN3, confNoN3};
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
-  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 0.05, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 1, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
                                      autopas::SelectorStrategyOption::fastestAbs, 1000, 3,20);
 
   EXPECT_EQ(confN3, tuner.getCurrentConfig());
@@ -560,7 +560,7 @@ TEST_F(AutoTunerTest, testBuildNotBuildTimeEstimation) {
 
   auto configsList = {confA, confB};
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
-  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 0.05, 0, 64, std::move(tuningStrategy),
+  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 1, 0, 64, std::move(tuningStrategy),
                                      0.3, 0.0, autopas::SelectorStrategyOption::fastestAbs, 1000, 3, rebuildFrequency);
 
   MockFunctor<Molecule> functor;

--- a/tests/testAutopas/tests/selectors/AutoTunerTest.cpp
+++ b/tests/testAutopas/tests/selectors/AutoTunerTest.cpp
@@ -25,7 +25,7 @@ TEST_F(AutoTunerTest, testAllConfigurations) {
   const double cutoff = 1;
   const double cellSizeFactor = 1;
   const double verletSkinPerTimestep = 0;
-  const unsigned verletRebuildFrequency = 2;
+  const unsigned verletRebuildFrequency = 20;
   const unsigned int verletClusterSize = 64;
   const double mpiTuningMaxDifferenceForBucket = 0.3;
   const double mpiTuningWeightForMaxDensity = 0.0;
@@ -51,7 +51,7 @@ TEST_F(AutoTunerTest, testAllConfigurations) {
   autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkinPerTimestep, verletRebuildFrequency,
                                          verletClusterSize, std::move(tuningStrategy), mpiTuningMaxDifferenceForBucket,
                                          mpiTuningWeightForMaxDensity, autopas::SelectorStrategyOption::fastestAbs, 100,
-                                         maxSamples, 20);
+                                         maxSamples);
 
   autopas::Logger::get()->set_level(autopas::Logger::LogLevel::off);
   //  autopas::Logger::get()->set_level(autopas::Logger::LogLevel::debug);
@@ -167,8 +167,8 @@ TEST_F(AutoTunerTest, testWillRebuildDDL) {
                   autopas::LoadEstimatorOption::none, autopas::DataLayoutOption::aos, autopas::Newton3Option::disabled);
 
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configs);
-  autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.1, 10, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
-                                         autopas::SelectorStrategyOption::fastestAbs, 1000, 2, 20);
+  autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.05, 20, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+                                         autopas::SelectorStrategyOption::fastestAbs, 1000, 2);
 
   EXPECT_EQ(*(configs.begin()), autoTuner.getCurrentConfig());
 
@@ -221,8 +221,8 @@ TEST_F(AutoTunerTest, testWillRebuildDDLOneConfigKicked) {
                   autopas::LoadEstimatorOption::none, autopas::DataLayoutOption::aos, autopas::Newton3Option::enabled);
 
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configs);
-  autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.1, 10, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
-                                         autopas::SelectorStrategyOption::fastestAbs, 1000, 2, 20);
+  autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.05, 20, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+                                         autopas::SelectorStrategyOption::fastestAbs, 1000, 2);
 
   EXPECT_EQ(*(configs.begin()), autoTuner.getCurrentConfig());
 
@@ -263,8 +263,8 @@ TEST_F(AutoTunerTest, testWillRebuildDL) {
                   autopas::LoadEstimatorOption::none, autopas::DataLayoutOption::aos, autopas::Newton3Option::disabled);
 
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configs);
-  autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.1, 10, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
-                                         autopas::SelectorStrategyOption::fastestAbs, 1000, 2, 20);
+  autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.05, 20, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+                                         autopas::SelectorStrategyOption::fastestAbs, 1000, 2);
 
   EXPECT_EQ(*(configs.begin()), autoTuner.getCurrentConfig());
 
@@ -302,7 +302,7 @@ TEST_F(AutoTunerTest, testForceRetuneBetweenPhases) {
   std::array<double, 3> bBoxMin = {0, 0, 0}, bBoxMax = {2, 4, 2};
   const double cutoff = 1;
   const double verletSkinPerTimestep = 0;
-  const unsigned int verletRebuildFrequency = 2;
+  const unsigned int verletRebuildFrequency = 20;
   const unsigned int verletClusterSize = 4;
   const double mpiTuningMaxDifferenceForBucket = 0.3;
   const double mpiTuningWeightForMaxDensity = 0.0;
@@ -314,7 +314,7 @@ TEST_F(AutoTunerTest, testForceRetuneBetweenPhases) {
   autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkinPerTimestep, verletRebuildFrequency,
                                          verletClusterSize, std::move(tuningStrategy), mpiTuningMaxDifferenceForBucket,
                                          mpiTuningWeightForMaxDensity, autopas::SelectorStrategyOption::fastestAbs, 100,
-                                         maxSamples, 20);
+                                         maxSamples);
 
   size_t numExpectedTuningIterations = configsList.size() * maxSamples;
   MockFunctor<Molecule> functor;
@@ -351,7 +351,7 @@ TEST_F(AutoTunerTest, testForceRetuneInPhase) {
   const double cutoff = 1;
   const double cellSizeFactor = 1;
   const double verletSkinPerTimestep = 0;
-  const unsigned int verletRebuildFrequency = 2;
+  const unsigned int verletRebuildFrequency = 20;
   const unsigned int verletClusterSize = 4;
   const double mpiTuningMaxDifferenceForBucket = 0.3;
   const double mpiTuningWeightForMaxDensity = 0.0;
@@ -373,7 +373,7 @@ TEST_F(AutoTunerTest, testForceRetuneInPhase) {
   autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkinPerTimestep, verletRebuildFrequency,
                                          verletClusterSize, std::move(tuningStrategy), mpiTuningMaxDifferenceForBucket,
                                          mpiTuningWeightForMaxDensity, autopas::SelectorStrategyOption::fastestAbs, 100,
-                                         maxSamples, 20);
+                                         maxSamples);
 
   size_t numExpectedTuningIterations = configsList.size() * maxSamples;
   MockFunctor<Molecule> functor;
@@ -420,8 +420,8 @@ TEST_F(AutoTunerTest, testNoConfig) {
   auto exp1 = []() {
     std::set<autopas::Configuration> configsList = {};
     auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
-    autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.1, 10, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
-                                           autopas::SelectorStrategyOption::fastestAbs, 1000, 3, 20);
+    autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.05, 20, 0, 64, std::move(tuningStrategy), 0.3,
+                                           0.0, autopas::SelectorStrategyOption::fastestAbs, 1000, 3);
   };
 
   EXPECT_THROW(exp1(), autopas::utils::ExceptionHandler::AutoPasException) << "Constructor with given configs";
@@ -435,8 +435,8 @@ TEST_F(AutoTunerTest, testNoConfig) {
     std::set<autopas::DataLayoutOption> dl = {};
     std::set<autopas::Newton3Option> n3 = {};
     auto tuningStrategy = std::make_unique<autopas::FullSearch>(co, csf, tr, le, dl, n3);
-    autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.1, 10, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
-                                           autopas::SelectorStrategyOption::fastestAbs, 1000, 3, 20);
+    autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.05, 20, 0, 64, std::move(tuningStrategy), 0.3,
+                                           0.0, autopas::SelectorStrategyOption::fastestAbs, 1000, 3);
   };
 
   EXPECT_THROW(exp2(), autopas::utils::ExceptionHandler::AutoPasException) << "Constructor which generates configs";
@@ -449,8 +449,8 @@ TEST_F(AutoTunerTest, testOneConfig) {
   auto configsList = {_confLc_c08};
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
   size_t maxSamples = 3;
-  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 0.1, 10, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
-                                     autopas::SelectorStrategyOption::fastestAbs, 1000, maxSamples, 20);
+  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 0.05, 20, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+                                     autopas::SelectorStrategyOption::fastestAbs, 1000, maxSamples);
 
   EXPECT_EQ(_confLc_c08, tuner.getCurrentConfig());
 
@@ -488,8 +488,8 @@ TEST_F(AutoTunerTest, testConfigSecondInvalid) {
 
   auto configsList = {confNoN3, confN3};
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
-  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 0.1, 10, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
-                                     autopas::SelectorStrategyOption::fastestAbs, 1000, 3, 20);
+  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 0.05, 20, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+                                     autopas::SelectorStrategyOption::fastestAbs, 1000, 3);
 
   EXPECT_EQ(confNoN3, tuner.getCurrentConfig());
 
@@ -524,8 +524,8 @@ TEST_F(AutoTunerTest, testLastConfigThrownOut) {
 
   auto configsList = {confN3, confNoN3};
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
-  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 0.1, 10, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
-                                     autopas::SelectorStrategyOption::fastestAbs, 1000, 3, 20);
+  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 0.05, 20, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+                                     autopas::SelectorStrategyOption::fastestAbs, 1000, 3);
 
   EXPECT_EQ(confN3, tuner.getCurrentConfig());
 
@@ -560,8 +560,8 @@ TEST_F(AutoTunerTest, testBuildNotBuildTimeEstimation) {
 
   auto configsList = {confA, confB};
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
-  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 0.1, 10, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
-                                     autopas::SelectorStrategyOption::fastestAbs, 1000, 3, rebuildFrequency);
+  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 0.05, rebuildFrequency, 0, 64, std::move(tuningStrategy),
+                                     0.3, 0.0, autopas::SelectorStrategyOption::fastestAbs, 1000, 3);
 
   MockFunctor<Molecule> functor;
   EXPECT_CALL(functor, isRelevantForTuning()).WillRepeatedly(::testing::Return(true));

--- a/tests/testAutopas/tests/selectors/AutoTunerTest.cpp
+++ b/tests/testAutopas/tests/selectors/AutoTunerTest.cpp
@@ -25,7 +25,7 @@ TEST_F(AutoTunerTest, testAllConfigurations) {
   const double cutoff = 1;
   const double cellSizeFactor = 1;
   const double verletSkinPerTimestep = 0;
-  const unsigned verletRebuildFrequency =2;
+  const unsigned verletRebuildFrequency = 2;
   const unsigned int verletClusterSize = 64;
   const double mpiTuningMaxDifferenceForBucket = 0.3;
   const double mpiTuningWeightForMaxDensity = 0.0;
@@ -48,8 +48,8 @@ TEST_F(AutoTunerTest, testAllConfigurations) {
       autopas::ContainerOption::getAllOptions(), std::set<double>({cellSizeFactor}),
       autopas::TraversalOption::getAllOptions(), autopas::LoadEstimatorOption::getAllOptions(),
       autopas::DataLayoutOption::getAllOptions(), autopas::Newton3Option::getAllOptions());
-  autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkinPerTimestep,verletRebuildFrequency, verletClusterSize,
-                                         std::move(tuningStrategy), mpiTuningMaxDifferenceForBucket,
+  autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkinPerTimestep, verletRebuildFrequency,
+                                         verletClusterSize, std::move(tuningStrategy), mpiTuningMaxDifferenceForBucket,
                                          mpiTuningWeightForMaxDensity, autopas::SelectorStrategyOption::fastestAbs, 100,
                                          maxSamples, 20);
 
@@ -302,7 +302,7 @@ TEST_F(AutoTunerTest, testForceRetuneBetweenPhases) {
   std::array<double, 3> bBoxMin = {0, 0, 0}, bBoxMax = {2, 4, 2};
   const double cutoff = 1;
   const double verletSkinPerTimestep = 0;
-  const unsigned int verletRebuildFrequency =2;
+  const unsigned int verletRebuildFrequency = 2;
   const unsigned int verletClusterSize = 4;
   const double mpiTuningMaxDifferenceForBucket = 0.3;
   const double mpiTuningWeightForMaxDensity = 0.0;
@@ -311,8 +311,8 @@ TEST_F(AutoTunerTest, testForceRetuneBetweenPhases) {
   auto configsList = {_confLc_c01, _confLc_c04, _confLc_c08};
 
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
-  autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkinPerTimestep,verletRebuildFrequency, verletClusterSize,
-                                         std::move(tuningStrategy), mpiTuningMaxDifferenceForBucket,
+  autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkinPerTimestep, verletRebuildFrequency,
+                                         verletClusterSize, std::move(tuningStrategy), mpiTuningMaxDifferenceForBucket,
                                          mpiTuningWeightForMaxDensity, autopas::SelectorStrategyOption::fastestAbs, 100,
                                          maxSamples, 20);
 
@@ -351,7 +351,7 @@ TEST_F(AutoTunerTest, testForceRetuneInPhase) {
   const double cutoff = 1;
   const double cellSizeFactor = 1;
   const double verletSkinPerTimestep = 0;
-  const unsigned int verletRebuildFrequency=2;
+  const unsigned int verletRebuildFrequency = 2;
   const unsigned int verletClusterSize = 4;
   const double mpiTuningMaxDifferenceForBucket = 0.3;
   const double mpiTuningWeightForMaxDensity = 0.0;
@@ -370,8 +370,8 @@ TEST_F(AutoTunerTest, testForceRetuneInPhase) {
   auto configsList = {confLc_c01, confLc_c04, confLc_c08};
 
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
-  autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkinPerTimestep, verletRebuildFrequency,verletClusterSize,
-                                         std::move(tuningStrategy), mpiTuningMaxDifferenceForBucket,
+  autopas::AutoTuner<Molecule> autoTuner(bBoxMin, bBoxMax, cutoff, verletSkinPerTimestep, verletRebuildFrequency,
+                                         verletClusterSize, std::move(tuningStrategy), mpiTuningMaxDifferenceForBucket,
                                          mpiTuningWeightForMaxDensity, autopas::SelectorStrategyOption::fastestAbs, 100,
                                          maxSamples, 20);
 

--- a/tests/testAutopas/tests/selectors/AutoTunerTest.cpp
+++ b/tests/testAutopas/tests/selectors/AutoTunerTest.cpp
@@ -167,7 +167,7 @@ TEST_F(AutoTunerTest, testWillRebuildDDL) {
                   autopas::LoadEstimatorOption::none, autopas::DataLayoutOption::aos, autopas::Newton3Option::disabled);
 
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configs);
-  autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 1, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+  autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.1, 10, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
                                          autopas::SelectorStrategyOption::fastestAbs, 1000, 2, 20);
 
   EXPECT_EQ(*(configs.begin()), autoTuner.getCurrentConfig());
@@ -221,7 +221,7 @@ TEST_F(AutoTunerTest, testWillRebuildDDLOneConfigKicked) {
                   autopas::LoadEstimatorOption::none, autopas::DataLayoutOption::aos, autopas::Newton3Option::enabled);
 
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configs);
-  autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 1, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+  autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.1, 10, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
                                          autopas::SelectorStrategyOption::fastestAbs, 1000, 2, 20);
 
   EXPECT_EQ(*(configs.begin()), autoTuner.getCurrentConfig());
@@ -263,7 +263,7 @@ TEST_F(AutoTunerTest, testWillRebuildDL) {
                   autopas::LoadEstimatorOption::none, autopas::DataLayoutOption::aos, autopas::Newton3Option::disabled);
 
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configs);
-  autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 1, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+  autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.1, 10, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
                                          autopas::SelectorStrategyOption::fastestAbs, 1000, 2, 20);
 
   EXPECT_EQ(*(configs.begin()), autoTuner.getCurrentConfig());
@@ -420,7 +420,7 @@ TEST_F(AutoTunerTest, testNoConfig) {
   auto exp1 = []() {
     std::set<autopas::Configuration> configsList = {};
     auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
-    autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 1, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+    autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.1, 10, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
                                            autopas::SelectorStrategyOption::fastestAbs, 1000, 3, 20);
   };
 
@@ -435,7 +435,7 @@ TEST_F(AutoTunerTest, testNoConfig) {
     std::set<autopas::DataLayoutOption> dl = {};
     std::set<autopas::Newton3Option> n3 = {};
     auto tuningStrategy = std::make_unique<autopas::FullSearch>(co, csf, tr, le, dl, n3);
-    autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 1, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+    autopas::AutoTuner<Molecule> autoTuner({0, 0, 0}, {10, 10, 10}, 0.1, 10, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
                                            autopas::SelectorStrategyOption::fastestAbs, 1000, 3, 20);
   };
 
@@ -449,7 +449,7 @@ TEST_F(AutoTunerTest, testOneConfig) {
   auto configsList = {_confLc_c08};
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
   size_t maxSamples = 3;
-  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 1, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 0.1, 10, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
                                      autopas::SelectorStrategyOption::fastestAbs, 1000, maxSamples, 20);
 
   EXPECT_EQ(_confLc_c08, tuner.getCurrentConfig());
@@ -488,7 +488,7 @@ TEST_F(AutoTunerTest, testConfigSecondInvalid) {
 
   auto configsList = {confNoN3, confN3};
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
-  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 1, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 0.1, 10, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
                                      autopas::SelectorStrategyOption::fastestAbs, 1000, 3, 20);
 
   EXPECT_EQ(confNoN3, tuner.getCurrentConfig());
@@ -524,7 +524,7 @@ TEST_F(AutoTunerTest, testLastConfigThrownOut) {
 
   auto configsList = {confN3, confNoN3};
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
-  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 1, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 0.1, 10, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
                                      autopas::SelectorStrategyOption::fastestAbs, 1000, 3, 20);
 
   EXPECT_EQ(confN3, tuner.getCurrentConfig());
@@ -560,7 +560,7 @@ TEST_F(AutoTunerTest, testBuildNotBuildTimeEstimation) {
 
   auto configsList = {confA, confB};
   auto tuningStrategy = std::make_unique<autopas::FullSearch>(configsList);
-  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 1, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
+  autopas::AutoTuner<Molecule> tuner({0, 0, 0}, {10, 10, 10}, 0.1, 10, 0, 64, std::move(tuningStrategy), 0.3, 0.0,
                                      autopas::SelectorStrategyOption::fastestAbs, 1000, 3, rebuildFrequency);
 
   MockFunctor<Molecule> functor;

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
@@ -8,7 +8,7 @@
 
 TEST_F(ContainerSelectorTest, testSelectAndGetCurrentContainer) {
   autopas::ContainerSelector<Particle> containerSelector(bBoxMin, bBoxMax, cutoff);
-  autopas::ContainerSelectorInfo containerInfo(cellSizeFactor, verletSkin, 64, autopas::LoadEstimatorOption::none);
+  autopas::ContainerSelectorInfo containerInfo(cellSizeFactor, verletSkinPerTimestep,verletRebuildFrequency, 64, autopas::LoadEstimatorOption::none);
 
   // expect an exception if nothing is selected yet
   EXPECT_THROW((containerSelector.getCurrentContainer()), autopas::utils::ExceptionHandler::AutoPasException);

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTest.cpp
@@ -8,7 +8,8 @@
 
 TEST_F(ContainerSelectorTest, testSelectAndGetCurrentContainer) {
   autopas::ContainerSelector<Particle> containerSelector(bBoxMin, bBoxMax, cutoff);
-  autopas::ContainerSelectorInfo containerInfo(cellSizeFactor, verletSkinPerTimestep,verletRebuildFrequency, 64, autopas::LoadEstimatorOption::none);
+  autopas::ContainerSelectorInfo containerInfo(cellSizeFactor, verletSkinPerTimestep, verletRebuildFrequency, 64,
+                                               autopas::LoadEstimatorOption::none);
 
   // expect an exception if nothing is selected yet
   EXPECT_THROW((containerSelector.getCurrentContainer()), autopas::utils::ExceptionHandler::AutoPasException);

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTest.h
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTest.h
@@ -18,5 +18,5 @@ class ContainerSelectorTest : public AutoPasTestBase {
   const double cutoff = 1;
   const double cellSizeFactor = 1;
   const double verletSkinPerTimestep = 0.2;
-  const unsigned int verletRebuildFrequency =2;
+  const unsigned int verletRebuildFrequency = 2;
 };

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTest.h
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTest.h
@@ -17,6 +17,6 @@ class ContainerSelectorTest : public AutoPasTestBase {
   const std::array<double, 3> bBoxMin = {0, 0, 0}, bBoxMax = {10, 10, 10};
   const double cutoff = 1;
   const double cellSizeFactor = 1;
-  const double verletSkinPerTimestep = 0.2;
+  const double verletSkinPerTimestep = 0.05;
   const unsigned int verletRebuildFrequency = 2;
 };

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTest.h
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTest.h
@@ -17,5 +17,6 @@ class ContainerSelectorTest : public AutoPasTestBase {
   const std::array<double, 3> bBoxMin = {0, 0, 0}, bBoxMax = {10, 10, 10};
   const double cutoff = 1;
   const double cellSizeFactor = 1;
-  const double verletSkin = 0.1;
+  const double verletSkinPerTimestep = 0.2;
+  const unsigned int verletRebuildFrequency =2;
 };

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTestFromTo.cpp
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTestFromTo.cpp
@@ -44,7 +44,7 @@ TEST_P(ContainerSelectorTestFromTo, testContainerConversion) {
   const auto &[from, to] = GetParam();
 
   autopas::ContainerSelector<Particle> containerSelector(bBoxMin, bBoxMax, cutoff);
-  autopas::ContainerSelectorInfo containerInfo(cellSizeFactor, verletSkin, 64, autopas::LoadEstimatorOption::none);
+  autopas::ContainerSelectorInfo containerInfo(cellSizeFactor, verletSkinPerTimestep,verletRebuildFrequency, 64, autopas::LoadEstimatorOption::none);
 
   // select container from which we want to convert from
   containerSelector.selectContainer(from, containerInfo);
@@ -53,8 +53,8 @@ TEST_P(ContainerSelectorTestFromTo, testContainerConversion) {
   {
     auto container = containerSelector.getCurrentContainer();
     auto getPossible1DPositions = [&](double min, double max) -> auto {
-      return std::array<double, 6>{min - cutoff - verletSkin,       min - cutoff, min, max, max + cutoff - 1e-3,
-                                   max + cutoff + verletSkin - 1e-3};
+      return std::array<double, 6>{min - cutoff - verletSkinPerTimestep*verletRebuildFrequency,       min - cutoff, min, max, max + cutoff - 1e-3,
+                                   max + cutoff + verletSkinPerTimestep*verletRebuildFrequency - 1e-3};
     };
     size_t id = 0;
 

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTestFromTo.cpp
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTestFromTo.cpp
@@ -44,7 +44,8 @@ TEST_P(ContainerSelectorTestFromTo, testContainerConversion) {
   const auto &[from, to] = GetParam();
 
   autopas::ContainerSelector<Particle> containerSelector(bBoxMin, bBoxMax, cutoff);
-  autopas::ContainerSelectorInfo containerInfo(cellSizeFactor, verletSkinPerTimestep,verletRebuildFrequency, 64, autopas::LoadEstimatorOption::none);
+  autopas::ContainerSelectorInfo containerInfo(cellSizeFactor, verletSkinPerTimestep, verletRebuildFrequency, 64,
+                                               autopas::LoadEstimatorOption::none);
 
   // select container from which we want to convert from
   containerSelector.selectContainer(from, containerInfo);
@@ -53,8 +54,12 @@ TEST_P(ContainerSelectorTestFromTo, testContainerConversion) {
   {
     auto container = containerSelector.getCurrentContainer();
     auto getPossible1DPositions = [&](double min, double max) -> auto {
-      return std::array<double, 6>{min - cutoff - verletSkinPerTimestep*verletRebuildFrequency,       min - cutoff, min, max, max + cutoff - 1e-3,
-                                   max + cutoff + verletSkinPerTimestep*verletRebuildFrequency - 1e-3};
+      return std::array<double, 6>{min - cutoff - verletSkinPerTimestep * verletRebuildFrequency,
+                                   min - cutoff,
+                                   min,
+                                   max,
+                                   max + cutoff - 1e-3,
+                                   max + cutoff + verletSkinPerTimestep * verletRebuildFrequency - 1e-3};
     };
     size_t id = 0;
 

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTestFromTo.h
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTestFromTo.h
@@ -32,6 +32,6 @@ class ContainerSelectorTestFromTo
   const std::array<double, 3> bBoxMin = {0, 0, 0}, bBoxMax = {10, 10, 10};
   const double cutoff = 1;
   const double cellSizeFactor = 1;
-  const double verletSkinPerTimestep = 0.2;
+  const double verletSkinPerTimestep = 0.05;
   const unsigned int verletRebuildFrequency = 2;
 };

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTestFromTo.h
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTestFromTo.h
@@ -33,5 +33,5 @@ class ContainerSelectorTestFromTo
   const double cutoff = 1;
   const double cellSizeFactor = 1;
   const double verletSkinPerTimestep = 0.2;
-  const unsigned int verletRebuildFrequency =2;
+  const unsigned int verletRebuildFrequency = 2;
 };

--- a/tests/testAutopas/tests/selectors/ContainerSelectorTestFromTo.h
+++ b/tests/testAutopas/tests/selectors/ContainerSelectorTestFromTo.h
@@ -32,5 +32,6 @@ class ContainerSelectorTestFromTo
   const std::array<double, 3> bBoxMin = {0, 0, 0}, bBoxMax = {10, 10, 10};
   const double cutoff = 1;
   const double cellSizeFactor = 1;
-  const double verletSkin = 0.1;
+  const double verletSkinPerTimestep = 0.2;
+  const unsigned int verletRebuildFrequency =2;
 };

--- a/tests/testAutopas/tests/sph/SPHTest.cpp
+++ b/tests/testAutopas/tests/sph/SPHTest.cpp
@@ -699,8 +699,8 @@ void testVerLetVsLC(FunctorType &fnctr, InitType init, CheckType check, autopas:
   double cutoff = 1.;
   using autopas::sph::SPHParticle;
 
-  autopas::VerletLists<SPHParticle> verletLists({0., 0., 0.}, {5., 5., 5.}, cutoff, 0.5);
-  autopas::LinkedCells<autopas::sph::SPHParticle> linkedCells({0., 0., 0.}, {5., 5., 5.}, cutoff, 0.5, 1.);
+  autopas::VerletLists<SPHParticle> verletLists({0., 0., 0.}, {5., 5., 5.}, cutoff, 0.5, 1);
+  autopas::LinkedCells<autopas::sph::SPHParticle> linkedCells({0., 0., 0.}, {5., 5., 5.}, cutoff, 0.5, 1., 1);
 
   autopas::sph::SPHParticle defaultSPHParticle({0., 0., 0.}, {1., .5, .25}, 0, 2.5,
                                                cutoff / autopas::sph::SPHKernels::getKernelSupportRadius(), 0.6);


### PR DESCRIPTION
# Description

Replacement of variable `verletSkin` with `verletSkinPerTimestep*rebuildFrequency`. The user defines `verletSkinPerTimestep` instead of `verletSkin` when creating an instance of `AutoPas`. The purpose of this is to make future changes to the Verlet calculations easier.

## Resolved Issues

- Only partially resolves issue #691

# How Has This Been Tested?

- [x] Code was recompiled. No additional tests were performed.
- [x] CI