### PR TITLE
Fix race conditions

### DIFF
--- a/examples/md-flexible/CMakeLists.txt
+++ b/examples/md-flexible/CMakeLists.txt
@@ -62,7 +62,7 @@ add_test(
         --distribution-mean 5.0
         --distribution-stddeviation 2.0
         --data-layout soa
-        --functor lj
+        --functor "Lennard-Jones"
         --iterations 10
         --particle-generator gauss
         --particles-total 10
@@ -76,28 +76,6 @@ add_test(
         CONFIGURATIONS checkExamples
 )
 
-#stable, periodic particle grid tested with all configurations
-add_test(
-        NAME md-flexible.test-sim
-        COMMAND
-        md-flexible
-        --container all
-        --traversal all
-        --cutoff 1.5
-        --functor lj
-        --tuning-phases 1
-        --particle-generator grid
-        --particles-per-dimension 10
-        --particle-spacing 1.1225
-        --verlet-rebuild-frequency 4
-        --verlet-skin-radius-per-timestep 0.05
-        --boundary-type periodic
-        --deltaT 0.005
-        --no-end-config
-        --no-flops
-        --no-progress-bar
-        CONFIGURATIONS checkExamples
-)
 
 # The AVX example should only be tested if AVX is available.
 set(HAS_AVX true)
@@ -125,6 +103,7 @@ else ()
 endif ()
 
 if (HAS_AVX)
+    set(TEST_FUNCTOR "Lennard-Jones-AVX")
     message(STATUS "AVX detected. Adding AVX test.")
     #dangerous, as lc_c04_combined_SoA uses unaligned values.
     add_test(
@@ -133,7 +112,7 @@ if (HAS_AVX)
             md-flexible
             --no-end-config
             --no-flops
-            --functor lennard-jones-AVX2
+            --functor "${TEST_FUNCTOR}"
             --deltaT 0
             --particle-generator uniform
             --log-level debug
@@ -143,8 +122,33 @@ if (HAS_AVX)
             CONFIGURATIONS checkExamples
     )
 else ()
-    message(STATUS "AVX could not be detected. Not adding AVX test.")
+  message(STATUS "AVX could not be detected. Not testing the AVX Functor.")
+  set(TEST_FUNCTOR "Lennard-Jones")
 endif ()
+
+#stable, periodic particle grid tested with all configurations
+message("TEST_FUNCTOR = ${TEST_FUNCTOR}")
+add_test(
+        NAME md-flexible.test-sim
+        COMMAND
+        md-flexible
+        --container all
+        --traversal all
+        --cutoff 1.5
+        --functor "${TEST_FUNCTOR}"
+        --tuning-phases 1
+        --particle-generator grid
+        --particles-per-dimension 10
+        --particle-spacing 1.1225
+        --verlet-rebuild-frequency 4
+        --verlet-skin-radius-per-timestep 0.05
+        --boundary-type periodic
+        --deltaT 0.005
+        --no-end-config
+        --no-flops
+        --no-progress-bar
+        CONFIGURATIONS checkExamples
+)
 
 add_test(
         NAME md-flexMeasurePerf

--- a/src/autopas/molecularDynamics/LJFunctorAVX.h
+++ b/src/autopas/molecularDynamics/LJFunctorAVX.h
@@ -697,9 +697,11 @@ class LJFunctorAVX
         x2tmp[vecIndex] = xptr[neighborList[j + vecIndex]];
         y2tmp[vecIndex] = yptr[neighborList[j + vecIndex]];
         z2tmp[vecIndex] = zptr[neighborList[j + vecIndex]];
-        fx2tmp[vecIndex] = fxptr[neighborList[j + vecIndex]];
-        fy2tmp[vecIndex] = fyptr[neighborList[j + vecIndex]];
-        fz2tmp[vecIndex] = fzptr[neighborList[j + vecIndex]];
+        if constexpr (newton3) {
+          fx2tmp[vecIndex] = fxptr[neighborList[j + vecIndex]];
+          fy2tmp[vecIndex] = fyptr[neighborList[j + vecIndex]];
+          fz2tmp[vecIndex] = fzptr[neighborList[j + vecIndex]];
+        }
         typeID2tmp[vecIndex] = typeIDptr[neighborList[j + vecIndex]];
         ownedStates2tmp[vecIndex] = ownedStatePtr[neighborList[j + vecIndex]];
       }
@@ -738,9 +740,12 @@ class LJFunctorAVX
         x2tmp[vecIndex] = xptr[neighborList[j + vecIndex]];
         y2tmp[vecIndex] = yptr[neighborList[j + vecIndex]];
         z2tmp[vecIndex] = zptr[neighborList[j + vecIndex]];
-        fx2tmp[vecIndex] = fxptr[neighborList[j + vecIndex]];
-        fy2tmp[vecIndex] = fyptr[neighborList[j + vecIndex]];
-        fz2tmp[vecIndex] = fzptr[neighborList[j + vecIndex]];
+        // if newton3 is used we need to load f of particle j so the kernel can update it too
+        if constexpr (newton3) {
+          fx2tmp[vecIndex] = fxptr[neighborList[j + vecIndex]];
+          fy2tmp[vecIndex] = fyptr[neighborList[j + vecIndex]];
+          fz2tmp[vecIndex] = fzptr[neighborList[j + vecIndex]];
+        }
         typeID2tmp[vecIndex] = typeIDptr[neighborList[j + vecIndex]];
         ownedStates2tmp[vecIndex] = ownedStatePtr[neighborList[j + vecIndex]];
       }

