### PR TITLE
Avoid Compiling Uninteresting Functors

### DIFF
--- a/.github/workflows/TestSuites.yaml
+++ b/.github/workflows/TestSuites.yaml
@@ -98,6 +98,10 @@ jobs:
             -DAUTOPAS_ENABLE_THREAD_SANITIZER=${{ matrix.config[7] }} \
             -DAUTOPAS_INTERNODE_TUNING=${UseMPI} \
             -DMD_FLEXIBLE_USE_MPI=${UseMPI} \
+            -DMD_FLEXIBLE_FUNCTOR_AUTOVEC=ON \
+            -DMD_FLEXIBLE_FUNCTOR_AUTOVEC_GLOBALS=OFF \
+            -DMD_FLEXIBLE_FUNCTOR_AUTOVEC_AVX=ON \
+            -DMD_FLEXIBLE_FUNCTOR_AUTOVEC_SVE=OFF \
             -DAUTOPAS_ENABLE_ALLLBL=${UseMPI} \
             ..
           entrypoint.sh cmake --build . --parallel 1 

--- a/examples/md-flexible/CMakeLists.txt
+++ b/examples/md-flexible/CMakeLists.txt
@@ -16,6 +16,20 @@ option(MD_FLEXIBLE_USE_MPI "Enable MPI parallelism for md-flexible." OFF)
 
 target_link_libraries(md-flexible PUBLIC autopas autopasTools yaml-cpp  ${ALL_LIB} $<$<BOOL:${MD_FLEXIBLE_USE_MPI}>:MPI::MPI_CXX>)
 
