### PR TITLE
AUTOPAS_ENABLE_ALLLBL -> MD_FLEXIBLE_ENABLE_ALLLBL

### DIFF
--- a/cmake/modules/autopas_all.cmake
+++ b/cmake/modules/autopas_all.cmake
@@ -1,6 +1,6 @@
 # cmake module for adding ALL
 
-option(MD_FLEXIBLE_ENABLE_ALLLBL "Enable ALL load balancing library" OFF)
+option(MD_FLEXIBLE_ENABLE_ALLLBL "Enable load balancing via ALL for MD-Flex" OFF)
 
 # Enable ExternalProject CMake module
 if (MD_FLEXIBLE_ENABLE_ALLLBL)

--- a/cmake/modules/autopas_all.cmake
+++ b/cmake/modules/autopas_all.cmake
@@ -1,10 +1,10 @@
 # cmake module for adding ALL
 
-option(AUTOPAS_ENABLE_ALLLBL "Enable ALL load balancing library" OFF)
+option(MD_FLEXIBLE_ENABLE_ALLLBL "Enable ALL load balancing library" OFF)
 
 # Enable ExternalProject CMake module
-if (AUTOPAS_ENABLE_ALLLBL)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DAUTOPAS_ENABLE_ALLLBL")
+if (MD_FLEXIBLE_ENABLE_ALLLBL)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMD_FLEXIBLE_ENABLE_ALLLBL")
 
   include(FetchContent)
   FetchContent_Declare(

--- a/cmake/modules/autopas_all.cmake
+++ b/cmake/modules/autopas_all.cmake
@@ -9,7 +9,7 @@ if (MD_FLEXIBLE_ENABLE_ALLLBL)
   include(FetchContent)
   FetchContent_Declare(
     allfetch
-    URL ${CMAKE_CURRENT_SOURCE_DIR}/ALL_20210930.zip
+    URL ${AUTOPAS_SOURCE_DIR}/libs/ALL_20210930.zip
     URL_HASH MD5=841b87748f82da1666bdc26f2038a3a1
   )
   

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -59,7 +59,7 @@ RegularGridDecomposition::RegularGridDecomposition(const MDFlexConfig &configura
   // initialize _neighborDomainIndices
   initializeNeighborIndices();
 
-#if defined(AUTOPAS_ENABLE_ALLLBL)
+#if defined(MD_FLEXIBLE_ENABLE_ALLLBL)
   if (_loadBalancerOption == LoadBalancerOption::all) {
     _allLoadBalancer = std::make_unique<ALL::ALL<double, double>>(ALL::TENSOR, _dimensionCount, 0);
     _allLoadBalancer->setCommunicator(_communicator);
@@ -85,7 +85,7 @@ void RegularGridDecomposition::update(const double &work) {
         balanceWithInvertedPressureLoadBalancer(work);
         break;
       }
-#if defined(AUTOPAS_ENABLE_ALLLBL)
+#if defined(MD_FLEXIBLE_ENABLE_ALLLBL)
       case LoadBalancerOption::all: {
         balanceWithAllLoadBalancer(work);
         break;
@@ -527,7 +527,7 @@ void RegularGridDecomposition::balanceWithInvertedPressureLoadBalancer(double wo
   }
 }
 
-#if defined(AUTOPAS_ENABLE_ALLLBL)
+#if defined(MD_FLEXIBLE_ENABLE_ALLLBL)
 void RegularGridDecomposition::balanceWithAllLoadBalancer(const double &work) {
   std::vector<ALL::Point<double>> domain(2, ALL::Point<double>(3));
 

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#if defined(AUTOPAS_ENABLE_ALLLBL)
+#if defined(MD_FLEXIBLE_ENABLE_ALLLBL)
 #include <ALL.hpp>
 #endif
 #include <memory>
@@ -254,7 +254,7 @@ class RegularGridDecomposition final : public DomainDecomposition {
    */
   std::array<double, _dimensionCount> _localBoxMax{};
 
-#if defined(AUTOPAS_ENABLE_ALLLBL)
+#if defined(MD_FLEXIBLE_ENABLE_ALLLBL)
   /**
    * The ALL load balancer used for diffuse load balancing
    * We cannot use a shared pointer here, because whenn the load balancer is deleted, it calls MPI_Comm_free after
@@ -336,7 +336,7 @@ class RegularGridDecomposition final : public DomainDecomposition {
    */
   void balanceWithInvertedPressureLoadBalancer(double work);
 
-#if defined(AUTOPAS_ENABLE_ALLLBL)
+#if defined(MD_FLEXIBLE_ENABLE_ALLLBL)
   /**
    * Balances the subdomains of the grid decomposition using the ALL load balancer.
    * @param work: The work performed by the process owning this sudomain.

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -2,7 +2,6 @@
 include(autopas_spdlog)
 include(autopas_harmony)
 include(autopas_eigen)
-include(autopas_all)
 
 add_subdirectory(fake-dlclose)
 


### PR DESCRIPTION
# Description

The CMake option for ALL is only relevant for md-flex. Rename it as to reduce confusion.

