### PR TITLE
Extend cubeClosestPacked for md_flexible

### DIFF
--- a/examples/md-flexible/src/configuration/objects/CubeClosestPacked.h
+++ b/examples/md-flexible/src/configuration/objects/CubeClosestPacked.h
@@ -47,30 +47,30 @@ class CubeClosestPacked : public Object {
   [[nodiscard]] size_t getParticlesTotal() const override {
     // Shorter part of the bisectrix when split at the intersection of all bisectrices.
     const double xOffset = _particleSpacing * 1. / 2.;
-    // Number of particles in the first row
+    // Number of particles in the first row.
     const size_t xNumRow = std::ceil(_boxLength[0] / _particleSpacing);
-    // True if total number of x-positions is odd
+    // True if the total number of x-positions is odd.
     const bool xOdd = static_cast<int>(std::ceil(_boxLength[0] / xOffset)) % 2 == 1;
 
     // Spacing in y direction when only moving 60° on the unit circle. Or the height in an equilateral triangle.
     const double spacingRow = _particleSpacing * sqrt(3. / 4.);
     // Shorter part of the bisectrix when split at the intersection of all bisectrices.
     const double yOffset = _particleSpacing * sqrt(1. / 12.);
-    // Number of rows in an even layer
+    // Number of rows in an even layer.
     const size_t yNumEven = std::ceil(_boxLength[1] / spacingRow);
-    // Number of rows in an odd layer
+    // Number of rows in an odd layer.
     const size_t yNumOdd = std::ceil((_boxLength[1] - yOffset) / spacingRow);
 
-    // Number of particles in an even layer
+    // Number of particles in an even layer.
     const size_t evenLayer = xNumRow * yNumEven - std::floor(xOdd * yNumEven * 0.5);
-    // Number of particles in an odd layer
+    // Number of particles in an odd layer.
     const size_t oddLayer = xNumRow * yNumOdd - std::ceil(xOdd * yNumOdd * 0.5);
 
     // Spacing in z direction. Height in an equilateral tetraeder.
     const double spacingLayer = _particleSpacing * sqrt(2. / 3.);
-    // Total number of layers
+    // Total number of layers.
     const double numLayers = std::ceil(_boxLength[2] / spacingLayer);
-    // Add up even and odd layers
+    // Add up all even and odd layers.
     return evenLayer * std::ceil(numLayers / 2.) + oddLayer * std::floor(numLayers / 2.);
   }
 
@@ -116,7 +116,7 @@ class CubeClosestPacked : public Object {
 
     for (double z = _bottomLeftCorner[2]; z < _topRightCorner[2]; z += spacingLayer) {
       double starty = evenLayer ? _bottomLeftCorner[1] : _bottomLeftCorner[1] + yOffset;
-      bool evenRow = evenLayer;  // To ensure alternating layers as in hexagonal close packed
+      bool evenRow = evenLayer;  // To ensure layers are alternating as for hexagonal close packed.
       for (double y = starty; y < _topRightCorner[1]; y += spacingRow) {
         double startx = evenRow ? _bottomLeftCorner[0] : _bottomLeftCorner[0] + xOffset;
         for (double x = startx; x < _topRightCorner[0]; x += _particleSpacing) {

--- a/examples/md-flexible/src/configuration/objects/CubeClosestPacked.h
+++ b/examples/md-flexible/src/configuration/objects/CubeClosestPacked.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <cmath>
-
 #include <functional>
 
 #include "Object.h"

--- a/examples/md-flexible/src/configuration/objects/CubeClosestPacked.h
+++ b/examples/md-flexible/src/configuration/objects/CubeClosestPacked.h
@@ -129,8 +129,6 @@ class CubeClosestPacked : public Object {
       }
       evenLayer = not evenLayer;
     }
-    std::cout << "NUMBER OF PARTICLES CALCULATED:" << getParticlesTotal() << std::endl;
-    std::cout << "NUMBER OF PARTICLES GENERATED:" << particles.size() << std::endl;
   }
 
  private:

--- a/examples/md-flexible/src/configuration/objects/Object.h
+++ b/examples/md-flexible/src/configuration/objects/Object.h
@@ -85,9 +85,7 @@ class Object {
    * Returns the total amount of Particles in the Object
    * @return ParticlesTotal
    */
-  [[nodiscard]] virtual size_t getParticlesTotal() const {
-    throw std::runtime_error("Objects::getParticlesTotal() not implemented.");
-  };
+  [[nodiscard]] virtual size_t getParticlesTotal() const = 0;
 
   /**
    * Getter for ParticleSpacing.

--- a/examples/md-flexible/tests/ParticlePropertiesLibraryTest.cpp
+++ b/examples/md-flexible/tests/ParticlePropertiesLibraryTest.cpp
@@ -92,4 +92,7 @@ TEST_F(ParticlePropertiesLibraryTest, ParticlePropertiesInitialization) {
   EXPECT_EQ(configuration.getParticlePropertiesLibrary()->getMass(3), 4.0);
   EXPECT_EQ(configuration.getParticlePropertiesLibrary()->get24Epsilon(3), 96.0);
   EXPECT_EQ(configuration.getParticlePropertiesLibrary()->getSigmaSquare(3), 16.0);
+  EXPECT_EQ(configuration.getParticlePropertiesLibrary()->getMass(4), 5.0);
+  EXPECT_EQ(configuration.getParticlePropertiesLibrary()->get24Epsilon(4), 120.0);
+  EXPECT_EQ(configuration.getParticlePropertiesLibrary()->getSigmaSquare(4), 25.0);
 }

--- a/examples/md-flexible/tests/configuration/GeneratorsTest.cpp
+++ b/examples/md-flexible/tests/configuration/GeneratorsTest.cpp
@@ -44,12 +44,14 @@ TEST_F(GeneratorsTest, MultipleObjectGeneration) {
   EXPECT_THAT(configuration.cubeGaussObjects, ::testing::SizeIs(1));
   EXPECT_THAT(configuration.cubeUniformObjects, ::testing::SizeIs(1));
   EXPECT_THAT(configuration.sphereObjects, ::testing::SizeIs(1));
+  EXPECT_THAT(configuration.cubeClosestPackedObjects, ::testing::SizeIs(1));
 
   // counters to checks if all particles types are well initialized for different Objects:
   int gridCounter = 0;
   int gaussCounter = 0;
   int uniformCounter = 0;
   int sphereCounter = 0;
+  int closestCounter = 0;
 
   std::array<double, 3> velocity = {0., 0., 0.};
   for (auto &particle : configuration.getParticles()) {
@@ -71,6 +73,10 @@ TEST_F(GeneratorsTest, MultipleObjectGeneration) {
         sphereCounter++;
         break;
       }
+      case 4: {
+        closestCounter++;
+        break;
+      }
       default: {
         throw std::runtime_error("something went wrong with the Types");
       }
@@ -81,6 +87,7 @@ TEST_F(GeneratorsTest, MultipleObjectGeneration) {
   EXPECT_EQ(gaussCounter, configuration.cubeGaussObjects.at(0).getParticlesTotal());
   EXPECT_EQ(uniformCounter, configuration.cubeUniformObjects.at(0).getParticlesTotal());
   EXPECT_EQ(sphereCounter, configuration.sphereObjects.at(0).getParticlesTotal());
+  EXPECT_EQ(closestCounter, configuration.cubeClosestPackedObjects.at(0).getParticlesTotal());
   // check if during initialization, not 2 Particles were initialized with same id
   std::set<size_t> ids;
   for (auto &particle : configuration.getParticles()) {

--- a/examples/md-flexible/tests/configuration/MDFlexConfigTest.cpp
+++ b/examples/md-flexible/tests/configuration/MDFlexConfigTest.cpp
@@ -68,6 +68,21 @@ TEST_F(MDFlexConfigTest, UniformBoxMinMax) {
   EXPECT_THAT(configuration.boxMax.value, expectedBoxMax);
 }
 
+TEST_F(MDFlexConfigTest, ClosestPackedBoxMinMax) {
+  std::vector<std::string> arguments = {"md-flexible", "--yaml-filename",
+                                        std::string(YAMLDIRECTORY) + "cubeClosestPacked.yaml"};
+
+  char *argv[3] = {&arguments[0][0], &arguments[1][0], &arguments[2][0]};
+
+  MDFlexConfig configuration(3, argv);
+
+  std::array<double, 3> expectedBoxMin = {-0.5, -0.5, 0.};
+  std::array<double, 3> expectedBoxMax = {7., 7.5, 27.5};
+
+  EXPECT_THAT(configuration.boxMin.value, expectedBoxMin);
+  EXPECT_THAT(configuration.boxMax.value, expectedBoxMax);
+}
+
 TEST_F(MDFlexConfigTest, calcAutoPasBox) {
   std::vector<std::string> arguments = {"md-flexible", "--yaml-filename",
                                         std::string(YAMLDIRECTORY) + "multipleObjectsWithMultipleTypesTest.yaml"};
@@ -78,7 +93,7 @@ TEST_F(MDFlexConfigTest, calcAutoPasBox) {
 
   std::array<double, 3> expectedBoxMin = {-10.75, -25.75, -15.75};
   EXPECT_EQ(configuration.boxMin.value, expectedBoxMin);
-  std::array<double, 3> expectedBoxMax = {23, 10, 15.75};
+  std::array<double, 3> expectedBoxMax = {23, 10, 27.5};
   EXPECT_EQ(configuration.boxMax.value, expectedBoxMax);
 }
 

--- a/examples/md-flexible/tests/yamlTestFiles/cubeClosestPacked.yaml
+++ b/examples/md-flexible/tests/yamlTestFiles/cubeClosestPacked.yaml
@@ -1,0 +1,15 @@
+#yaml input for cubeClosestPacked
+#used in:
+#MDFlexConfigTests.ClosestBoxMinMax
+#YamlParser
+Objects:
+  CubeClosestPacked:
+    0:
+      particle-type              :  0
+      particle-epsilon           :  5.
+      particle-sigma             :  5.
+      particle-mass              :  5.
+      box-length                 :  [6.5, 7., 7.]
+      bottomLeftCorner           :  [0., 0., 20.]
+      particle-spacing           :  1
+      velocity                   :  [0., 0., 0.]

--- a/examples/md-flexible/tests/yamlTestFiles/multipleObjectsWithMultipleTypesTest.yaml
+++ b/examples/md-flexible/tests/yamlTestFiles/multipleObjectsWithMultipleTypesTest.yaml
@@ -46,3 +46,13 @@ Objects:
       radius: 10
       particle-spacing: 1.5
       velocity: [0.,0.,0.]
+  CubeClosestPacked:
+    0:
+      particle-type              :  4
+      particle-epsilon           :  5.
+      particle-sigma             :  5.
+      particle-mass              :  5.
+      box-length                 :  [6.5, 7., 7.]
+      bottomLeftCorner           :  [0., 0., 20.]
+      particle-spacing           :  1
+      velocity                   :  [0., 0., 0.]

--- a/tools/autopasTools/generators/ClosestPackingGenerator.h
+++ b/tools/autopasTools/generators/ClosestPackingGenerator.h
@@ -49,7 +49,7 @@ class ClosestPackingGenerator {
     size_t id = defaultParticle.getID();
     for (double z = boxMin[2]; z < boxMax[2]; z += spacingLayer) {
       double starty = evenLayer ? boxMin[1] : boxMin[1] + yOffset;
-      bool evenRow = evenLayer;  // To ensure alternating layers as in hexagonal close packed
+      bool evenRow = evenLayer;  // To ensure layers are alternating as for hexagonal close packed.
       for (double y = starty; y < boxMax[1]; y += spacingRow) {
         double startx = evenRow ? boxMin[0] : boxMin[0] + xOffset;
         for (double x = startx; x < boxMax[0]; x += spacing) {

--- a/tools/autopasTools/generators/ClosestPackingGenerator.h
+++ b/tools/autopasTools/generators/ClosestPackingGenerator.h
@@ -45,11 +45,11 @@ class ClosestPackingGenerator {
 
     // The packing alternates between odd and even layers and rows
     bool evenLayer = true;
-    bool evenRow = true;
 
     size_t id = defaultParticle.getID();
     for (double z = boxMin[2]; z < boxMax[2]; z += spacingLayer) {
       double starty = evenLayer ? boxMin[1] : boxMin[1] + yOffset;
+      bool evenRow = evenLayer;  // To ensure alternating layers as in hexagonal close packed
       for (double y = starty; y < boxMax[1]; y += spacingRow) {
         double startx = evenRow ? boxMin[0] : boxMin[0] + xOffset;
         for (double x = startx; x < boxMax[0]; x += spacing) {


### PR DESCRIPTION
# Description

- Add `getParticlesTotal()` for cubeClosestPacked 
- Add cubeClosestPacked object to md_flexible tests

# How Has This Been Tested?
Calculation has been tested with all combinations of odd or even rows, columns, layers

### Example image for better understanding:
![image](https://user-images.githubusercontent.com/43962524/223774729-87218bc8-ec7b-45a5-a5fa-2f3c8d940fd4.png)
`xNumRow` = 4
`xOdd` = true, da insgesamt 7 x-Positionen
`yNumEven` = 4 (dunkelblaue, vorderste layer)
`yNumOdd` = 3 (hellblauere, hintere layer)