### PR TITLE
Enhanced MD-Flex Yaml Parser

### DIFF
--- a/examples/md-flexible/input/AllOptions.yaml
+++ b/examples/md-flexible/input/AllOptions.yaml
@@ -1,87 +1,103 @@
-container                        :  [DirectSum, LinkedCells, LinkedCellsReferences, VarVerletListsAsBuild, VerletClusterLists, VerletLists, VerletListsCells, PairwiseVerletLists]
-verlet-rebuild-frequency         :  20
-verlet-skin-radius-per-timestep  :  0.01
-verlet-cluster-size              :  4
-selector-strategy                :  Fastest-Absolute-Value
-data-layout                      :  [AoS, SoA]
-traversal                        :  [ds_sequential, lc_sliced, lc_sliced_balanced, lc_sliced_c02, lc_c01, lc_c01_combined_SoA, lc_c04, lc_c04_HCP, lc_c04_combined_SoA, lc_c08, lc_c18, vcl_cluster_iteration, vcl_c06, vcl_c01_balanced, vcl_sliced, vcl_sliced_balanced, vcl_sliced_c02, vl_list_iteration, vlc_c01, vlc_c18, vlc_sliced, vlc_sliced_balanced, vlc_sliced_c02, vvl_as_built, vlp_c01, vlp_c18, vlp_sliced, vlp_sliced_balanced, vlp_sliced_c02]
-tuning-strategy                  :  full-Search
-mpi-strategy                     :  no-mpi
-tuning-interval                  :  5000
-tuning-samples                   :  3
-tuning-max-evidence              :  10
-functor                          :  Lennard-Jones (12-6) avx
-newton3                          :  [disabled, enabled]
-cutoff                           :  1
-box-min                          :  [-1.75, -1.75, -1.75]
-box-max                          :  [7.25, 7.25, 7.25]
-cell-size                        :  [1]
-deltaT                           :  0.000001
-iterations                       :  10
-periodic-boundaries              :  true
+container                            :  [DirectSum, LinkedCells, LinkedCellsReferences, VarVerletListsAsBuild, VerletClusterLists, VerletLists, VerletListsCells, PairwiseVerletLists]
+verlet-rebuild-frequency             :  20
+verlet-skin-radius-per-timestep      :  0.01
+verlet-cluster-size                  :  4
+selector-strategy                    :  Fastest-Absolute-Value
+data-layout                          :  [AoS, SoA]
+traversal                            :  [ds_sequential, lc_sliced, lc_sliced_balanced, lc_sliced_c02, lc_c01, lc_c01_combined_SoA, lc_c04, lc_c04_HCP, lc_c04_combined_SoA, lc_c08, lc_c18, vcl_cluster_iteration, vcl_c06, vcl_c01_balanced, vcl_sliced, vcl_sliced_balanced, vcl_sliced_c02, vl_list_iteration, vlc_c01, vlc_c18, vlc_sliced, vlc_sliced_balanced, vlc_sliced_c02, vvl_as_built, vlp_c01, vlp_c18, vlp_sliced, vlp_sliced_balanced, vlp_sliced_c02]
+tuning-strategy                      :  full-Search
+mpi-strategy                         :  no-mpi
+tuning-interval                      :  5000
+tuning-samples                       :  3
+tuning-max-evidence                  :  10
+functor                              :  Lennard-Jones (12-6) avx
+newton3                              :  [disabled, enabled]
+cutoff                               :  1
+box-min                              :  [-1.75, -1.75, -1.75]
+box-max                              :  [7.25, 7.25, 7.25]
+cell-size                            :  [1]
+deltaT                               :  0.000001
+iterations                           :  10
+boundary-type                        :  [periodic, periodic, periodic]
+subdivide-dimension                  :  [true, true, true]
+load-balancing-interval              :  100
+tuning-phases                        :  0
+load-estimator                       :  [none, squared-particles-per-cell, neighbor-list-length]
+relative-optimum-range               :  1.2
+max-tuning-phases-without-test       :  5
+relative-blacklist-range             :  0
+evidence-for-prediction              :  3
+extrapolation-method                 :  linear-regression
+mpi-tuning-max-difference-for-bucket :  0.2
+mpi-tuning-weight-for-max-density    :  0.1
+tuning-acquisition-function          :  upper-confidence-bound
+fastParticlesThrow                   :  false
+globalForce                          :  [0, 0, 0]
+load-balancer                        :  InvertedPressure
 Objects:                         
   CubeGrid:
     0:
-      particles-per-dimension    :  [10, 10, 10]
-      particle-spacing           :  1.1225
-      bottomLeftCorner           :  [0, 0, 0]
-      velocity                   :  [0, 0, 0]
-      particle-type              :  0
-      particle-epsilon           :  1
-      particle-sigma             :  1
-      particle-mass              :  1
+      particles-per-dimension        :  [10, 10, 10]
+      particle-spacing               :  1.1225
+      bottomLeftCorner               :  [0, 0, 0]
+      velocity                       :  [0, 0, 0]
+      particle-type                  :  0
+      particle-epsilon               :  1
+      particle-sigma                 :  1
+      particle-mass                  :  1
   CubeGauss:
     0:
-      distribution-mean          :  [2, 2, 2]
-      distribution-stddeviation  :  [2, 2, 2]
-      numberOfParticles          :  100
-      box-length                 :  [8, 8, 8]
-      bottomLeftCorner           :  [15, 15, 15]
-      velocity                   :  [0, 0, 0]
-      particle-type              :  1
-      particle-epsilon           :  1
-      particle-sigma             :  1
-      particle-mass              :  1
+      distribution-mean              :  [2, 2, 2]
+      distribution-stddeviation      :  [2, 2, 2]
+      numberOfParticles              :  100
+      box-length                     :  [8, 8, 8]
+      bottomLeftCorner               :  [15, 15, 15]
+      velocity                       :  [0, 0, 0]
+      particle-type                  :  1
+      particle-epsilon               :  1
+      particle-sigma                 :  1
+      particle-mass                  :  1
   CubeUniform:
     0:
-      numberOfParticles          :  100
-      box-length                 :  [10, 10, 10]
-      bottomLeftCorner           :  [15, 0, 0]
-      velocity                   :  [0, 0, 0]
-      particle-type              :  2
-      particle-epsilon           :  1
-      particle-sigma             :  1
-      particle-mass              :  1
+      numberOfParticles              :  100
+      box-length                     :  [10, 10, 10]
+      bottomLeftCorner               :  [15, 0, 0]
+      velocity                       :  [0, 0, 0]
+      particle-type                  :  2
+      particle-epsilon               :  1
+      particle-sigma                 :  1
+      particle-mass                  :  1
   CubeClosestPacked:
     0:
-      box-length                 :  [4, 4, 4]
-      bottomLeftCorner           :  [0, 0, 15]
-      particle-spacing           :  1.1225
-      velocity                   :  [0, 0, 0]
-      particle-type              :  3
-      particle-epsilon           :  1
-      particle-sigma             :  1
-      particle-mass              :  1
+      box-length                     :  [4, 4, 4]
+      bottomLeftCorner               :  [0, 0, 15]
+      particle-spacing               :  1.1225
+      velocity                       :  [0, 0, 0]
+      particle-type                  :  3
+      particle-epsilon               :  1
+      particle-sigma                 :  1
+      particle-mass                  :  1
   Sphere:
     0:
-      center                     :  [4, 16, 4]
-      radius                     :  3
-      particle-spacing           :  1.1225
-      velocity                   :  [0, 0, 0]
-      particle-type              :  4
-      particle-epsilon           :  1
-      particle-sigma             :  1
-      particle-mass              :  1
+      center                         :  [4, 16, 4]
+      radius                         :  3
+      particle-spacing               :  1.1225
+      velocity                       :  [0, 0, 0]
+      particle-type                  :  4
+      particle-epsilon               :  1
+      particle-sigma                 :  1
+      particle-mass                  :  1
 thermostat:
-  initialTemperature             :  1
-  targetTemperature              :  4
-  deltaTemperature               :  0.1
-  thermostatInterval             :  10
-  addBrownianMotion              :  true
-log-level                        :  info
-no-flops                         :  false
-no-end-config                    :  false
-no-progress-bar                  :  false
-vtk-filename                     :  AllOptionsSim
-vtk-write-frequency              :  1
-#checkpoint : AllOptionsSim_10.vtk
+  initialTemperature                 :  1
+  targetTemperature                  :  4
+  deltaTemperature                   :  0.1
+  thermostatInterval                 :  10
+  addBrownianMotion                  :  true
+log-level                            :  info
+no-flops                             :  false
+no-end-config                        :  false
+no-progress-bar                      :  false
+vtk-filename                         :  AllOptionsSim
+vtk-write-frequency                  :  1
+#checkpoint                          : AllOptionsSim_10.vtk
+#log-file                            : log.txt

--- a/examples/md-flexible/src/configuration/YamlParser.cpp
+++ b/examples/md-flexible/src/configuration/YamlParser.cpp
@@ -10,377 +10,353 @@
 bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
   YAML::Node node = YAML::LoadFile(config.yamlFilename.value);
 