+option(MD_FLEXIBLE_FUNCTOR_AUTOVEC "Compile AutoVec Functor without calculation of global values." OFF)
+option(MD_FLEXIBLE_FUNCTOR_AUTOVEC_GLOBALS "Compile AutoVec Functor with calculation of global values." OFF)
+option(MD_FLEXIBLE_FUNCTOR_AVX "If instruction set is available, compile AVX Functor without calculation of global values." ON)
+option(MD_FLEXIBLE_FUNCTOR_SVE "If instruction set is available, compile SVE Functor without calculation of global values." ON)
+
+target_compile_definitions(
+        md-flexible
+        PUBLIC
+        $<$<BOOL:${MD_FLEXIBLE_FUNCTOR_AUTOVEC}>:MD_FLEXIBLE_FUNCTOR_AUTOVEC>
+        $<$<BOOL:${MD_FLEXIBLE_FUNCTOR_AUTOVEC_GLOBALS}>:MD_FLEXIBLE_FUNCTOR_AUTOVEC_GLOBALS>
+        $<$<BOOL:${MD_FLEXIBLE_FUNCTOR_AVX}>:MD_FLEXIBLE_FUNCTOR_AVX>
+        $<$<BOOL:${MD_FLEXIBLE_FUNCTOR_SVE}>:MD_FLEXIBLE_FUNCTOR_SVE>
+)
+
 # --- copy script files to build dir ---
 file(
         GLOB_RECURSE SCRIPTS

--- a/examples/md-flexible/src/Simulation.h
+++ b/examples/md-flexible/src/Simulation.h
@@ -313,4 +313,17 @@ class Simulation {
    */
   [[maybe_unused]] void checkNumParticles(size_t expectedNumParticlesGlobal, size_t numParticlesCurrentlyMigratingLocal,
                                           int lineNumber);
+
+  /**
+   *
+   * Apply the functor chosen and configured via _configuration to the given lambda function f(auto functor).
+   * @note This templated function is private and hence implemented in the .cpp
+   *
+   * @tparam T Return type of f.
+   * @tparam F Function type T f(auto functor).
+   * @param f lambda function.
+   * @return Return value of f.
+   */
+  template <class T, class F>
+  T applyWithChosenFunctor(F f);
 };

--- a/examples/md-flexible/src/templateInstantiations/iteratePairwiseLJFunctor.cpp
+++ b/examples/md-flexible/src/templateInstantiations/iteratePairwiseLJFunctor.cpp
@@ -6,6 +6,7 @@
  * other compilation units to only declare, but not instantiate this template.
  */
 
+#if defined(MD_FLEXIBLE_FUNCTOR_AUTOVEC)
 #include "autopas/AutoPasImpl.h"
 #include "autopas/molecularDynamics/LJFunctor.h"
 #include "src/TypeDefinitions.h"
@@ -13,3 +14,4 @@
 //! @cond Doxygen_Suppress
 template bool autopas::AutoPas<ParticleType>::iteratePairwise(autopas::LJFunctor<ParticleType, true, true> *);
 //! @endcond
+#endif

--- a/examples/md-flexible/src/templateInstantiations/iteratePairwiseLJFunctorAVX.cpp
+++ b/examples/md-flexible/src/templateInstantiations/iteratePairwiseLJFunctorAVX.cpp
@@ -5,7 +5,7 @@
  * AutoPas class and the particle type used by md-flexible. This is linked into the md-flexible executable to enable the
  * other compilation units to only declare, but not instantiate this template.
  */
-
+#if defined(MD_FLEXIBLE_FUNCTOR_AVX) && defined(__AVX__)
 #include "autopas/AutoPasImpl.h"
 #include "autopas/molecularDynamics/LJFunctorAVX.h"
 #include "src/TypeDefinitions.h"
@@ -13,3 +13,4 @@
 //! @cond Doxygen_Suppress
 template bool autopas::AutoPas<ParticleType>::iteratePairwise(autopas::LJFunctorAVX<ParticleType, true, true> *);
 //! @endcond
+#endif

--- a/examples/md-flexible/src/templateInstantiations/iteratePairwiseLJFunctorGlobals.cpp
+++ b/examples/md-flexible/src/templateInstantiations/iteratePairwiseLJFunctorGlobals.cpp
@@ -6,6 +6,7 @@
  * other compilation units to only declare, but not instantiate this template.
  */
 
+#if defined(MD_FLEXIBLE_FUNCTOR_AUTOVEC_GLOBALS)
 #include "autopas/AutoPasImpl.h"
 #include "autopas/molecularDynamics/LJFunctor.h"
 #include "src/TypeDefinitions.h"
@@ -14,3 +15,4 @@
 template bool autopas::AutoPas<ParticleType>::iteratePairwise(
     autopas::LJFunctor<ParticleType, true, true, autopas::FunctorN3Modes::Both, true> *);
 //! @endcond
+#endif

--- a/examples/md-flexible/src/templateInstantiations/iteratePairwiseLJFunctorSVE.cpp
+++ b/examples/md-flexible/src/templateInstantiations/iteratePairwiseLJFunctorSVE.cpp
@@ -6,7 +6,7 @@
  * other compilation units to only declare, but not instantiate this template.
  */
 
-#ifdef __ARM_FEATURE_SVE
+#if defined(MD_FLEXIBLE_FUNCTOR_SVE) && defined(__ARM_FEATURE_SVE)
 #include "autopas/AutoPasImpl.h"
 #include "autopas/molecularDynamics/LJFunctorSVE.h"
 #include "src/TypeDefinitions.h"

--- a/src/autopas/molecularDynamics/LJFunctorAVX.h
+++ b/src/autopas/molecularDynamics/LJFunctorAVX.h
@@ -42,7 +42,7 @@ namespace autopas {
 template <class Particle, bool applyShift = false, bool useMixing = false,
           FunctorN3Modes useNewton3 = FunctorN3Modes::Both, bool calculateGlobals = false,
           bool relevantForTuning = true>
-class LJFunctorAVX final
+class LJFunctorAVX
     : public Functor<Particle,
                      LJFunctorAVX<Particle, applyShift, useMixing, useNewton3, calculateGlobals, relevantForTuning>> {
   using SoAArraysType = typename Particle::SoAArraysType;

--- a/src/autopas/molecularDynamics/LJFunctorAVX.h
+++ b/src/autopas/molecularDynamics/LJFunctorAVX.h
@@ -5,8 +5,9 @@
  * @author F. Gratl
  */
 #pragma once
-
-#ifdef __AVX__
+#ifndef __AVX__
+#pragma message "Requested to compile LJFunctorAVX but AVX is not available!"
+#else
 #include <immintrin.h>
 #endif
 
@@ -41,7 +42,7 @@ namespace autopas {
 template <class Particle, bool applyShift = false, bool useMixing = false,
           FunctorN3Modes useNewton3 = FunctorN3Modes::Both, bool calculateGlobals = false,
           bool relevantForTuning = true>
-class LJFunctorAVX
+class LJFunctorAVX final
     : public Functor<Particle,
                      LJFunctorAVX<Particle, applyShift, useMixing, useNewton3, calculateGlobals, relevantForTuning>> {
   using SoAArraysType = typename Particle::SoAArraysType;

--- a/src/autopas/molecularDynamics/LJFunctorSVE.h
+++ b/src/autopas/molecularDynamics/LJFunctorSVE.h
@@ -6,7 +6,9 @@
  */
 #pragma once
 
-#ifdef __ARM_FEATURE_SVE
+#ifndef __ARM_FEATURE_SVE
+#pragma message "Requested to compile LJFunctorSVE but SVE is not available!"
+#else
 #include <arm_sve.h>
 #endif
 


### PR DESCRIPTION
# Description

Currently, we always compile all functors for MD-Flexible. This PR introduces mechanisms to choose which ones to compile to reduce compile time and memory consumption.

- [x] CMake options to enable individual functors
- [x] ~Compile Functors only once for MD-Flex AND Tests~ Only `FlopCounterFucntor` is currently shared -> no further effort taken.
- [x] Optimize CI with new options.

## ~Related Pull Requests~

## ~Resolved Issues~

# How Has This Been Tested?

- [x] CI
