### PR TITLE
Add particles in bulk

### DIFF
--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -207,16 +207,7 @@ void RegularGridDecomposition::exchangeHaloParticles(AutoPasType &autoPasContain
         particlesForLeftNeighbor, particlesForRightNeighbor, leftNeighbor, rightNeighbor);
     haloParticles.insert(haloParticles.end(), receivedHaloParticles.begin(), receivedHaloParticles.end());
   }
-#ifdef AUTOPAS_OPENMP
-  // reduce scheduling overhead for large numbers of halo particles.
-  // No need to fill all buffers exactly equal because they will be rebalanced later anyway.
-  const auto ompChunkSize = std::max(1ul, haloParticles.size() / static_cast<size_t>(4 * omp_get_max_threads()));
-#pragma omp parallel for schedule(dynamic, ompChunkSize)
-#endif
-  // we can't use range based for loops here because clang accepts this only starting with version 11
-  for (size_t i = 0; i < haloParticles.size(); ++i) {
-    autoPasContainer.addHaloParticle(haloParticles[i]);
-  }
+  autoPasContainer.addHaloParticles(haloParticles);
 }
 
 void RegularGridDecomposition::exchangeMigratingParticles(AutoPasType &autoPasContainer,

--- a/src/autopas/AutoPasDecl.h
+++ b/src/autopas/AutoPasDecl.h
@@ -1115,6 +1115,6 @@ class AutoPas {
    * Typically `[&](auto i) {addParticle(collection[i]);}`.
    */
   template <class F>
-  void addParticleAux(size_t numParticlesToAdd, size_t numHalosToAdd, size_t collectionSize, F loopBody);
+  void addParticlesAux(size_t numParticlesToAdd, size_t numHalosToAdd, size_t collectionSize, F loopBody);
 };  // class AutoPas
 }  // namespace autopas

--- a/src/autopas/AutoPasDecl.h
+++ b/src/autopas/AutoPasDecl.h
@@ -142,7 +142,8 @@ class AutoPas {
   void reserve(size_t numParticles);
 
   /**
-   * Reserve memory for a given number of particles in the container and logic layers.
+   * Reserve memory for a given number of particles in the container and logic layers
+   * (e.g. LogicHandler::_particleBuffer).
    * This function assumes a uniform distribution of particles throughout the domain.
    * For example, this means that in a LinkedCells Container in each cell vector.reserve(numParticles/numCells) is
    * called.
@@ -1105,14 +1106,15 @@ class AutoPas {
 
   /**
    * Helper function to reduce code duplication for all forms of addParticle while minimizing overhead through loops.
-   * @tparam F
-   * @param numParticlesToAdd
-   * @param numHalosToAdd
-   * @param collectionSize
-   * @param innerBody Function to be called in the parallel loop over collectionSize.
+   * Triggers reserve() and provides a parallel loop with deliberate scheduling.
+   * @tparam F Function type of loopBody: (int) -> void.
+   * @param numParticlesToAdd For how many new owned particles should space be allocated.
+   * @param numHalosToAdd For how many new halo particles should space be allocated.
+   * @param collectionSize Size of the collection from which particles are added.
+   * @param loopBody Function to be called in the parallel loop over collectionSize.
    * Typically `[&](auto i) {addParticle(collection[i]);}`.
    */
   template <class F>
-  void addParticleAux(size_t numParticlesToAdd, size_t numHalosToAdd, size_t collectionSize, F innerBody);
+  void addParticleAux(size_t numParticlesToAdd, size_t numHalosToAdd, size_t collectionSize, F loopBody);
 };  // class AutoPas
 }  // namespace autopas

