### PR TITLE
Adapt number of spacial locks at resize

### DIFF
--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -129,8 +129,7 @@ class AutoTuner {
     // The container might have changed sufficiently enough so that we need more or less spacial locks
     const auto boxLength = boxMax - boxMin;
     const auto container = getContainer();
-    const auto interactionLengthInv =
-        1. / (container->cutoff + container->verletSkinPerTimestep * container->rebuildFrequency);
+    const auto interactionLengthInv = 1. / (container->getInteractionLength());
     initSpacialLocks(boxLength, interactionLengthInv);
   }
 


### PR DESCRIPTION
# Description

When we resize the container also adapt the number of spacial locks.

## Related Pull Requests

- fix for bug introduced via #712

## ~Resolved Issues~

# How Has This Been Tested?

- [ ] Exploding Liquid with ls1 and three ranks.