--- a/src/autopas/molecularDynamics/LJFunctorAVX.h
+++ b/src/autopas/molecularDynamics/LJFunctorAVX.h
@@ -560,7 +560,7 @@ class LJFunctorAVX
     fzacc = _mm256_add_pd(fzacc, fz);
 
     // if newton 3 is used subtract fD from particle j
-    if (newton3) {
+    if constexpr (newton3) {
       const __m256d fx2 =
           remainderIsMasked ? _mm256_maskload_pd(&fx2ptr[j], _masks[rest - 1]) : _mm256_loadu_pd(&fx2ptr[j]);
       const __m256d fy2 =
@@ -580,7 +580,7 @@ class LJFunctorAVX
                         : _mm256_storeu_pd(&fz2ptr[j], fz2new);
     }
 
-    if (calculateGlobals) {
+    if constexpr (calculateGlobals) {
       // Global Virial
       const __m256d virialX = _mm256_mul_pd(fx, drx);
       const __m256d virialY = _mm256_mul_pd(fy, dry);
@@ -676,8 +676,11 @@ class LJFunctorAVX
 
     // load 4 neighbors
     size_t j = 0;
+    // Loop over all neighbors as long as we can fill full vectors
+    // (until `neighborList.size() - neighborList.size() % vecLength`)
+    //
     // If b is a power of 2 the following holds:
-    // a & ~(b -1) == a - (a mod b)
+    // a & ~(b - 1) == a - (a mod b)
     for (; j < (neighborList.size() & ~(vecLength - 1)); j += vecLength) {
       // AVX2 variant:
       // create buffer for 4 interaction particles
@@ -706,7 +709,7 @@ class LJFunctorAVX
                                 &typeIDptr[indexFirst], typeID2tmp.data(), fxacc, fyacc, fzacc, &virialSumX,
                                 &virialSumY, &virialSumZ, &upotSum, 0);
 
-      if (newton3) {
+      if constexpr (newton3) {
         for (size_t vecIndex = 0; vecIndex < vecLength; ++vecIndex) {
           fxptr[neighborList[j + vecIndex]] = fx2tmp[vecIndex];
           fyptr[neighborList[j + vecIndex]] = fy2tmp[vecIndex];
@@ -714,9 +717,10 @@ class LJFunctorAVX
         }
       }
     }
+    // Remainder loop
     // If b is a power of 2 the following holds:
-    // a & (b -1) == a mod b
-    const int rest = (int)(neighborList.size() & (vecLength - 1));
+    // a & (b - 1) == a mod b
+    const auto rest = static_cast<int>(neighborList.size() & (vecLength - 1));
     if (rest > 0) {
       // AVX2 variant:
       // create buffer for 4 interaction particles
@@ -746,7 +750,7 @@ class LJFunctorAVX
                                &typeIDptr[indexFirst], typeID2tmp.data(), fxacc, fyacc, fzacc, &virialSumX, &virialSumY,
                                &virialSumZ, &upotSum, rest);
 
-      if (newton3) {
+      if constexpr (newton3) {
         for (size_t vecIndex = 0; vecIndex < rest; ++vecIndex) {
           fxptr[neighborList[j + vecIndex]] = fx2tmp[vecIndex];
           fyptr[neighborList[j + vecIndex]] = fy2tmp[vecIndex];


### PR DESCRIPTION
# Description

LJFunctoAVX::SoAFunctorVerlet had a race condition and we had no test to detect it.

## Related Pull Requests

- builds on top of #709 

## ~Resolved Issues~

# How Has This Been Tested?

- [x] Manually with TSan `md-flexible --containers verletLists --data-layout SoA --newton3 disabled`
- [x] CI: now with one example using AVX