-  if (node[config.containerOptions.name]) {
-    config.containerOptions.value = autopas::ContainerOption::parseOptions(
-        autopas::utils::ArrayUtils::to_string(node[config.containerOptions.name], ", ", {"", ""}));
-  }
-  if (node[config.boxMin.name]) {
-    auto tmpNode = node[config.boxMin.name];
-    config.boxMin.value = {tmpNode[0].as<double>(), tmpNode[1].as<double>(), tmpNode[2].as<double>()};
-  }
-  if (node[config.boxMax.name]) {
-    auto tmpNode = node[config.boxMax.name];
-    config.boxMax.value = {tmpNode[0].as<double>(), tmpNode[1].as<double>(), tmpNode[2].as<double>()};
-  }
-  if (node[config.subdivideDimension.name]) {
-    auto tmpNode = node[config.subdivideDimension.name];
-    config.subdivideDimension.value = {tmpNode[0].as<bool>(), tmpNode[1].as<bool>(), tmpNode[2].as<bool>()};
-  }
-  if (node[config.loadBalancingInterval.name]) {
-    config.loadBalancingInterval.value = node[config.loadBalancingInterval.name].as<unsigned int>();
-  }
-  if (node[config.selectorStrategy.name]) {
-    auto parsedOptions =
-        autopas::SelectorStrategyOption::parseOptions(node[config.selectorStrategy.name].as<std::string>());
-    if (parsedOptions.size() != 1) {
-      throw std::runtime_error(
-          "YamlParser::parseYamlFile: Pass exactly one selector strategy option! Possible values:\n" +
-          autopas::utils::ArrayUtils::to_string(autopas::SelectorStrategyOption::getAllOptions(), "", {"(", ")"}));
-    }
-    config.selectorStrategy.value = *parsedOptions.begin();
-  }
-  if (node[config.boundaryOption.name]) {
-    auto tmpNode = node[config.boundaryOption.name];
-    config.boundaryOption.value = {options::BoundaryTypeOption::parseOptionExact(tmpNode[0].as<std::string>()),
-                                   options::BoundaryTypeOption::parseOptionExact(tmpNode[1].as<std::string>()),
-                                   options::BoundaryTypeOption::parseOptionExact(tmpNode[2].as<std::string>())};
-  }
-  if (node[config.cutoff.name]) {
-    config.cutoff.value = node[config.cutoff.name].as<double>();
-  }
-  if (node[config.cellSizeFactors.name]) {
-    config.cellSizeFactors.value = autopas::utils::StringUtils::parseNumberSet(
-        autopas::utils::ArrayUtils::to_string(node[config.cellSizeFactors.name], ", ", {"", ""}));
-  }
-  if (node[config.dataLayoutOptions.name]) {
-    config.dataLayoutOptions.value = autopas::DataLayoutOption::parseOptions(
-        autopas::utils::ArrayUtils::to_string(node[config.dataLayoutOptions.name], ", ", {"", ""}));
-  }
-  if (node[config.functorOption.name]) {
-    auto strArg = node[config.functorOption.name].as<std::string>();
-    transform(strArg.begin(), strArg.end(), strArg.begin(), ::tolower);
-    if (strArg.find("avx") != std::string::npos) {
-      config.functorOption.value = MDFlexConfig::FunctorOption::lj12_6_AVX;
-    } else if (strArg.find("sve") != std::string::npos) {
-      config.functorOption.value = MDFlexConfig::FunctorOption::lj12_6_SVE;
-    } else if (strArg.find("glob") != std::string::npos) {
-      config.functorOption.value = MDFlexConfig::FunctorOption::lj12_6_Globals;
-    } else if (strArg.find("lj") != std::string::npos or strArg.find("lennard-jones") != std::string::npos) {
-      config.functorOption.value = MDFlexConfig::FunctorOption::lj12_6;
-    }
-  }
-  if (node[config.iterations.name]) {
-    config.iterations.value = node[config.iterations.name].as<unsigned long>();
-  }
-  if (node[config.tuningPhases.name]) {
-    config.tuningPhases.value = node[config.tuningPhases.name].as<unsigned long>();
-  }
-  if (node[config.dontMeasureFlops.name]) {
-    // "not" needed because of semantics
-    config.dontMeasureFlops.value = not node[config.dontMeasureFlops.name].as<bool>();
-  }
-  if (node[config.dontCreateEndConfig.name]) {
-    // "not" needed because of semantics
-    config.dontCreateEndConfig.value = not node[config.dontCreateEndConfig.name].as<bool>();
-  }
-  if (node[config.dontShowProgressBar.name]) {
-    config.dontShowProgressBar.value = node[config.dontShowProgressBar.name].as<bool>();
-  }
-  if (node[config.newton3Options.name]) {
-    config.newton3Options.value = autopas::Newton3Option::parseOptions(
-        autopas::utils::ArrayUtils::to_string(node[config.newton3Options.name], ", ", {"", ""}));
-  }
-  if (node[config.deltaT.name]) {
-    config.deltaT.value = node[config.deltaT.name].as<double>();
-  }
-  if (node[config.traversalOptions.name]) {
-    config.traversalOptions.value = autopas::TraversalOption::parseOptions(
-        autopas::utils::ArrayUtils::to_string(node[config.traversalOptions.name], ", ", {"", ""}));
-  }
-  if (node[config.loadEstimatorOptions.name]) {
-    config.loadEstimatorOptions.value = autopas::LoadEstimatorOption::parseOptions(
-        autopas::utils::ArrayUtils::to_string(node[config.loadEstimatorOptions.name], ", ", {"", ""}));
-  }
-  if (node[config.tuningInterval.name]) {
-    config.tuningInterval.value = node[config.tuningInterval.name].as<unsigned int>();
-  }
-  if (node[config.tuningSamples.name]) {
-    config.tuningSamples.value = node[config.tuningSamples.name].as<unsigned int>();
-  }
-  if (node[config.tuningMaxEvidence.name]) {
-    config.tuningMaxEvidence.value = node[config.tuningMaxEvidence.name].as<unsigned int>();
-  }
-  if (node[config.relativeOptimumRange.name]) {
-    config.relativeOptimumRange.value = node[config.relativeOptimumRange.name].as<double>();
-  }
-  if (node[config.maxTuningPhasesWithoutTest.name]) {
-    config.maxTuningPhasesWithoutTest.value = node[config.maxTuningPhasesWithoutTest.name].as<unsigned int>();
-  }
-  if (node[config.relativeBlacklistRange.name]) {
-    config.relativeBlacklistRange.value = node[config.relativeBlacklistRange.name].as<double>();
-  }
-  if (node[config.evidenceFirstPrediction.name]) {
-    config.evidenceFirstPrediction.value = node[config.evidenceFirstPrediction.name].as<unsigned int>();
-  }
-  if (node[config.extrapolationMethodOption.name]) {
-    auto parsedOptions =
-        autopas::ExtrapolationMethodOption::parseOptions(node[config.extrapolationMethodOption.name].as<std::string>());
-    if (parsedOptions.size() != 1) {
-      throw std::runtime_error(
-          "YamlParser::parseYamlFile: Pass exactly one extrapolation method option! Possible values:\n" +
-          autopas::utils::ArrayUtils::to_string(autopas::ExtrapolationMethodOption::getAllOptions(), "", {"(", ")"}));
-    }
-    config.extrapolationMethodOption.value = *parsedOptions.begin();
-  }
-  if (node[config.tuningStrategyOption.name]) {
-    auto parsedOptions =
-        autopas::TuningStrategyOption::parseOptions(node[config.tuningStrategyOption.name].as<std::string>());
-    if (parsedOptions.size() != 1) {
-      throw std::runtime_error(
-          "YamlParser::parseYamlFile: Pass exactly one tuning strategy option! Possible values:\n" +
-          autopas::utils::ArrayUtils::to_string(autopas::TuningStrategyOption::getAllOptions(), "", {"(", ")"}));
-    }
-    config.tuningStrategyOption.value = *parsedOptions.begin();
-  }
-  if (node[config.mpiStrategyOption.name]) {
-    auto parsedOptions =
-        autopas::MPIStrategyOption::parseOptions(node[config.mpiStrategyOption.name].as<std::string>());
-    if (parsedOptions.size() != 1) {
-      throw std::runtime_error(
-          "YamlParser::parseYamlFile: Pass exactly one mpi strategy option!"
-          "AutoPas cannot switch between several.");
-    }
-    config.mpiStrategyOption.value = *parsedOptions.begin();
-  }
-  if (node[config.MPITuningMaxDifferenceForBucket.name]) {
-    config.MPITuningMaxDifferenceForBucket.value = node[config.MPITuningMaxDifferenceForBucket.name].as<double>();
-  }
-  if (node[config.MPITuningWeightForMaxDensity.name]) {
-    config.MPITuningWeightForMaxDensity.value = node[config.MPITuningWeightForMaxDensity.name].as<double>();
-  }
-  if (node[config.acquisitionFunctionOption.name]) {
-    auto parsedOptions =
-        autopas::AcquisitionFunctionOption::parseOptions(node[config.acquisitionFunctionOption.name].as<std::string>());
-    if (parsedOptions.size() != 1) {
-      throw std::runtime_error(
-          "YamlParser::parseYamlFile: Pass exactly one acquisition function option! Possible values:\n" +
-          autopas::utils::ArrayUtils::to_string(autopas::AcquisitionFunctionOption::getAllOptions(), "", {"(", ")"}));
-    }
-    config.acquisitionFunctionOption.value = *parsedOptions.begin();
-  }
-  if (node[config.logLevel.name]) {
-    auto strArg = node[config.logLevel.name].as<std::string>();
-    switch (std::tolower(strArg[0])) {
-      case 't': {
-        config.logLevel.value = autopas::Logger::LogLevel::trace;
-        break;
-      }
-      case 'd': {
-        config.logLevel.value = autopas::Logger::LogLevel::debug;
-        break;
-      }
-      case 'i': {
-        config.logLevel.value = autopas::Logger::LogLevel::info;
-        break;
-      }
-      case 'w': {
-        config.logLevel.value = autopas::Logger::LogLevel::warn;
-        break;
-      }
-      case 'e': {
-        config.logLevel.value = autopas::Logger::LogLevel::err;
-        break;
-      }
-      case 'c': {
-        config.logLevel.value = autopas::Logger::LogLevel::critical;
-        break;
-      }
-      case 'o': {
-        config.logLevel.value = autopas::Logger::LogLevel::off;
-        break;
-      }
-    }
-  }
-  if (node[config.checkpointfile.name]) {
-    config.checkpointfile.value = node[config.checkpointfile.name].as<std::string>();
-  }
-  if (node[config.logFileName.name]) {
-    config.logFileName.value = node[config.logFileName.name].as<std::string>();
-  }
-  if (node[config.verletRebuildFrequency.name]) {
-    config.verletRebuildFrequency.value = node[config.verletRebuildFrequency.name].as<unsigned int>();
-  }
-  if (node[config.verletSkinRadiusPerTimestep.name]) {
-    config.verletSkinRadiusPerTimestep.value = node[config.verletSkinRadiusPerTimestep.name].as<double>();
-  }
-  if (node[config.fastParticlesThrow.name]) {
-    config.fastParticlesThrow.value = node[config.fastParticlesThrow.name].as<bool>();
-  }
-  if (node[config.verletClusterSize.name]) {
-    config.verletClusterSize.value = node[config.verletClusterSize.name].as<unsigned int>();
-  }
-  if (node[config.vtkFileName.name]) {
-    config.vtkFileName.value = node[config.vtkFileName.name].as<std::string>();
-  }
-  if (node[config.vtkWriteFrequency.name]) {
-    config.vtkWriteFrequency.value = node[config.vtkWriteFrequency.name].as<size_t>();
-  }
-  if (node[config.globalForce.name]) {
-    config.globalForce.value = {node[config.globalForce.name][0].as<double>(),
-                                node[config.globalForce.name][1].as<double>(),
-                                node[config.globalForce.name][2].as<double>()};
-  }
-  if (node[MDFlexConfig::objectsStr]) {
-    // remove default objects
-    config.cubeGridObjects.clear();
-    config.cubeGaussObjects.clear();
-    config.cubeUniformObjects.clear();
-    config.sphereObjects.clear();
-    config.cubeClosestPackedObjects.clear();
-    config.epsilonMap.value.clear();
-    config.sigmaMap.value.clear();
-    config.massMap.value.clear();
+  // iterate over all keys to identify known/unknown parameters
+  for (auto itemIterator = node.begin(); itemIterator != node.end(); ++itemIterator) {
+    std::string key = itemIterator->first.as<std::string>();
 
-    for (auto objectIterator = node[MDFlexConfig::objectsStr].begin();
-         objectIterator != node[MDFlexConfig::objectsStr].end(); ++objectIterator) {
-      if (objectIterator->first.as<std::string>() == MDFlexConfig::cubeGridObjectsStr) {
-        for (auto it = objectIterator->second.begin(); it != objectIterator->second.end(); ++it) {
-          CubeGrid cubeGrid({it->second[MDFlexConfig::velocityStr][0].as<double>(),
-                             it->second[MDFlexConfig::velocityStr][1].as<double>(),
-                             it->second[MDFlexConfig::velocityStr][2].as<double>()},
-                            it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
-                            it->second[config.epsilonMap.name].as<double>(),
-                            it->second[config.sigmaMap.name].as<double>(), it->second[config.massMap.name].as<double>(),
-                            {it->second[config.particlesPerDim.name][0].as<unsigned long>(),
-                             it->second[config.particlesPerDim.name][1].as<unsigned long>(),
-                             it->second[config.particlesPerDim.name][2].as<unsigned long>()},
-                            it->second[config.particleSpacing.name].as<double>(),
-                            {it->second[MDFlexConfig::bottomLeftBackCornerStr][0].as<double>(),
-                             it->second[MDFlexConfig::bottomLeftBackCornerStr][1].as<double>(),
-                             it->second[MDFlexConfig::bottomLeftBackCornerStr][2].as<double>()});
+    if (key == config.containerOptions.name) {
+      config.containerOptions.value =
+          autopas::ContainerOption::parseOptions(autopas::utils::ArrayUtils::to_string(node[key], ", ", {"", ""}));
+    } else if (key == config.boxMin.name) {
+      auto tmpNode = node[config.boxMin.name];
+      config.boxMin.value = {tmpNode[0].as<double>(), tmpNode[1].as<double>(), tmpNode[2].as<double>()};
+    } else if (key == config.boxMax.name) {
+      auto tmpNode = node[config.boxMax.name];
+      config.boxMax.value = {tmpNode[0].as<double>(), tmpNode[1].as<double>(), tmpNode[2].as<double>()};
+    } else if (key == config.subdivideDimension.name) {
+      auto tmpNode = node[config.subdivideDimension.name];
+      config.subdivideDimension.value = {tmpNode[0].as<bool>(), tmpNode[1].as<bool>(), tmpNode[2].as<bool>()};
+    } else if (key == config.loadBalancingInterval.name) {
+      config.loadBalancingInterval.value = node[config.loadBalancingInterval.name].as<unsigned int>();
+    } else if (key == config.selectorStrategy.name) {
+      std::set<autopas::options::SelectorStrategyOption> parsedOptions;
+      if (node[config.selectorStrategy.name].IsSequence()) {
+        if (node[config.selectorStrategy.name].size() > 1) {
+          throw std::runtime_error("Pass exactly one selector strategy option! Possible values:\n" +
+                                   autopas::utils::ArrayUtils::to_string(
+                                       autopas::SelectorStrategyOption::getAllOptions(), ", ", {"(", ")"}));
+        }
+        parsedOptions = autopas::SelectorStrategyOption::parseOptions(
+            autopas::utils::ArrayUtils::to_string(node[config.selectorStrategy.name], "", {"", ""}));
+      } else {
+        parsedOptions =
+            autopas::SelectorStrategyOption::parseOptions(node[config.selectorStrategy.name].as<std::string>());
+      }
+      config.selectorStrategy.value = *parsedOptions.begin();
+    } else if (key == config.boundaryOption.name) {
+      auto tmpNode = node[config.boundaryOption.name];
+      config.boundaryOption.value = {options::BoundaryTypeOption::parseOptionExact(tmpNode[0].as<std::string>()),
+                                     options::BoundaryTypeOption::parseOptionExact(tmpNode[1].as<std::string>()),
+                                     options::BoundaryTypeOption::parseOptionExact(tmpNode[2].as<std::string>())};
+    } else if (key == config.cutoff.name) {
+      config.cutoff.value = node[config.cutoff.name].as<double>();
+    } else if (key == config.cellSizeFactors.name) {
+      config.cellSizeFactors.value = autopas::utils::StringUtils::parseNumberSet(
+          autopas::utils::ArrayUtils::to_string(node[config.cellSizeFactors.name], ", ", {"", ""}));
+      if (config.cellSizeFactors.value->isEmpty()) {
+        throw std::runtime_error("cell size factor is empty");
+      }
+    } else if (key == config.dataLayoutOptions.name) {
+      config.dataLayoutOptions.value = autopas::DataLayoutOption::parseOptions(
+          autopas::utils::ArrayUtils::to_string(node[config.dataLayoutOptions.name], ", ", {"", ""}));
+      if (config.dataLayoutOptions.value.empty()) {
+        throw std::runtime_error("dataLayoutOptions is empty");
+      }
+    } else if (key == config.functorOption.name) {
+      auto strArg = node[config.functorOption.name].as<std::string>();
+      transform(strArg.begin(), strArg.end(), strArg.begin(), ::tolower);
+      if (strArg.find("avx") != std::string::npos) {
+        config.functorOption.value = MDFlexConfig::FunctorOption::lj12_6_AVX;
+      } else if (strArg.find("sve") != std::string::npos) {
+        config.functorOption.value = MDFlexConfig::FunctorOption::lj12_6_SVE;
+      } else if (strArg.find("glob") != std::string::npos) {
+        config.functorOption.value = MDFlexConfig::FunctorOption::lj12_6_Globals;
+      } else if (strArg.find("lj") != std::string::npos or strArg.find("lennard-jones") != std::string::npos) {
+        config.functorOption.value = MDFlexConfig::FunctorOption::lj12_6;
+      }
+    } else if (key == config.iterations.name) {
+      config.iterations.value = node[config.iterations.name].as<unsigned long>();
+    } else if (key == config.tuningPhases.name) {
+      config.tuningPhases.value = node[config.tuningPhases.name].as<unsigned long>();
+    } else if (key == config.dontMeasureFlops.name) {
+      // "not" needed because of semantics
+      config.dontMeasureFlops.value = not node[config.dontMeasureFlops.name].as<bool>();
+    } else if (key == config.dontCreateEndConfig.name) {
+      // "not" needed because of semantics
+      config.dontCreateEndConfig.value = not node[config.dontCreateEndConfig.name].as<bool>();
+    } else if (key == config.dontShowProgressBar.name) {
+      config.dontShowProgressBar.value = node[config.dontShowProgressBar.name].as<bool>();
+    } else if (key == config.newton3Options.name) {
+      config.newton3Options.value = autopas::Newton3Option::parseOptions(
+          autopas::utils::ArrayUtils::to_string(node[config.newton3Options.name], ", ", {"", ""}));
+    } else if (key == config.deltaT.name) {
+      config.deltaT.value = node[config.deltaT.name].as<double>();
+    } else if (key == config.traversalOptions.name) {
+      config.traversalOptions.value = autopas::TraversalOption::parseOptions(
+          autopas::utils::ArrayUtils::to_string(node[config.traversalOptions.name], ", ", {"", ""}));
+    } else if (key == config.loadEstimatorOptions.name) {
+      config.loadEstimatorOptions.value = autopas::LoadEstimatorOption::parseOptions(
+          autopas::utils::ArrayUtils::to_string(node[config.loadEstimatorOptions.name], ", ", {"", ""}));
+    } else if (key == config.tuningInterval.name) {
+      config.tuningInterval.value = node[config.tuningInterval.name].as<unsigned int>();
+    } else if (key == config.tuningSamples.name) {
+      config.tuningSamples.value = node[config.tuningSamples.name].as<unsigned int>();
+    } else if (key == config.tuningMaxEvidence.name) {
+      config.tuningMaxEvidence.value = node[config.tuningMaxEvidence.name].as<unsigned int>();
+    } else if (key == config.relativeOptimumRange.name) {
+      config.relativeOptimumRange.value = node[config.relativeOptimumRange.name].as<double>();
+    } else if (key == config.maxTuningPhasesWithoutTest.name) {
+      config.maxTuningPhasesWithoutTest.value = node[config.maxTuningPhasesWithoutTest.name].as<unsigned int>();
+    } else if (key == config.relativeBlacklistRange.name) {
+      config.relativeBlacklistRange.value = node[config.relativeBlacklistRange.name].as<double>();
+    } else if (key == config.evidenceFirstPrediction.name) {
+      config.evidenceFirstPrediction.value = node[config.evidenceFirstPrediction.name].as<unsigned int>();
+    } else if (key == config.extrapolationMethodOption.name) {
+      auto parsedOptions = autopas::ExtrapolationMethodOption::parseOptions(
+          node[config.extrapolationMethodOption.name].as<std::string>());
+      if (parsedOptions.size() != 1) {
+        throw std::runtime_error(
+            "YamlParser::parseYamlFile: Pass exactly one extrapolation method option! Possible values:\n" +
+            autopas::utils::ArrayUtils::to_string(autopas::ExtrapolationMethodOption::getAllOptions(), "", {"(", ")"}));
+      }
+      config.extrapolationMethodOption.value = *parsedOptions.begin();
+    } else if (key == config.tuningStrategyOption.name) {
+      auto parsedOptions =
+          autopas::TuningStrategyOption::parseOptions(node[config.tuningStrategyOption.name].as<std::string>());
+      if (parsedOptions.size() != 1) {
+        throw std::runtime_error(
+            "YamlParser::parseYamlFile: Pass exactly one tuning strategy option! Possible values:\n" +
+            autopas::utils::ArrayUtils::to_string(autopas::TuningStrategyOption::getAllOptions(), "", {"(", ")"}));
+      }
+      config.tuningStrategyOption.value = *parsedOptions.begin();
+    } else if (key == config.mpiStrategyOption.name) {
+      auto parsedOptions =
+          autopas::MPIStrategyOption::parseOptions(node[config.mpiStrategyOption.name].as<std::string>());
+      if (parsedOptions.size() != 1) {
+        throw std::runtime_error(
+            "YamlParser::parseYamlFile: Pass exactly one mpi strategy option!"
+            "AutoPas cannot switch between several.");
+      }
+      config.mpiStrategyOption.value = *parsedOptions.begin();
+    } else if (key == config.MPITuningMaxDifferenceForBucket.name) {
+      config.MPITuningMaxDifferenceForBucket.value = node[config.MPITuningMaxDifferenceForBucket.name].as<double>();
+    } else if (key == config.MPITuningWeightForMaxDensity.name) {
+      config.MPITuningWeightForMaxDensity.value = node[config.MPITuningWeightForMaxDensity.name].as<double>();
+    } else if (key == config.acquisitionFunctionOption.name) {
+      auto parsedOptions = autopas::AcquisitionFunctionOption::parseOptions(
+          node[config.acquisitionFunctionOption.name].as<std::string>());
+      if (parsedOptions.size() != 1) {
+        throw std::runtime_error(
+            "YamlParser::parseYamlFile: Pass exactly one acquisition function option! Possible values:\n" +
+            autopas::utils::ArrayUtils::to_string(autopas::AcquisitionFunctionOption::getAllOptions(), "", {"(", ")"}));
+      }
+      config.acquisitionFunctionOption.value = *parsedOptions.begin();
+    } else if (key == config.logLevel.name) {
+      auto strArg = node[config.logLevel.name].as<std::string>();
+      switch (std::tolower(strArg[0])) {
+        case 't': {
+          config.logLevel.value = autopas::Logger::LogLevel::trace;
+          break;
+        }
+        case 'd': {
+          config.logLevel.value = autopas::Logger::LogLevel::debug;
+          break;
+        }
+        case 'i': {
+          config.logLevel.value = autopas::Logger::LogLevel::info;
+          break;
+        }
+        case 'w': {
+          config.logLevel.value = autopas::Logger::LogLevel::warn;
+          break;
+        }
+        case 'e': {
+          config.logLevel.value = autopas::Logger::LogLevel::err;
+          break;
+        }
+        case 'c': {
+          config.logLevel.value = autopas::Logger::LogLevel::critical;
+          break;
+        }
+        case 'o': {
+          config.logLevel.value = autopas::Logger::LogLevel::off;
+          break;
+        }
+      }
+    } else if (key == config.checkpointfile.name) {
+      config.checkpointfile.value = node[config.checkpointfile.name].as<std::string>();
+    } else if (key == config.logFileName.name) {
+      config.logFileName.value = node[config.logFileName.name].as<std::string>();
+    } else if (key == config.verletRebuildFrequency.name) {
+      config.verletRebuildFrequency.value = node[config.verletRebuildFrequency.name].as<unsigned int>();
+    } else if (key == config.verletSkinRadiusPerTimestep.name) {
+      config.verletSkinRadiusPerTimestep.value = node[config.verletSkinRadiusPerTimestep.name].as<double>();
+    } else if (key == config.fastParticlesThrow.name) {
+      config.fastParticlesThrow.value = node[config.fastParticlesThrow.name].as<bool>();
+    } else if (key == config.verletClusterSize.name) {
+      config.verletClusterSize.value = node[config.verletClusterSize.name].as<unsigned int>();
+    } else if (key == config.vtkFileName.name) {
+      config.vtkFileName.value = node[config.vtkFileName.name].as<std::string>();
+    } else if (key == config.vtkWriteFrequency.name) {
+      config.vtkWriteFrequency.value = node[config.vtkWriteFrequency.name].as<size_t>();
+    } else if (key == config.globalForce.name) {
+      config.globalForce.value = {node[config.globalForce.name][0].as<double>(),
+                                  node[config.globalForce.name][1].as<double>(),
+                                  node[config.globalForce.name][2].as<double>()};
+    } else if (key == MDFlexConfig::objectsStr) {
+      // remove default objects
+      config.cubeGridObjects.clear();
+      config.cubeGaussObjects.clear();
+      config.cubeUniformObjects.clear();
+      config.sphereObjects.clear();
+      config.cubeClosestPackedObjects.clear();
+      config.epsilonMap.value.clear();
+      config.sigmaMap.value.clear();
+      config.massMap.value.clear();
 
-          config.cubeGridObjects.emplace_back(cubeGrid);
-          config.addParticleType(it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
-                                 it->second[config.epsilonMap.name].as<double>(),
-                                 it->second[config.sigmaMap.name].as<double>(),
-                                 it->second[config.massMap.name].as<double>());
+      for (auto objectIterator = node[MDFlexConfig::objectsStr].begin();
+           objectIterator != node[MDFlexConfig::objectsStr].end(); ++objectIterator) {
+        if (objectIterator->first.as<std::string>() == MDFlexConfig::cubeGridObjectsStr) {
+          for (auto it = objectIterator->second.begin(); it != objectIterator->second.end(); ++it) {
+            CubeGrid cubeGrid({it->second[MDFlexConfig::velocityStr][0].as<double>(),
+                               it->second[MDFlexConfig::velocityStr][1].as<double>(),
+                               it->second[MDFlexConfig::velocityStr][2].as<double>()},
+                              it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
+                              it->second[config.epsilonMap.name].as<double>(),
+                              it->second[config.sigmaMap.name].as<double>(),
+                              it->second[config.massMap.name].as<double>(),
+                              {it->second[config.particlesPerDim.name][0].as<unsigned long>(),
+                               it->second[config.particlesPerDim.name][1].as<unsigned long>(),
+                               it->second[config.particlesPerDim.name][2].as<unsigned long>()},
+                              it->second[config.particleSpacing.name].as<double>(),
+                              {it->second[MDFlexConfig::bottomLeftBackCornerStr][0].as<double>(),
+                               it->second[MDFlexConfig::bottomLeftBackCornerStr][1].as<double>(),
+                               it->second[MDFlexConfig::bottomLeftBackCornerStr][2].as<double>()});
+
+            config.cubeGridObjects.emplace_back(cubeGrid);
+            config.addParticleType(it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
+                                   it->second[config.epsilonMap.name].as<double>(),
+                                   it->second[config.sigmaMap.name].as<double>(),
+                                   it->second[config.massMap.name].as<double>());
+          }
+          continue;
         }
-        continue;
-      }
-      if (objectIterator->first.as<std::string>() == MDFlexConfig::cubeGaussObjectsStr) {
-        for (auto it = objectIterator->second.begin(); it != objectIterator->second.end(); ++it) {
-          CubeGauss cubeGauss(
-              {it->second[MDFlexConfig::velocityStr][0].as<double>(),
-               it->second[MDFlexConfig::velocityStr][1].as<double>(),
-               it->second[MDFlexConfig::velocityStr][2].as<double>()},
-              it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
-              it->second[config.epsilonMap.name].as<double>(), it->second[config.sigmaMap.name].as<double>(),
-              it->second[config.massMap.name].as<double>(),
-              it->second[MDFlexConfig::particlesPerObjectStr].as<size_t>(),
-              {it->second[config.boxLength.name][0].as<double>(), it->second[config.boxLength.name][1].as<double>(),
-               it->second[config.boxLength.name][2].as<double>()},
-              {it->second[config.distributionMean.name][0].as<double>(),
-               it->second[config.distributionMean.name][1].as<double>(),
-               it->second[config.distributionMean.name][2].as<double>()},
-              {it->second[config.distributionStdDev.name][0].as<double>(),
-               it->second[config.distributionStdDev.name][1].as<double>(),
-               it->second[config.distributionStdDev.name][2].as<double>()},
-              {it->second[MDFlexConfig::bottomLeftBackCornerStr][0].as<double>(),
-               it->second[MDFlexConfig::bottomLeftBackCornerStr][1].as<double>(),
-               it->second[MDFlexConfig::bottomLeftBackCornerStr][2].as<double>()});
-          config.cubeGaussObjects.emplace_back(cubeGauss);
-          config.addParticleType(it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
-                                 it->second[config.epsilonMap.name].as<double>(),
-                                 it->second[config.sigmaMap.name].as<double>(),
-                                 it->second[config.massMap.name].as<double>());
+        if (objectIterator->first.as<std::string>() == MDFlexConfig::cubeGaussObjectsStr) {
+          for (auto it = objectIterator->second.begin(); it != objectIterator->second.end(); ++it) {
+            CubeGauss cubeGauss(
+                {it->second[MDFlexConfig::velocityStr][0].as<double>(),
+                 it->second[MDFlexConfig::velocityStr][1].as<double>(),
+                 it->second[MDFlexConfig::velocityStr][2].as<double>()},
+                it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
+                it->second[config.epsilonMap.name].as<double>(), it->second[config.sigmaMap.name].as<double>(),
+                it->second[config.massMap.name].as<double>(),
+                it->second[MDFlexConfig::particlesPerObjectStr].as<size_t>(),
+                {it->second[config.boxLength.name][0].as<double>(), it->second[config.boxLength.name][1].as<double>(),
+                 it->second[config.boxLength.name][2].as<double>()},
+                {it->second[config.distributionMean.name][0].as<double>(),
+                 it->second[config.distributionMean.name][1].as<double>(),
+                 it->second[config.distributionMean.name][2].as<double>()},
+                {it->second[config.distributionStdDev.name][0].as<double>(),
+                 it->second[config.distributionStdDev.name][1].as<double>(),
+                 it->second[config.distributionStdDev.name][2].as<double>()},
+                {it->second[MDFlexConfig::bottomLeftBackCornerStr][0].as<double>(),
+                 it->second[MDFlexConfig::bottomLeftBackCornerStr][1].as<double>(),
+                 it->second[MDFlexConfig::bottomLeftBackCornerStr][2].as<double>()});
+            config.cubeGaussObjects.emplace_back(cubeGauss);
+            config.addParticleType(it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
+                                   it->second[config.epsilonMap.name].as<double>(),
+                                   it->second[config.sigmaMap.name].as<double>(),
+                                   it->second[config.massMap.name].as<double>());
+          }
+          continue;
         }
-        continue;
-      }
-      if (objectIterator->first.as<std::string>() == MDFlexConfig::cubeUniformObjectsStr) {
-        for (auto it = objectIterator->second.begin(); it != objectIterator->second.end(); ++it) {
-          CubeUniform cubeUniform(
-              {it->second[MDFlexConfig::velocityStr][0].as<double>(),
-               it->second[MDFlexConfig::velocityStr][1].as<double>(),
-               it->second[MDFlexConfig::velocityStr][2].as<double>()},
-              it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
-              it->second[config.epsilonMap.name].as<double>(), it->second[config.sigmaMap.name].as<double>(),
-              it->second[config.massMap.name].as<double>(),
-              it->second[MDFlexConfig::particlesPerObjectStr].as<size_t>(),
-              {it->second[config.boxLength.name][0].as<double>(), it->second[config.boxLength.name][1].as<double>(),
-               it->second[config.boxLength.name][2].as<double>()},
-              {it->second[MDFlexConfig::bottomLeftBackCornerStr][0].as<double>(),
-               it->second[MDFlexConfig::bottomLeftBackCornerStr][1].as<double>(),
-               it->second[MDFlexConfig::bottomLeftBackCornerStr][2].as<double>()});
-          config.cubeUniformObjects.emplace_back(cubeUniform);
-          config.addParticleType(it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
-                                 it->second[config.epsilonMap.name].as<double>(),
-                                 it->second[config.sigmaMap.name].as<double>(),
-                                 it->second[config.massMap.name].as<double>());
+        if (objectIterator->first.as<std::string>() == MDFlexConfig::cubeUniformObjectsStr) {
+          for (auto it = objectIterator->second.begin(); it != objectIterator->second.end(); ++it) {
+            CubeUniform cubeUniform(
+                {it->second[MDFlexConfig::velocityStr][0].as<double>(),
+                 it->second[MDFlexConfig::velocityStr][1].as<double>(),
+                 it->second[MDFlexConfig::velocityStr][2].as<double>()},
+                it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
+                it->second[config.epsilonMap.name].as<double>(), it->second[config.sigmaMap.name].as<double>(),
+                it->second[config.massMap.name].as<double>(),
+                it->second[MDFlexConfig::particlesPerObjectStr].as<size_t>(),
+                {it->second[config.boxLength.name][0].as<double>(), it->second[config.boxLength.name][1].as<double>(),
+                 it->second[config.boxLength.name][2].as<double>()},
+                {it->second[MDFlexConfig::bottomLeftBackCornerStr][0].as<double>(),
+                 it->second[MDFlexConfig::bottomLeftBackCornerStr][1].as<double>(),
+                 it->second[MDFlexConfig::bottomLeftBackCornerStr][2].as<double>()});
+            config.cubeUniformObjects.emplace_back(cubeUniform);
+            config.addParticleType(it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
+                                   it->second[config.epsilonMap.name].as<double>(),
+                                   it->second[config.sigmaMap.name].as<double>(),
+                                   it->second[config.massMap.name].as<double>());
+          }
+          continue;
         }
-        continue;
-      }
-      if (objectIterator->first.as<std::string>() == MDFlexConfig::sphereObjectsStr) {
-        for (auto it = objectIterator->second.begin(); it != objectIterator->second.end(); ++it) {
-          Sphere sphere({it->second[MDFlexConfig::velocityStr][0].as<double>(),
-                         it->second[MDFlexConfig::velocityStr][1].as<double>(),
-                         it->second[MDFlexConfig::velocityStr][2].as<double>()},
-                        it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
-                        it->second[config.epsilonMap.name].as<double>(), it->second[config.sigmaMap.name].as<double>(),
-                        it->second[config.massMap.name].as<double>(),
-                        {it->second[MDFlexConfig::sphereCenterStr][0].as<double>(),
-                         it->second[MDFlexConfig::sphereCenterStr][1].as<double>(),
-                         it->second[MDFlexConfig::sphereCenterStr][2].as<double>()},
-                        it->second[MDFlexConfig::sphereRadiusStr].as<int>(),
-                        it->second[config.particleSpacing.name].as<double>());
-          config.sphereObjects.emplace_back(sphere);
-          config.addParticleType(it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
-                                 it->second[config.epsilonMap.name].as<double>(),
-                                 it->second[config.sigmaMap.name].as<double>(),
-                                 it->second[config.massMap.name].as<double>());
+        if (objectIterator->first.as<std::string>() == MDFlexConfig::sphereObjectsStr) {
+          for (auto it = objectIterator->second.begin(); it != objectIterator->second.end(); ++it) {
+            Sphere sphere({it->second[MDFlexConfig::velocityStr][0].as<double>(),
+                           it->second[MDFlexConfig::velocityStr][1].as<double>(),
+                           it->second[MDFlexConfig::velocityStr][2].as<double>()},
+                          it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
+                          it->second[config.epsilonMap.name].as<double>(),
+                          it->second[config.sigmaMap.name].as<double>(), it->second[config.massMap.name].as<double>(),
+                          {it->second[MDFlexConfig::sphereCenterStr][0].as<double>(),
+                           it->second[MDFlexConfig::sphereCenterStr][1].as<double>(),
+                           it->second[MDFlexConfig::sphereCenterStr][2].as<double>()},
+                          it->second[MDFlexConfig::sphereRadiusStr].as<int>(),
+                          it->second[config.particleSpacing.name].as<double>());
+            config.sphereObjects.emplace_back(sphere);
+            config.addParticleType(it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
+                                   it->second[config.epsilonMap.name].as<double>(),
+                                   it->second[config.sigmaMap.name].as<double>(),
+                                   it->second[config.massMap.name].as<double>());
+          }
+          continue;
         }
-        continue;
-      }
-      if (objectIterator->first.as<std::string>() == MDFlexConfig::cubeClosestPackedObjectsStr) {
-        for (auto it = objectIterator->second.begin(); it != objectIterator->second.end(); ++it) {
-          CubeClosestPacked cubeClosestPacked(
-              {it->second[MDFlexConfig::velocityStr][0].as<double>(),
-               it->second[MDFlexConfig::velocityStr][1].as<double>(),
-               it->second[MDFlexConfig::velocityStr][2].as<double>()},
-              it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
-              it->second[config.epsilonMap.name].as<double>(), it->second[config.sigmaMap.name].as<double>(),
-              it->second[config.massMap.name].as<double>(), it->second[config.particleSpacing.name].as<double>(),
-              {it->second[config.boxLength.name][0].as<double>(), it->second[config.boxLength.name][1].as<double>(),
-               it->second[config.boxLength.name][2].as<double>()},
-              {it->second[MDFlexConfig::bottomLeftBackCornerStr][0].as<double>(),
-               it->second[MDFlexConfig::bottomLeftBackCornerStr][1].as<double>(),
-               it->second[MDFlexConfig::bottomLeftBackCornerStr][2].as<double>()});
-          config.cubeClosestPackedObjects.emplace_back(cubeClosestPacked);
-          config.addParticleType(it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
-                                 it->second[config.epsilonMap.name].as<double>(),
-                                 it->second[config.sigmaMap.name].as<double>(),
-                                 it->second[config.massMap.name].as<double>());
+        if (objectIterator->first.as<std::string>() == MDFlexConfig::cubeClosestPackedObjectsStr) {
+          for (auto it = objectIterator->second.begin(); it != objectIterator->second.end(); ++it) {
+            CubeClosestPacked cubeClosestPacked(
+                {it->second[MDFlexConfig::velocityStr][0].as<double>(),
+                 it->second[MDFlexConfig::velocityStr][1].as<double>(),
+                 it->second[MDFlexConfig::velocityStr][2].as<double>()},
+                it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
+                it->second[config.epsilonMap.name].as<double>(), it->second[config.sigmaMap.name].as<double>(),
+                it->second[config.massMap.name].as<double>(), it->second[config.particleSpacing.name].as<double>(),
+                {it->second[config.boxLength.name][0].as<double>(), it->second[config.boxLength.name][1].as<double>(),
+                 it->second[config.boxLength.name][2].as<double>()},
+                {it->second[MDFlexConfig::bottomLeftBackCornerStr][0].as<double>(),
+                 it->second[MDFlexConfig::bottomLeftBackCornerStr][1].as<double>(),
+                 it->second[MDFlexConfig::bottomLeftBackCornerStr][2].as<double>()});
+            config.cubeClosestPackedObjects.emplace_back(cubeClosestPacked);
+            config.addParticleType(it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
+                                   it->second[config.epsilonMap.name].as<double>(),
+                                   it->second[config.sigmaMap.name].as<double>(),
+                                   it->second[config.massMap.name].as<double>());
+          }
+          continue;
         }
-        continue;
       }
+    } else if (key == config.useThermostat.name) {
+      config.useThermostat.value = true;
+
+      config.initTemperature.value = node[config.useThermostat.name][config.initTemperature.name].as<double>();
+      config.thermostatInterval.value = node[config.useThermostat.name][config.thermostatInterval.name].as<size_t>();
+      config.targetTemperature.value = node[config.useThermostat.name][config.targetTemperature.name].as<double>();
+      config.deltaTemp.value = node[config.useThermostat.name][config.deltaTemp.name].as<double>();
+      config.addBrownianMotion.value = node[config.useThermostat.name][config.addBrownianMotion.name].as<bool>();
+    } else if (key == config.loadBalancer.name) {
+      auto parsedOptions = LoadBalancerOption::parseOptions(node[config.loadBalancer.name].as<std::string>());
+      if (parsedOptions.size() != 1) {
+        throw std::runtime_error(
+            "YamlParser::parseYamlFile: Pass exactly one load balancer option! Possible values:\n" +
+            autopas::utils::ArrayUtils::to_string(LoadBalancerOption::getAllOptions(), "", {"(", ")"}));
+      }
+      config.loadBalancer.value = *parsedOptions.begin();
+    } else {
+      std::cerr << "Unrecognized option in input YAML: " + key << std::endl;
     }
   }
-  if (node[config.useThermostat.name]) {
-    config.useThermostat.value = true;
 
-    config.initTemperature.value = node[config.useThermostat.name][config.initTemperature.name].as<double>();
-    config.thermostatInterval.value = node[config.useThermostat.name][config.thermostatInterval.name].as<size_t>();
-    config.targetTemperature.value = node[config.useThermostat.name][config.targetTemperature.name].as<double>();
-    config.deltaTemp.value = node[config.useThermostat.name][config.deltaTemp.name].as<double>();
-    config.addBrownianMotion.value = node[config.useThermostat.name][config.addBrownianMotion.name].as<bool>();
-  }
-  if (node[config.loadBalancer.name]) {
-    auto parsedOptions = LoadBalancerOption::parseOptions(node[config.loadBalancer.name].as<std::string>());
-    if (parsedOptions.size() != 1) {
-      throw std::runtime_error(
-          "YamlParser::parseYamlFile: Pass exactly one load balancer option! Possible values:\n" +
-          autopas::utils::ArrayUtils::to_string(LoadBalancerOption::getAllOptions(), "", {"(", ")"}));
-    }
-    config.loadBalancer.value = *parsedOptions.begin();
-  }
   return true;
 }

--- a/examples/md-flexible/src/configuration/YamlParser.cpp
+++ b/examples/md-flexible/src/configuration/YamlParser.cpp
@@ -90,8 +90,13 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
                                        options::BoundaryTypeOption::parseOptionExact(tmpNode[1].as<std::string>()),
                                        options::BoundaryTypeOption::parseOptionExact(tmpNode[2].as<std::string>())};
       } else if (key == config.cutoff.name) {
-        expected = "Positive floating point value.";
+        expected = "Positive floating point value > 0.";
         description = config.cutoff.description;
+
+        double tmp = node[config.cutoff.name].as<double>();
+        if (tmp <= 0) {
+          throw YamlParserException("Cutoff has to be > 0!");
+        }
 
         config.cutoff.value = node[config.cutoff.name].as<double>();
       } else if (key == config.cellSizeFactors.name) {
@@ -131,12 +136,12 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
           throw YamlParserException("Unrecognized functor!");
         }
       } else if (key == config.iterations.name) {
-        expected = "Unsigned Integer";
+        expected = "Unsigned Integer > 0";
         description = config.iterations.description;
 
         long tmp = node[config.iterations.name].as<long>();
         if (tmp < 1) {
-          throw YamlParserException("The number of iterations has to be a positive integer.");
+          throw YamlParserException("The number of iterations has to be a positive integer > 0.");
         }
         config.iterations.value = tmp;
 
@@ -224,12 +229,12 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
 
         config.tuningSamples.value = tmp;
       } else if (key == config.tuningMaxEvidence.name) {
-        expected = "Unsigned Integer";
+        expected = "Unsigned Integer >= 1";
         description = config.tuningMaxEvidence.description;
 
         int tmp = node[config.tuningMaxEvidence.name].as<int>();
         if (tmp < 1) {
-          throw YamlParserException("Tuning max evidence has to be a positive integer!");
+          throw YamlParserException("Tuning max evidence has to be a positive integer >= 1!");
         }
 
         config.tuningMaxEvidence.value = tmp;
@@ -404,12 +409,12 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
           throw YamlParserException("Parsed log filename is empty!");
         }
       } else if (key == config.verletRebuildFrequency.name) {
-        expected = "Unsigned Integer";
+        expected = "Unsigned Integer >= 1";
         description = config.verletRebuildFrequency.description;
 
         int tmp = node[config.verletRebuildFrequency.name].as<int>();
-        if (tmp < 0) {
-          throw YamlParserException("Verlet rebuild frequency has to be a positive integer!");
+        if (tmp < 1) {
+          throw YamlParserException("Verlet rebuild frequency has to be a positive integer >= 1!");
         }
 
         config.verletRebuildFrequency.value = tmp;
@@ -638,8 +643,13 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         config.initTemperature.value = node[config.useThermostat.name][config.initTemperature.name].as<double>();
 
         m = node[key][config.thermostatInterval.name].Mark();
-        expected = "Unsigned Integer";
+        expected = "Unsigned Integer > 0";
         description = config.thermostatInterval.description;
+
+        int tmp = node[config.useThermostat.name][config.thermostatInterval.name].as<size_t>();
+        if (tmp <= 1) {
+          throw YamlParserException("thermostatInterval has to be > 0!");
+        }
         config.thermostatInterval.value = node[config.useThermostat.name][config.thermostatInterval.name].as<size_t>();
 
         m = node[key][config.targetTemperature.name].Mark();
@@ -684,8 +694,9 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
                 << "Parameter description: " << description << std::endl;
       return false;
     } catch (const YamlParserException &e) {
-      std::cerr << "Incorrect input-parameter for key " << key << ": " << e.what() << std::endl
-                << "Message: " << e.what() << std::endl
+      std::cerr << "Error while parsing the YAML-file in line " << (m.line + 1) << " at column " << m.column
+                << std::endl
+                << "Incorrect input-parameter for key " << key << ": " << e.what() << std::endl
                 << "Expected: " << expected << std::endl
                 << "Parameter description: " << description << std::endl;
       return false;

--- a/examples/md-flexible/src/configuration/YamlParser.cpp
+++ b/examples/md-flexible/src/configuration/YamlParser.cpp
@@ -632,11 +632,31 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
 
         config.useThermostat.value = true;
 
+        m = node[key][config.initTemperature.name].Mark();
+        expected = "Floating-Point Value";
+        description = config.initTemperature.description;
         config.initTemperature.value = node[config.useThermostat.name][config.initTemperature.name].as<double>();
+
+        m = node[key][config.thermostatInterval.name].Mark();
+        expected = "Unsigned Integer";
+        description = config.thermostatInterval.description;
         config.thermostatInterval.value = node[config.useThermostat.name][config.thermostatInterval.name].as<size_t>();
+
+        m = node[key][config.targetTemperature.name].Mark();
+        expected = "Floating-Point Value";
+        description = config.targetTemperature.description;
         config.targetTemperature.value = node[config.useThermostat.name][config.targetTemperature.name].as<double>();
+
+        m = node[key][config.deltaTemp.name].Mark();
+        expected = "Floating-Point Value";
+        description = config.deltaTemp.description;
         config.deltaTemp.value = node[config.useThermostat.name][config.deltaTemp.name].as<double>();
+
+        m = node[key][config.addBrownianMotion.name].Mark();
+        expected = "Boolean Value";
+        description = config.addBrownianMotion.description;
         config.addBrownianMotion.value = node[config.useThermostat.name][config.addBrownianMotion.name].as<bool>();
+
       } else if (key == config.loadBalancer.name) {
         expected = "YAML-sequence of possible values.";
         description = config.loadBalancer.description;
@@ -653,8 +673,7 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         }
         config.loadBalancer.value = *parsedOptions.begin();
       } else {
-        std::cerr << "Unrecognized option in input YAML: " + key + ". Press any key to continue anyway" << std::endl;
-        getchar();
+        std::cerr << "Unrecognized option in input YAML: " + key << std::endl;
         // return false;
       }
     } catch (const YAML::Exception &e) {

--- a/examples/md-flexible/src/configuration/YamlParser.cpp
+++ b/examples/md-flexible/src/configuration/YamlParser.cpp
@@ -215,19 +215,19 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         expected = "YAML-sequence of three floats. Example: [42, 42, 42].";
         description = config.boxMax.description;
 
-        auto tmpNode = node[config.boxMax.name];
+        auto tmpNode = node[key];
         config.boxMax.value = {tmpNode[0].as<double>(), tmpNode[1].as<double>(), tmpNode[2].as<double>()};
       } else if (key == config.subdivideDimension.name) {
         expected = "YAML-sequence of three ints in [0, 1].";
         description = config.subdivideDimension.description;
 
-        auto tmpNode = node[config.subdivideDimension.name];
+        auto tmpNode = node[key];
         config.subdivideDimension.value = {tmpNode[0].as<bool>(), tmpNode[1].as<bool>(), tmpNode[2].as<bool>()};
       } else if (key == config.loadBalancingInterval.name) {
         expected = "Unsigned Integer";
         description = config.loadBalancingInterval.description;
 
-        int tmp = node[config.loadBalancingInterval.name].as<int>();
+        int tmp = node[key].as<int>();
         if (tmp < 0) {
           throw YamlParserException("Load balancing interval must be a positive integer.");
         }
@@ -238,15 +238,14 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         description = config.selectorStrategy.description;
 
         std::set<autopas::options::SelectorStrategyOption> parsedOptions;
-        if (node[config.selectorStrategy.name].IsSequence()) {
-          if (node[config.selectorStrategy.name].size() != 1) {
+        if (node[key].IsSequence()) {
+          if (node[key].size() != 1) {
             throw YamlParserException("Pass Exactly one selector strategy.");
           }
           parsedOptions = autopas::SelectorStrategyOption::parseOptions(
-              autopas::utils::ArrayUtils::to_string(node[config.selectorStrategy.name], "", {"", ""}));
+              autopas::utils::ArrayUtils::to_string(node[key], "", {"", ""}));
         } else {
-          parsedOptions =
-              autopas::SelectorStrategyOption::parseOptions(node[config.selectorStrategy.name].as<std::string>());
+          parsedOptions = autopas::SelectorStrategyOption::parseOptions(node[key].as<std::string>());
         }
         config.selectorStrategy.value = *parsedOptions.begin();
 
@@ -254,7 +253,7 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         expected = "YAML-sequence of three possible values.";
         description = config.boundaryOption.description;
 
-        auto tmpNode = node[config.boundaryOption.name];
+        auto tmpNode = node[key];
         config.boundaryOption.value = {options::BoundaryTypeOption::parseOptionExact(tmpNode[0].as<std::string>()),
                                        options::BoundaryTypeOption::parseOptionExact(tmpNode[1].as<std::string>()),
                                        options::BoundaryTypeOption::parseOptionExact(tmpNode[2].as<std::string>())};
@@ -262,18 +261,18 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         expected = "Positive floating point value > 0.";
         description = config.cutoff.description;
 
-        double tmp = node[config.cutoff.name].as<double>();
+        double tmp = node[key].as<double>();
         if (tmp <= 0) {
           throw YamlParserException("Cutoff has to be > 0!");
         }
 
-        config.cutoff.value = node[config.cutoff.name].as<double>();
+        config.cutoff.value = tmp;
       } else if (key == config.cellSizeFactors.name) {
         expected = "YAML-sequence of floats.";
         description = config.cellSizeFactors.description;
 
         config.cellSizeFactors.value = autopas::utils::StringUtils::parseNumberSet(
-            autopas::utils::ArrayUtils::to_string(node[config.cellSizeFactors.name], ", ", {"", ""}));
+            autopas::utils::ArrayUtils::to_string(node[key], ", ", {"", ""}));
 
         if (config.cellSizeFactors.value->isEmpty()) {
           throw YamlParserException("Parsed cell-size-factor-list is empty.");
@@ -282,8 +281,8 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         expected = "YAML-sequence of possible values.";
         description = config.dataLayoutOptions.description;
 
-        config.dataLayoutOptions.value = autopas::DataLayoutOption::parseOptions(
-            autopas::utils::ArrayUtils::to_string(node[config.dataLayoutOptions.name], ", ", {"", ""}));
+        config.dataLayoutOptions.value =
+            autopas::DataLayoutOption::parseOptions(autopas::utils::ArrayUtils::to_string(node[key], ", ", {"", ""}));
         if (config.dataLayoutOptions.value.empty()) {
           throw YamlParserException("Parsed data-layouts-list is empty.");
         }
@@ -291,7 +290,7 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         expected = "One of the possible values.";
         description = config.functorOption.description;
 
-        auto strArg = node[config.functorOption.name].as<std::string>();
+        auto strArg = node[key].as<std::string>();
         transform(strArg.begin(), strArg.end(), strArg.begin(), ::tolower);
         if (strArg.find("avx") != std::string::npos) {
           config.functorOption.value = MDFlexConfig::FunctorOption::lj12_6_AVX;
@@ -308,7 +307,7 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         expected = "Unsigned Integer > 0";
         description = config.iterations.description;
 
-        long tmp = node[config.iterations.name].as<long>();
+        long tmp = node[key].as<long>();
         if (tmp < 1) {
           throw YamlParserException("The number of iterations has to be a positive integer > 0.");
         }
@@ -318,7 +317,7 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         expected = "Unsigned Integer";
         description = config.tuningPhases.description;
 
-        long tmp = node[config.tuningPhases.name].as<long>();
+        long tmp = node[key].as<long>();
         if (tmp < 0) {
           throw YamlParserException("The number of tuning phases has to be a positive integer.");
         }
@@ -329,24 +328,24 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         description = config.dontMeasureFlops.description;
 
         // "not" needed because of semantics
-        config.dontMeasureFlops.value = not node[config.dontMeasureFlops.name].as<bool>();
+        config.dontMeasureFlops.value = not node[key].as<bool>();
       } else if (key == config.dontCreateEndConfig.name) {
         expected = "Boolean Value";
         description = config.dontCreateEndConfig.description;
 
         // "not" needed because of semantics
-        config.dontCreateEndConfig.value = not node[config.dontCreateEndConfig.name].as<bool>();
+        config.dontCreateEndConfig.value = not node[key].as<bool>();
       } else if (key == config.dontShowProgressBar.name) {
         expected = "Boolean Value";
         description = config.dontShowProgressBar.description;
 
-        config.dontShowProgressBar.value = node[config.dontShowProgressBar.name].as<bool>();
+        config.dontShowProgressBar.value = node[key].as<bool>();
       } else if (key == config.newton3Options.name) {
         expected = "YAML-sequence of possible values.";
         description = config.newton3Options.description;
 
-        config.newton3Options.value = autopas::Newton3Option::parseOptions(
-            autopas::utils::ArrayUtils::to_string(node[config.newton3Options.name], ", ", {"", ""}));
+        config.newton3Options.value =
+            autopas::Newton3Option::parseOptions(autopas::utils::ArrayUtils::to_string(node[key], ", ", {"", ""}));
         if (config.newton3Options.value.empty()) {
           throw YamlParserException("Unknown Newton3 option!");
         }
@@ -354,13 +353,13 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         expected = "Positive floating point value.";
         description = config.deltaT.description;
 
-        config.deltaT.value = node[config.deltaT.name].as<double>();
+        config.deltaT.value = node[key].as<double>();
       } else if (key == config.traversalOptions.name) {
         expected = "YAML-sequence of possible values.";
         description = config.traversalOptions.description;
 
-        config.traversalOptions.value = autopas::TraversalOption::parseOptions(
-            autopas::utils::ArrayUtils::to_string(node[config.traversalOptions.name], ", ", {"", ""}));
+        config.traversalOptions.value =
+            autopas::TraversalOption::parseOptions(autopas::utils::ArrayUtils::to_string(node[key], ", ", {"", ""}));
 
         if (config.traversalOptions.value.empty()) {
           throw YamlParserException("Parsed traversal-list is empty. Maybe you used an unknown option.");
@@ -371,7 +370,7 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         description = config.loadEstimatorOptions.description;
 
         config.loadEstimatorOptions.value = autopas::LoadEstimatorOption::parseOptions(
-            autopas::utils::ArrayUtils::to_string(node[config.loadEstimatorOptions.name], ", ", {"", ""}));
+            autopas::utils::ArrayUtils::to_string(node[key], ", ", {"", ""}));
 
         if (config.loadEstimatorOptions.value.empty()) {
           throw YamlParserException("Parsed load-estimator-list is empty. Maybe you used an unknown option.");
@@ -381,7 +380,7 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         expected = "Unsigned Integer";
         description = config.tuningInterval.description;
 
-        int tmp = node[config.tuningInterval.name].as<int>();
+        int tmp = node[key].as<int>();
         if (tmp < 1) {
           throw YamlParserException("Tuning interval has to be a positive integer!");
         }
@@ -391,7 +390,7 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         expected = "Unsigned Integer >= 1";
         description = config.tuningSamples.description;
 
-        int tmp = node[config.tuningSamples.name].as<int>();
+        int tmp = node[key].as<int>();
         if (tmp < 1) {
           throw YamlParserException("Tuning samples has to be a positive integer!");
         }
@@ -401,7 +400,7 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         expected = "Unsigned Integer >= 1";
         description = config.tuningMaxEvidence.description;
 
-        int tmp = node[config.tuningMaxEvidence.name].as<int>();
+        int tmp = node[key].as<int>();
         if (tmp < 1) {
           throw YamlParserException("Tuning max evidence has to be a positive integer >= 1!");
         }
@@ -411,7 +410,7 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         expected = "Floating point value >= 1";
         description = config.relativeOptimumRange.description;
 
-        double tmp = node[config.relativeOptimumRange.name].as<double>();
+        double tmp = node[key].as<double>();
         if (tmp < 1.0) {
           throw YamlParserException("Relative optimum range has to be greater or equal one!");
         }
@@ -421,7 +420,7 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         expected = "Unsigned Integer";
         description = config.maxTuningPhasesWithoutTest.description;
 
-        int tmp = node[config.maxTuningPhasesWithoutTest.name].as<int>();
+        int tmp = node[key].as<int>();
         if (tmp < 1) {
           throw YamlParserException("Max tuning phases without test has to be positive!");
         }
@@ -431,7 +430,7 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         expected = "Floating point value >= 1 or 0";
         description = config.relativeBlacklistRange.description;
 
-        double tmp = node[config.relativeBlacklistRange.name].as<double>();
+        double tmp = node[key].as<double>();
         if (tmp < 1.0 and tmp != 0.0) {
           throw YamlParserException(
               "Relative range for blacklist range has to be greater or equal one or has to be zero!");
@@ -442,7 +441,7 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         expected = "Unsigned Integer >= 2";
         description = config.evidenceFirstPrediction.description;
 
-        int tmp = node[config.evidenceFirstPrediction.name].as<int>();
+        int tmp = node[key].as<int>();
         if (tmp < 2) {
           throw YamlParserException("The number of evidence for the first prediction has to be at least two!");
         }
@@ -453,15 +452,14 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         description = config.extrapolationMethodOption.description;
 
         std::set<autopas::options::ExtrapolationMethodOption> parsedOptions;
-        if (node[config.extrapolationMethodOption.name].IsSequence()) {
-          if (node[config.extrapolationMethodOption.name].size() != 1) {
+        if (node[key].IsSequence()) {
+          if (node[key].size() != 1) {
             throw YamlParserException("Pass exactly one extrapolation method!");
           }
           parsedOptions = autopas::ExtrapolationMethodOption::parseOptions(
-              autopas::utils::ArrayUtils::to_string(node[config.extrapolationMethodOption.name], "", {"", ""}));
+              autopas::utils::ArrayUtils::to_string(node[key], "", {"", ""}));
         } else {
-          parsedOptions = autopas::ExtrapolationMethodOption::parseOptions(
-              node[config.extrapolationMethodOption.name].as<std::string>());
+          parsedOptions = autopas::ExtrapolationMethodOption::parseOptions(node[key].as<std::string>());
         }
         config.extrapolationMethodOption.value = *parsedOptions.begin();
 
@@ -470,15 +468,14 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         description = config.tuningStrategyOption.description;
 
         std::set<autopas::options::TuningStrategyOption> parsedOptions;
-        if (node[config.tuningStrategyOption.name].IsSequence()) {
-          if (node[config.tuningStrategyOption.name].size() != 1) {
+        if (node[key].IsSequence()) {
+          if (node[key].size() != 1) {
             throw YamlParserException("Pass Exactly one tuning strategy!");
           }
           parsedOptions = autopas::TuningStrategyOption::parseOptions(
-              autopas::utils::ArrayUtils::to_string(node[config.tuningStrategyOption.name], "", {"", ""}));
+              autopas::utils::ArrayUtils::to_string(node[key], "", {"", ""}));
         } else {
-          parsedOptions =
-              autopas::TuningStrategyOption::parseOptions(node[config.tuningStrategyOption.name].as<std::string>());
+          parsedOptions = autopas::TuningStrategyOption::parseOptions(node[key].as<std::string>());
         }
         config.tuningStrategyOption.value = *parsedOptions.begin();
       } else if (key == config.mpiStrategyOption.name) {
@@ -486,48 +483,46 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         description = config.mpiStrategyOption.description;
 
         std::set<autopas::options::MPIStrategyOption> parsedOptions;
-        if (node[config.mpiStrategyOption.name].IsSequence()) {
-          if (node[config.mpiStrategyOption.name].size() != 1) {
+        if (node[key].IsSequence()) {
+          if (node[key].size() != 1) {
             throw YamlParserException("Pass exactly one MPI strategy!");
           }
-          parsedOptions = autopas::MPIStrategyOption::parseOptions(
-              autopas::utils::ArrayUtils::to_string(node[config.mpiStrategyOption.name], "", {"", ""}));
-        } else {
           parsedOptions =
-              autopas::MPIStrategyOption::parseOptions(node[config.mpiStrategyOption.name].as<std::string>());
+              autopas::MPIStrategyOption::parseOptions(autopas::utils::ArrayUtils::to_string(node[key], "", {"", ""}));
+        } else {
+          parsedOptions = autopas::MPIStrategyOption::parseOptions(node[key].as<std::string>());
         }
         config.mpiStrategyOption.value = *parsedOptions.begin();
       } else if (key == config.MPITuningMaxDifferenceForBucket.name) {
         expected = "Floating-point Value";
         description = config.MPITuningMaxDifferenceForBucket.description;
 
-        config.MPITuningMaxDifferenceForBucket.value = node[config.MPITuningMaxDifferenceForBucket.name].as<double>();
+        config.MPITuningMaxDifferenceForBucket.value = node[key].as<double>();
       } else if (key == config.MPITuningWeightForMaxDensity.name) {
         expected = "Floating-point Value";
         description = config.MPITuningWeightForMaxDensity.description;
 
-        config.MPITuningWeightForMaxDensity.value = node[config.MPITuningWeightForMaxDensity.name].as<double>();
+        config.MPITuningWeightForMaxDensity.value = node[key].as<double>();
       } else if (key == config.acquisitionFunctionOption.name) {
         expected = "Exactly one acquisition function option out of the possible values.";
         description = config.acquisitionFunctionOption.description;
 
         std::set<autopas::options::AcquisitionFunctionOption> parsedOptions;
-        if (node[config.acquisitionFunctionOption.name].IsSequence()) {
-          if (node[config.acquisitionFunctionOption.name].size() != 1) {
+        if (node[key].IsSequence()) {
+          if (node[key].size() != 1) {
             throw YamlParserException("Pass Exactly one acquisition function option!");
           }
           parsedOptions = autopas::AcquisitionFunctionOption::parseOptions(
-              autopas::utils::ArrayUtils::to_string(node[config.acquisitionFunctionOption.name], "", {"", ""}));
+              autopas::utils::ArrayUtils::to_string(node[key], "", {"", ""}));
         } else {
-          parsedOptions = autopas::AcquisitionFunctionOption::parseOptions(
-              node[config.acquisitionFunctionOption.name].as<std::string>());
+          parsedOptions = autopas::AcquisitionFunctionOption::parseOptions(node[key].as<std::string>());
         }
         config.acquisitionFunctionOption.value = *parsedOptions.begin();
       } else if (key == config.logLevel.name) {
         expected = "Log level out of the possible values.";
         description = config.logLevel.description;
 
-        auto strArg = node[config.logLevel.name].as<std::string>();
+        auto strArg = node[key].as<std::string>();
         switch (std::tolower(strArg[0])) {
           case 't': {
             config.logLevel.value = autopas::Logger::LogLevel::trace;
@@ -565,7 +560,7 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         expected = "String";
         description = config.checkpointfile.description;
 
-        config.checkpointfile.value = node[config.checkpointfile.name].as<std::string>();
+        config.checkpointfile.value = node[key].as<std::string>();
         if (config.checkpointfile.value.empty()) {
           throw YamlParserException("Parsed checkpoint filename is empty!");
         }
@@ -573,7 +568,7 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         expected = "String";
         description = config.logFileName.description;
 
-        config.logFileName.value = node[config.logFileName.name].as<std::string>();
+        config.logFileName.value = node[key].as<std::string>();
         if (config.logFileName.value.empty()) {
           throw YamlParserException("Parsed log filename is empty!");
         }
@@ -581,7 +576,7 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         expected = "Unsigned Integer >= 1";
         description = config.verletRebuildFrequency.description;
 
-        int tmp = node[config.verletRebuildFrequency.name].as<int>();
+        int tmp = node[key].as<int>();
         if (tmp < 1) {
           throw YamlParserException("Verlet rebuild frequency has to be a positive integer >= 1!");
         }
@@ -591,17 +586,17 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         expected = "Positive floating-point value.";
         description = config.verletSkinRadiusPerTimestep.description;
 
-        config.verletSkinRadiusPerTimestep.value = node[config.verletSkinRadiusPerTimestep.name].as<double>();
+        config.verletSkinRadiusPerTimestep.value = node[key].as<double>();
       } else if (key == config.fastParticlesThrow.name) {
         expected = "Boolean Value";
         description = config.fastParticlesThrow.description;
 
-        config.fastParticlesThrow.value = node[config.fastParticlesThrow.name].as<bool>();
+        config.fastParticlesThrow.value = node[key].as<bool>();
       } else if (key == config.verletClusterSize.name) {
         expected = "Unsigned Integer";
         description = config.verletClusterSize.description;
 
-        int tmp = node[config.verletClusterSize.name].as<int>();
+        int tmp = node[key].as<int>();
         if (tmp < 0) {
           throw YamlParserException("Verlet cluster size has to be a positive integer!");
         }
@@ -611,7 +606,7 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         expected = "String";
         description = config.vtkFileName.description;
 
-        config.vtkFileName.value = node[config.vtkFileName.name].as<std::string>();
+        config.vtkFileName.value = node[key].as<std::string>();
         if (config.vtkFileName.value.empty()) {
           throw YamlParserException("Parsed VTK filename is empty!");
         }
@@ -619,7 +614,7 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         expected = "Unsigned Integer >= 1";
         description = config.vtkWriteFrequency.description;
 
-        int tmp = node[config.vtkWriteFrequency.name].as<int>();
+        int tmp = node[key].as<int>();
         if (tmp < 1) {
           throw YamlParserException("VTK write frequency has to be a positive integer >= 1!");
         }
@@ -629,9 +624,7 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         expected = "YAML-sequence of three floats. Example: [0, 0, -9.81].";
         description = config.globalForce.description;
 
-        config.globalForce.value = {node[config.globalForce.name][0].as<double>(),
-                                    node[config.globalForce.name][1].as<double>(),
-                                    node[config.globalForce.name][2].as<double>()};
+        config.globalForce.value = {node[key][0].as<double>(), node[key][1].as<double>(), node[key][2].as<double>()};
       } else if (key == MDFlexConfig::objectsStr) {
         expected = "See AllOptions.yaml for examples.";
         description = "";
@@ -734,46 +727,46 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         m = node[key][config.initTemperature.name].Mark();
         expected = "Floating-Point Value";
         description = config.initTemperature.description;
-        config.initTemperature.value = node[config.useThermostat.name][config.initTemperature.name].as<double>();
+        config.initTemperature.value = node[key][config.initTemperature.name].as<double>();
 
         m = node[key][config.thermostatInterval.name].Mark();
         expected = "Unsigned Integer > 0";
         description = config.thermostatInterval.description;
 
-        int tmp = node[config.useThermostat.name][config.thermostatInterval.name].as<size_t>();
+        int tmp = node[key][config.thermostatInterval.name].as<size_t>();
         if (tmp <= 1) {
           throw YamlParserException("thermostatInterval has to be > 0!");
         }
-        config.thermostatInterval.value = node[config.useThermostat.name][config.thermostatInterval.name].as<size_t>();
+        config.thermostatInterval.value = node[key][config.thermostatInterval.name].as<size_t>();
 
         m = node[key][config.targetTemperature.name].Mark();
         expected = "Floating-Point Value";
         description = config.targetTemperature.description;
-        config.targetTemperature.value = node[config.useThermostat.name][config.targetTemperature.name].as<double>();
+        config.targetTemperature.value = node[key][config.targetTemperature.name].as<double>();
 
         m = node[key][config.deltaTemp.name].Mark();
         expected = "Floating-Point Value";
         description = config.deltaTemp.description;
-        config.deltaTemp.value = node[config.useThermostat.name][config.deltaTemp.name].as<double>();
+        config.deltaTemp.value = node[key][config.deltaTemp.name].as<double>();
 
         m = node[key][config.addBrownianMotion.name].Mark();
         expected = "Boolean Value";
         description = config.addBrownianMotion.description;
-        config.addBrownianMotion.value = node[config.useThermostat.name][config.addBrownianMotion.name].as<bool>();
+        config.addBrownianMotion.value = node[key][config.addBrownianMotion.name].as<bool>();
 
       } else if (key == config.loadBalancer.name) {
         expected = "YAML-sequence of possible values.";
         description = config.loadBalancer.description;
 
         std::set<LoadBalancerOption> parsedOptions;
-        if (node[config.loadBalancer.name].IsSequence()) {
-          if (node[config.loadBalancer.name].size() != 1) {
+        if (node[key].IsSequence()) {
+          if (node[key].size() != 1) {
             throw YamlParserException("Pass Exactly one load balancer option!");
           }
-          parsedOptions = LoadBalancerOption::parseOptions(
-              autopas::utils::ArrayUtils::to_string(node[config.loadBalancer.name], "", {"", ""}));
+          parsedOptions =
+              LoadBalancerOption::parseOptions(autopas::utils::ArrayUtils::to_string(node[key], "", {"", ""}));
         } else {
-          parsedOptions = LoadBalancerOption::parseOptions(node[config.loadBalancer.name].as<std::string>());
+          parsedOptions = LoadBalancerOption::parseOptions(node[key].as<std::string>());
         }
         config.loadBalancer.value = *parsedOptions.begin();
       } else {
@@ -783,7 +776,7 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
     } catch (const YAML::Exception &e) {
       // We do not use e.mark, as this don't provides the correct line number in some cases. Use the mark from above;
       std::cerr << "Error while parsing the YAML-file in line " << (m.line + 1) << " at column " << m.column
-                << std::endl
+                << ", key: " << key << std::endl
                 << "Expected: " << expected << std::endl
                 << "Parameter description: " << description << std::endl;
       return false;
@@ -796,7 +789,7 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
       return false;
     } catch (const std::exception &e) {
       std::cerr << "Error while parsing the YAML-file in line " << (m.line + 1) << " at column " << m.column
-                << std::endl
+                << ", key: " << key << std::endl
                 << "Message: " << e.what() << std::endl
                 << "Expected: " << expected << std::endl
                 << "Parameter description: " << description << std::endl;

--- a/examples/md-flexible/src/configuration/YamlParser.cpp
+++ b/examples/md-flexible/src/configuration/YamlParser.cpp
@@ -8,353 +8,675 @@
 #include <string>
 
 bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
+  /*
+  Global variables used to print the expected input and a description of the parameter if an error occurs while
+  parsing. Yaml mark is used to identify the current line of the error.
+  */
+  std::string expected;
+  std::string description;
+  YAML::Mark m;
+
   YAML::Node node = YAML::LoadFile(config.yamlFilename.value);
 
-  // iterate over all keys to identify known/unknown parameters
+  // We iterate over all keys to identify known/unknown parameters.
   for (auto itemIterator = node.begin(); itemIterator != node.end(); ++itemIterator) {
-    std::string key = itemIterator->first.as<std::string>();
+    std::string key;
+    try {
+      key = itemIterator->first.as<std::string>();
+      m = node[key].Mark();
 
-    if (key == config.containerOptions.name) {
-      config.containerOptions.value =
-          autopas::ContainerOption::parseOptions(autopas::utils::ArrayUtils::to_string(node[key], ", ", {"", ""}));
-    } else if (key == config.boxMin.name) {
-      auto tmpNode = node[config.boxMin.name];
-      config.boxMin.value = {tmpNode[0].as<double>(), tmpNode[1].as<double>(), tmpNode[2].as<double>()};
-    } else if (key == config.boxMax.name) {
-      auto tmpNode = node[config.boxMax.name];
-      config.boxMax.value = {tmpNode[0].as<double>(), tmpNode[1].as<double>(), tmpNode[2].as<double>()};
-    } else if (key == config.subdivideDimension.name) {
-      auto tmpNode = node[config.subdivideDimension.name];
-      config.subdivideDimension.value = {tmpNode[0].as<bool>(), tmpNode[1].as<bool>(), tmpNode[2].as<bool>()};
-    } else if (key == config.loadBalancingInterval.name) {
-      config.loadBalancingInterval.value = node[config.loadBalancingInterval.name].as<unsigned int>();
-    } else if (key == config.selectorStrategy.name) {
-      std::set<autopas::options::SelectorStrategyOption> parsedOptions;
-      if (node[config.selectorStrategy.name].IsSequence()) {
-        if (node[config.selectorStrategy.name].size() > 1) {
-          throw std::runtime_error("Pass exactly one selector strategy option! Possible values:\n" +
-                                   autopas::utils::ArrayUtils::to_string(
-                                       autopas::SelectorStrategyOption::getAllOptions(), ", ", {"(", ")"}));
-        }
-        parsedOptions = autopas::SelectorStrategyOption::parseOptions(
-            autopas::utils::ArrayUtils::to_string(node[config.selectorStrategy.name], "", {"", ""}));
-      } else {
-        parsedOptions =
-            autopas::SelectorStrategyOption::parseOptions(node[config.selectorStrategy.name].as<std::string>());
-      }
-      config.selectorStrategy.value = *parsedOptions.begin();
-    } else if (key == config.boundaryOption.name) {
-      auto tmpNode = node[config.boundaryOption.name];
-      config.boundaryOption.value = {options::BoundaryTypeOption::parseOptionExact(tmpNode[0].as<std::string>()),
-                                     options::BoundaryTypeOption::parseOptionExact(tmpNode[1].as<std::string>()),
-                                     options::BoundaryTypeOption::parseOptionExact(tmpNode[2].as<std::string>())};
-    } else if (key == config.cutoff.name) {
-      config.cutoff.value = node[config.cutoff.name].as<double>();
-    } else if (key == config.cellSizeFactors.name) {
-      config.cellSizeFactors.value = autopas::utils::StringUtils::parseNumberSet(
-          autopas::utils::ArrayUtils::to_string(node[config.cellSizeFactors.name], ", ", {"", ""}));
-      if (config.cellSizeFactors.value->isEmpty()) {
-        throw std::runtime_error("cell size factor is empty");
-      }
-    } else if (key == config.dataLayoutOptions.name) {
-      config.dataLayoutOptions.value = autopas::DataLayoutOption::parseOptions(
-          autopas::utils::ArrayUtils::to_string(node[config.dataLayoutOptions.name], ", ", {"", ""}));
-      if (config.dataLayoutOptions.value.empty()) {
-        throw std::runtime_error("dataLayoutOptions is empty");
-      }
-    } else if (key == config.functorOption.name) {
-      auto strArg = node[config.functorOption.name].as<std::string>();
-      transform(strArg.begin(), strArg.end(), strArg.begin(), ::tolower);
-      if (strArg.find("avx") != std::string::npos) {
-        config.functorOption.value = MDFlexConfig::FunctorOption::lj12_6_AVX;
-      } else if (strArg.find("sve") != std::string::npos) {
-        config.functorOption.value = MDFlexConfig::FunctorOption::lj12_6_SVE;
-      } else if (strArg.find("glob") != std::string::npos) {
-        config.functorOption.value = MDFlexConfig::FunctorOption::lj12_6_Globals;
-      } else if (strArg.find("lj") != std::string::npos or strArg.find("lennard-jones") != std::string::npos) {
-        config.functorOption.value = MDFlexConfig::FunctorOption::lj12_6;
-      }
-    } else if (key == config.iterations.name) {
-      config.iterations.value = node[config.iterations.name].as<unsigned long>();
-    } else if (key == config.tuningPhases.name) {
-      config.tuningPhases.value = node[config.tuningPhases.name].as<unsigned long>();
-    } else if (key == config.dontMeasureFlops.name) {
-      // "not" needed because of semantics
-      config.dontMeasureFlops.value = not node[config.dontMeasureFlops.name].as<bool>();
-    } else if (key == config.dontCreateEndConfig.name) {
-      // "not" needed because of semantics
-      config.dontCreateEndConfig.value = not node[config.dontCreateEndConfig.name].as<bool>();
-    } else if (key == config.dontShowProgressBar.name) {
-      config.dontShowProgressBar.value = node[config.dontShowProgressBar.name].as<bool>();
-    } else if (key == config.newton3Options.name) {
-      config.newton3Options.value = autopas::Newton3Option::parseOptions(
-          autopas::utils::ArrayUtils::to_string(node[config.newton3Options.name], ", ", {"", ""}));
-    } else if (key == config.deltaT.name) {
-      config.deltaT.value = node[config.deltaT.name].as<double>();
-    } else if (key == config.traversalOptions.name) {
-      config.traversalOptions.value = autopas::TraversalOption::parseOptions(
-          autopas::utils::ArrayUtils::to_string(node[config.traversalOptions.name], ", ", {"", ""}));
-    } else if (key == config.loadEstimatorOptions.name) {
-      config.loadEstimatorOptions.value = autopas::LoadEstimatorOption::parseOptions(
-          autopas::utils::ArrayUtils::to_string(node[config.loadEstimatorOptions.name], ", ", {"", ""}));
-    } else if (key == config.tuningInterval.name) {
-      config.tuningInterval.value = node[config.tuningInterval.name].as<unsigned int>();
-    } else if (key == config.tuningSamples.name) {
-      config.tuningSamples.value = node[config.tuningSamples.name].as<unsigned int>();
-    } else if (key == config.tuningMaxEvidence.name) {
-      config.tuningMaxEvidence.value = node[config.tuningMaxEvidence.name].as<unsigned int>();
-    } else if (key == config.relativeOptimumRange.name) {
-      config.relativeOptimumRange.value = node[config.relativeOptimumRange.name].as<double>();
-    } else if (key == config.maxTuningPhasesWithoutTest.name) {
-      config.maxTuningPhasesWithoutTest.value = node[config.maxTuningPhasesWithoutTest.name].as<unsigned int>();
-    } else if (key == config.relativeBlacklistRange.name) {
-      config.relativeBlacklistRange.value = node[config.relativeBlacklistRange.name].as<double>();
-    } else if (key == config.evidenceFirstPrediction.name) {
-      config.evidenceFirstPrediction.value = node[config.evidenceFirstPrediction.name].as<unsigned int>();
-    } else if (key == config.extrapolationMethodOption.name) {
-      auto parsedOptions = autopas::ExtrapolationMethodOption::parseOptions(
-          node[config.extrapolationMethodOption.name].as<std::string>());
-      if (parsedOptions.size() != 1) {
-        throw std::runtime_error(
-            "YamlParser::parseYamlFile: Pass exactly one extrapolation method option! Possible values:\n" +
-            autopas::utils::ArrayUtils::to_string(autopas::ExtrapolationMethodOption::getAllOptions(), "", {"(", ")"}));
-      }
-      config.extrapolationMethodOption.value = *parsedOptions.begin();
-    } else if (key == config.tuningStrategyOption.name) {
-      auto parsedOptions =
-          autopas::TuningStrategyOption::parseOptions(node[config.tuningStrategyOption.name].as<std::string>());
-      if (parsedOptions.size() != 1) {
-        throw std::runtime_error(
-            "YamlParser::parseYamlFile: Pass exactly one tuning strategy option! Possible values:\n" +
-            autopas::utils::ArrayUtils::to_string(autopas::TuningStrategyOption::getAllOptions(), "", {"(", ")"}));
-      }
-      config.tuningStrategyOption.value = *parsedOptions.begin();
-    } else if (key == config.mpiStrategyOption.name) {
-      auto parsedOptions =
-          autopas::MPIStrategyOption::parseOptions(node[config.mpiStrategyOption.name].as<std::string>());
-      if (parsedOptions.size() != 1) {
-        throw std::runtime_error(
-            "YamlParser::parseYamlFile: Pass exactly one mpi strategy option!"
-            "AutoPas cannot switch between several.");
-      }
-      config.mpiStrategyOption.value = *parsedOptions.begin();
-    } else if (key == config.MPITuningMaxDifferenceForBucket.name) {
-      config.MPITuningMaxDifferenceForBucket.value = node[config.MPITuningMaxDifferenceForBucket.name].as<double>();
-    } else if (key == config.MPITuningWeightForMaxDensity.name) {
-      config.MPITuningWeightForMaxDensity.value = node[config.MPITuningWeightForMaxDensity.name].as<double>();
-    } else if (key == config.acquisitionFunctionOption.name) {
-      auto parsedOptions = autopas::AcquisitionFunctionOption::parseOptions(
-          node[config.acquisitionFunctionOption.name].as<std::string>());
-      if (parsedOptions.size() != 1) {
-        throw std::runtime_error(
-            "YamlParser::parseYamlFile: Pass exactly one acquisition function option! Possible values:\n" +
-            autopas::utils::ArrayUtils::to_string(autopas::AcquisitionFunctionOption::getAllOptions(), "", {"(", ")"}));
-      }
-      config.acquisitionFunctionOption.value = *parsedOptions.begin();
-    } else if (key == config.logLevel.name) {
-      auto strArg = node[config.logLevel.name].as<std::string>();
-      switch (std::tolower(strArg[0])) {
-        case 't': {
-          config.logLevel.value = autopas::Logger::LogLevel::trace;
-          break;
-        }
-        case 'd': {
-          config.logLevel.value = autopas::Logger::LogLevel::debug;
-          break;
-        }
-        case 'i': {
-          config.logLevel.value = autopas::Logger::LogLevel::info;
-          break;
-        }
-        case 'w': {
-          config.logLevel.value = autopas::Logger::LogLevel::warn;
-          break;
-        }
-        case 'e': {
-          config.logLevel.value = autopas::Logger::LogLevel::err;
-          break;
-        }
-        case 'c': {
-          config.logLevel.value = autopas::Logger::LogLevel::critical;
-          break;
-        }
-        case 'o': {
-          config.logLevel.value = autopas::Logger::LogLevel::off;
-          break;
-        }
-      }
-    } else if (key == config.checkpointfile.name) {
-      config.checkpointfile.value = node[config.checkpointfile.name].as<std::string>();
-    } else if (key == config.logFileName.name) {
-      config.logFileName.value = node[config.logFileName.name].as<std::string>();
-    } else if (key == config.verletRebuildFrequency.name) {
-      config.verletRebuildFrequency.value = node[config.verletRebuildFrequency.name].as<unsigned int>();
-    } else if (key == config.verletSkinRadiusPerTimestep.name) {
-      config.verletSkinRadiusPerTimestep.value = node[config.verletSkinRadiusPerTimestep.name].as<double>();
-    } else if (key == config.fastParticlesThrow.name) {
-      config.fastParticlesThrow.value = node[config.fastParticlesThrow.name].as<bool>();
-    } else if (key == config.verletClusterSize.name) {
-      config.verletClusterSize.value = node[config.verletClusterSize.name].as<unsigned int>();
-    } else if (key == config.vtkFileName.name) {
-      config.vtkFileName.value = node[config.vtkFileName.name].as<std::string>();
-    } else if (key == config.vtkWriteFrequency.name) {
-      config.vtkWriteFrequency.value = node[config.vtkWriteFrequency.name].as<size_t>();
-    } else if (key == config.globalForce.name) {
-      config.globalForce.value = {node[config.globalForce.name][0].as<double>(),
-                                  node[config.globalForce.name][1].as<double>(),
-                                  node[config.globalForce.name][2].as<double>()};
-    } else if (key == MDFlexConfig::objectsStr) {
-      // remove default objects
-      config.cubeGridObjects.clear();
-      config.cubeGaussObjects.clear();
-      config.cubeUniformObjects.clear();
-      config.sphereObjects.clear();
-      config.cubeClosestPackedObjects.clear();
-      config.epsilonMap.value.clear();
-      config.sigmaMap.value.clear();
-      config.massMap.value.clear();
+      if (key == config.containerOptions.name) {
+        expected = "YAML-sequence of possible values.";
+        description = config.containerOptions.description;
 
-      for (auto objectIterator = node[MDFlexConfig::objectsStr].begin();
-           objectIterator != node[MDFlexConfig::objectsStr].end(); ++objectIterator) {
-        if (objectIterator->first.as<std::string>() == MDFlexConfig::cubeGridObjectsStr) {
-          for (auto it = objectIterator->second.begin(); it != objectIterator->second.end(); ++it) {
-            CubeGrid cubeGrid({it->second[MDFlexConfig::velocityStr][0].as<double>(),
+        config.containerOptions.value =
+            autopas::ContainerOption::parseOptions(autopas::utils::ArrayUtils::to_string(node[key], ", ", {"", ""}));
+
+        if (config.containerOptions.value.empty()) {
+          throw YamlParserException("Parsed container list is empty. You used possibly an unknown container option.");
+        }
+
+      } else if (key == config.boxMin.name) {
+        expected = "YAML-sequence of three floats. Example: [0, 0, 0].";
+        description = config.boxMin.description;
+
+        auto tmpNode = node[key];
+        config.boxMin.value = {tmpNode[0].as<double>(), tmpNode[1].as<double>(), tmpNode[2].as<double>()};
+      } else if (key == config.boxMax.name) {
+        expected = "YAML-sequence of three floats. Example: [42, 42, 42].";
+        description = config.boxMax.description;
+
+        auto tmpNode = node[config.boxMax.name];
+        config.boxMax.value = {tmpNode[0].as<double>(), tmpNode[1].as<double>(), tmpNode[2].as<double>()};
+      } else if (key == config.subdivideDimension.name) {
+        expected = "YAML-sequence of three ints in [0, 1].";
+        description = config.subdivideDimension.description;
+
+        auto tmpNode = node[config.subdivideDimension.name];
+        config.subdivideDimension.value = {tmpNode[0].as<bool>(), tmpNode[1].as<bool>(), tmpNode[2].as<bool>()};
+      } else if (key == config.loadBalancingInterval.name) {
+        expected = "Unsigned Integer";
+        description = config.loadBalancingInterval.description;
+
+        int tmp = node[config.loadBalancingInterval.name].as<int>();
+        if (tmp < 0) {
+          throw YamlParserException("Load balancing interval must be a positive integer.");
+        }
+
+        config.loadBalancingInterval.value = tmp;
+      } else if (key == config.selectorStrategy.name) {
+        expected = "Exactly one selector strategy out of the possible values.";
+        description = config.selectorStrategy.description;
+
+        std::set<autopas::options::SelectorStrategyOption> parsedOptions;
+        if (node[config.selectorStrategy.name].IsSequence()) {
+          if (node[config.selectorStrategy.name].size() != 1) {
+            throw YamlParserException("Pass Exactly one selector strategy.");
+          }
+          parsedOptions = autopas::SelectorStrategyOption::parseOptions(
+              autopas::utils::ArrayUtils::to_string(node[config.selectorStrategy.name], "", {"", ""}));
+        } else {
+          parsedOptions =
+              autopas::SelectorStrategyOption::parseOptions(node[config.selectorStrategy.name].as<std::string>());
+        }
+        config.selectorStrategy.value = *parsedOptions.begin();
+
+      } else if (key == config.boundaryOption.name) {
+        expected = "YAML-sequence of three possible values.";
+        description = config.boundaryOption.description;
+
+        auto tmpNode = node[config.boundaryOption.name];
+        config.boundaryOption.value = {options::BoundaryTypeOption::parseOptionExact(tmpNode[0].as<std::string>()),
+                                       options::BoundaryTypeOption::parseOptionExact(tmpNode[1].as<std::string>()),
+                                       options::BoundaryTypeOption::parseOptionExact(tmpNode[2].as<std::string>())};
+      } else if (key == config.cutoff.name) {
+        expected = "Positive floating point value.";
+        description = config.cutoff.description;
+
+        config.cutoff.value = node[config.cutoff.name].as<double>();
+      } else if (key == config.cellSizeFactors.name) {
+        expected = "YAML-sequence of floats.";
+        description = config.cellSizeFactors.description;
+
+        config.cellSizeFactors.value = autopas::utils::StringUtils::parseNumberSet(
+            autopas::utils::ArrayUtils::to_string(node[config.cellSizeFactors.name], ", ", {"", ""}));
+
+        if (config.cellSizeFactors.value->isEmpty()) {
+          throw YamlParserException("Parsed cell-size-factor-list is empty.");
+        }
+      } else if (key == config.dataLayoutOptions.name) {
+        expected = "YAML-sequence of possible values.";
+        description = config.dataLayoutOptions.description;
+
+        config.dataLayoutOptions.value = autopas::DataLayoutOption::parseOptions(
+            autopas::utils::ArrayUtils::to_string(node[config.dataLayoutOptions.name], ", ", {"", ""}));
+        if (config.dataLayoutOptions.value.empty()) {
+          throw YamlParserException("Parsed data-layouts-list is empty.");
+        }
+      } else if (key == config.functorOption.name) {
+        expected = "One of the possible values.";
+        description = config.functorOption.description;
+
+        auto strArg = node[config.functorOption.name].as<std::string>();
+        transform(strArg.begin(), strArg.end(), strArg.begin(), ::tolower);
+        if (strArg.find("avx") != std::string::npos) {
+          config.functorOption.value = MDFlexConfig::FunctorOption::lj12_6_AVX;
+        } else if (strArg.find("sve") != std::string::npos) {
+          config.functorOption.value = MDFlexConfig::FunctorOption::lj12_6_SVE;
+        } else if (strArg.find("glob") != std::string::npos) {
+          config.functorOption.value = MDFlexConfig::FunctorOption::lj12_6_Globals;
+        } else if (strArg.find("lj") != std::string::npos or strArg.find("lennard-jones") != std::string::npos) {
+          config.functorOption.value = MDFlexConfig::FunctorOption::lj12_6;
+        } else {
+          throw YamlParserException("Unrecognized functor!");
+        }
+      } else if (key == config.iterations.name) {
+        expected = "Unsigned Integer";
+        description = config.iterations.description;
+
+        long tmp = node[config.iterations.name].as<long>();
+        if (tmp < 1) {
+          throw YamlParserException("The number of iterations has to be a positive integer.");
+        }
+        config.iterations.value = tmp;
+
+      } else if (key == config.tuningPhases.name) {
+        expected = "Unsigned Integer";
+        description = config.tuningPhases.description;
+
+        long tmp = node[config.tuningPhases.name].as<long>();
+        if (tmp < 0) {
+          throw YamlParserException("The number of tuning phases has to be a positive integer.");
+        }
+
+        config.tuningPhases.value = tmp;
+      } else if (key == config.dontMeasureFlops.name) {
+        expected = "Boolean Value";
+        description = config.dontMeasureFlops.description;
+
+        // "not" needed because of semantics
+        config.dontMeasureFlops.value = not node[config.dontMeasureFlops.name].as<bool>();
+      } else if (key == config.dontCreateEndConfig.name) {
+        expected = "Boolean Value";
+        description = config.dontCreateEndConfig.description;
+
+        // "not" needed because of semantics
+        config.dontCreateEndConfig.value = not node[config.dontCreateEndConfig.name].as<bool>();
+      } else if (key == config.dontShowProgressBar.name) {
+        expected = "Boolean Value";
+        description = config.dontShowProgressBar.description;
+
+        config.dontShowProgressBar.value = node[config.dontShowProgressBar.name].as<bool>();
+      } else if (key == config.newton3Options.name) {
+        expected = "YAML-sequence of possible values.";
+        description = config.newton3Options.description;
+
+        config.newton3Options.value = autopas::Newton3Option::parseOptions(
+            autopas::utils::ArrayUtils::to_string(node[config.newton3Options.name], ", ", {"", ""}));
+        if (config.newton3Options.value.empty()) {
+          throw YamlParserException("Unknown Newton3 option!");
+        }
+      } else if (key == config.deltaT.name) {
+        expected = "Positive floating point value.";
+        description = config.deltaT.description;
+
+        config.deltaT.value = node[config.deltaT.name].as<double>();
+      } else if (key == config.traversalOptions.name) {
+        expected = "YAML-sequence of possible values.";
+        description = config.traversalOptions.description;
+
+        config.traversalOptions.value = autopas::TraversalOption::parseOptions(
+            autopas::utils::ArrayUtils::to_string(node[config.traversalOptions.name], ", ", {"", ""}));
+
+        if (config.traversalOptions.value.empty()) {
+          throw YamlParserException("Parsed traversal-list is empty. Maybe you used an unknown option.");
+        }
+
+      } else if (key == config.loadEstimatorOptions.name) {
+        expected = "YAML-sequence of possible values.";
+        description = config.loadEstimatorOptions.description;
+
+        config.loadEstimatorOptions.value = autopas::LoadEstimatorOption::parseOptions(
+            autopas::utils::ArrayUtils::to_string(node[config.loadEstimatorOptions.name], ", ", {"", ""}));
+
+        if (config.loadEstimatorOptions.value.empty()) {
+          throw YamlParserException("Parsed load-estimator-list is empty. Maybe you used an unknown option.");
+        }
+
+      } else if (key == config.tuningInterval.name) {
+        expected = "Unsigned Integer";
+        description = config.tuningInterval.description;
+
+        int tmp = node[config.tuningInterval.name].as<int>();
+        if (tmp < 1) {
+          throw YamlParserException("Tuning interval has to be a positive integer!");
+        }
+
+        config.tuningInterval.value = tmp;
+      } else if (key == config.tuningSamples.name) {
+        expected = "Unsigned Integer >= 1";
+        description = config.tuningSamples.description;
+
+        int tmp = node[config.tuningSamples.name].as<int>();
+        if (tmp < 1) {
+          throw YamlParserException("Tuning samples has to be a positive integer!");
+        }
+
+        config.tuningSamples.value = tmp;
+      } else if (key == config.tuningMaxEvidence.name) {
+        expected = "Unsigned Integer";
+        description = config.tuningMaxEvidence.description;
+
+        int tmp = node[config.tuningMaxEvidence.name].as<int>();
+        if (tmp < 1) {
+          throw YamlParserException("Tuning max evidence has to be a positive integer!");
+        }
+
+        config.tuningMaxEvidence.value = tmp;
+      } else if (key == config.relativeOptimumRange.name) {
+        expected = "Floating point value >= 1";
+        description = config.relativeOptimumRange.description;
+
+        double tmp = node[config.relativeOptimumRange.name].as<double>();
+        if (tmp < 1.0) {
+          throw YamlParserException("Relative optimum range has to be greater or equal one!");
+        }
+
+        config.relativeOptimumRange.value = tmp;
+      } else if (key == config.maxTuningPhasesWithoutTest.name) {
+        expected = "Unsigned Integer";
+        description = config.maxTuningPhasesWithoutTest.description;
+
+        int tmp = node[config.maxTuningPhasesWithoutTest.name].as<int>();
+        if (tmp < 1) {
+          throw YamlParserException("Max tuning phases without test has to be positive!");
+        }
+
+        config.maxTuningPhasesWithoutTest.value = tmp;
+      } else if (key == config.relativeBlacklistRange.name) {
+        expected = "Floating point value >= 1 or 0";
+        description = config.relativeBlacklistRange.description;
+
+        double tmp = node[config.relativeBlacklistRange.name].as<double>();
+        if (tmp < 1.0 and tmp != 0.0) {
+          throw YamlParserException(
+              "Relative range for blacklist range has to be greater or equal one or has to be zero!");
+        }
+
+        config.relativeBlacklistRange.value = tmp;
+      } else if (key == config.evidenceFirstPrediction.name) {
+        expected = "Unsigned Integer >= 2";
+        description = config.evidenceFirstPrediction.description;
+
+        int tmp = node[config.evidenceFirstPrediction.name].as<int>();
+        if (tmp < 2) {
+          throw YamlParserException("The number of evidence for the first prediction has to be at least two!");
+        }
+
+        config.evidenceFirstPrediction.value = tmp;
+      } else if (key == config.extrapolationMethodOption.name) {
+        expected = "Exactly one extrapolation method out of the possible values.";
+        description = config.extrapolationMethodOption.description;
+
+        std::set<autopas::options::ExtrapolationMethodOption> parsedOptions;
+        if (node[config.extrapolationMethodOption.name].IsSequence()) {
+          if (node[config.extrapolationMethodOption.name].size() != 1) {
+            throw YamlParserException("Pass exactly one extrapolation method!");
+          }
+          parsedOptions = autopas::ExtrapolationMethodOption::parseOptions(
+              autopas::utils::ArrayUtils::to_string(node[config.extrapolationMethodOption.name], "", {"", ""}));
+        } else {
+          parsedOptions = autopas::ExtrapolationMethodOption::parseOptions(
+              node[config.extrapolationMethodOption.name].as<std::string>());
+        }
+        config.extrapolationMethodOption.value = *parsedOptions.begin();
+
+      } else if (key == config.tuningStrategyOption.name) {
+        expected = "Exactly one tuning strategy option out of the possible values.";
+        description = config.tuningStrategyOption.description;
+
+        std::set<autopas::options::TuningStrategyOption> parsedOptions;
+        if (node[config.tuningStrategyOption.name].IsSequence()) {
+          if (node[config.tuningStrategyOption.name].size() != 1) {
+            throw YamlParserException("Pass Exactly one tuning strategy!");
+          }
+          parsedOptions = autopas::TuningStrategyOption::parseOptions(
+              autopas::utils::ArrayUtils::to_string(node[config.tuningStrategyOption.name], "", {"", ""}));
+        } else {
+          parsedOptions =
+              autopas::TuningStrategyOption::parseOptions(node[config.tuningStrategyOption.name].as<std::string>());
+        }
+        config.tuningStrategyOption.value = *parsedOptions.begin();
+      } else if (key == config.mpiStrategyOption.name) {
+        expected = "Exactly one MPI strategy option out of the possible values.";
+        description = config.mpiStrategyOption.description;
+
+        std::set<autopas::options::MPIStrategyOption> parsedOptions;
+        if (node[config.mpiStrategyOption.name].IsSequence()) {
+          if (node[config.mpiStrategyOption.name].size() != 1) {
+            throw YamlParserException("Pass exactly one MPI strategy!");
+          }
+          parsedOptions = autopas::MPIStrategyOption::parseOptions(
+              autopas::utils::ArrayUtils::to_string(node[config.mpiStrategyOption.name], "", {"", ""}));
+        } else {
+          parsedOptions =
+              autopas::MPIStrategyOption::parseOptions(node[config.mpiStrategyOption.name].as<std::string>());
+        }
+        config.mpiStrategyOption.value = *parsedOptions.begin();
+      } else if (key == config.MPITuningMaxDifferenceForBucket.name) {
+        expected = "Floating-point Value";
+        description = config.MPITuningMaxDifferenceForBucket.description;
+
+        config.MPITuningMaxDifferenceForBucket.value = node[config.MPITuningMaxDifferenceForBucket.name].as<double>();
+      } else if (key == config.MPITuningWeightForMaxDensity.name) {
+        expected = "Floating-point Value";
+        description = config.MPITuningWeightForMaxDensity.description;
+
+        config.MPITuningWeightForMaxDensity.value = node[config.MPITuningWeightForMaxDensity.name].as<double>();
+      } else if (key == config.acquisitionFunctionOption.name) {
+        expected = "Exactly one acquisition function option out of the possible values.";
+        description = config.acquisitionFunctionOption.description;
+
+        std::set<autopas::options::AcquisitionFunctionOption> parsedOptions;
+        if (node[config.acquisitionFunctionOption.name].IsSequence()) {
+          if (node[config.acquisitionFunctionOption.name].size() != 1) {
+            throw YamlParserException("Pass Exactly one acquisition function option!");
+          }
+          parsedOptions = autopas::AcquisitionFunctionOption::parseOptions(
+              autopas::utils::ArrayUtils::to_string(node[config.acquisitionFunctionOption.name], "", {"", ""}));
+        } else {
+          parsedOptions = autopas::AcquisitionFunctionOption::parseOptions(
+              node[config.acquisitionFunctionOption.name].as<std::string>());
+        }
+        config.acquisitionFunctionOption.value = *parsedOptions.begin();
+      } else if (key == config.logLevel.name) {
+        expected = "Log level out of the possible values.";
+        description = config.logLevel.description;
+
+        auto strArg = node[config.logLevel.name].as<std::string>();
+        switch (std::tolower(strArg[0])) {
+          case 't': {
+            config.logLevel.value = autopas::Logger::LogLevel::trace;
+            break;
+          }
+          case 'd': {
+            config.logLevel.value = autopas::Logger::LogLevel::debug;
+            break;
+          }
+          case 'i': {
+            config.logLevel.value = autopas::Logger::LogLevel::info;
+            break;
+          }
+          case 'w': {
+            config.logLevel.value = autopas::Logger::LogLevel::warn;
+            break;
+          }
+          case 'e': {
+            config.logLevel.value = autopas::Logger::LogLevel::err;
+            break;
+          }
+          case 'c': {
+            config.logLevel.value = autopas::Logger::LogLevel::critical;
+            break;
+          }
+          case 'o': {
+            config.logLevel.value = autopas::Logger::LogLevel::off;
+            break;
+          }
+          default: {
+            throw YamlParserException("Unknown Log Level parsed!");
+          }
+        }
+      } else if (key == config.checkpointfile.name) {
+        expected = "String";
+        description = config.checkpointfile.description;
+
+        config.checkpointfile.value = node[config.checkpointfile.name].as<std::string>();
+        if (config.checkpointfile.value.empty()) {
+          throw YamlParserException("Parsed checkpoint filename is empty!");
+        }
+      } else if (key == config.logFileName.name) {
+        expected = "String";
+        description = config.logFileName.description;
+
+        config.logFileName.value = node[config.logFileName.name].as<std::string>();
+        if (config.logFileName.value.empty()) {
+          throw YamlParserException("Parsed log filename is empty!");
+        }
+      } else if (key == config.verletRebuildFrequency.name) {
+        expected = "Unsigned Integer";
+        description = config.verletRebuildFrequency.description;
+
+        int tmp = node[config.verletRebuildFrequency.name].as<int>();
+        if (tmp < 0) {
+          throw YamlParserException("Verlet rebuild frequency has to be a positive integer!");
+        }
+
+        config.verletRebuildFrequency.value = tmp;
+      } else if (key == config.verletSkinRadiusPerTimestep.name) {
+        expected = "Positive floating-point value.";
+        description = config.verletSkinRadiusPerTimestep.description;
+
+        config.verletSkinRadiusPerTimestep.value = node[config.verletSkinRadiusPerTimestep.name].as<double>();
+      } else if (key == config.fastParticlesThrow.name) {
+        expected = "Boolean Value";
+        description = config.fastParticlesThrow.description;
+
+        config.fastParticlesThrow.value = node[config.fastParticlesThrow.name].as<bool>();
+      } else if (key == config.verletClusterSize.name) {
+        expected = "Unsigned Integer";
+        description = config.verletClusterSize.description;
+
+        int tmp = node[config.verletClusterSize.name].as<int>();
+        if (tmp < 0) {
+          throw YamlParserException("Verlet cluster size has to be a positive integer!");
+        }
+
+        config.verletClusterSize.value = tmp;
+      } else if (key == config.vtkFileName.name) {
+        expected = "String";
+        description = config.vtkFileName.description;
+
+        config.vtkFileName.value = node[config.vtkFileName.name].as<std::string>();
+        if (config.vtkFileName.value.empty()) {
+          throw YamlParserException("Parsed VTK filename is empty!");
+        }
+      } else if (key == config.vtkWriteFrequency.name) {
+        expected = "Unsigned Integer >= 1";
+        description = config.vtkWriteFrequency.description;
+
+        int tmp = node[config.vtkWriteFrequency.name].as<int>();
+        if (tmp < 1) {
+          throw YamlParserException("VTK write frequency has to be a positive integer >= 1!");
+        }
+
+        config.vtkWriteFrequency.value = (size_t)tmp;
+      } else if (key == config.globalForce.name) {
+        expected = "YAML-sequence of three floats. Example: [0, 0, -9.81].";
+        description = config.globalForce.description;
+
+        config.globalForce.value = {node[config.globalForce.name][0].as<double>(),
+                                    node[config.globalForce.name][1].as<double>(),
+                                    node[config.globalForce.name][2].as<double>()};
+      } else if (key == MDFlexConfig::objectsStr) {
+        expected = "See AllOptions.yaml for examples.";
+        description = "";
+
+        // remove default objects
+        config.cubeGridObjects.clear();
+        config.cubeGaussObjects.clear();
+        config.cubeUniformObjects.clear();
+        config.sphereObjects.clear();
+        config.cubeClosestPackedObjects.clear();
+        config.epsilonMap.value.clear();
+        config.sigmaMap.value.clear();
+        config.massMap.value.clear();
+
+        for (auto objectIterator = node[MDFlexConfig::objectsStr].begin();
+             objectIterator != node[MDFlexConfig::objectsStr].end(); ++objectIterator) {
+          if (objectIterator->first.as<std::string>() == MDFlexConfig::cubeGridObjectsStr) {
+            try {
+              for (auto it = objectIterator->second.begin(); it != objectIterator->second.end(); ++it) {
+                CubeGrid cubeGrid({it->second[MDFlexConfig::velocityStr][0].as<double>(),
+                                   it->second[MDFlexConfig::velocityStr][1].as<double>(),
+                                   it->second[MDFlexConfig::velocityStr][2].as<double>()},
+                                  it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
+                                  it->second[config.epsilonMap.name].as<double>(),
+                                  it->second[config.sigmaMap.name].as<double>(),
+                                  it->second[config.massMap.name].as<double>(),
+                                  {it->second[config.particlesPerDim.name][0].as<unsigned long>(),
+                                   it->second[config.particlesPerDim.name][1].as<unsigned long>(),
+                                   it->second[config.particlesPerDim.name][2].as<unsigned long>()},
+                                  it->second[config.particleSpacing.name].as<double>(),
+                                  {it->second[MDFlexConfig::bottomLeftBackCornerStr][0].as<double>(),
+                                   it->second[MDFlexConfig::bottomLeftBackCornerStr][1].as<double>(),
+                                   it->second[MDFlexConfig::bottomLeftBackCornerStr][2].as<double>()});
+
+                config.cubeGridObjects.emplace_back(cubeGrid);
+                config.addParticleType(it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
+                                       it->second[config.epsilonMap.name].as<double>(),
+                                       it->second[config.sigmaMap.name].as<double>(),
+                                       it->second[config.massMap.name].as<double>());
+              }
+            } catch (const std::exception &e) {
+              // std::cerr << e.what() << std::endl;
+              std::cerr << "YamlParser: Error parsing one of " << MDFlexConfig::cubeGridObjectsStr << " objects. "
+                        << "See AllOptions.yaml for examples." << std::endl;
+              return false;
+            }
+          } else if (objectIterator->first.as<std::string>() == MDFlexConfig::cubeGaussObjectsStr) {
+            try {
+              for (auto it = objectIterator->second.begin(); it != objectIterator->second.end(); ++it) {
+                CubeGauss cubeGauss({it->second[MDFlexConfig::velocityStr][0].as<double>(),
+                                     it->second[MDFlexConfig::velocityStr][1].as<double>(),
+                                     it->second[MDFlexConfig::velocityStr][2].as<double>()},
+                                    it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
+                                    it->second[config.epsilonMap.name].as<double>(),
+                                    it->second[config.sigmaMap.name].as<double>(),
+                                    it->second[config.massMap.name].as<double>(),
+                                    it->second[MDFlexConfig::particlesPerObjectStr].as<size_t>(),
+                                    {it->second[config.boxLength.name][0].as<double>(),
+                                     it->second[config.boxLength.name][1].as<double>(),
+                                     it->second[config.boxLength.name][2].as<double>()},
+                                    {it->second[config.distributionMean.name][0].as<double>(),
+                                     it->second[config.distributionMean.name][1].as<double>(),
+                                     it->second[config.distributionMean.name][2].as<double>()},
+                                    {it->second[config.distributionStdDev.name][0].as<double>(),
+                                     it->second[config.distributionStdDev.name][1].as<double>(),
+                                     it->second[config.distributionStdDev.name][2].as<double>()},
+                                    {it->second[MDFlexConfig::bottomLeftBackCornerStr][0].as<double>(),
+                                     it->second[MDFlexConfig::bottomLeftBackCornerStr][1].as<double>(),
+                                     it->second[MDFlexConfig::bottomLeftBackCornerStr][2].as<double>()});
+                config.cubeGaussObjects.emplace_back(cubeGauss);
+                config.addParticleType(it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
+                                       it->second[config.epsilonMap.name].as<double>(),
+                                       it->second[config.sigmaMap.name].as<double>(),
+                                       it->second[config.massMap.name].as<double>());
+              }
+            } catch (const std::exception &e) {
+              std::cerr << "YamlParser: Error parsing one of " << MDFlexConfig::cubeGaussObjectsStr << " objects. "
+                        << "See AllOptions.yaml for examples." << std::endl;
+              return false;
+            }
+          } else if (objectIterator->first.as<std::string>() == MDFlexConfig::cubeUniformObjectsStr) {
+            try {
+              for (auto it = objectIterator->second.begin(); it != objectIterator->second.end(); ++it) {
+                CubeUniform cubeUniform({it->second[MDFlexConfig::velocityStr][0].as<double>(),
+                                         it->second[MDFlexConfig::velocityStr][1].as<double>(),
+                                         it->second[MDFlexConfig::velocityStr][2].as<double>()},
+                                        it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
+                                        it->second[config.epsilonMap.name].as<double>(),
+                                        it->second[config.sigmaMap.name].as<double>(),
+                                        it->second[config.massMap.name].as<double>(),
+                                        it->second[MDFlexConfig::particlesPerObjectStr].as<size_t>(),
+                                        {it->second[config.boxLength.name][0].as<double>(),
+                                         it->second[config.boxLength.name][1].as<double>(),
+                                         it->second[config.boxLength.name][2].as<double>()},
+                                        {it->second[MDFlexConfig::bottomLeftBackCornerStr][0].as<double>(),
+                                         it->second[MDFlexConfig::bottomLeftBackCornerStr][1].as<double>(),
+                                         it->second[MDFlexConfig::bottomLeftBackCornerStr][2].as<double>()});
+                config.cubeUniformObjects.emplace_back(cubeUniform);
+                config.addParticleType(it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
+                                       it->second[config.epsilonMap.name].as<double>(),
+                                       it->second[config.sigmaMap.name].as<double>(),
+                                       it->second[config.massMap.name].as<double>());
+              }
+            } catch (const std::exception &e) {
+              std::cerr << "YamlParser: Error parsing one of " << MDFlexConfig::cubeUniformObjectsStr << " objects. "
+                        << "See AllOptions.yaml for examples." << std::endl;
+              return false;
+            }
+          } else if (objectIterator->first.as<std::string>() == MDFlexConfig::sphereObjectsStr) {
+            try {
+              for (auto it = objectIterator->second.begin(); it != objectIterator->second.end(); ++it) {
+                Sphere sphere({it->second[MDFlexConfig::velocityStr][0].as<double>(),
                                it->second[MDFlexConfig::velocityStr][1].as<double>(),
                                it->second[MDFlexConfig::velocityStr][2].as<double>()},
                               it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
                               it->second[config.epsilonMap.name].as<double>(),
                               it->second[config.sigmaMap.name].as<double>(),
                               it->second[config.massMap.name].as<double>(),
-                              {it->second[config.particlesPerDim.name][0].as<unsigned long>(),
-                               it->second[config.particlesPerDim.name][1].as<unsigned long>(),
-                               it->second[config.particlesPerDim.name][2].as<unsigned long>()},
-                              it->second[config.particleSpacing.name].as<double>(),
-                              {it->second[MDFlexConfig::bottomLeftBackCornerStr][0].as<double>(),
-                               it->second[MDFlexConfig::bottomLeftBackCornerStr][1].as<double>(),
-                               it->second[MDFlexConfig::bottomLeftBackCornerStr][2].as<double>()});
+                              {it->second[MDFlexConfig::sphereCenterStr][0].as<double>(),
+                               it->second[MDFlexConfig::sphereCenterStr][1].as<double>(),
+                               it->second[MDFlexConfig::sphereCenterStr][2].as<double>()},
+                              it->second[MDFlexConfig::sphereRadiusStr].as<int>(),
+                              it->second[config.particleSpacing.name].as<double>());
+                config.sphereObjects.emplace_back(sphere);
+                config.addParticleType(it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
+                                       it->second[config.epsilonMap.name].as<double>(),
+                                       it->second[config.sigmaMap.name].as<double>(),
+                                       it->second[config.massMap.name].as<double>());
+              }
+            } catch (const std::exception &e) {
+              std::cerr << "YamlParser: Error parsing one of " << MDFlexConfig::sphereObjectsStr << " objects. "
+                        << "See AllOptions.yaml for examples." << std::endl;
+              return false;
+            }
+          } else if (objectIterator->first.as<std::string>() == MDFlexConfig::cubeClosestPackedObjectsStr) {
+            try {
+              for (auto it = objectIterator->second.begin(); it != objectIterator->second.end(); ++it) {
+                CubeClosestPacked cubeClosestPacked(
+                    {it->second[MDFlexConfig::velocityStr][0].as<double>(),
+                     it->second[MDFlexConfig::velocityStr][1].as<double>(),
+                     it->second[MDFlexConfig::velocityStr][2].as<double>()},
+                    it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
+                    it->second[config.epsilonMap.name].as<double>(), it->second[config.sigmaMap.name].as<double>(),
+                    it->second[config.massMap.name].as<double>(), it->second[config.particleSpacing.name].as<double>(),
+                    {it->second[config.boxLength.name][0].as<double>(),
+                     it->second[config.boxLength.name][1].as<double>(),
+                     it->second[config.boxLength.name][2].as<double>()},
+                    {it->second[MDFlexConfig::bottomLeftBackCornerStr][0].as<double>(),
+                     it->second[MDFlexConfig::bottomLeftBackCornerStr][1].as<double>(),
+                     it->second[MDFlexConfig::bottomLeftBackCornerStr][2].as<double>()});
+                config.cubeClosestPackedObjects.emplace_back(cubeClosestPacked);
+                config.addParticleType(it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
+                                       it->second[config.epsilonMap.name].as<double>(),
+                                       it->second[config.sigmaMap.name].as<double>(),
+                                       it->second[config.massMap.name].as<double>());
+              }
+            } catch (const std::exception &e) {
+              std::cerr << "YamlParser: Error parsing one of " << MDFlexConfig::cubeClosestPackedObjectsStr
+                        << " objects. "
+                        << "See AllOptions.yaml for examples." << std::endl;
+              return false;
+            }
+          } else {
+            std::cerr << "YamlParser: Unrecognized generator \"" << objectIterator->first.as<std::string>()
+                      << "\" used." << std::endl;
+            return false;
+          }
+        }
+      } else if (key == config.useThermostat.name) {
+        expected = "See AllOptions.yaml for examples.";
+        description = config.useThermostat.description;
 
-            config.cubeGridObjects.emplace_back(cubeGrid);
-            config.addParticleType(it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
-                                   it->second[config.epsilonMap.name].as<double>(),
-                                   it->second[config.sigmaMap.name].as<double>(),
-                                   it->second[config.massMap.name].as<double>());
-          }
-          continue;
-        }
-        if (objectIterator->first.as<std::string>() == MDFlexConfig::cubeGaussObjectsStr) {
-          for (auto it = objectIterator->second.begin(); it != objectIterator->second.end(); ++it) {
-            CubeGauss cubeGauss(
-                {it->second[MDFlexConfig::velocityStr][0].as<double>(),
-                 it->second[MDFlexConfig::velocityStr][1].as<double>(),
-                 it->second[MDFlexConfig::velocityStr][2].as<double>()},
-                it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
-                it->second[config.epsilonMap.name].as<double>(), it->second[config.sigmaMap.name].as<double>(),
-                it->second[config.massMap.name].as<double>(),
-                it->second[MDFlexConfig::particlesPerObjectStr].as<size_t>(),
-                {it->second[config.boxLength.name][0].as<double>(), it->second[config.boxLength.name][1].as<double>(),
-                 it->second[config.boxLength.name][2].as<double>()},
-                {it->second[config.distributionMean.name][0].as<double>(),
-                 it->second[config.distributionMean.name][1].as<double>(),
-                 it->second[config.distributionMean.name][2].as<double>()},
-                {it->second[config.distributionStdDev.name][0].as<double>(),
-                 it->second[config.distributionStdDev.name][1].as<double>(),
-                 it->second[config.distributionStdDev.name][2].as<double>()},
-                {it->second[MDFlexConfig::bottomLeftBackCornerStr][0].as<double>(),
-                 it->second[MDFlexConfig::bottomLeftBackCornerStr][1].as<double>(),
-                 it->second[MDFlexConfig::bottomLeftBackCornerStr][2].as<double>()});
-            config.cubeGaussObjects.emplace_back(cubeGauss);
-            config.addParticleType(it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
-                                   it->second[config.epsilonMap.name].as<double>(),
-                                   it->second[config.sigmaMap.name].as<double>(),
-                                   it->second[config.massMap.name].as<double>());
-          }
-          continue;
-        }
-        if (objectIterator->first.as<std::string>() == MDFlexConfig::cubeUniformObjectsStr) {
-          for (auto it = objectIterator->second.begin(); it != objectIterator->second.end(); ++it) {
-            CubeUniform cubeUniform(
-                {it->second[MDFlexConfig::velocityStr][0].as<double>(),
-                 it->second[MDFlexConfig::velocityStr][1].as<double>(),
-                 it->second[MDFlexConfig::velocityStr][2].as<double>()},
-                it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
-                it->second[config.epsilonMap.name].as<double>(), it->second[config.sigmaMap.name].as<double>(),
-                it->second[config.massMap.name].as<double>(),
-                it->second[MDFlexConfig::particlesPerObjectStr].as<size_t>(),
-                {it->second[config.boxLength.name][0].as<double>(), it->second[config.boxLength.name][1].as<double>(),
-                 it->second[config.boxLength.name][2].as<double>()},
-                {it->second[MDFlexConfig::bottomLeftBackCornerStr][0].as<double>(),
-                 it->second[MDFlexConfig::bottomLeftBackCornerStr][1].as<double>(),
-                 it->second[MDFlexConfig::bottomLeftBackCornerStr][2].as<double>()});
-            config.cubeUniformObjects.emplace_back(cubeUniform);
-            config.addParticleType(it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
-                                   it->second[config.epsilonMap.name].as<double>(),
-                                   it->second[config.sigmaMap.name].as<double>(),
-                                   it->second[config.massMap.name].as<double>());
-          }
-          continue;
-        }
-        if (objectIterator->first.as<std::string>() == MDFlexConfig::sphereObjectsStr) {
-          for (auto it = objectIterator->second.begin(); it != objectIterator->second.end(); ++it) {
-            Sphere sphere({it->second[MDFlexConfig::velocityStr][0].as<double>(),
-                           it->second[MDFlexConfig::velocityStr][1].as<double>(),
-                           it->second[MDFlexConfig::velocityStr][2].as<double>()},
-                          it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
-                          it->second[config.epsilonMap.name].as<double>(),
-                          it->second[config.sigmaMap.name].as<double>(), it->second[config.massMap.name].as<double>(),
-                          {it->second[MDFlexConfig::sphereCenterStr][0].as<double>(),
-                           it->second[MDFlexConfig::sphereCenterStr][1].as<double>(),
-                           it->second[MDFlexConfig::sphereCenterStr][2].as<double>()},
-                          it->second[MDFlexConfig::sphereRadiusStr].as<int>(),
-                          it->second[config.particleSpacing.name].as<double>());
-            config.sphereObjects.emplace_back(sphere);
-            config.addParticleType(it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
-                                   it->second[config.epsilonMap.name].as<double>(),
-                                   it->second[config.sigmaMap.name].as<double>(),
-                                   it->second[config.massMap.name].as<double>());
-          }
-          continue;
-        }
-        if (objectIterator->first.as<std::string>() == MDFlexConfig::cubeClosestPackedObjectsStr) {
-          for (auto it = objectIterator->second.begin(); it != objectIterator->second.end(); ++it) {
-            CubeClosestPacked cubeClosestPacked(
-                {it->second[MDFlexConfig::velocityStr][0].as<double>(),
-                 it->second[MDFlexConfig::velocityStr][1].as<double>(),
-                 it->second[MDFlexConfig::velocityStr][2].as<double>()},
-                it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
-                it->second[config.epsilonMap.name].as<double>(), it->second[config.sigmaMap.name].as<double>(),
-                it->second[config.massMap.name].as<double>(), it->second[config.particleSpacing.name].as<double>(),
-                {it->second[config.boxLength.name][0].as<double>(), it->second[config.boxLength.name][1].as<double>(),
-                 it->second[config.boxLength.name][2].as<double>()},
-                {it->second[MDFlexConfig::bottomLeftBackCornerStr][0].as<double>(),
-                 it->second[MDFlexConfig::bottomLeftBackCornerStr][1].as<double>(),
-                 it->second[MDFlexConfig::bottomLeftBackCornerStr][2].as<double>()});
-            config.cubeClosestPackedObjects.emplace_back(cubeClosestPacked);
-            config.addParticleType(it->second[MDFlexConfig::particleTypeStr].as<unsigned long>(),
-                                   it->second[config.epsilonMap.name].as<double>(),
-                                   it->second[config.sigmaMap.name].as<double>(),
-                                   it->second[config.massMap.name].as<double>());
-          }
-          continue;
-        }
-      }
-    } else if (key == config.useThermostat.name) {
-      config.useThermostat.value = true;
+        config.useThermostat.value = true;
 
-      config.initTemperature.value = node[config.useThermostat.name][config.initTemperature.name].as<double>();
-      config.thermostatInterval.value = node[config.useThermostat.name][config.thermostatInterval.name].as<size_t>();
-      config.targetTemperature.value = node[config.useThermostat.name][config.targetTemperature.name].as<double>();
-      config.deltaTemp.value = node[config.useThermostat.name][config.deltaTemp.name].as<double>();
-      config.addBrownianMotion.value = node[config.useThermostat.name][config.addBrownianMotion.name].as<bool>();
-    } else if (key == config.loadBalancer.name) {
-      auto parsedOptions = LoadBalancerOption::parseOptions(node[config.loadBalancer.name].as<std::string>());
-      if (parsedOptions.size() != 1) {
-        throw std::runtime_error(
-            "YamlParser::parseYamlFile: Pass exactly one load balancer option! Possible values:\n" +
-            autopas::utils::ArrayUtils::to_string(LoadBalancerOption::getAllOptions(), "", {"(", ")"}));
+        config.initTemperature.value = node[config.useThermostat.name][config.initTemperature.name].as<double>();
+        config.thermostatInterval.value = node[config.useThermostat.name][config.thermostatInterval.name].as<size_t>();
+        config.targetTemperature.value = node[config.useThermostat.name][config.targetTemperature.name].as<double>();
+        config.deltaTemp.value = node[config.useThermostat.name][config.deltaTemp.name].as<double>();
+        config.addBrownianMotion.value = node[config.useThermostat.name][config.addBrownianMotion.name].as<bool>();
+      } else if (key == config.loadBalancer.name) {
+        expected = "YAML-sequence of possible values.";
+        description = config.loadBalancer.description;
+
+        std::set<LoadBalancerOption> parsedOptions;
+        if (node[config.loadBalancer.name].IsSequence()) {
+          if (node[config.loadBalancer.name].size() != 1) {
+            throw YamlParserException("Pass Exactly one load balancer option!");
+          }
+          parsedOptions = LoadBalancerOption::parseOptions(
+              autopas::utils::ArrayUtils::to_string(node[config.loadBalancer.name], "", {"", ""}));
+        } else {
+          parsedOptions = LoadBalancerOption::parseOptions(node[config.loadBalancer.name].as<std::string>());
+        }
+        config.loadBalancer.value = *parsedOptions.begin();
+      } else {
+        std::cerr << "Unrecognized option in input YAML: " + key + ". Press any key to continue anyway" << std::endl;
+        getchar();
+        // return false;
       }
-      config.loadBalancer.value = *parsedOptions.begin();
-    } else {
-      std::cerr << "Unrecognized option in input YAML: " + key << std::endl;
+    } catch (const YAML::Exception &e) {
+      // We do not use e.mark, as this don't provides the correct line number in some cases. Use the mark from above;
+      std::cerr << "Error while parsing the YAML-file in line " << (m.line + 1) << " at column " << m.column
+                << std::endl
+                << "Expected: " << expected << std::endl
+                << "Parameter description: " << description << std::endl;
+      return false;
+    } catch (const YamlParserException &e) {
+      std::cerr << "Incorrect input-parameter for key " << key << ": " << e.what() << std::endl
+                << "Message: " << e.what() << std::endl
+                << "Expected: " << expected << std::endl
+                << "Parameter description: " << description << std::endl;
+      return false;
+    } catch (const std::exception &e) {
+      std::cerr << "Error while parsing the YAML-file in line " << (m.line + 1) << " at column " << m.column
+                << std::endl
+                << "Message: " << e.what() << std::endl
+                << "Expected: " << expected << std::endl
+                << "Parameter description: " << description << std::endl;
+      return false;
     }
   }
 

--- a/examples/md-flexible/src/configuration/YamlParser.h
+++ b/examples/md-flexible/src/configuration/YamlParser.h
@@ -1,7 +1,7 @@
 /**
  * @file YamlParser.h
- * @author N. Fottner
- * @date 15.07.2019
+ * @author N. Fottner, D. Martin
+ * @date 15.07.2019, 11.04.2023
  */
 #pragma once
 
@@ -24,7 +24,15 @@ class YamlParserException : public std::exception {
   const char *message;
 
  public:
+  /**
+   * Constructor for YamlParserException
+   * @param msg The message of the exception.
+   */
   YamlParserException(const char *msg) : message(msg) {}
+
+  /**
+   * @return Returns the message of the exception.
+   */
   const char *what() const noexcept override { return message; }
 };
 
@@ -34,4 +42,185 @@ class YamlParserException : public std::exception {
  * @return false if any errors occurred during parsing.
  */
 bool parseYamlFile(MDFlexConfig &config);
+
+/**
+ * Parses the scalar value of a key in a Object-Node of a YAML-config.
+ * @param it YAML-iterator that points to a key of an Object-Node.
+ * @param key The key to parse.
+ * @param exp The expected value of the key.
+ * @return Parsed value of key. Throws a runtime_error if key could not be parsed.
+ */
+template <typename T>
+T parseObjectValue(YAML::iterator &it, const char *key, const char *exp);
+
+/**
+ * Parses the sequence value of a key in a Object-Node of a YAML-config
+ * @param it YAML-iterator that points to a key of an Object-Node.
+ * @param key The key to parse.
+ * @param exp The expected value of the key.
+ * @return Parsed value of key. Throws a runtime_error if key could not be parsed.
+ */
+template <typename T, size_t S>
+std::array<T, S> MDFlexParser::YamlParser::parseObjectValue(YAML::iterator &it, const char *key, const char *exp);
+
+/**
+ * Parses a CubeGrid-Object from a CubeGrid-Yaml-Node.
+ * @param config configuration where the input is stored.
+ * @param it YAML-iterator that points to the root of a CubeGrid-Node.
+ * @return Particles from the CubeGrid-Generator.
+ */
+CubeGrid parseCubeGridObject(MDFlexConfig &config, YAML::iterator &it);
+
+/**
+ * Parses a CubeUniform-Object from a CubeUniform-Yaml-Node.
+ * @param config configuration where the input is stored.
+ * @param it YAML-iterator that points to the root of a CubeUniform-Node.
+ * @return Particles from the CubeUniform-Generator.
+ */
+CubeUniform parseCubeUniformObject(MDFlexConfig &config, YAML::iterator &it);
+
+/**
+ * Parses a CubeGauss-Object from a CubeGauss-Yaml-Node.
+ * @param config configuration where the input is stored.
+ * @param it YAML-iterator that points to the root of a CubeGauss-Node.
+ * @return Particles from the CubeGauss-Generator.
+ */
+CubeGauss parseCubeGaussObject(MDFlexConfig &config, YAML::iterator &it);
+
+/**
+ * Parses a Sphere-Object from a Sphere-Yaml-Node.
+ * @param config configuration where the input is stored.
+ * @param it YAML-iterator that points to the root of a Sphere-Node.
+ * @return Particles from the Sphere-Generator.
+ */
+Sphere parseSphereObject(MDFlexConfig &config, YAML::iterator &it);
+
+/**
+ * Parses a CubeClosestPacked-Object from a CubeClosestPacked-Yaml-Node.
+ * @param config configuration where the input is stored.
+ * @param it YAML-iterator that points to the root of a CubeClosestPacked-Node.
+ * @return Particles from the CubeClosestPacked-Generator.
+ */
+CubeClosestPacked parseCubeClosestPacked(MDFlexConfig &config, YAML::iterator &it);
+
+/**
+ * Throws an exception if a parameter from a particle-generator is missing, or could not be parsed.
+ * @param key The YAML-key that is missing, or caused the error.
+ * @param exp The expected value of this key.
+ * @return
+ */
+void throwObjectParseException(const char *key, const char *exp);
+
+/**
+ * Parses the velcity-parameter of a particle-generator.
+ * @param config configuration where the input is stored.
+ * @param it YAML-iterator that points to the velocity-node of a particleobject.
+ * @return Initial particle velocity in x, y and z direction as array.
+ */
+std::array<double, 3> parseVelocity(MDFlexConfig &config, YAML::iterator &it);
+
+/**
+ * Parses the particle-type-parameter of a particle-generator.
+ * @param config configuration where the input is stored.
+ * @param it YAML-iterator that points to the particle-type-node of a particleobject.
+ * @return Particletype to be generated.
+ */
+unsigned long parseParticleType(MDFlexConfig &config, YAML::iterator &it);
+
+/**
+ * Parses the particle-epsilon-parameter of a particle-generator.
+ * @param config configuration where the input is stored.
+ * @param it YAML-iterator that points to the particle-epsilon-node of a particleobject.
+ * @return Epsilon for particles to be generated.
+ */
+double parseEpsilon(MDFlexConfig &config, YAML::iterator &it);
+
+/**
+ * Parses the particle-sigma-parameter of a particle-generator.
+ * @param config configuration where the input is stored.
+ * @param it YAML-iterator that points to the particle-sigma-node of a particleobject.
+ * @return Sigma for particles to be generated.
+ */
+double parseSigma(MDFlexConfig &config, YAML::iterator &it);
+
+/**
+ * Parses the particle-mass-parameter of a particle-generator.
+ * @param config configuration where the input is stored.
+ * @param it YAML-iterator that points to the particle-mass-node of a particleobject.
+ * @return Mass for particles to be generated.
+ */
+double parseMass(MDFlexConfig &config, YAML::iterator &it);
+
+/**
+ * Parses the particle-spacing-parameter of a particle-generator.
+ * @param config configuration where the input is stored.
+ * @param it YAML-iterator that points to the particle-spacing-node of a particleobject.
+ * @return Spacing between particles to be generated.
+ */
+double parseParticleSpacing(MDFlexConfig &config, YAML::iterator &it);
+
+/**
+ * Parses the particles-per-dimension-parameter of a particle-generator.
+ * @param config configuration where the input is stored.
+ * @param it YAML-iterator that points to the particles-per-dimension-node of a particleobject.
+ * @return Particles per dimension as array.
+ */
+std::array<unsigned long, 3> parseParticlesPerDim(MDFlexConfig &config, YAML::iterator &it);
+
+/**
+ * Parses the bottomLeftCorner-parameter of a particle-generator.
+ * @param config configuration where the input is stored.
+ * @param it YAML-iterator that points to the bottomLeftCorner-node of a particleobject.
+ * @return Bottom left corner of particles to be generated.
+ */
+std::array<double, 3> parseBottomLeftCorner(MDFlexConfig &config, YAML::iterator &it);
+
+/**
+ * Parses the distribution-mean-parameter of a particle-generator.
+ * @param config configuration where the input is stored.
+ * @param it YAML-iterator that points to the distribution-mean-node of a particleobject.
+ * @return Mean value for normal distribution in x, y and z direction.
+ */
+std::array<double, 3> parseDistrMean(MDFlexConfig &config, YAML::iterator &it);
+
+/**
+ * Parses the distribution-stddeviation-parameter of a particle-generator.
+ * @param config configuration where the input is stored.
+ * @param it YAML-iterator that points to the distribution-stddeviation-node of a particleobject.
+ * @return Standard deviation for normal distribution in x, y and z direction as array.
+ */
+std::array<double, 3> parseDistrStdDev(MDFlexConfig &config, YAML::iterator &it);
+
+/**
+ * Parses the numberOfParticles-parameter of a particle-generator.
+ * @param config configuration where the input is stored.
+ * @param it YAML-iterator that points to the numberOfParticles-node of a particleobject.
+ * @return Number of particles to be generated
+ */
+size_t parseNumParticles(MDFlexConfig &config, YAML::iterator &it);
+
+/**
+ * Parses the box-length-parameter of a particle-generator.
+ * @param config configuration where the input is stored.
+ * @param it YAML-iterator that points to the box-length-node of a particleobject.
+ * @return Box size in which particles should be generated in x, y and z direction as array.
+ */
+std::array<double, 3> parseBoxLength(MDFlexConfig &config, YAML::iterator &it);
+
+/**
+ * Parses the center-parameter of a sphere-generator.
+ * @param config configuration where the input is stored.
+ * @param it YAML-iterator that points to the center-node of a sphereobject.
+ * @return Center of the sphere object.
+ */
+std::array<double, 3> parseCenter(MDFlexConfig &config, YAML::iterator &it);
+
+/**
+ * Parses the radius-parameter of a sphere-generator.
+ * @param config configuration where the input is stored.
+ * @param it YAML-iterator that points to the radius-node of a sphereobject.
+ * @return Radius of the sphere object.
+ */
+double parseRadius(MDFlexConfig &config, YAML::iterator &it);
+
 }  // namespace MDFlexParser::YamlParser

--- a/examples/md-flexible/src/configuration/YamlParser.h
+++ b/examples/md-flexible/src/configuration/YamlParser.h
@@ -15,11 +15,23 @@
  * Parser for input through YAML files.
  */
 namespace MDFlexParser::YamlParser {
+
+/**
+ * Custom Exception for the Yaml parser that is thrown if an error occured during parsing.
+ */
+class YamlParserException : public std::exception {
+ private:
+  const char *message;
+
+ public:
+  YamlParserException(const char *msg) : message(msg) {}
+  const char *what() const noexcept override { return message; }
+};
+
 /**
  * Parses the Input for the simulation from the Yaml File specified in the configuration
  * @param config configuration where the input is stored.
  * @return false if any errors occurred during parsing.
- * @note FIXME: at the moment false is never returned and the parser just ungracefully crashes.
  */
 bool parseYamlFile(MDFlexConfig &config);
 }  // namespace MDFlexParser::YamlParser


### PR DESCRIPTION
# Description

The YAML parser now provides more detailed output when an incorrect input file is used. In contrast to the previous version, it now iterates over all parameters, so that unknown/incorrectly written parameters are detected. In this case a warning is issued. If the value for a parameter cannot be parsed or is in a wrong format, an error message with the line number, the name of the corresponding parameter and the expected value is printed. For some parameters an error reason is also given (e.g. "only one option allowed"). In addition, the description (config.PARAM.description) is displayed for each parameter that cannot be parsed. 

Furthermore all missing options in AllOptions.yaml with their default values have been added.

## Resolved Issues

- partly solves #706

# How Has This Been Tested?

For each parameter in AllOptions.yaml, incorrect and correct values were tested as examples.