### PR TITLE
Compiler info

### DIFF
--- a/src/autopas/AutoPasImpl.h
+++ b/src/autopas/AutoPasImpl.h
@@ -14,6 +14,7 @@
 #include "autopas/AutoPasDecl.h"
 #include "autopas/InstanceCounter.h"
 #include "autopas/Version.h"
+#include "autopas/utils/CompileInfo.h"
 
 // These next three includes have dependencies to all of AutoPas and thus are moved here from AutoPasDecl.h.
 #include "autopas/LogicHandler.h"
@@ -55,6 +56,7 @@ AutoPas<Particle> &AutoPas<Particle>::operator=(AutoPas &&other) noexcept {
 template <class Particle>
 void AutoPas<Particle>::init() {
   AutoPasLog(info, "AutoPas Version: {}", AutoPas_VERSION);
+  AutoPasLog(info, "Compiled with  : {}", utils::CompileInfo::getCompilerInfo());
   if (_numSamples % _verletRebuildFrequency != 0) {
     AutoPasLog(warn,
                "Number of samples ({}) is not a multiple of the rebuild frequency ({}). This can lead to problems "

--- a/src/autopas/namespaces.h
+++ b/src/autopas/namespaces.h
@@ -54,6 +54,11 @@ namespace ArrayMath {}
 namespace ArrayUtils {}
 
 /**
+ * Namespace for functions that provide information about what the code was compiled with.
+ */
+namespace CompileInfo {}
+
+/**
  * Some functions to parse enums from (input-) strings.
  */
 namespace StringUtils {}

--- a/src/autopas/utils/CompileInfo.cpp
+++ b/src/autopas/utils/CompileInfo.cpp
@@ -6,7 +6,7 @@
 
 #include "CompileInfo.h"
 
-std::string utils::CompileInfo::getCompilerInfo() {
+std::string autopas::utils::CompileInfo::getCompilerInfo() {
   std::stringstream ss;
   // prefix if not included in VERSION
 #if defined(__FUJITSU) or defined(__CLANG_FUJITSU)

--- a/src/autopas/utils/CompileInfo.cpp
+++ b/src/autopas/utils/CompileInfo.cpp
@@ -8,24 +8,34 @@
 
 std::string utils::CompileInfo::getCompilerInfo() {
   std::stringstream ss;
-#if defined(__GNUC__) and not(defined(__clang__) or defined(__INTEL_COMPILER))
+  // prefix if not included in VERSION
+#if defined(__FUJITSU) or defined(__CLANG_FUJITSU)
+  ss << "Fujitsu ";
+#elif defined(__GNUC__) and not(defined(__clang__) or defined(__INTEL_COMPILER))
   ss << "GCC ";
 #endif
-  // defined for:
+
+  // Main version info. Defined for:
   //   - icpc (without version)
   //   - icpx
   //   - gcc (without name)
   //   - clang
+  //   - fcc (weird version number)
 #if defined(__VERSION__)
   ss << __VERSION__;
 #endif
+
+  // suffix for compilers where version is not clear yet
   // icpc does not specify the version in __VERSION__
 #if defined(__INTEL_COMPILER)
   ss << " (icpc version: " << __INTEL_COMPILER << "." << __INTEL_COMPILER_UPDATE << ")";
+#elif defined(__FCC_version__)
+  ss << " (FCC version: " << __FCC_version__ << ")";
 #endif
   // Base case if nothing could be found
   if (ss.str().empty()) {
     ss << "Unknown";
   }
+
   return ss.str();
 }

--- a/src/autopas/utils/CompileInfo.cpp
+++ b/src/autopas/utils/CompileInfo.cpp
@@ -1,0 +1,31 @@
+/**
+ * @file CompileInfo.cpp
+ * @author F. Gratl
+ * @date 20.04.2023
+ */
+
+#include "CompileInfo.h"
+
+std::string utils::CompileInfo::getCompilerInfo() {
+  std::stringstream ss;
+#if defined(__GNUC__) and not(defined(__clang__) or defined(__INTEL_COMPILER))
+  ss << "GCC ";
+#endif
+  // defined for:
+  //   - icpc (without version)
+  //   - icpx
+  //   - gcc (without name)
+  //   - clang
+#if defined(__VERSION__)
+  ss << __VERSION__;
+#endif
+  // icpc does not specify the version in __VERSION__
+#if defined(__INTEL_COMPILER)
+  ss << " (icpc version: " << __INTEL_COMPILER << "." << __INTEL_COMPILER_UPDATE << ")";
+#endif
+  // Base case if nothing could be found
+  if (ss.str().empty()) {
+    ss << "Unknown";
+  }
+  return ss.str();
+}

--- a/src/autopas/utils/CompileInfo.h
+++ b/src/autopas/utils/CompileInfo.h
@@ -18,6 +18,7 @@ namespace autopas::utils::CompileInfo {
  *   - gcc
  *   - icpc
  *   - icpx
+ *   - fcc (trad and clang mode)
  * @return String : "Name Version.Number"
  */
 std::string getCompilerInfo();

--- a/src/autopas/utils/CompileInfo.h
+++ b/src/autopas/utils/CompileInfo.h
@@ -9,7 +9,7 @@
 #include <sstream>
 #include <string>
 
-namespace utils::CompileInfo {
+namespace autopas::utils::CompileInfo {
 
 /**
  * Get name and version number of a list of known compilers.
@@ -21,4 +21,4 @@ namespace utils::CompileInfo {
  * @return String : "Name Version.Number"
  */
 std::string getCompilerInfo();
-}  // namespace CompileInfo
+}  // namespace autopas::utils::CompileInfo

--- a/src/autopas/utils/CompileInfo.h
+++ b/src/autopas/utils/CompileInfo.h
@@ -1,0 +1,24 @@
+/**
+ * @file CompileInfo.h
+ * @author F. Gratl
+ * @date 20.04.2023
+ */
+
+#pragma once
+
+#include <sstream>
+#include <string>
+
+namespace utils::CompileInfo {
+
+/**
+ * Get name and version number of a list of known compilers.
+ * Currently known compilers:
+ *   - clang
+ *   - gcc
+ *   - icpc
+ *   - icpx
+ * @return String : "Name Version.Number"
+ */
+std::string getCompilerInfo();
+}  // namespace CompileInfo


### PR DESCRIPTION
# Description

Always print the name and version of the used compiler together with the autopas version.
Tries to use the generally available `__VERSION__` macro and adds further information if the output is insufficient.

Tested compilers:
- [x] gcc
- [x] clang
- [x] icpc
- [x] icpx
- [x] fcc

## ~Related Pull Requests~

## ~Resolved Issues~

# How Has This Been Tested?

Compiled md-flex and looked at the output.