--- a/src/autopas/AutoPasDecl.h
+++ b/src/autopas/AutoPasDecl.h
@@ -135,10 +135,21 @@ class AutoPas {
    * This function assumes a uniform distribution of particles throughout the domain.
    * For example, this means that in a LinkedCells Container in each cell vector.reserve(numParticles/numCells) is
    * called.
+   * @note This functions will create an estimate for the number of halo particles.
    * @param numParticles No buffer factor is applied. It is probably wise to slighly over-reserve to account for
    * imbalance or particle movement.
    */
   void reserve(size_t numParticles);
+
+  /**
+   * Reserve memory for a given number of particles in the container and logic layers.
+   * This function assumes a uniform distribution of particles throughout the domain.
+   * For example, this means that in a LinkedCells Container in each cell vector.reserve(numParticles/numCells) is
+   * called.
+   * @param numParticles
+   * @param numHaloParticles
+   */
+  void reserve(size_t numParticles, size_t numHaloParticles);
 
   /**
    * Adds a particle to the container.

--- a/src/autopas/AutoPasDecl.h
+++ b/src/autopas/AutoPasDecl.h
@@ -157,18 +157,60 @@ class AutoPas {
    * @param p Reference to the particle to be added
    * @note An exception is thrown if the particle is added and it is not inside of the owned domain (defined by
    * boxmin and boxmax) of the container.
-   * @note This function is NOT thread-safe.
+   * @note This function is NOT thread-safe if the container is Octree.
    */
   void addParticle(const Particle &p);
+
+  /**
+   * Adds all particles from the collection to the container.
+   * @note This function uses addParticlesIf().
+   * @tparam Collection Collection type that contains the particles (e.g. std::vector). Needs to support `.size()`.
+   * @param particles
+   */
+  template <class Collection>
+  void addParticles(Collection &&particles);
+
+  /**
+   * Adds all particles for which predicate(particle) == true to the container.
+   * @note This function uses reserve().
+   * @note This function uses addParticle().
+   * @tparam Collection Collection type that contains the particles (e.g. std::vector). Needs to support `.size()`.
+   * @tparam F Function type of predicate. Should be of the form: (const Particle &) -> bool.
+   * @param particles Particles that are potentially added.
+   * @param predicate Condition that determines if an individual particle should be added.
+   */
+  template <class Collection, class F>
+  void addParticlesIf(Collection &&particles, F predicate);
 
   /**
    * Adds a particle to the container that lies in the halo region of the container.
    * @param haloParticle Particle to be added.
    * @note An exception is thrown if the halo particle is added and it is inside of the owned domain (defined by boxmin
    * and boxmax) of the container.
-   * @note This function is NOT thread-safe.
+   * @note This function is NOT thread-safe if the container is Octree.
    */
   void addHaloParticle(const Particle &haloParticle);
+
+  /**
+   * Adds all halo particles from the collection to the container.
+   * @note This function uses addHaloParticlesIf().
+   * @tparam Collection Collection type that contains the particles (e.g. std::vector). Needs to support `.size()`.
+   * @param particles
+   */
+  template <class Collection>
+  void addHaloParticles(Collection &&particles);
+
+  /**
+   * Adds all halo particles for which predicate(particle) == true to the container.
+   * @note This function uses reserve().
+   * @note This function uses addHaloParticle().
+   * @tparam Collection Collection type that contains the particles (e.g. std::vector). Needs to support `.size()`.
+   * @tparam F Function type of predicate. Should be of the form: (const Particle &) -> bool.
+   * @param particles Particles that are potentially added.
+   * @param predicate Condition that determines if an individual particle should be added.
+   */
+  template <class Collection, class F>
+  void addHaloParticlesIf(Collection &&particles, F predicate);
 
   /**
    * Deletes all particles.
@@ -1061,5 +1103,16 @@ class AutoPas {
    */
   std::string _outputSuffix{""};
 
+  /**
+   * Helper function to reduce code duplication for all forms of addParticle while minimizing overhead through loops.
+   * @tparam F
+   * @param numParticlesToAdd
+   * @param numHalosToAdd
+   * @param collectionSize
+   * @param innerBody Function to be called in the parallel loop over collectionSize.
+   * Typically `[&](auto i) {addParticle(collection[i]);}`.
+   */
+  template <class F>
+  void addParticleAux(size_t numParticlesToAdd, size_t numHalosToAdd, size_t collectionSize, F innerBody);
 };  // class AutoPas
 }  // namespace autopas

--- a/src/autopas/AutoPasImpl.h
+++ b/src/autopas/AutoPasImpl.h
@@ -117,6 +117,11 @@ void AutoPas<Particle>::reserve(size_t numParticles) {
 }
 
 template <class Particle>
+void AutoPas<Particle>::reserve(size_t numParticles, size_t numHaloParticles) {
+  _logicHandler->reserve(numParticles);
+}
+
+template <class Particle>
 void AutoPas<Particle>::addParticle(const Particle &p) {
   _logicHandler->addParticle(p);
 }

