### PR TITLE
WrapMPI bugfix

### DIFF
--- a/src/autopas/utils/WrapMPI.h
+++ b/src/autopas/utils/WrapMPI.h
@@ -833,7 +833,7 @@ inline int AutoPas_MPI_Allgather(void *buffer_send, int count_send, AutoPas_MPI_
 
 inline int AutoPas_MPI_Comm_split(AutoPas_MPI_Comm old_communicator, int color, int key,
                                   AutoPas_MPI_Comm *new_communicator) {
-  new_communicator = &old_communicator;
+  *new_communicator = old_communicator;
   return AUTOPAS_MPI_SUCCESS;
 }
 


### PR DESCRIPTION
# Description

Copy old_communicator to the location of new_communicator instead of pointing new_communicator to a temporary

## ~Related Pull Requests~

## ~Resolved Issues~

# How Has This Been Tested?

- [ ] CI

I'm actually surprised the previous version didn't lead to segfaults.