### PR TITLE
Mirror particles for reflecting

### DIFF
--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -234,7 +234,8 @@ void Simulation::run() {
       _timers.migratingParticleExchange.stop();
 
       _timers.reflectParticlesAtBoundaries.start();
-      _domainDecomposition->reflectParticlesAtBoundaries(*_autoPasContainer, *_configuration.getParticlePropertiesLibrary());
+      _domainDecomposition->reflectParticlesAtBoundaries(*_autoPasContainer,
+                                                         *_configuration.getParticlePropertiesLibrary());
       _timers.reflectParticlesAtBoundaries.stop();
 
       _timers.haloParticleExchange.start();

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -234,7 +234,7 @@ void Simulation::run() {
       _timers.migratingParticleExchange.stop();
 
       _timers.reflectParticlesAtBoundaries.start();
-      _domainDecomposition->reflectParticlesAtBoundaries(*_autoPasContainer);
+      _domainDecomposition->reflectParticlesAtBoundaries(*_autoPasContainer, *_configuration.getParticlePropertiesLibrary());
       _timers.reflectParticlesAtBoundaries.stop();
 
       _timers.haloParticleExchange.start();

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -43,7 +43,7 @@ RegularGridDecomposition::RegularGridDecomposition(const MDFlexConfig &configura
   for (auto sigmaMapElement : configuration.sigmaMap.value) {
     maxSigma = std::max(maxSigma, sigmaMapElement.second);
   }
-  _maxReflectiveSkin = std::pow(maxSigma, 1/6.);
+  _maxReflectiveSkin = sixthRootOfTwo * maxSigma;
 
   // initialize _communicator and _domainIndex
   initializeMPICommunicator();

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -258,9 +258,11 @@ void RegularGridDecomposition::exchangeMigratingParticles(AutoPasType &autoPasCo
   }
 }
 
-void RegularGridDecomposition::reflectParticlesAtBoundaries(AutoPasType &autoPasContainer, ParticlePropertiesLibraryType &PPL) {
+void RegularGridDecomposition::reflectParticlesAtBoundaries(AutoPasType &autoPasContainer,
+                                                            ParticlePropertiesLibraryType &PPL) {
   std::array<double, _dimensionCount> reflSkinMin{}, reflSkinMax{};
-  auto functorLJ = autopas::LJFunctor<ParticleType, false, true, autopas::FunctorN3Modes::Newton3Off, false, false>(_maxReflectiveSkin * 2., PPL);
+  auto functorLJ = autopas::LJFunctor<ParticleType, false, true, autopas::FunctorN3Modes::Newton3Off, false, false>(
+      _maxReflectiveSkin * 2., PPL);
 
   for (int dimensionIndex = 0; dimensionIndex < _dimensionCount; ++dimensionIndex) {
     // skip if boundary is not reflective
@@ -271,7 +273,8 @@ void RegularGridDecomposition::reflectParticlesAtBoundaries(AutoPasType &autoPas
            p.isValid(); ++p) {
         // Check that particle is within 6th root of 2 * sigma
         const auto position = p->getR();
-        const auto distanceToBoundary = isUpper ? reflSkinMax[dimensionIndex] - position[dimensionIndex] : position[dimensionIndex] - reflSkinMin[dimensionIndex];
+        const auto distanceToBoundary = isUpper ? reflSkinMax[dimensionIndex] - position[dimensionIndex]
+                                                : position[dimensionIndex] - reflSkinMin[dimensionIndex];
         if (distanceToBoundary < sixthRootOfTwo * PPL.getSigma(p->getTypeId()) / 2.) {
           // Create mirror particle and shift it to other side of reflective boundary
           ParticleType mirrorParticle;

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -44,7 +44,7 @@ RegularGridDecomposition::RegularGridDecomposition(const MDFlexConfig &configura
   // particles, we iterate once over particles within the largest possible range where a particle might experience a
   // repulsion, i.e. sixthRootOfTwo * maxSigma / 2.0.
   double maxSigma{0};
-  for (const auto &[_, sigma] : leMap) {
+  for (const auto &[_, sigma] : configuration.sigmaMap.value) {
     maxSigma = std::max(maxSigma, sigma);
   }
   _maxReflectiveSkin = sixthRootOfTwo * maxSigma / 2.;
@@ -266,7 +266,7 @@ void RegularGridDecomposition::reflectParticlesAtBoundaries(AutoPasType &autoPas
                                                             ParticlePropertiesLibraryType &particlePropertiesLib) {
   std::array<double, _dimensionCount> reflSkinMin{}, reflSkinMax{};
   auto functorLJ = autopas::LJFunctor<ParticleType, false, true, autopas::FunctorN3Modes::Both, false, false>(
-      _maxReflectiveSkin * 2., PPL);
+      _maxReflectiveSkin * 2., particlePropertiesLib);
 
   for (int dimensionIndex = 0; dimensionIndex < _dimensionCount; ++dimensionIndex) {
     // skip if boundary is not reflective
@@ -278,7 +278,7 @@ void RegularGridDecomposition::reflectParticlesAtBoundaries(AutoPasType &autoPas
         // Check that particle is within 6th root of 2 * sigma
         const auto position = p->getR();
         const auto distanceToBoundary = std::abs(reflSkinMax[dimensionIndex] - position[dimensionIndex]);
-        if (distanceToBoundary < sixthRootOfTwo * PPL.getSigma(p->getTypeId()) / 2.) {
+        if (distanceToBoundary < sixthRootOfTwo * particlePropertiesLib.getSigma(p->getTypeId()) / 2.) {
           // Create mirror particle and shift it to other side of reflective boundary
           ParticleType mirrorParticle;
           auto position = p->getR();

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -43,7 +43,7 @@ RegularGridDecomposition::RegularGridDecomposition(const MDFlexConfig &configura
   for (auto sigmaMapElement : configuration.sigmaMap.value) {
     maxSigma = std::max(maxSigma, sigmaMapElement.second);
   }
-  _maxReflectiveSkin = sixthRootOfTwo * maxSigma;
+  _maxReflectiveSkin = sixthRootOfTwo * maxSigma / 2.;
 
   // initialize _communicator and _domainIndex
   initializeMPICommunicator();

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -274,15 +274,15 @@ void RegularGridDecomposition::reflectParticlesAtBoundaries(AutoPasType &autoPas
         const auto distanceToBoundary = isUpper ? reflSkinMax[dimensionIndex] - position[dimensionIndex] : position[dimensionIndex] - reflSkinMin[dimensionIndex];
         if (distanceToBoundary < sixthRootOfTwo * PPL.getSigma(p->getTypeId()) / 2.) {
           // Create mirror particle and shift it to other side of reflective boundary
-          auto mirrorParticle = p;
-          auto mirrorPos = mirrorParticle->getR();
-          mirrorPos[dimensionIndex] =
-              isUpper ? reflSkinMax[dimensionIndex] + (reflSkinMax[dimensionIndex] - mirrorPos[dimensionIndex])
-                      : reflSkinMin[dimensionIndex] - mirrorPos[dimensionIndex];
-          mirrorParticle->setR(mirrorPos);
+          ParticleType mirrorParticle;
+          auto position = p->getR();
+          position[dimensionIndex] =
+              isUpper ? reflSkinMax[dimensionIndex] + (reflSkinMax[dimensionIndex] - position[dimensionIndex])
+                      : reflSkinMin[dimensionIndex] - position[dimensionIndex];
+          mirrorParticle.setR(position);
 
           // Interact original particle with its mirror
-          functorLJ.AoSFunctor(*p, *mirrorParticle, false);
+          functorLJ.AoSFunctor(*p, mirrorParticle, false);
         }
       }
     };

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -271,14 +271,14 @@ void RegularGridDecomposition::reflectParticlesAtBoundaries(AutoPasType &autoPas
            p.isValid(); ++p) {
         // Check that particle is within 6th root of 2 * sigma
         const auto position = p->getR();
-        const auto distanceToBoundary = isUpper ? position[dimensionIndex] - reflSkinMin[dimensionIndex] : reflSkinMax[dimensionIndex] - position[dimensionIndex];
-        if (distanceToBoundary < sixthRootOfTwo * PPL.getSigma(p->getTypeId())) {
+        const auto distanceToBoundary = isUpper ? reflSkinMax[dimensionIndex] - position[dimensionIndex] : position[dimensionIndex] - reflSkinMin[dimensionIndex];
+        if (distanceToBoundary < sixthRootOfTwo * PPL.getSigma(p->getTypeId()) / 2.) {
           // Create mirror particle and shift it to other side of reflective boundary
           auto mirrorParticle = p;
           auto mirrorPos = mirrorParticle->getR();
           mirrorPos[dimensionIndex] =
-              isUpper ? reflSkinMin[dimensionIndex] - mirrorPos[dimensionIndex]
-                      : reflSkinMax[dimensionIndex] + (reflSkinMax[dimensionIndex] - mirrorPos[dimensionIndex]);
+              isUpper ? reflSkinMax[dimensionIndex] + (reflSkinMax[dimensionIndex] - mirrorPos[dimensionIndex])
+                      : reflSkinMin[dimensionIndex] - mirrorPos[dimensionIndex];
           mirrorParticle->setR(mirrorPos);
 
           // Interact original particle with its mirror

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -39,6 +39,10 @@ RegularGridDecomposition::RegularGridDecomposition(const MDFlexConfig &configura
 
   _decomposition = DomainTools::generateDecomposition(_subdomainCount, configuration.subdivideDimension.value);
 
+  // For reflection, we interact particles with their 'mirror' only if it would cause a repulsive force. This occurs
+  // only for particles within sixthRootOfTwo * sigma / 2.0 of the boundary. For minimal redundant iterating over
+  // particles, we iterate once over particles within the largest possible range where a particle might experience a
+  // repulsion, i.e. sixthRootOfTwo * maxSigma / 2.0.
   double maxSigma{0};
   for (const auto &[_, sigma] : leMap) {
     maxSigma = std::max(maxSigma, sigma);

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -39,6 +39,12 @@ RegularGridDecomposition::RegularGridDecomposition(const MDFlexConfig &configura
 
   _decomposition = DomainTools::generateDecomposition(_subdomainCount, configuration.subdivideDimension.value);
 
+  double maxSigma{0};
+  for (auto sigmaMapElement : configuration.sigmaMap.value) {
+    maxSigma = std::max(maxSigma, sigmaMapElement.second);
+  }
+  _maxReflectiveSkin = std::pow(maxSigma, 1/6.);
+
   // initialize _communicator and _domainIndex
   initializeMPICommunicator();
   // initialize _planarCommunicators and domainID

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -277,7 +277,8 @@ void RegularGridDecomposition::reflectParticlesAtBoundaries(AutoPasType &autoPas
            p.isValid(); ++p) {
         // Check that particle is within 6th root of 2 * sigma
         const auto position = p->getR();
-        const auto distanceToBoundary = std::abs(reflSkinMax[dimensionIndex] - position[dimensionIndex]);
+        const auto distanceToBoundary = isUpper ? reflSkinMax[dimensionIndex] - position[dimensionIndex]
+                                                : position[dimensionIndex] - reflSkinMin[dimensionIndex];
         if (distanceToBoundary < sixthRootOfTwo * particlePropertiesLib.getSigma(p->getTypeId()) / 2.) {
           // Create mirror particle and shift it to other side of reflective boundary
           ParticleType mirrorParticle;

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -268,12 +268,10 @@ void RegularGridDecomposition::reflectParticlesAtBoundaries(AutoPasType &autoPas
     auto reflect = [&](bool isUpper) {
       for (auto p = autoPasContainer.getRegionIterator(reflSkinMin, reflSkinMax, autopas::IteratorBehavior::owned);
            p.isValid(); ++p) {
-        auto vel = p->getV();
-        // reverse velocity in dimension if towards boundary
-        if ((vel[dimensionIndex] < 0) xor isUpper) {
-          vel[dimensionIndex] *= -1;
-        }
-        p->setV(vel);
+        auto mirrorParticle = p;
+        auto mirrorPos = mirrorParticle->getR();
+        mirrorPos[dimensionIndex]
+        mirrorParticle->setR()
       }
     };
 
@@ -281,7 +279,7 @@ void RegularGridDecomposition::reflectParticlesAtBoundaries(AutoPasType &autoPas
     if (_localBoxMin[dimensionIndex] == _globalBoxMin[dimensionIndex]) {
       reflSkinMin = _globalBoxMin;
       reflSkinMax = _globalBoxMax;
-      reflSkinMax[dimensionIndex] = _globalBoxMin[dimensionIndex] + autoPasContainer.getVerletSkinPerTimestep() / 2;
+      reflSkinMax[dimensionIndex] = _globalBoxMin[dimensionIndex] + _maxReflectiveSkin;
 
       reflect(false);
     }
@@ -289,7 +287,7 @@ void RegularGridDecomposition::reflectParticlesAtBoundaries(AutoPasType &autoPas
     if (_localBoxMax[dimensionIndex] == _globalBoxMax[dimensionIndex]) {
       reflSkinMin = _globalBoxMin;
       reflSkinMax = _globalBoxMax;
-      reflSkinMin[dimensionIndex] = _globalBoxMax[dimensionIndex] - autoPasContainer.getVerletSkinPerTimestep() / 2;
+      reflSkinMin[dimensionIndex] = _globalBoxMax[dimensionIndex] - _maxReflectiveSkin;
 
       reflect(true);
     }

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -260,7 +260,7 @@ void RegularGridDecomposition::exchangeMigratingParticles(AutoPasType &autoPasCo
 
 void RegularGridDecomposition::reflectParticlesAtBoundaries(AutoPasType &autoPasContainer, ParticlePropertiesLibraryType &PPL) {
   std::array<double, _dimensionCount> reflSkinMin{}, reflSkinMax{};
-  auto functorLJ = autopas::LJFunctor<ParticleType, false, true, autopas::FunctorN3Modes::Newton3Off, false, false>(_maxReflectiveSkin, PPL);
+  auto functorLJ = autopas::LJFunctor<ParticleType, false, true, autopas::FunctorN3Modes::Newton3Off, false, false>(_maxReflectiveSkin * 2., PPL);
 
   for (int dimensionIndex = 0; dimensionIndex < _dimensionCount; ++dimensionIndex) {
     // skip if boundary is not reflective

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
@@ -15,6 +15,7 @@
 #include "src/TypeDefinitions.h"
 #include "src/configuration/MDFlexConfig.h"
 #include "src/options/BoundaryTypeOption.h"
+#include "autopas/molecularDynamics/LJFunctor.h"
 
 namespace {
 const double sixthRootOfTwo = std::pow(2., 1./6.);
@@ -136,8 +137,9 @@ class RegularGridDecomposition final : public DomainDecomposition {
    * would experience a repulsive effect (i.e. is within the 6th root of sigma from the border).
    *
    * @param autoPasContainer: The container, where the migrating particles originate from.
+   * @param PPL: Particle Properties Library (needed to get particle's sigma)
    */
-  void reflectParticlesAtBoundaries(AutoPasType &autoPasContainer);
+  void reflectParticlesAtBoundaries(AutoPasType &autoPasContainer, ParticlePropertiesLibraryType &PPL);
 
  private:
   /**

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
@@ -126,6 +126,11 @@ class RegularGridDecomposition final : public DomainDecomposition {
 
   /**
    * Reflects particles within a reflective skin along the inside of a boundary.
+   *
+   * Particle reflection occurs by interacting the particle with particle mirrored onto the other side of the boundary.
+   * Iteraction occurs using the AoS variant of the chosen functor. Particle reflection only occurs if the particle
+   * would experience a repulsive effect (i.e. is within the 6th root of sigma from the border).
+   *
    * @param autoPasContainer: The container, where the migrating particles originate from.
    */
   void reflectParticlesAtBoundaries(AutoPasType &autoPasContainer);
@@ -160,6 +165,10 @@ class RegularGridDecomposition final : public DomainDecomposition {
    * Stores the rebuild Frequency.
    */
   unsigned int _rebuildFrequency;
+  /**
+   * The greatest distance from a reflective boundary at which a particle might experience reflection.
+   */
+  double _maxReflectiveSkin;
   /**
    * The minimum coordinates of the global domain.
    */

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
@@ -22,7 +22,7 @@ namespace {
  * Sixth Root of Two precomputed here, as it is used a lot in reflecting boundaries.
  */
 const double sixthRootOfTwo = std::pow(2., 1. / 6.);
-}
+}  // namespace
 
 /**
  * This class can be used as a domain decomposition which divides the domain in equal sized rectangular subdomains.

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
@@ -11,14 +11,14 @@
 #include <memory>
 
 #include "DomainDecomposition.h"
+#include "autopas/molecularDynamics/LJFunctor.h"
 #include "autopas/utils/WrapMPI.h"
 #include "src/TypeDefinitions.h"
 #include "src/configuration/MDFlexConfig.h"
 #include "src/options/BoundaryTypeOption.h"
-#include "autopas/molecularDynamics/LJFunctor.h"
 
 namespace {
-const double sixthRootOfTwo = std::pow(2., 1./6.);
+const double sixthRootOfTwo = std::pow(2., 1. / 6.);
 }
 
 /**

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
@@ -16,6 +16,10 @@
 #include "src/configuration/MDFlexConfig.h"
 #include "src/options/BoundaryTypeOption.h"
 
+namespace {
+const double sixthRootOfTwo = std::pow(2., 1./6.);
+}
+
 /**
  * This class can be used as a domain decomposition which divides the domain in equal sized rectangular subdomains.
  * The number of subdomains is equal to the number of MPI processes available.

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
@@ -18,6 +18,9 @@
 #include "src/options/BoundaryTypeOption.h"
 
 namespace {
+/**
+ * Sixth Root of Two precomputed here, as it is used a lot in reflecting boundaries.
+ */
 const double sixthRootOfTwo = std::pow(2., 1. / 6.);
 }
 

--- a/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
@@ -64,9 +64,9 @@ auto MixedBoundaryConditionTest::setUpExpectations(
           break;
         case ::options::BoundaryTypeOption::reflective:
           // if near a reflective boundary and flying towards it the velocity sign is flipped
-          if (particlePositions[id][dim] < boxMin[dim] + sixthRootOfTwo * sigma) {
+          if (particlePositions[id][dim] < boxMin[dim] + sixthRootOfTwo * sigma / 2.) {
             expectedForces[id][dim] = forceFromReflection(particlePositions[id], (int)dim, false);
-          } else {
+          } else if (particlePositions[id][dim] > boxMax[dim] - sixthRootOfTwo * sigma / 2.) {
             expectedForces[id][dim] = forceFromReflection(particlePositions[id], (int)dim, true);
           }
           break;

--- a/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
@@ -13,8 +13,8 @@
 extern template class autopas::AutoPas<ParticleType>;
 
 auto MixedBoundaryConditionTest::setUpExpectations(
-    const std::vector<std::array<double, 3>> &particlePositions,
-    const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax, const double sigma, const double interactionLength,
+    const std::vector<std::array<double, 3>> &particlePositions, const std::array<double, 3> &boxMin,
+    const std::array<double, 3> &boxMax, const double sigma, const double interactionLength,
     const std::array<options::BoundaryTypeOption, 3> &boundaryConditions) {
   const auto boxLength = autopas::utils::ArrayMath::sub(boxMax, boxMin);
   auto expectedPositions = particlePositions;
@@ -22,9 +22,10 @@ auto MixedBoundaryConditionTest::setUpExpectations(
   std::vector<std::array<double, 3>> expectedForces;
   expectedForces.resize(particlePositions.size());
 
-  auto forceFromReflection = [&](const std::array<double, 3> position, const int dimensionOfBoundary, const bool isUpper) {
-    const auto distanceToBoundary = isUpper ? boxMax[dimensionOfBoundary] - position[dimensionOfBoundary]:
-                                            position[dimensionOfBoundary] - boxMin[dimensionOfBoundary];
+  auto forceFromReflection = [&](const std::array<double, 3> position, const int dimensionOfBoundary,
+                                 const bool isUpper) {
+    const auto distanceToBoundary = isUpper ? boxMax[dimensionOfBoundary] - position[dimensionOfBoundary]
+                                            : position[dimensionOfBoundary] - boxMin[dimensionOfBoundary];
     const auto distanceToMirrorParticle = distanceToBoundary * 2.;
     const auto distanceSquared = distanceToMirrorParticle * distanceToMirrorParticle;
 
@@ -221,9 +222,9 @@ TEST_F(MixedBoundaryConditionTest, testMixedReflection) {
   const std::array<options::BoundaryTypeOption, 3> boundaryConditions = {options::BoundaryTypeOption::periodic,
                                                                          options::BoundaryTypeOption::reflective,
                                                                          options::BoundaryTypeOption::reflective};
-  const std::vector<std::array<double, 3>> particlePositions = {
-      {1.0, 0.005, 1.0}, {1.0, 0.005, 0.005}, {4.995, 0.005, 0.005},
-      {4.0, 4.995, 4.0}, {4.0, 4.995, 4.995}, {0.005, 4.995, 4.995}};
+  const std::vector<std::array<double, 3>> particlePositions = {{1.0, 0.005, 1.0},     {1.0, 0.005, 0.005},
+                                                                {4.995, 0.005, 0.005}, {4.0, 4.995, 4.0},
+                                                                {4.0, 4.995, 4.995},   {0.005, 4.995, 4.995}};
   // particle 0 tests for reflection along a reflective boundary
   // particle 1 tests for reflection in the edge between two reflective boundaries
   // particle 2 tests for reflection only in the directions with reflective boundaries in a periodic/refl/refl corner
@@ -236,8 +237,8 @@ TEST_F(MixedBoundaryConditionTest, testMixedReflection) {
  * Designed to test that exchangeMigratingParticles and exchangeHaloParticles in the mixed boundary case
  * Note: this is not designed to replace the more extensive tests in RegularGridDecompositionTest, but to test the
  * periodic BC in the mixed case.
- * Places particles in within range of reflection and such that it is either periodically translated or halo particles are
- * created to test that particles these particles have the correct reflections.
+ * Places particles in within range of reflection and such that it is either periodically translated or halo particles
+ * are created to test that particles these particles have the correct reflections.
  */
 TEST_F(MixedBoundaryConditionTest, testPeriodic) {
   const std::array<options::BoundaryTypeOption, 3> boundaryConditions = {options::BoundaryTypeOption::periodic,
@@ -247,9 +248,10 @@ TEST_F(MixedBoundaryConditionTest, testPeriodic) {
   const std::vector<std::array<double, 3>> particlePositions = {
       {-0.005, 0.005, 0.005}, {0.005, 0.005, 0.005}, {5.005, 4.995, 4.995}, {4.995, 4.995, 4.995}};
 
-  // particle 0 tests that a particle that needs to be periodically translated in x, is also reflected correctly in y and z
-  // particle 1 tests that a particle in a periodic/reflective/reflective corner produces a correctly reflected halo
-  //    particle
+  // particle 0 tests that a particle that needs to be periodically translated in x, is also reflected correctly in y
+  // and z
+  // particle 1 tests that a particle in a periodic/reflective/reflective corner produces a correctly reflected
+  // halo particle
   // particles 2 & 3 do the same, but for the rightmost boundary.
 
   testFunction(particlePositions, boundaryConditions);
@@ -269,8 +271,9 @@ TEST_F(MixedBoundaryConditionTest, testNoBoundary) {
       options::BoundaryTypeOption::none, options::BoundaryTypeOption::none, options::BoundaryTypeOption::none};
 
   const std::vector<std::array<double, 3>> particlePositions = {
-      {-0.005, 2.5, 2.5}, {0.005, 2.5, 2.5}, {4.995, 2.5, 2.5}, {5.005, 2.5, 2.5}, {2.5, -0.005, 2.5}, {2.5, 0.005, 2.5},
-      {2.5, 4.995, 2.5}, {2.5, 5.005, 2.5}, {2.5, 2.5, -0.005}, {2.5, 2.5, 0.005}, {2.5, 2.5, 4.995}, {2.5, 2.5, 5.005}};
+      {-0.005, 2.5, 2.5}, {0.005, 2.5, 2.5}, {4.995, 2.5, 2.5}, {5.005, 2.5, 2.5},
+      {2.5, -0.005, 2.5}, {2.5, 0.005, 2.5}, {2.5, 4.995, 2.5}, {2.5, 5.005, 2.5},
+      {2.5, 2.5, -0.005}, {2.5, 2.5, 0.005}, {2.5, 2.5, 4.995}, {2.5, 2.5, 5.005}};
 
   // particle 0 tests the lack of periodic translation in the left x-boundary
   // particle 1 tests the lack of reflection in the left x-boundary

--- a/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.h
+++ b/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.h
@@ -32,9 +32,8 @@ class MixedBoundaryConditionTest : public AutoPasTestBase {
    * @return
    */
   static auto setUpExpectations(const std::vector<std::array<double, 3>> &particlePositions,
-                                const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax,
-                                double sigma, double interactionLength,
-                                const std::array<options::BoundaryTypeOption, 3> &boundaryConditions);
+                                const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax, double sigma,
+                                double interactionLength, const std::array<options::BoundaryTypeOption, 3> &boundaryConditions);
 
   void testFunction(const std::vector<std::array<double, 3>> &particlePositions,
                     const std::array<options::BoundaryTypeOption, 3> &boundaryConditions);

--- a/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.h
+++ b/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.h
@@ -33,7 +33,8 @@ class MixedBoundaryConditionTest : public AutoPasTestBase {
    */
   static auto setUpExpectations(const std::vector<std::array<double, 3>> &particlePositions,
                                 const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax, double sigma,
-                                double interactionLength, const std::array<options::BoundaryTypeOption, 3> &boundaryConditions);
+                                double interactionLength,
+                                const std::array<options::BoundaryTypeOption, 3> &boundaryConditions);
 
   void testFunction(const std::vector<std::array<double, 3>> &particlePositions,
                     const std::array<options::BoundaryTypeOption, 3> &boundaryConditions);

--- a/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.h
+++ b/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.h
@@ -32,12 +32,10 @@ class MixedBoundaryConditionTest : public AutoPasTestBase {
    * @return
    */
   static auto setUpExpectations(const std::vector<std::array<double, 3>> &particlePositions,
-                                const std::vector<std::array<double, 3>> &particleForces,
                                 const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax,
-                                const double sigma, const double interactionLength,
+                                double sigma, double interactionLength,
                                 const std::array<options::BoundaryTypeOption, 3> &boundaryConditions);
 
   void testFunction(const std::vector<std::array<double, 3>> &particlePositions,
-                    const std::vector<std::array<double, 3>> &particleVelocities,
                     const std::array<options::BoundaryTypeOption, 3> &boundaryConditions);
 };

--- a/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.h
+++ b/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.h
@@ -26,15 +26,15 @@ class MixedBoundaryConditionTest : public AutoPasTestBase {
    * @param particleVelocities
    * @param boxMin global box min
    * @param boxMax global box max
-   * @param reflectionSkin
+   * @param sigma sigma of particle used
    * @param interactionLength
    * @param boundaryConditions
    * @return
    */
   static auto setUpExpectations(const std::vector<std::array<double, 3>> &particlePositions,
-                                const std::vector<std::array<double, 3>> &particleVelocities,
+                                const std::vector<std::array<double, 3>> &particleForces,
                                 const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax,
-                                const double reflectionSkin, const double interactionLength,
+                                const double sigma, const double interactionLength,
                                 const std::array<options::BoundaryTypeOption, 3> &boundaryConditions);
 
   void testFunction(const std::vector<std::array<double, 3>> &particlePositions,

--- a/examples/md-flexible/tests/domainDecomposition/ReflectiveBoundaryConditionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/ReflectiveBoundaryConditionTest.cpp
@@ -14,51 +14,72 @@
 extern template class autopas::AutoPas<ParticleType>;
 
 /**
- * Very simple test of reflective boundaries in all 3 dimension. Places 2 particles on every face, with one travelling
- * towards the boundary and the other away.
+ * Very simple test of reflective boundaries in all 3 dimension. Places identical particles on every face and tests that the particle
+ * receives the correct force.
  */
 TEST_P(ReflectiveBoundaryConditionTest, simpleReflectionTest) {
   // initialise AutoPas container & domainDecomposition
   MDFlexConfig config(0, nullptr);
 
-  config.boxMin.value = {0., 0., 0.};
-  config.boxMax.value = {5., 5., 5.};
-  const std::array<double, 3> boxLength = autopas::utils::ArrayMath::sub(config.boxMax.value, config.boxMin.value);
+  const std::array<double, 3> boxMin = {0., 0., 0.};
+  const std::array<double, 3> boxMax = {5., 5., 5.};
+
+  config.boxMin.value = boxMin;
+  config.boxMax.value = boxMax;
+  const std::array<double, 3> boxLength = autopas::utils::ArrayMath::sub(boxMax, boxMin);
   config.subdivideDimension.value = {true, true, true};
-  config.cutoff.value = 0.3;
-  config.verletSkinRadiusPerTimestep.value = 0.02;
-  config.verletRebuildFrequency.value = 10;
+  const double cutoff = 0.3;
+  config.cutoff.value = cutoff;
+  const double sigma = 1.;
+  config.addParticleType(0, 1., sigma, 1.);
   config.boundaryOption.value = {options::BoundaryTypeOption::reflective, options::BoundaryTypeOption::reflective,
                                  options::BoundaryTypeOption::reflective};
 
   RegularGridDecomposition domainDecomposition(config);
 
   auto autoPasContainer = std::make_shared<autopas::AutoPas<ParticleType>>(std::cout);
+  auto particlePropertiesLibrary = std::make_shared<ParticlePropertiesLibraryType>(cutoff);
 
-  autoPasContainer->setBoxMin(domainDecomposition.getLocalBoxMin());
-  autoPasContainer->setBoxMax(domainDecomposition.getLocalBoxMax());
-  autoPasContainer->setCutoff(config.cutoff.value);
-  autoPasContainer->setVerletSkinPerTimestep(config.verletSkinRadiusPerTimestep.value);
-  autoPasContainer->setVerletRebuildFrequency(config.verletRebuildFrequency.value);
+  autoPasContainer->setBoxMin(boxMin);
+  autoPasContainer->setBoxMax(boxMax);
+  autoPasContainer->setCutoff(cutoff);
   autoPasContainer->init();
+
+  particlePropertiesLibrary->addType(0, 1., sigma, 1.);
+  particlePropertiesLibrary->calculateMixingCoefficients();
 
   // get particle properties
   const std::array<double, 3> particlePosition = std::get<0>(GetParam());
   const std::array<double, 3> particleVelocity = std::get<1>(GetParam());
 
   // derive expected position
-  auto calcReflectedVelocity = [](const std::array<double, 3> velocities, const std::array<bool, 3> isReflected) {
-    auto reflVel = velocities;
-    for (int i = 0; i < 3; ++i) {
-      if (isReflected[i]) {
-        reflVel[i] *= -1;
-      }
-    }
-    return reflVel;
+  auto forceFromReflection = [&](const std::array<double, 3> position, const int dimensionOfBoundary, const bool isUpper) {
+    const auto distanceToBoundary = isUpper ? boxMax[dimensionOfBoundary] - position[dimensionOfBoundary]:
+                                            position[dimensionOfBoundary] - boxMin[dimensionOfBoundary];
+    const auto distanceToMirrorParticle = distanceToBoundary * 2.;
+    const auto distanceSquared = distanceToMirrorParticle * distanceToMirrorParticle;
+
+    const auto inverseDistanceSquared = 1. / distanceSquared;
+    const auto lj2 = sigma * sigma * inverseDistanceSquared;
+    const auto lj6 = lj2 * lj2 * lj2;
+    const auto lj12 = lj6 * lj6;
+    const auto lj12m6 = lj12 - lj6;
+    const auto ljForceFactor = 24 * (lj12 + lj12m6) * inverseDistanceSquared;
+    const auto force = ljForceFactor * distanceToMirrorParticle * (isUpper ? -1. : 1.);
+
+    return force;
   };
 
-  const std::array<double, 3> expectedPosition = particlePosition;
-  const std::array<double, 3> expectedVelocity = calcReflectedVelocity(particleVelocity, std::get<2>(GetParam()));
+  const auto expectedPosition = particlePosition;
+  const auto expectedVelocity = particleVelocity;
+  std::array<double, 3> expectedForce = {0., 0., 0.};
+  for (int dimension = 0; dimension < 3; ++dimension) {
+    if (particlePosition[dimension] < boxMin[dimension] + sixthRootOfTwo * sigma) {
+      expectedForce[dimension] = forceFromReflection(particlePosition, dimension, false);
+    } else if (particlePosition[dimension] > boxMax[dimension] - sixthRootOfTwo * sigma) {
+      expectedForce[dimension] = forceFromReflection(particlePosition, dimension, true);
+    }
+  }
 
   // create particle and add to container
   // in the MPI case this is expected to be wrong for all but one rank
@@ -67,6 +88,7 @@ TEST_P(ReflectiveBoundaryConditionTest, simpleReflectionTest) {
     particle.setID(0);
     particle.setR(particlePosition);
     particle.setV(particleVelocity);
+    particle.setF({0., 0., 0.});
     autoPasContainer->addParticle(particle);
 #if not defined(AUTOPAS_INCLUDE_MPI)
   } else {
@@ -78,18 +100,20 @@ TEST_P(ReflectiveBoundaryConditionTest, simpleReflectionTest) {
 
   // apply BCs + domain exchange
   domainDecomposition.exchangeMigratingParticles(*autoPasContainer, emigrants);
-  domainDecomposition.reflectParticlesAtBoundaries(*autoPasContainer);
+  domainDecomposition.reflectParticlesAtBoundaries(*autoPasContainer, *particlePropertiesLibrary);
   domainDecomposition.exchangeHaloParticles(*autoPasContainer);
 
-  if (domainDecomposition.isInsideLocalDomain(expectedPosition)) {
+  if (domainDecomposition.isInsideLocalDomain(particlePosition)) {
     EXPECT_EQ(1, autoPasContainer->getNumberOfParticles(autopas::IteratorBehavior::owned));
     // check particles have been successfully reflected (and not translated)
     const auto &reflectedParticle = autoPasContainer->begin(autopas::IteratorBehavior::owned);
     const auto &reflectedPosition = reflectedParticle->getR();
     const auto &reflectedVelocity = reflectedParticle->getV();
+    const auto &reflectedForce = reflectedParticle->getF();
     for (size_t i = 0; i < 3; ++i) {
       EXPECT_NEAR(reflectedPosition[i], expectedPosition[i], 1e-13) << "Unexpected position[" << i << "]";
       EXPECT_NEAR(reflectedVelocity[i], expectedVelocity[i], 1e-13) << "Unexpected velocity[" << i << "]";
+      EXPECT_NEAR(reflectedForce[i], expectedForce[i], 1e-13) << "Unexpected force[" << i << "]";
     }
 #if not defined(AUTOPAS_INCLUDE_MPI)
   } else {

--- a/examples/md-flexible/tests/domainDecomposition/ReflectiveBoundaryConditionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/ReflectiveBoundaryConditionTest.cpp
@@ -241,18 +241,22 @@ void testReflectiveBoundaryZoning(const std::array<double, 3> particlePosition, 
 
   domainDecomposition.reflectParticlesAtBoundaries(*autoPasContainer, *particlePropertiesLibrary);
 
-  if (domainDecomposition.isInsideLocalDomain(particlePosition)) {  
+  if (domainDecomposition.isInsideLocalDomain(particlePosition)) {
     auto returnedParticle = autoPasContainer->begin();
 
     const auto reflectedForce = returnedParticle->getF();
 
     for (int dim = 0; dim < 3; dim++) {
       if (expectReflection[dim]) {
-	EXPECT_NE(reflectedForce[dim], 0.) << "Particle does not experience reflective force in the " << dim << " dimension when it should.\n"
-					   << "Position = " << autopas::utils::ArrayUtils::to_string(particlePosition) << "; Actual Force = " << autopas::utils::ArrayUtils::to_string(reflectedForce) << ";";
+        EXPECT_NE(reflectedForce[dim], 0.)
+            << "Particle does not experience reflective force in the " << dim << " dimension when it should.\n"
+            << "Position = " << autopas::utils::ArrayUtils::to_string(particlePosition)
+            << "; Actual Force = " << autopas::utils::ArrayUtils::to_string(reflectedForce) << ";";
       } else {
-	EXPECT_DOUBLE_EQ(reflectedForce[dim], 0.) << "Particle experiences reflective force in the " << dim << " dimension when it shouldn't.\n"
-						  << "Position = " << autopas::utils::ArrayUtils::to_string(particlePosition) << "; Actual Force = " << autopas::utils::ArrayUtils::to_string(reflectedForce) << ";";
+        EXPECT_DOUBLE_EQ(reflectedForce[dim], 0.)
+            << "Particle experiences reflective force in the " << dim << " dimension when it shouldn't.\n"
+            << "Position = " << autopas::utils::ArrayUtils::to_string(particlePosition)
+            << "; Actual Force = " << autopas::utils::ArrayUtils::to_string(reflectedForce) << ";";
       }
     }
   }
@@ -271,12 +275,12 @@ void testReflectiveBoundaryZoning(const std::array<double, 3> particlePosition, 
  * This is repeated for all boundaries.
  */
 TEST_F(ReflectiveBoundaryConditionTest, reflectiveZoningTest) {
-  testReflectiveBoundaryZoning({0.05, 2.5,  2.5},  0);
-  testReflectiveBoundaryZoning({2.5,  0.05, 2.5},  0);
-  testReflectiveBoundaryZoning({2.5,  2.5,  0.05}, 0);
-  testReflectiveBoundaryZoning({4.95, 2.5,  2.5},  0);
-  testReflectiveBoundaryZoning({2.5,  4.95, 2.5},  0);
-  testReflectiveBoundaryZoning({2.5,  2.5,  4.95}, 0);
+  testReflectiveBoundaryZoning({0.05, 2.5, 2.5}, 0);
+  testReflectiveBoundaryZoning({2.5, 0.05, 2.5}, 0);
+  testReflectiveBoundaryZoning({2.5, 2.5, 0.05}, 0);
+  testReflectiveBoundaryZoning({4.95, 2.5, 2.5}, 0);
+  testReflectiveBoundaryZoning({2.5, 4.95, 2.5}, 0);
+  testReflectiveBoundaryZoning({2.5, 2.5, 4.95}, 0);
 
   testReflectiveBoundaryZoning({0.1, 2.5, 2.5}, 1);
   testReflectiveBoundaryZoning({2.5, 0.1, 2.5}, 1);
@@ -292,10 +296,10 @@ TEST_F(ReflectiveBoundaryConditionTest, reflectiveZoningTest) {
   testReflectiveBoundaryZoning({2.5, 4.9, 2.5}, 0);
   testReflectiveBoundaryZoning({2.5, 2.5, 4.9}, 0);
 
-  testReflectiveBoundaryZoning({0.15, 2.5,  2.5}, 1);
-  testReflectiveBoundaryZoning({2.5,  0.15, 2.5}, 1);
-  testReflectiveBoundaryZoning({2.5,  2.5,  0.15}, 1);
-  testReflectiveBoundaryZoning({4.85, 2.5,  2.5}, 1);
-  testReflectiveBoundaryZoning({2.5,  4.85, 2.5}, 1);
-  testReflectiveBoundaryZoning({2.5,  2.5,  4.85}, 1);
+  testReflectiveBoundaryZoning({0.15, 2.5, 2.5}, 1);
+  testReflectiveBoundaryZoning({2.5, 0.15, 2.5}, 1);
+  testReflectiveBoundaryZoning({2.5, 2.5, 0.15}, 1);
+  testReflectiveBoundaryZoning({4.85, 2.5, 2.5}, 1);
+  testReflectiveBoundaryZoning({2.5, 4.85, 2.5}, 1);
+  testReflectiveBoundaryZoning({2.5, 2.5, 4.85}, 1);
 }

--- a/examples/md-flexible/tests/domainDecomposition/ReflectiveBoundaryConditionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/ReflectiveBoundaryConditionTest.cpp
@@ -239,9 +239,11 @@ void testReflectiveBoundaryZoning(const std::array<double, 3> particlePosition, 
 
   for (int dim = 0; dim < 3; dim++) {
     if (expectReflection[dim]) {
-      EXPECT_NE(reflectedForce[dim], 0.);
+      EXPECT_NE(reflectedForce[dim], 0.) << "Particle does not experience reflective force in the " << dim << " dimension when it should.\n"
+          << "Position = " << autopas::utils::ArrayUtils::to_string(particlePosition) << "; Actual Force = " << autopas::utils::ArrayUtils::to_string(reflectedForce) << ";";
     } else {
-      EXPECT_DOUBLE_EQ(reflectedForce[dim], 0.);
+      EXPECT_DOUBLE_EQ(reflectedForce[dim], 0.) << "Particle experiences reflective force in the " << dim << " dimension when it shouldn't.\n"
+                                                << "Position = " << autopas::utils::ArrayUtils::to_string(particlePosition) << "; Actual Force = " << autopas::utils::ArrayUtils::to_string(reflectedForce) << ";";
     }
   }
 }

--- a/examples/md-flexible/tests/domainDecomposition/ReflectiveBoundaryConditionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/ReflectiveBoundaryConditionTest.cpp
@@ -35,6 +35,8 @@ TEST_P(ReflectiveBoundaryConditionTest, simpleReflectionTest) {
   config.subdivideDimension.value = {true, true, true};
   const double cutoff = 0.3;
   config.cutoff.value = cutoff;
+  config.verletSkinRadiusPerTimestep.value = 0.02;
+  config.verletRebuildFrequency.value = 10;
   const double sigma = 1.;
   config.addParticleType(0, 1., sigma, 1.);
   config.boundaryOption.value = {options::BoundaryTypeOption::reflective, options::BoundaryTypeOption::reflective,
@@ -48,6 +50,8 @@ TEST_P(ReflectiveBoundaryConditionTest, simpleReflectionTest) {
   autoPasContainer->setBoxMin(boxMin);
   autoPasContainer->setBoxMax(boxMax);
   autoPasContainer->setCutoff(cutoff);
+  autoPasContainer->setVerletSkinPerTimestep(config.verletSkinRadiusPerTimestep.value);
+  autoPasContainer->setVerletRebuildFrequency(config.verletRebuildFrequency.value);
   autoPasContainer->init();
 
   particlePropertiesLibrary->addType(0, 1., sigma, 1.);
@@ -180,14 +184,16 @@ void testReflectiveBoundaryZoning(const std::array<double, 3> particlePosition, 
 
   const std::array<double, 3> boxMin = {0., 0., 0.};
   const std::array<double, 3> boxMax = {5., 5., 5.};
-  const std::array<double, 2> sigmas = {1., 2.};
-  const double cutoff = 2.5;
+  const std::array<double, 2> sigmas = {0.1, 0.2};
+  const double cutoff = 0.3;
 
   config.boxMin.value = boxMin;
   config.boxMax.value = boxMax;
   const std::array<double, 3> boxLength = autopas::utils::ArrayMath::sub(boxMax, boxMin);
   config.subdivideDimension.value = {true, true, true};
   config.cutoff.value = cutoff;
+  config.verletSkinRadiusPerTimestep.value = 0.01;
+  config.verletRebuildFrequency.value = 10;
   config.addParticleType(0, 1., sigmas[0], 1.);
   config.addParticleType(1, 1., sigmas[1], 1.);
   config.boundaryOption.value = {options::BoundaryTypeOption::reflective, options::BoundaryTypeOption::reflective,
@@ -201,6 +207,8 @@ void testReflectiveBoundaryZoning(const std::array<double, 3> particlePosition, 
   autoPasContainer->setBoxMin(boxMin);
   autoPasContainer->setBoxMax(boxMax);
   autoPasContainer->setCutoff(cutoff);
+  autoPasContainer->setVerletSkinPerTimestep(config.verletSkinRadiusPerTimestep.value);
+  autoPasContainer->setVerletRebuildFrequency(config.verletRebuildFrequency.value);
   autoPasContainer->init();
 
   particlePropertiesLibrary->addType(0, 1., sigmas[0], 1.);
@@ -251,31 +259,31 @@ void testReflectiveBoundaryZoning(const std::array<double, 3> particlePosition, 
  * This is repeated for all boundaries.
  */
 TEST_F(ReflectiveBoundaryConditionTest, reflectiveZoningTest) {
-  testReflectiveBoundaryZoning({0.5, 2.5, 2.5}, 0);
-  testReflectiveBoundaryZoning({2.5, 0.5, 2.5}, 0);
-  testReflectiveBoundaryZoning({2.5, 2.5, 0.5}, 0);
-  testReflectiveBoundaryZoning({4.5, 2.5, 2.5}, 0);
-  testReflectiveBoundaryZoning({2.5, 4.5, 2.5}, 0);
-  testReflectiveBoundaryZoning({2.5, 2.5, 4.5}, 0);
+  testReflectiveBoundaryZoning({0.05, 2.5,  2.5},  0);
+  testReflectiveBoundaryZoning({2.5,  0.05, 2.5},  0);
+  testReflectiveBoundaryZoning({2.5,  2.5,  0.05}, 0);
+  testReflectiveBoundaryZoning({4.95, 2.5,  2.5},  0);
+  testReflectiveBoundaryZoning({2.5,  4.95, 2.5},  0);
+  testReflectiveBoundaryZoning({2.5,  2.5,  4.95}, 0);
 
-  testReflectiveBoundaryZoning({1.0, 2.5, 2.5}, 1);
-  testReflectiveBoundaryZoning({2.5, 1.0, 2.5}, 1);
-  testReflectiveBoundaryZoning({2.5, 2.5, 1.0}, 1);
-  testReflectiveBoundaryZoning({4.0, 2.5, 2.5}, 1);
-  testReflectiveBoundaryZoning({2.5, 4.0, 2.5}, 1);
-  testReflectiveBoundaryZoning({2.5, 2.5, 4.0}, 1);
+  testReflectiveBoundaryZoning({0.1, 2.5, 2.5}, 1);
+  testReflectiveBoundaryZoning({2.5, 0.1, 2.5}, 1);
+  testReflectiveBoundaryZoning({2.5, 2.5, 0.1}, 1);
+  testReflectiveBoundaryZoning({4.9, 2.5, 2.5}, 1);
+  testReflectiveBoundaryZoning({2.5, 4.9, 2.5}, 1);
+  testReflectiveBoundaryZoning({2.5, 2.5, 4.9}, 1);
 
-  testReflectiveBoundaryZoning({1.0, 2.5, 2.5}, 0);
-  testReflectiveBoundaryZoning({2.5, 1.0, 2.5}, 0);
-  testReflectiveBoundaryZoning({2.5, 2.5, 1.0}, 0);
-  testReflectiveBoundaryZoning({4.0, 2.5, 2.5}, 0);
-  testReflectiveBoundaryZoning({2.5, 4.0, 2.5}, 0);
-  testReflectiveBoundaryZoning({2.5, 2.5, 4.0}, 0);
+  testReflectiveBoundaryZoning({0.1, 2.5, 2.5}, 0);
+  testReflectiveBoundaryZoning({2.5, 0.1, 2.5}, 0);
+  testReflectiveBoundaryZoning({2.5, 2.5, 0.1}, 0);
+  testReflectiveBoundaryZoning({4.9, 2.5, 2.5}, 0);
+  testReflectiveBoundaryZoning({2.5, 4.9, 2.5}, 0);
+  testReflectiveBoundaryZoning({2.5, 2.5, 4.9}, 0);
 
-  testReflectiveBoundaryZoning({1.5, 2.5, 2.5}, 1);
-  testReflectiveBoundaryZoning({2.5, 1.5, 2.5}, 1);
-  testReflectiveBoundaryZoning({2.5, 2.5, 1.5}, 1);
-  testReflectiveBoundaryZoning({3.5, 2.5, 2.5}, 1);
-  testReflectiveBoundaryZoning({2.5, 3.5, 2.5}, 1);
-  testReflectiveBoundaryZoning({2.5, 2.5, 3.5}, 1);
+  testReflectiveBoundaryZoning({0.15, 2.5,  2.5}, 1);
+  testReflectiveBoundaryZoning({2.5,  0.15, 2.5}, 1);
+  testReflectiveBoundaryZoning({2.5,  2.5,  0.15}, 1);
+  testReflectiveBoundaryZoning({4.85, 2.5,  2.5}, 1);
+  testReflectiveBoundaryZoning({2.5,  4.85, 2.5}, 1);
+  testReflectiveBoundaryZoning({2.5,  2.5,  4.85}, 1);
 }

--- a/examples/md-flexible/tests/domainDecomposition/ReflectiveBoundaryConditionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/ReflectiveBoundaryConditionTest.cpp
@@ -16,8 +16,8 @@
 extern template class autopas::AutoPas<ParticleType>;
 
 /**
- * Very simple test of reflective boundaries in all 3 dimension. Places identical particles on every face and tests that the particle
- * receives the correct force.
+ * Very simple test of reflective boundaries in all 3 dimension. Places identical particles on every face and tests that
+ * the particle receives the correct force.
  */
 TEST_P(ReflectiveBoundaryConditionTest, simpleReflectionTest) {
   // initialise AutoPas container & domainDecomposition
@@ -58,9 +58,10 @@ TEST_P(ReflectiveBoundaryConditionTest, simpleReflectionTest) {
   const std::array<double, 3> particleVelocity = std::get<1>(GetParam());
 
   // derive expected position
-  auto forceFromReflection = [&](const std::array<double, 3> position, const int dimensionOfBoundary, const bool isUpper) {
-    const auto distanceToBoundary = isUpper ? boxMax[dimensionOfBoundary] - position[dimensionOfBoundary]:
-                                            position[dimensionOfBoundary] - boxMin[dimensionOfBoundary];
+  auto forceFromReflection = [&](const std::array<double, 3> position, const int dimensionOfBoundary,
+                                 const bool isUpper) {
+    const auto distanceToBoundary = isUpper ? boxMax[dimensionOfBoundary] - position[dimensionOfBoundary]
+                                            : position[dimensionOfBoundary] - boxMin[dimensionOfBoundary];
     const auto distanceToMirrorParticle = distanceToBoundary * 2.;
     const auto distanceSquared = distanceToMirrorParticle * distanceToMirrorParticle;
 
@@ -177,7 +178,6 @@ void testReflectiveBoundaryZoning(const std::array<double, 3> particlePosition, 
   config.sigmaMap.value.clear();
   config.massMap.value.clear();
 
-
   const std::array<double, 3> boxMin = {0., 0., 0.};
   const std::array<double, 3> boxMax = {5., 5., 5.};
   const std::array<double, 2> sigmas = {1., 2.};
@@ -207,11 +207,11 @@ void testReflectiveBoundaryZoning(const std::array<double, 3> particlePosition, 
   particlePropertiesLibrary->addType(1, 1., sigmas[1], 1.);
   particlePropertiesLibrary->calculateMixingCoefficients();
 
-  std::array<bool,3> expectReflection = {false, false, false};
+  std::array<bool, 3> expectReflection = {false, false, false};
   for (int dim = 0; dim < 3; dim++) {
     if (particlePosition[dim] < boxMin[dim] + sixthRootOfTwo * sigmas[particleTypeID] / 2.) {
       expectReflection[dim] = true;
-    } else if (particlePosition[dim] > boxMax[dim] - sixthRootOfTwo * sigmas[particleTypeID] /2.) {
+    } else if (particlePosition[dim] > boxMax[dim] - sixthRootOfTwo * sigmas[particleTypeID] / 2.) {
       expectReflection[dim] = true;
     }
   }

--- a/src/autopas/molecularDynamics/ParticlePropertiesLibrary.h
+++ b/src/autopas/molecularDynamics/ParticlePropertiesLibrary.h
@@ -99,6 +99,13 @@ class ParticlePropertiesLibrary {
   floatType getSigmaSquare(intType i) const;
 
   /**
+   * Getter for the particle's sigma.
+   * @param i typeId of the particle.
+   * @return sigma_i
+   */
+  floatType getSigma(intType i) const;
+
+  /**
    * Getter for the particle's mass.
    * @param i typeId of the particle.
    * @return mass_i
@@ -233,6 +240,11 @@ floatType ParticlePropertiesLibrary<floatType, intType>::get24Epsilon(intType i)
 template <typename floatType, typename intType>
 floatType ParticlePropertiesLibrary<floatType, intType>::getSigmaSquare(intType i) const {
   return _computedMixingData[i * _numRegisteredTypes + i].sigmaSquare;
+}
+
+template <typename floatType, typename intType>
+floatType ParticlePropertiesLibrary<floatType, intType>::getSigma(intType i) const {
+  return _sigmas[i];
 }
 
 template <typename floatType, typename intType>


### PR DESCRIPTION
# Description

Replaces the existing reflecting boundary mechanism with one based on mirror particles. Here 'mirror' particles are placed on the opposite side of a reflecting boundary from an original particle, and the two interact via the standard Lennard-Jones functor. Interactions are limited to when particles are within a range such that any LJ interaction leads to repulsion only.

## Resolved Issues

- [x] fixes #713 
- [x] implements #714 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Standard Reflecting Boundary tests have been modified to test for correct force for the current scheme
- [x] Additional test that checks correct zoning of reflecting boundaries (i.e. that particles react only when it leads to repulsion, for several different sigma values)
- [x] Falling Drop can be run without error.
