### PR TITLE
Fix MD-flexible example

### DIFF
--- a/examples/md-flexible/input/AllOptions.yaml
+++ b/examples/md-flexible/input/AllOptions.yaml
@@ -10,20 +10,20 @@ mpi-strategy                     :  no-mpi
 tuning-interval                  :  5000
 tuning-samples                   :  3
 tuning-max-evidence              :  10
-functor                          :  Lennard-Jones (12-6)
+functor                          :  Lennard-Jones (12-6) avx
 newton3                          :  [disabled, enabled]
 cutoff                           :  1
 box-min                          :  [-1.75, -1.75, -1.75]
 box-max                          :  [7.25, 7.25, 7.25]
 cell-size                        :  [1]
-deltaT                           :  0.001
+deltaT                           :  0.000001
 iterations                       :  10
 periodic-boundaries              :  true
 Objects:                         
   CubeGrid:
-    0:  
+    0:
       particles-per-dimension    :  [10, 10, 10]
-      particle-spacing           :  0.5
+      particle-spacing           :  1.1225
       bottomLeftCorner           :  [0, 0, 0]
       velocity                   :  [0, 0, 0]
       particle-type              :  0
@@ -31,22 +31,22 @@ Objects:
       particle-sigma             :  1
       particle-mass              :  1
   CubeGauss:
-    0:  
+    0:
       distribution-mean          :  [2, 2, 2]
-      distribution-stddeviation  :  [1, 1, 1]
+      distribution-stddeviation  :  [2, 2, 2]
       numberOfParticles          :  100
-      box-length                 :  [4, 4, 4]
-      bottomLeftCorner           :  [0, 0, 0]
+      box-length                 :  [8, 8, 8]
+      bottomLeftCorner           :  [15, 15, 15]
       velocity                   :  [0, 0, 0]
       particle-type              :  1
       particle-epsilon           :  1
       particle-sigma             :  1
       particle-mass              :  1
   CubeUniform:
-    0:  
+    0:
       numberOfParticles          :  100
-      box-length                 :  [4, 4, 4]
-      bottomLeftCorner           :  [0, 0, 0]
+      box-length                 :  [10, 10, 10]
+      bottomLeftCorner           :  [15, 0, 0]
       velocity                   :  [0, 0, 0]
       particle-type              :  2
       particle-epsilon           :  1
@@ -55,20 +55,20 @@ Objects:
   CubeClosestPacked:
     0:
       box-length                 :  [4, 4, 4]
-      bottomLeftCorner           :  [0, 0, 0]
-      particle-spacing           :  0.5
+      bottomLeftCorner           :  [0, 0, 15]
+      particle-spacing           :  1.1225
       velocity                   :  [0, 0, 0]
       particle-type              :  2
       particle-epsilon           :  1
       particle-sigma             :  1
       particle-mass              :  1
   Sphere:
-    0:  
-      center                     :  [5, 5, 5]
+    0:
+      center                     :  [4, 16, 4]
       radius                     :  3
-      particle-spacing           :  0.5
+      particle-spacing           :  1.1225
       velocity                   :  [0, 0, 0]
-      particle-type              :  4
+      particle-type              :  3
       particle-epsilon           :  1
       particle-sigma             :  1
       particle-mass              :  1
@@ -77,7 +77,7 @@ thermostat:
   targetTemperature              :  4
   deltaTemperature               :  0.1
   thermostatInterval             :  10
-  addBrownianMotion              :  false
+  addBrownianMotion              :  true
 log-level                        :  info
 no-flops                         :  false
 no-end-config                    :  false

--- a/examples/md-flexible/input/AllOptions.yaml
+++ b/examples/md-flexible/input/AllOptions.yaml
@@ -58,7 +58,7 @@ Objects:
       bottomLeftCorner           :  [0, 0, 15]
       particle-spacing           :  1.1225
       velocity                   :  [0, 0, 0]
-      particle-type              :  2
+      particle-type              :  3
       particle-epsilon           :  1
       particle-sigma             :  1
       particle-mass              :  1
@@ -68,7 +68,7 @@ Objects:
       radius                     :  3
       particle-spacing           :  1.1225
       velocity                   :  [0, 0, 0]
-      particle-type              :  3
+      particle-type              :  4
       particle-epsilon           :  1
       particle-sigma             :  1
       particle-mass              :  1

--- a/examples/md-flexible/src/configuration/MDFlexConfig.cpp
+++ b/examples/md-flexible/src/configuration/MDFlexConfig.cpp
@@ -286,6 +286,7 @@ std::string MDFlexConfig::to_string() const {
   printObjectCollection(cubeGridObjects, cubeGridObjectsStr, os);
   printObjectCollection(cubeGaussObjects, cubeGaussObjectsStr, os);
   printObjectCollection(cubeUniformObjects, cubeUniformObjectsStr, os);
+  printObjectCollection(cubeClosestPackedObjects, cubeClosestPackedObjectsStr, os);
   printObjectCollection(sphereObjects, sphereObjectsStr, os);
 
   if (not globalForceIsZero()) {


### PR DESCRIPTION
# Description
Using AllOptions.yaml file as input for md-flexible used to throw errors.
## Changes
### In `AllOptions.yaml`:
- Correct `particle-type` ordering
- Turn on Brownian Motion to avoid 0 velocities
- Reduce the timestep

### In `MDFlexConfig.cpp`:
- Add ClosestPackedCube objects to the output

## Resolved Issues

- [x] fixes #591

# How Has This Been Tested?

Ran the md-flexible simulation and visualized in paraview:
![image](https://user-images.githubusercontent.com/43962524/222716672-ecb6651b-ab1f-4983-b62d-5ac9e9ab9bd7.png)