--- a/src/autopas/AutoPasImpl.h
+++ b/src/autopas/AutoPasImpl.h
@@ -124,7 +124,7 @@ void AutoPas<Particle>::reserve(size_t numParticles, size_t numHaloParticles) {
 template <class Particle>
 template <class F>
 void AutoPas<Particle>::addParticleAux(size_t numParticlesToAdd, size_t numHalosToAdd, size_t collectionSize,
-                                       F innerBody) {
+                                       F loopBody) {
   reserve(getNumberOfParticles(IteratorBehavior::owned) + numParticlesToAdd,
           getNumberOfParticles(IteratorBehavior::halo) + numHalosToAdd);
 #ifdef AUTOPAS_OPENMP
@@ -134,7 +134,7 @@ void AutoPas<Particle>::addParticleAux(size_t numParticlesToAdd, size_t numHalos
     schedule(static, std::max(1ul, collectionSize / omp_get_max_threads()))
 #endif
   for (auto i = 0; i < collectionSize; ++i) {
-    innerBody(i);
+    loopBody(i);
   }
 }
 

--- a/src/autopas/AutoPasImpl.h
+++ b/src/autopas/AutoPasImpl.h
@@ -123,8 +123,8 @@ void AutoPas<Particle>::reserve(size_t numParticles, size_t numHaloParticles) {
 
 template <class Particle>
 template <class F>
-void AutoPas<Particle>::addParticleAux(size_t numParticlesToAdd, size_t numHalosToAdd, size_t collectionSize,
-                                       F loopBody) {
+void AutoPas<Particle>::addParticlesAux(size_t numParticlesToAdd, size_t numHalosToAdd, size_t collectionSize,
+                                        F loopBody) {
   reserve(getNumberOfParticles(IteratorBehavior::owned) + numParticlesToAdd,
           getNumberOfParticles(IteratorBehavior::halo) + numHalosToAdd);
 #ifdef AUTOPAS_OPENMP
@@ -146,7 +146,7 @@ void AutoPas<Particle>::addParticle(const Particle &p) {
 template <class Particle>
 template <class Collection>
 void AutoPas<Particle>::addParticles(Collection &&particles) {
-  addParticleAux(particles.size(), 0, particles.size(), [&](auto i) { addParticle(particles[i]); });
+  addParticlesAux(particles.size(), 0, particles.size(), [&](auto i) { addParticle(particles[i]); });
 }
 
 template <class Particle>
@@ -166,7 +166,7 @@ void AutoPas<Particle>::addParticlesIf(Collection &&particles, F predicate) {
     }
   }
 
-  addParticleAux(numTrue, 0, particles.size(), [&](auto i) {
+  addParticlesAux(numTrue, 0, particles.size(), [&](auto i) {
     if (predicateMask[i]) {
       addParticle(particles[i]);
     }
@@ -199,7 +199,7 @@ void AutoPas<Particle>::addHaloParticle(const Particle &haloParticle) {
 template <class Particle>
 template <class Collection>
 void AutoPas<Particle>::addHaloParticles(Collection &&particles) {
-  addParticleAux(0, particles.size(), particles.size(), [&](auto i) { addHaloParticle(particles[i]); });
+  addParticlesAux(0, particles.size(), particles.size(), [&](auto i) { addHaloParticle(particles[i]); });
 }
 
 template <class Particle>
@@ -219,7 +219,7 @@ void AutoPas<Particle>::addHaloParticlesIf(Collection &&particles, F predicate) 
     }
   }
 
-  addParticleAux(0, numTrue, particles.size(), [&](auto i) {
+  addParticlesAux(0, numTrue, particles.size(), [&](auto i) {
     if (predicateMask[i]) {
       addHaloParticle(particles[i]);
     }

--- a/src/autopas/AutoPasImpl.h
+++ b/src/autopas/AutoPasImpl.h
@@ -128,10 +128,7 @@ void AutoPas<Particle>::addParticlesAux(size_t numParticlesToAdd, size_t numHalo
   reserve(getNumberOfParticles(IteratorBehavior::owned) + numParticlesToAdd,
           getNumberOfParticles(IteratorBehavior::halo) + numHalosToAdd);
 #ifdef AUTOPAS_OPENMP
-  // Hotfix: As long as the octree restructures itself during particle insertion this has to be done in serial.
-  const int numThreads = getContainerType() == autopas::ContainerOption::octree ? 1 : autopas_get_max_threads();
-#pragma omp parallel for num_threads(numThreads), \
-    schedule(static, std::max(1ul, collectionSize / omp_get_max_threads()))
+#pragma omp parallel for schedule(static, std::max(1ul, collectionSize / omp_get_max_threads()))
 #endif
   for (auto i = 0; i < collectionSize; ++i) {
     loopBody(i);

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -179,9 +179,10 @@ class LogicHandler {
   }
 
   /**
-   * @copydoc AutoPas::reserve()
+   * Estimates number of halo particles via autopas::utils::NumParticlesEstimator::estimateNumHalosUniform() then
+   * calls LogicHandler::reserve(size_t numParticles, size_t numHaloParticles).
    *
-   * Reserves space in the particle buffers and the container. Estimates number of halo particles.
+   * @param numParticles Total number of owned particles.
    */
   void reserve(size_t numParticles) {
     const auto &container = _autoTuner.getContainer();
@@ -193,8 +194,8 @@ class LogicHandler {
   /**
    * Reserves space in the particle buffers and the container.
    *
-   * @param numParticles
-   * @param numHaloParticles
+   * @param numParticles Total number of owned particles.
+   * @param numHaloParticles Total number of halo particles.
    */
   void reserve(size_t numParticles, size_t numHaloParticles) {
     const auto numHaloParticlesPerBuffer = numHaloParticles / _haloParticleBuffer.size();

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -181,23 +181,32 @@ class LogicHandler {
   /**
    * @copydoc AutoPas::reserve()
    *
-   * Reserves space in the particle buffers.
+   * Reserves space in the particle buffers and the container. Estimates number of halo particles.
    */
   void reserve(size_t numParticles) {
     const auto &container = _autoTuner.getContainer();
     const auto numParticlesHaloEstimate = autopas::utils::NumParticlesEstimator::estimateNumHalosUniform(
         numParticles, container->getBoxMin(), container->getBoxMax(), container->getInteractionLength());
-    const auto numParticlesHaloEstimatePerBuffer = numParticlesHaloEstimate / _haloParticleBuffer.size();
+    reserve(numParticles, numParticlesHaloEstimate);
+  }
 
+  /**
+   * Reserves space in the particle buffers and the container.
+   *
+   * @param numParticles
+   * @param numHaloParticles
+   */
+  void reserve(size_t numParticles, size_t numHaloParticles) {
+    const auto numHaloParticlesPerBuffer = numHaloParticles / _haloParticleBuffer.size();
     for (auto &buffer : _haloParticleBuffer) {
-      buffer.reserve(numParticlesHaloEstimatePerBuffer);
+      buffer.reserve(numHaloParticlesPerBuffer);
     }
     // there is currently no good heuristic for this buffer so reuse the one for halos.
     for (auto &buffer : _particleBuffer) {
-      buffer.reserve(numParticlesHaloEstimatePerBuffer);
+      buffer.reserve(numHaloParticlesPerBuffer);
     }
 
-    container->reserve(numParticles, numParticlesHaloEstimate);
+    _autoTuner.getContainer()->reserve(numParticles, numHaloParticles);
   }
 
   /**

--- a/src/autopas/cells/ParticleCell.h
+++ b/src/autopas/cells/ParticleCell.h
@@ -54,12 +54,19 @@ class ParticleCell {
   using ParticleType = Particle;
 
   /**
-   * Destructor of ParticleCell.
+   * Default destructor.
    */
   virtual ~ParticleCell() = default;
 
+  /**
+   * Default default constructor.
+   */
   explicit ParticleCell() = default;
 
+  /**
+   * Default move constructor.
+   * @param other
+   */
   ParticleCell(ParticleCell &&other) noexcept = default;
 
   /**

--- a/src/autopas/cells/ParticleCell.h
+++ b/src/autopas/cells/ParticleCell.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "autopas/utils/WrapOpenMP.h"
 #include "autopas/utils/inBox.h"
 
 namespace autopas {
@@ -108,6 +109,11 @@ class ParticleCell {
    * @return cell side length
    */
   [[nodiscard]] virtual std::array<double, 3> getCellLength() const = 0;
+
+  /**
+   * Lock object for exclusive access to this cell.
+   */
+  AutoPasLock _cellLock;
 };
 
 }  // namespace autopas

--- a/src/autopas/cells/ParticleCell.h
+++ b/src/autopas/cells/ParticleCell.h
@@ -58,6 +58,16 @@ class ParticleCell {
    */
   virtual ~ParticleCell() = default;
 
+  explicit ParticleCell() = default;
+
+  ParticleCell(ParticleCell &&other) noexcept = default;
+
+  /**
+   * Copy constructor that creates a new default constructed lock for the new cell.
+   * @param other
+   */
+  ParticleCell(const ParticleCell &other) : _cellLock(){};
+
   /**
    * Adds a Particle to the cell.
    * @param p the particle to be added

--- a/src/autopas/cells/ParticleCell.h
+++ b/src/autopas/cells/ParticleCell.h
@@ -113,7 +113,7 @@ class ParticleCell {
   /**
    * Lock object for exclusive access to this cell.
    */
-  AutoPasLock _cellLock;
+  AutoPasLock _cellLock{};
 };
 
 }  // namespace autopas

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -61,7 +61,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    * @note This function invalidates the neighbor lists.
    */
   void addParticleImpl(const Particle &p) override {
-    _neighborListIsValid = false;
+    _neighborListIsValid.store(false, std::memory_order_relaxed);
     // position is already checked, so call impl directly.
     _linkedCells.addParticleImpl(p);
   }
@@ -71,7 +71,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    * @note This function invalidates the neighbor lists.
    */
   void addHaloParticleImpl(const Particle &haloParticle) override {
-    _neighborListIsValid = false;
+    _neighborListIsValid.store(false, std::memory_order_relaxed);
     // position is already checked, so call impl directly.
     _linkedCells.addHaloParticleImpl(haloParticle);
   }
@@ -86,7 +86,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    * @note This function invalidates the neighbor lists.
    */
   void deleteHaloParticles() override {
-    _neighborListIsValid = false;
+    _neighborListIsValid.store(false, std::memory_order_relaxed);
     _linkedCells.deleteHaloParticles();
   }
 
@@ -95,7 +95,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    * @note This function invalidates the neighbor lists.
    */
   void deleteAllParticles() override {
-    _neighborListIsValid = false;
+    _neighborListIsValid.store(false, std::memory_order_relaxed);
     _linkedCells.deleteAllParticles();
   }
 
@@ -155,7 +155,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
     if (keepNeighborListsValid) {
       return autopas::LeavingParticleCollector::collectParticlesAndMarkNonOwnedAsDummy(_linkedCells);
     }
-    _neighborListIsValid = false;
+    _neighborListIsValid.store(false, std::memory_order_relaxed);
     return _linkedCells.updateContainer(false);
   }
 
@@ -315,7 +315,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
   LinkedCells<Particle> _linkedCells;
 
   /// specifies if the neighbor list is currently valid
-  bool _neighborListIsValid{false};
+  std::atomic<bool> _neighborListIsValid{false};
 
   /// specifies if the current verlet list was built for newton3
   bool _verletBuiltNewton3{false};

--- a/src/autopas/containers/verletListsCellBased/varVerletLists/VarVerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/varVerletLists/VarVerletLists.h
@@ -66,7 +66,7 @@ class VarVerletLists : public VerletListsLinkedBase<Particle> {
     this->_verletBuiltNewton3 = traversal->getUseNewton3();
     _neighborList.buildAoSNeighborList(this->_linkedCells, traversal->getUseNewton3());
     // the neighbor list is now valid
-    this->_neighborListIsValid = true;
+    this->_neighborListIsValid.store(true, std::memory_order_relaxed);
 
     if (traversal->getDataLayout() == DataLayoutOption::soa and not _neighborList.isSoAListValid()) {
       _neighborList.generateSoAFromAoS();

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -102,7 +102,7 @@ class VerletLists : public VerletListsLinkedBase<Particle> {
     this->_verletBuiltNewton3 = traversal->getUseNewton3();
     this->updateVerletListsAoS(traversal->getUseNewton3());
     // the neighbor list is now valid
-    this->_neighborListIsValid = true;
+    this->_neighborListIsValid.store(true, std::memory_order_relaxed);
 
     if (not _soaListIsValid and traversal->getDataLayout() == DataLayoutOption::soa) {
       // only do this if we need it, i.e., if we are using soa!

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -64,7 +64,6 @@ class VerletLists : public VerletListsLinkedBase<Particle> {
               const double cellSizeFactor = 1.0)
       : VerletListsLinkedBase<Particle>(boxMin, boxMax, cutoff, skinPerTimestep, rebuildFrequency,
                                         compatibleTraversals::allVLCompatibleTraversals(), cellSizeFactor),
-        _soaListIsValid(false),
         _buildVerletListType(buildVerletListType) {}
 
   /**
@@ -231,7 +230,7 @@ class VerletLists : public VerletListsLinkedBase<Particle> {
   /**
    * Shows if the SoA neighbor list is currently valid.
    */
-  bool _soaListIsValid;
+  bool _soaListIsValid{false};
 
   /**
    * Specifies for what data layout the verlet lists are build.

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
@@ -128,7 +128,7 @@ class VerletListsCells : public VerletListsLinkedBase<Particle> {
     }
 
     // the neighbor list is now valid
-    this->_neighborListIsValid = true;
+    this->_neighborListIsValid.store(true, std::memory_order_relaxed);
   }
 
   /**

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -536,7 +536,7 @@ void AutoTuner<Particle>::doRemainderTraversal(PairwiseFunctor *f, T containerPt
   // not absolutely necessary but an assumption that is used in this implementation.
   if (particleBuffers.size() != haloParticleBuffers.size()) {
     utils::ExceptionHandler::exception("particleBuffers.size() ({}) != haloParticleBuffers.size() ({})",
-                                        particleBuffers.size(), haloParticleBuffers.size());
+                                       particleBuffers.size(), haloParticleBuffers.size());
   }
 
   // Balance buffers. This makes processing them with static scheduling quite efficient.

--- a/src/autopas/utils/ParticleCellHelpers.h
+++ b/src/autopas/utils/ParticleCellHelpers.h
@@ -38,7 +38,7 @@ static bool checkParticleInCellAndUpdateByID(CellType &cell, const typename Cell
 template <class CellType>
 static bool checkParticleInCellAndUpdateByIDAndPosition(CellType &cell, const typename CellType::ParticleType &particle,
                                                         double absError) {
-  // FIXME: This calls begin and end AND is in a parallel region. => Race conditions for octree
+  std::lock_guard<AutoPasLock> cellLock(cell._cellLock);
   for (auto &p : cell) {
     if (p.getID() == particle.getID()) {
       auto distanceVec = autopas::utils::ArrayMath::sub(p.getR(), particle.getR());

--- a/src/autopas/utils/ParticleCellHelpers.h
+++ b/src/autopas/utils/ParticleCellHelpers.h
@@ -38,6 +38,7 @@ static bool checkParticleInCellAndUpdateByID(CellType &cell, const typename Cell
 template <class CellType>
 static bool checkParticleInCellAndUpdateByIDAndPosition(CellType &cell, const typename CellType::ParticleType &particle,
                                                         double absError) {
+  // FIXME: This calls begin and end AND is in a parallel region. => RC for octree
   for (auto &p : cell) {
     if (p.getID() == particle.getID()) {
       auto distanceVec = autopas::utils::ArrayMath::sub(p.getR(), particle.getR());

--- a/src/autopas/utils/ParticleCellHelpers.h
+++ b/src/autopas/utils/ParticleCellHelpers.h
@@ -38,7 +38,7 @@ static bool checkParticleInCellAndUpdateByID(CellType &cell, const typename Cell
 template <class CellType>
 static bool checkParticleInCellAndUpdateByIDAndPosition(CellType &cell, const typename CellType::ParticleType &particle,
                                                         double absError) {
-  // FIXME: This calls begin and end AND is in a parallel region. => RC for octree
+  // FIXME: This calls begin and end AND is in a parallel region. => Race conditions for octree
   for (auto &p : cell) {
     if (p.getID() == particle.getID()) {
       auto distanceVec = autopas::utils::ArrayMath::sub(p.getR(), particle.getR());

--- a/tests/testAutopas/tests/autopasInterface/AutoPasAllContainersTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasAllContainersTest.cpp
@@ -1,0 +1,66 @@
+/**
+ * @file AutoPasAllContainersTest.cpp
+ * @author F. Gratl
+ * @date 29.03.23
+ */
+
+#include "AutoPasAllContainersTest.h"
+
+#include "autopas/AutoPasImpl.h"
+#include "autopasTools/generators/RandomGenerator.h"
+#include "testingHelpers/commonTypedefs.h"
+
+extern template class autopas::AutoPas<Molecule>;
+
+INSTANTIATE_TEST_SUITE_P(Generated, AutoPasAllContainersTest,
+                         ::testing::ValuesIn(autopas::ContainerOption::getAllOptions()));
+
+/**
+ * Fill a container with randomly generated particles, invoke addParticles, then check if the expected amount was added.
+ */
+TEST_P(AutoPasAllContainersTest, addParticlesTest) {
+  /// Config
+  constexpr auto numMols = 100;
+  constexpr std::array<double, 3> boxMin{0., 0., 0.};
+  constexpr std::array<double, 3> boxMax{10., 10., 10.};
+
+  /// Setup
+  // initialize AutoPas
+  autopas::AutoPas<Molecule> autoPas;
+  autoPas.setBoxMin(boxMin);
+  autoPas.setBoxMax(boxMax);
+  const auto containerOption = GetParam();
+  autoPas.setAllowedContainers({containerOption});
+  autoPas.setAllowedTraversals(autopas::TraversalOption::getAllOptions());
+  autoPas.setNumSamples(autoPas.getTuningInterval());  // to avoid warnings
+  autoPas.init();
+  // generate some random molecules
+  std::vector<Molecule> mols;
+  mols.reserve(numMols);
+  for (size_t i = 0; i < numMols; ++i) {
+    mols.emplace_back(autopasTools::generators::RandomGenerator::randomPosition(boxMin, boxMax),
+                      std::array<double, 3>{0., 0., 0.}, i, 0);
+  }
+
+  /// Test
+  // add every second particle
+  autoPas.addParticlesIf(mols, [](const auto &p) { return p.getID() % 2 == 0; });
+
+  /// Expectations
+  EXPECT_EQ(autoPas.getNumberOfParticles(autopas::IteratorBehavior::owned), numMols / 2)
+      << "AutoPas' counters are wrong!";
+  EXPECT_EQ(autoPas.getNumberOfParticles(autopas::IteratorBehavior::halo), 0) << "AutoPas' counters are wrong!";
+  // count what is actually in the container
+  size_t numParticlesFound = 0;
+  size_t numHalosFound = 0;
+  for (const auto &p : autoPas) {
+    if (p.isOwned()) {
+      ++numParticlesFound;
+    }
+    if (p.isHalo()) {
+      ++numHalosFound;
+    }
+  }
+  EXPECT_EQ(numParticlesFound, numMols / 2) << "Either iterators are broken or the wrong number of particles is wrong!";
+  EXPECT_EQ(numHalosFound, 0) << "Either iterators are broken or the wrong number of particles is wrong!";
+}

--- a/tests/testAutopas/tests/autopasInterface/AutoPasAllContainersTest.h
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasAllContainersTest.h
@@ -1,0 +1,16 @@
+/**
+ * @file AutoPasAllContainersTest.h
+ * @author F. Gratl
+ * @date 29.03.23
+ */
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include "AutoPasTestBase.h"
+#include "autopas/options/ContainerOption.h"
+
+using ParamType = autopas::options::ContainerOption;
+
+class AutoPasAllContainersTest : public AutoPasTestBase, public ::testing::WithParamInterface<ParamType> {};


### PR DESCRIPTION
# Description

Utility functions to remove loops over `addParticle()`.

- [x] `addParticles()`
- [x] `addParticlesIf()`
- [x] `addHaloParticles()`
- [x] `addHaloParticlesIf()`
- ensures reserve is called every time.

## Related Pull Requests

- Builds upon #724 

## Resolved Issues

- [x] creates a workaround for `Octree::addParticle()` being not thread safe.

# How Has This Been Tested?

- new tests