### PR TITLE
update actions/checkout@v2 -> v3

### DIFF
--- a/.github/workflows/TestSuites.yaml
+++ b/.github/workflows/TestSuites.yaml
@@ -20,7 +20,7 @@ jobs:
   StyleCheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: DoozyX/clang-format-lint-action@v0.12
         with:
           source: 'src tests examples'
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Checks
         # this exits immediately when any command returns != 0
         run: |
@@ -81,7 +81,7 @@ jobs:
         LSAN_OPTIONS: "verbosity=1:log_threads=1"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build everything
         run: |

--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build documentation
         # writes all warnings to warnings.out


### PR DESCRIPTION
# Description

There is a deprecation warning to update this GitHub actions action. We also did this in ls1.

