### PR TITLE
Dont pass copies

### DIFF
--- a/examples/md-flexible/CMakeLists.txt
+++ b/examples/md-flexible/CMakeLists.txt
@@ -127,7 +127,6 @@ else ()
 endif ()
 
 #stable, periodic particle grid tested with all configurations
-message("TEST_FUNCTOR = ${TEST_FUNCTOR}")
 add_test(
         NAME md-flexible.test-sim
         COMMAND

--- a/examples/md-flexible/src/configuration/objects/Sphere.h
+++ b/examples/md-flexible/src/configuration/objects/Sphere.h
@@ -61,14 +61,15 @@ class Sphere : public Object {
       for (int y = 0; y <= _radius; ++y) {
         for (int x = 0; x <= _radius; ++x) {
           // position relative to the center
-          std::array<double, 3> relativePos = {(double)x, (double)y, (double)z};
+          const std::array<double, 3> relativePos = {(double)x, (double)y, (double)z};
           // mirror to rest of sphere
           for (int i = -1; i <= 1; i += 2) {
             for (int k = -1; k <= 1; k += 2) {
               for (int l = -1; l <= 1; l += 2) {
-                std::array<double, 3> mirrorMultipliers = {(double)i, (double)k, (double)l};
+                const std::array<double, 3> mirrorMultipliers = {(double)i, (double)k, (double)l};
                 // position mirrored, scaled and absolute
-                std::array<double, 3> posVector = _center + ((relativePos * mirrorMultipliers) * _particleSpacing);
+                const std::array<double, 3> posVector =
+                    _center + ((relativePos * mirrorMultipliers) * _particleSpacing);
 
                 double distFromCentersSquare = autopas::utils::ArrayMath::dot(posVector - _center, posVector - _center);
                 const auto r = (_radius + 1) * _particleSpacing;

--- a/examples/md-flexible/src/domainDecomposition/DomainDecomposition.h
+++ b/examples/md-flexible/src/domainDecomposition/DomainDecomposition.h
@@ -42,25 +42,25 @@ class DomainDecomposition {
    * Returns the minimum coordinates of the global domain.
    * @return bottom left front corner of the global domain.
    */
-  [[nodiscard]] virtual std::array<double, 3> getGlobalBoxMin() const = 0;
+  [[nodiscard]] virtual const std::array<double, 3> &getGlobalBoxMin() const = 0;
 
   /**
    * Returns the maximum coordinates of the global domain.
    * @return top right back corner of the global domain.
    */
-  [[nodiscard]] virtual std::array<double, 3> getGlobalBoxMax() const = 0;
+  [[nodiscard]] virtual const std::array<double, 3> &getGlobalBoxMax() const = 0;
 
   /**
    * Returns the minimum coordinates of the local domain.
    * @return bottom left front corner of the local domain.
    */
-  [[nodiscard]] virtual std::array<double, 3> getLocalBoxMin() const = 0;
+  [[nodiscard]] virtual const std::array<double, 3> &getLocalBoxMin() const = 0;
 
   /**
    * Returns the maximum coordinates of the local domain.
    * @return top right back corner of the local domain.
    */
-  [[nodiscard]] virtual std::array<double, 3> getLocalBoxMax() const = 0;
+  [[nodiscard]] virtual const std::array<double, 3> &getLocalBoxMax() const = 0;
 
   /**
    * Checks if the provided coordinates are located in the local domain.

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
@@ -181,12 +181,12 @@ class RegularGridDecomposition final : public DomainDecomposition {
   /**
    * The minimum coordinates of the global domain.
    */
-  const std::array<double, _dimensionCount> _globalBoxMin;
+  std::array<double, _dimensionCount> _globalBoxMin;
 
   /**
    * The maximum coordinates of the global domain.
    */
-  const std::array<double, _dimensionCount> _globalBoxMax;
+  std::array<double, _dimensionCount> _globalBoxMax;
 
   /**
    * Boundary condition types of all dimensions.
@@ -214,7 +214,7 @@ class RegularGridDecomposition final : public DomainDecomposition {
    * Indicator to MPI to view all communication dimensions as periodic.
    * @note For usage in MPI functions, the const needs to be casted away.
    */
-  const std::vector<int> _periods{_dimensionCount, 1};
+  std::vector<int> _periods{_dimensionCount, 1};
 
   /**
    * The MPI communicator containing all processes which own a subdomain in this decomposition.

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
@@ -61,31 +61,31 @@ class RegularGridDecomposition final : public DomainDecomposition {
    * Returns the minimum coordinates of global domain.
    * @return bottom left front corner of the global domain.
    */
-  [[nodiscard]] std::array<double, 3> getGlobalBoxMin() const override { return _globalBoxMin; }
+  [[nodiscard]] const std::array<double, 3> &getGlobalBoxMin() const override { return _globalBoxMin; }
 
   /**
    * Returns the maximum coordinates of global domain.
    * @return top right back corner of the global domain.
    */
-  [[nodiscard]] std::array<double, 3> getGlobalBoxMax() const override { return _globalBoxMax; }
+  [[nodiscard]] const std::array<double, 3> &getGlobalBoxMax() const override { return _globalBoxMax; }
 
   /**
    * Returns the minimum coordinates of local domain.
    * @return bottom left front corner of the local domain.
    */
-  [[nodiscard]] std::array<double, 3> getLocalBoxMin() const override { return _localBoxMin; }
+  [[nodiscard]] const std::array<double, 3> &getLocalBoxMin() const override { return _localBoxMin; }
 
   /**
    * Returns the maximum coordinates of local domain.
    * @return top right back corner of the local domain.
    */
-  [[nodiscard]] std::array<double, 3> getLocalBoxMax() const override { return _localBoxMax; }
+  [[nodiscard]] const std::array<double, 3> &getLocalBoxMax() const override { return _localBoxMax; }
 
   /**
    * Returns the number of domains in each dimension
    * @return vector containing the number of subdomains along each dimension
    */
-  [[nodiscard]] std::array<int, 3> getDecomposition() const { return _decomposition; }
+  [[nodiscard]] const std::array<int, 3> &getDecomposition() const { return _decomposition; }
 
   /**
    * Returns the numnber of subdomains in the decomposition.
@@ -97,7 +97,7 @@ class RegularGridDecomposition final : public DomainDecomposition {
    * Returns the current processes domain id.
    * @return domain id of the current processor
    */
-  [[nodiscard]] const std::array<int, 3> getDomainId() const { return _domainId; }
+  [[nodiscard]] const std::array<int, 3> &getDomainId() const { return _domainId; }
 
   /**
    * Returns the number of subdomains in the simulation.
@@ -117,7 +117,7 @@ class RegularGridDecomposition final : public DomainDecomposition {
    * @param subdomainIndex: The index of the subdomain for which to calculate the extent.
    * @return extent of the subdomain with index subdomainIndex.
    */
-  [[nodiscard]] std::array<int, 6> getExtentOfSubdomain(const int subdomainIndex) const;
+  [[nodiscard]] std::array<int, 6> getExtentOfSubdomain(int subdomainIndex) const;
 
   /**
    * Exchanges halo particles with all neighbors of the provided AutoPasContainer.

--- a/examples/md-flexible/tests/configuration/GeneratorsTest.cpp
+++ b/examples/md-flexible/tests/configuration/GeneratorsTest.cpp
@@ -13,8 +13,8 @@
 
 TEST_F(GeneratorsTest, GridFillwithBoxMin) {
   auto autoPas = autopas::AutoPas<Molecule>(std::cout);
-  std::array<double, 3> boxmin = {5., 5., 5.};
-  std::array<double, 3> boxmax = {10., 10., 10.};
+  const std::array<double, 3> boxmin = {5., 5., 5.};
+  const std::array<double, 3> boxmax = {10., 10., 10.};
   autoPas.setBoxMax(boxmax);
   autoPas.setBoxMin(boxmin);
   Molecule dummy;
@@ -53,7 +53,7 @@ TEST_F(GeneratorsTest, MultipleObjectGeneration) {
   int sphereCounter = 0;
   int closestCounter = 0;
 
-  std::array<double, 3> velocity = {0., 0., 0.};
+  const std::array<double, 3> velocity = {0., 0., 0.};
   for (auto &particle : configuration.getParticles()) {
     EXPECT_EQ(velocity, particle.getV());  // velocity set to {0.,0.,0.} in parsingFile
     switch (particle.getTypeId()) {

--- a/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/MixedBoundaryConditionTest.cpp
@@ -23,7 +23,7 @@ auto MixedBoundaryConditionTest::setUpExpectations(
   std::vector<std::array<double, 3>> expectedForces;
   expectedForces.resize(particlePositions.size());
 
-  auto forceFromReflection = [&](const std::array<double, 3> position, const int dimensionOfBoundary,
+  auto forceFromReflection = [&](const std::array<double, 3> &position, const int dimensionOfBoundary,
                                  const bool isUpper) {
     const auto distanceToBoundary = isUpper ? boxMax[dimensionOfBoundary] - position[dimensionOfBoundary]
                                             : position[dimensionOfBoundary] - boxMin[dimensionOfBoundary];

--- a/examples/md-flexible/tests/domainDecomposition/ReflectiveBoundaryConditionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/ReflectiveBoundaryConditionTest.cpp
@@ -64,7 +64,7 @@ TEST_P(ReflectiveBoundaryConditionTest, simpleReflectionTest) {
   const std::array<double, 3> particleVelocity = std::get<1>(GetParam());
 
   // derive expected position
-  auto forceFromReflection = [&](const std::array<double, 3> position, const int dimensionOfBoundary,
+  auto forceFromReflection = [&](const std::array<double, 3> &position, const int dimensionOfBoundary,
                                  const bool isUpper) {
     const auto distanceToBoundary = isUpper ? boxMax[dimensionOfBoundary] - position[dimensionOfBoundary]
                                             : position[dimensionOfBoundary] - boxMin[dimensionOfBoundary];
@@ -175,7 +175,7 @@ INSTANTIATE_TEST_SUITE_P(
  * @param particlePosition
  * @param particleType Must be either 0 or 1. 0 corresponds to a sigma of 0.1, 1 corresponds to a sigma of 0.2.
  */
-void testReflectiveBoundaryZoning(const std::array<double, 3> particlePosition, int particleTypeID) {
+void testReflectiveBoundaryZoning(const std::array<double, 3> &particlePosition, int particleTypeID) {
   using namespace autopas::utils::ArrayMath::literals;
   if (particleTypeID != 0 and particleTypeID != 1) {
     std::cerr << "testReflectiveBoundaryZoning only takes particle types of 0 or 1 only!";

--- a/examples/sph-mpi/sph-main-mpi.cpp
+++ b/examples/sph-mpi/sph-main-mpi.cpp
@@ -446,7 +446,7 @@ void printConservativeVariables(AutoPasContainer &sphSystem, MPI_Comm &comm) {
   }
 }
 
-MPI_Comm getDecomposition(const std::array<double, 3> globalMin, const std::array<double, 3> globalMax,
+MPI_Comm getDecomposition(const std::array<double, 3> &globalMin, const std::array<double, 3> &globalMax,
                           std::array<double, 3> &localMin, std::array<double, 3> &localMax) {
   int numProcs;
   MPI_Comm_size(MPI_COMM_WORLD, &numProcs);

--- a/src/autopas/AutoPasDecl.h
+++ b/src/autopas/AutoPasDecl.h
@@ -414,8 +414,8 @@ class AutoPas {
    * @note not actually parallel until kokkos integration
    */
   template <typename Lambda>
-  void forEachInRegionParallel(Lambda forEachLambda, std::array<double, 3> lowerCorner,
-                               std::array<double, 3> higherCorner,
+  void forEachInRegionParallel(Lambda forEachLambda, const std::array<double, 3> &lowerCorner,
+                               const std::array<double, 3> &higherCorner,
                                IteratorBehavior behavior = IteratorBehavior::ownedOrHalo) {
     // TODO (lgaertner): parallelize with kokkos integration
     withStaticContainerType(getContainer(), [&](auto containerPtr) {
@@ -428,8 +428,8 @@ class AutoPas {
    * @note const version
    */
   template <typename Lambda>
-  void forEachInRegionParallel(Lambda forEachLambda, std::array<double, 3> lowerCorner,
-                               std::array<double, 3> higherCorner,
+  void forEachInRegionParallel(Lambda forEachLambda, const std::array<double, 3> &lowerCorner,
+                               const std::array<double, 3> &higherCorner,
                                IteratorBehavior behavior = IteratorBehavior::ownedOrHalo) const {
     // TODO (lgaertner): parallelize with kokkos integration
     withStaticContainerType(getContainer(), [&](auto containerPtr) {
@@ -446,7 +446,8 @@ class AutoPas {
    * @param behavior @see IteratorBehavior default: @see IteratorBehavior::ownerOrHalo
    */
   template <typename Lambda>
-  void forEachInRegion(Lambda forEachLambda, std::array<double, 3> lowerCorner, std::array<double, 3> higherCorner,
+  void forEachInRegion(Lambda forEachLambda, const std::array<double, 3> &lowerCorner,
+                       const std::array<double, 3> &higherCorner,
                        IteratorBehavior behavior = IteratorBehavior::ownedOrHalo) {
     withStaticContainerType(getContainer(), [&](auto containerPtr) {
       containerPtr->forEachInRegion(forEachLambda, lowerCorner, higherCorner, behavior);
@@ -458,7 +459,8 @@ class AutoPas {
    * @note const version
    */
   template <typename Lambda>
-  void forEachInRegion(Lambda forEachLambda, std::array<double, 3> lowerCorner, std::array<double, 3> higherCorner,
+  void forEachInRegion(Lambda forEachLambda, const std::array<double, 3> &lowerCorner,
+                       const std::array<double, 3> &higherCorner,
                        IteratorBehavior behavior = IteratorBehavior::ownedOrHalo) const {
     withStaticContainerType(getContainer(), [&](auto containerPtr) {
       containerPtr->forEachInRegion(forEachLambda, lowerCorner, higherCorner, behavior);
@@ -477,8 +479,8 @@ class AutoPas {
    * @note not actually parallel until kokkos integration
    */
   template <typename Lambda, typename A>
-  void reduceInRegionParallel(Lambda reduceLambda, A &result, std::array<double, 3> lowerCorner,
-                              std::array<double, 3> higherCorner,
+  void reduceInRegionParallel(Lambda reduceLambda, A &result, const std::array<double, 3> &lowerCorner,
+                              const std::array<double, 3> &higherCorner,
                               IteratorBehavior behavior = IteratorBehavior::ownedOrHalo) {
     // TODO lgaertner: parallelize with kokkos integration
     withStaticContainerType(getContainer(), [&](auto containerPtr) {
@@ -491,8 +493,8 @@ class AutoPas {
    * @note const version
    */
   template <typename Lambda, typename A>
-  void reduceInRegionParallel(Lambda reduceLambda, A &result, std::array<double, 3> lowerCorner,
-                              std::array<double, 3> higherCorner,
+  void reduceInRegionParallel(Lambda reduceLambda, A &result, const std::array<double, 3> &lowerCorner,
+                              const std::array<double, 3> &higherCorner,
                               IteratorBehavior behavior = IteratorBehavior::ownedOrHalo) const {
     // TODO lgaertner: parallelize with kokkos integration
     withStaticContainerType(getContainer(), [&](auto containerPtr) {
@@ -511,8 +513,9 @@ class AutoPas {
    * @param behavior @see IteratorBehavior default: @see IteratorBehavior::ownerOrHalo
    */
   template <typename Lambda, typename A>
-  void reduceInRegion(Lambda reduceLambda, A &result, std::array<double, 3> lowerCorner,
-                      std::array<double, 3> higherCorner, IteratorBehavior behavior = IteratorBehavior::ownedOrHalo) {
+  void reduceInRegion(Lambda reduceLambda, A &result, const std::array<double, 3> &lowerCorner,
+                      const std::array<double, 3> &higherCorner,
+                      IteratorBehavior behavior = IteratorBehavior::ownedOrHalo) {
     withStaticContainerType(getContainer(), [&](auto containerPtr) {
       containerPtr->reduceInRegion(reduceLambda, result, lowerCorner, higherCorner, behavior);
     });
@@ -523,8 +526,8 @@ class AutoPas {
    * @note const version
    */
   template <typename Lambda, typename A>
-  void reduceInRegion(Lambda reduceLambda, A &result, std::array<double, 3> lowerCorner,
-                      std::array<double, 3> higherCorner,
+  void reduceInRegion(Lambda reduceLambda, A &result, const std::array<double, 3> &lowerCorner,
+                      const std::array<double, 3> &higherCorner,
                       IteratorBehavior behavior = IteratorBehavior::ownedOrHalo) const {
     withStaticContainerType(getContainer(), [&](auto containerPtr) {
       containerPtr->reduceInRegion(reduceLambda, result, lowerCorner, higherCorner, behavior);
@@ -557,13 +560,13 @@ class AutoPas {
    * Get the lower corner of the container without the halo.
    * @return lower corner of the container.
    */
-  [[nodiscard]] std::array<double, 3> getBoxMin() const;
+  [[nodiscard]] const std::array<double, 3> &getBoxMin() const;
 
   /**
    * Get the upper corner of the container without the halo.
    * @return upper corner of the container.
    */
-  [[nodiscard]] std::array<double, 3> getBoxMax() const;
+  [[nodiscard]] const std::array<double, 3> &getBoxMax() const;
 
   /**
    * get the bool value indicating if the search space is trivial (not more than one configuration to test).

--- a/src/autopas/AutoPasImpl.h
+++ b/src/autopas/AutoPasImpl.h
@@ -282,12 +282,12 @@ unsigned long AutoPas<Particle>::getContainerType() const {
 }
 
 template <class Particle>
-std::array<double, 3> AutoPas<Particle>::getBoxMin() const {
+const std::array<double, 3> &AutoPas<Particle>::getBoxMin() const {
   return _autoTuner->getContainer()->getBoxMin();
 }
 
 template <class Particle>
-std::array<double, 3> AutoPas<Particle>::getBoxMax() const {
+const std::array<double, 3> &AutoPas<Particle>::getBoxMax() const {
   return _autoTuner->getContainer()->getBoxMax();
 }
 

--- a/src/autopas/containers/CellBasedParticleContainer.h
+++ b/src/autopas/containers/CellBasedParticleContainer.h
@@ -34,7 +34,7 @@ class CellBasedParticleContainer : public ParticleContainerInterface<typename Pa
    * @param cutoff
    * @param skin
    */
-  CellBasedParticleContainer(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax,
+  CellBasedParticleContainer(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax,
                              const double cutoff, const double skin)
       : _cells(), _boxMin(boxMin), _boxMax(boxMax), _cutoff(cutoff), _skin(skin) {}
 

--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -41,7 +41,7 @@ class CellBlock3D : public CellBorderAndFlagManager {
    * @param interactionLength max. radius of interaction between particles
    * @param cellSizeFactor cell size factor relative to interactionLength
    */
-  CellBlock3D(std::vector<ParticleCell> &vec, const std::array<double, 3> bMin, const std::array<double, 3> bMax,
+  CellBlock3D(std::vector<ParticleCell> &vec, const std::array<double, 3> &bMin, const std::array<double, 3> &bMax,
               double interactionLength, double cellSizeFactor = 1.0) {
     rebuild(vec, bMin, bMax, interactionLength, cellSizeFactor);
 
@@ -257,13 +257,13 @@ class CellBlock3D : public CellBorderAndFlagManager {
    * Get the lower corner of the halo region.
    * @return Coordinates of the lower corner.
    */
-  [[nodiscard]] std::array<double, 3> getHaloBoxMin() const { return _haloBoxMin; }
+  [[nodiscard]] const std::array<double, 3> &getHaloBoxMin() const { return _haloBoxMin; }
 
   /**
    * Get the upper corner of the halo region.
    * @return Coordinates of the upper corner.
    */
-  [[nodiscard]] std::array<double, 3> getHaloBoxMax() const { return _haloBoxMax; }
+  [[nodiscard]] const std::array<double, 3> &getHaloBoxMax() const { return _haloBoxMax; }
 
   /**
    * Get the number of cells per interaction length.

--- a/src/autopas/containers/cellPairTraversals/SlicedBalancedBasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/SlicedBalancedBasedTraversal.h
@@ -69,9 +69,9 @@ class SlicedBalancedBasedTraversal
       std::array<unsigned long, 3> lowerCorner = {0, 0, 0};
       std::array<unsigned long, 3> upperCorner = this->_cellsPerDimension;
       // upper corner is inclusive, so subtract 1 from each coordinate
-      upperCorner[0]--;
-      upperCorner[1]--;
-      upperCorner[2]--;
+      --upperCorner[0];
+      --upperCorner[1];
+      --upperCorner[2];
       lowerCorner[maxDimension] = x;
       upperCorner[maxDimension] = x;
       if (not this->_loadEstimator) {

--- a/src/autopas/containers/cellPairTraversals/SlicedLockBasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/SlicedLockBasedTraversal.h
@@ -78,11 +78,13 @@ void SlicedLockBasedTraversal<ParticleCell, PairwiseFunctor, dataLayout, useNewt
   locks.resize((numSlices - 1) * this->_overlapLongestAxis);
 
   // 0) check if applicable
-  std::array<size_t, 2> overLapps23{this->_overlap[this->_dimsPerLength[1]], this->_overlap[this->_dimsPerLength[2]]};
-
-  if (not spaciallyForward) {
-    overLapps23 = {0ul, 0ul};
-  }
+  const auto overLapps23 = [&]() -> std::array<size_t, 2> {
+    if constexpr (spaciallyForward) {
+      return {this->_overlap[this->_dimsPerLength[1]], this->_overlap[this->_dimsPerLength[2]]};
+    } else {
+      return {0ul, 0ul};
+    }
+  }();
 
   std::vector<utils::Timer> timers;
   std::vector<double> threadTimes;

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -53,7 +53,7 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
    * @param skinPerTimestep
    * @param verletRebuildFrequency
    */
-  DirectSum(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, double cutoff,
+  DirectSum(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax, double cutoff,
             double skinPerTimestep, unsigned int verletRebuildFrequency)
       : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep * verletRebuildFrequency),
         _cellBorderFlagManager() {

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -59,7 +59,7 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
    * @param loadEstimator the load estimation algorithm for balanced traversals.
    * By default all applicable traversals are allowed.
    */
-  LinkedCells(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
+  LinkedCells(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax, const double cutoff,
               const double skinPerTimestep, const unsigned int rebuildFrequency, const double cellSizeFactor = 1.0,
               LoadEstimatorOption loadEstimator = LoadEstimatorOption::squaredParticlesPerCell)
       : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep * rebuildFrequency),

--- a/src/autopas/containers/linkedCells/LinkedCellsReferences.h
+++ b/src/autopas/containers/linkedCells/LinkedCellsReferences.h
@@ -58,7 +58,7 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
    * @param loadEstimator the load estimation algorithm for balanced traversals.
    * By default all applicable traversals are allowed.
    */
-  LinkedCellsReferences(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
+  LinkedCellsReferences(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax, const double cutoff,
                         const double skinPerTimestep, const unsigned int rebuildFrequency,
                         const double cellSizeFactor = 1.0,
                         LoadEstimatorOption loadEstimator = LoadEstimatorOption::squaredParticlesPerCell)

--- a/src/autopas/containers/linkedCells/traversals/LCC01Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC01Traversal.h
@@ -199,10 +199,11 @@ inline void LCC01Traversal<ParticleCell, PairwiseFunctor, dataLayout, useNewton3
   for (long x = -this->_overlap[0]; x <= 0l; ++x) {
     for (long y = -this->_overlap[1]; y <= static_cast<long>(this->_overlap[1]); ++y) {
       for (long z = -this->_overlap[2]; z <= static_cast<long>(this->_overlap[2]); ++z) {
-        std::array<double, 3> pos = {};
-        pos[0] = std::max(0l, (std::abs(x) - 1l)) * this->_cellLength[0];
-        pos[1] = std::max(0l, (std::abs(y) - 1l)) * this->_cellLength[1];
-        pos[2] = std::max(0l, (std::abs(z) - 1l)) * this->_cellLength[2];
+        const std::array<double, 3> pos = {
+            std::max(0l, (std::abs(x) - 1l)) * this->_cellLength[0],
+            std::max(0l, (std::abs(y) - 1l)) * this->_cellLength[1],
+            std::max(0l, (std::abs(z) - 1l)) * this->_cellLength[2],
+        };
         const double distSquare = utils::ArrayMath::dot(pos, pos);
         if (distSquare <= interactionLengthSquare) {
           const long currentOffset = utils::ThreeDimensionalMapping::threeToOneD(
@@ -222,7 +223,7 @@ inline void LCC01Traversal<ParticleCell, PairwiseFunctor, dataLayout, useNewton3
               _cellOffsets[index].insert(_cellOffsets[index].cbegin(),
                                          std::make_pair(offset, utils::ArrayMath::normalize(pos)));
             } else {
-              _cellOffsets[index].push_back(std::make_pair(offset, utils::ArrayMath::normalize(pos)));
+              _cellOffsets[index].emplace_back(offset, utils::ArrayMath::normalize(pos));
             }
           }
         }

--- a/src/autopas/containers/linkedCells/traversals/LCC04SoACellHandler.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC04SoACellHandler.h
@@ -39,7 +39,7 @@ class LCC04SoACellHandler {
    * @param cellLength cell length.
    * @param overlap number of overlapping cells in each direction as result from cutoff and cellLength.
    */
-  explicit LCC04SoACellHandler(PairwiseFunctor *pairwiseFunctor, std::array<unsigned long, 3> cellsPerDimension,
+  explicit LCC04SoACellHandler(PairwiseFunctor *pairwiseFunctor, const std::array<unsigned long, 3> &cellsPerDimension,
                                const double interactionLength, const std::array<double, 3> &cellLength,
                                const std::array<unsigned long, 3> &overlap = {1ul, 1ul, 1ul})
       : _interactionLength(interactionLength),
@@ -73,7 +73,7 @@ class LCC04SoACellHandler {
    * docs/C08TraversalScheme.py
    * @param cellsPerDimension
    */
-  void computeOffsets(std::array<unsigned long, 3> cellsPerDimension);
+  void computeOffsets(const std::array<unsigned long, 3> &cellsPerDimension);
 
   /**
    * Interaction Length (cutoff + skin).
@@ -321,7 +321,7 @@ inline void LCC04SoACellHandler<ParticleCell, PairwiseFunctor, dataLayout, useNe
 
 template <class ParticleCell, class PairwiseFunctor, DataLayoutOption::Value dataLayout, bool useNewton3>
 inline void LCC04SoACellHandler<ParticleCell, PairwiseFunctor, dataLayout, useNewton3>::computeOffsets(
-    std::array<unsigned long, 3> cellsPerDimension) {
+    const std::array<unsigned long, 3> &cellsPerDimension) {
   using namespace autopas::utils::ArrayMath::literals;
   using std::make_pair;
 

--- a/src/autopas/containers/linkedCells/traversals/LCC08CellHandler.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC08CellHandler.h
@@ -38,7 +38,7 @@ class LCC08CellHandler {
    * @todo Pass cutoff to _cellFunctor instead of interactionLength, unless this functor is used to build verlet-lists,
    * in that case the interactionLength is needed!
    */
-  explicit LCC08CellHandler(PairwiseFunctor *pairwiseFunctor, std::array<unsigned long, 3> cellsPerDimension,
+  explicit LCC08CellHandler(PairwiseFunctor *pairwiseFunctor, const std::array<unsigned long, 3> &cellsPerDimension,
                             const double interactionLength, const std::array<double, 3> &cellLength,
                             const std::array<unsigned long, 3> &overlap)
       : _cellFunctor(pairwiseFunctor, interactionLength /*should use cutoff here, if not used to build verlet-lists*/),
@@ -70,7 +70,7 @@ class LCC08CellHandler {
    * docs/C08TraversalScheme.py
    * @param cellsPerDimension
    */
-  void computeOffsets(std::array<unsigned long, 3> cellsPerDimension);
+  void computeOffsets(const std::array<unsigned long, 3> &cellsPerDimension);
 
   /**
    * Overlap of interacting cells. Array allows asymmetric cell sizes.
@@ -115,7 +115,7 @@ inline void LCC08CellHandler<ParticleCell, PairwiseFunctor, dataLayout, useNewto
 
 template <class ParticleCell, class PairwiseFunctor, DataLayoutOption::Value dataLayout, bool useNewton3>
 inline void LCC08CellHandler<ParticleCell, PairwiseFunctor, dataLayout, useNewton3>::computeOffsets(
-    std::array<unsigned long, 3> cellsPerDimension) {
+    const std::array<unsigned long, 3> &cellsPerDimension) {
   using namespace autopas::utils::ArrayMath::literals;
   using std::make_pair;
 

--- a/src/autopas/containers/linkedCells/traversals/LCC18Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC18Traversal.h
@@ -129,10 +129,11 @@ inline void LCC18Traversal<ParticleCell, PairwiseFunctor, dataLayout, useNewton3
           if (std::abs(yArray + y) <= _overlap_s[1]) {
             for (long xArray = -_overlap_s[0]; xArray <= _overlap_s[0]; ++xArray) {
               if (std::abs(xArray + x) <= _overlap_s[0]) {
-                std::array<double, 3> pos = {};
-                pos[0] = std::max(0l, (std::abs(x) - 1l)) * this->_cellLength[0];
-                pos[1] = std::max(0l, (std::abs(y) - 1l)) * this->_cellLength[1];
-                pos[2] = std::max(0l, (std::abs(z) - 1l)) * this->_cellLength[2];
+                const std::array<double, 3> pos = {
+                    std::max(0l, (std::abs(x) - 1l)) * this->_cellLength[0],
+                    std::max(0l, (std::abs(y) - 1l)) * this->_cellLength[1],
+                    std::max(0l, (std::abs(z) - 1l)) * this->_cellLength[2],
+                };
                 // calculate distance between base cell and other cell
                 const double distSquare = utils::ArrayMath::dot(pos, pos);
                 // only add cell offset if cell is within cutoff radius

--- a/src/autopas/containers/octree/Octree.h
+++ b/src/autopas/containers/octree/Octree.h
@@ -356,8 +356,8 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
     using namespace autopas::utils::ArrayMath::literals;
 
     // this is a dummy since it is not actually used
-    std::array<unsigned long, 3> dims = {1, 1, 1};
-    std::array<double, 3> cellLength = this->getBoxMax() - this->getBoxMin();
+    const std::array<unsigned long, 3> dims = {1, 1, 1};
+    const std::array<double, 3> cellLength = this->getBoxMax() - this->getBoxMin();
     return TraversalSelectorInfo(dims, this->getInteractionLength(), cellLength, 0);
   }
 

--- a/src/autopas/containers/octree/Octree.h
+++ b/src/autopas/containers/octree/Octree.h
@@ -71,8 +71,8 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
    * @param rebuildFrequency The Rebuild Frequency
    * @param cellSizeFactor The cell size factor
    */
-  Octree(std::array<double, 3> boxMin, std::array<double, 3> boxMax, const double cutoff, const double skinPerTimestep,
-         const unsigned int rebuildFrequency, const double cellSizeFactor)
+  Octree(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax, const double cutoff,
+         const double skinPerTimestep, const unsigned int rebuildFrequency, const double cellSizeFactor)
       : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep * rebuildFrequency) {
     using namespace autopas::utils::ArrayMath::literals;
 

--- a/src/autopas/containers/octree/OctreeInnerNode.h
+++ b/src/autopas/containers/octree/OctreeInnerNode.h
@@ -31,8 +31,9 @@ class OctreeInnerNode : public OctreeNodeInterface<Particle> {
    * @param interactionLength The minimum distance at which a force is considered nonzero, cutoff+skin.
    * @param cellSizeFactor The cell size factor
    */
-  OctreeInnerNode(std::array<double, 3> boxMin, std::array<double, 3> boxMax, OctreeNodeInterface<Particle> *parent,
-                  int unsigned treeSplitThreshold, double interactionLength, double cellSizeFactor)
+  OctreeInnerNode(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax,
+                  OctreeNodeInterface<Particle> *parent, int unsigned treeSplitThreshold, double interactionLength,
+                  double cellSizeFactor)
       : OctreeNodeInterface<Particle>(boxMin, boxMax, parent, treeSplitThreshold, interactionLength, cellSizeFactor) {
     using namespace autopas::utils;
     using namespace autopas::utils::ArrayMath::literals;
@@ -205,7 +206,8 @@ class OctreeInnerNode : public OctreeNodeInterface<Particle> {
     }
   }
 
-  std::set<OctreeLeafNode<Particle> *> getLeavesInRange(std::array<double, 3> min, std::array<double, 3> max) override {
+  std::set<OctreeLeafNode<Particle> *> getLeavesInRange(const std::array<double, 3> &min,
+                                                        const std::array<double, 3> &max) override {
     std::set<OctreeLeafNode<Particle> *> result;
     for (auto &child : _children) {
       double vol = child->getEnclosedVolumeWith(min, max);

--- a/src/autopas/containers/octree/OctreeLeafNode.h
+++ b/src/autopas/containers/octree/OctreeLeafNode.h
@@ -159,7 +159,8 @@ class OctreeLeafNode : public OctreeNodeInterface<Particle>, public FullParticle
     leaves.push_back((OctreeLeafNode<Particle> *)this);
   }
 
-  std::set<OctreeLeafNode<Particle> *> getLeavesInRange(std::array<double, 3> min, std::array<double, 3> max) override {
+  std::set<OctreeLeafNode<Particle> *> getLeavesInRange(const std::array<double, 3> &min,
+                                                        const std::array<double, 3> &max) override {
     if (this->getEnclosedVolumeWith(min, max) > 0.0) {
       return {this};
     } else {

--- a/src/autopas/containers/octree/OctreeNodeInterface.h
+++ b/src/autopas/containers/octree/OctreeNodeInterface.h
@@ -127,8 +127,8 @@ class OctreeNodeInterface {
    * @param max The maximum coordinate in 3D space of the query area
    * @return A set of all leaf nodes that are in the query region
    */
-  virtual std::set<OctreeLeafNode<Particle> *> getLeavesInRange(std::array<double, 3> min,
-                                                                std::array<double, 3> max) = 0;
+  virtual std::set<OctreeLeafNode<Particle> *> getLeavesInRange(const std::array<double, 3> &min,
+                                                                const std::array<double, 3> &max) = 0;
 
   /**
    * Check if a 3d point is inside the node's axis aligned bounding box. (Set by the boxMin and boxMax fields.)
@@ -368,13 +368,13 @@ class OctreeNodeInterface {
    * Get the minimum coordinate of the enclosing box.
    * @return A point in 3D space
    */
-  [[nodiscard]] std::array<double, 3> getBoxMin() const { return _boxMin; }
+  [[nodiscard]] const std::array<double, 3> &getBoxMin() const { return _boxMin; }
 
   /**
    * Get the maximum coordinate of the enclosing box.
    * @return A point in 3D space
    */
-  [[nodiscard]] std::array<double, 3> getBoxMax() const { return _boxMax; }
+  [[nodiscard]] const std::array<double, 3> &getBoxMax() const { return _boxMax; }
 
   /**
    * Get the parent node of this node.

--- a/src/autopas/containers/octree/OctreeNodeWrapper.h
+++ b/src/autopas/containers/octree/OctreeNodeWrapper.h
@@ -58,7 +58,7 @@ class OctreeNodeWrapper : public ParticleCell<Particle> {
    * @param interactionLength The minimum distance at which a force is considered nonzero, cutoff+skin.
    * @param cellSizeFactor The cell size factor
    */
-  OctreeNodeWrapper(std::array<double, 3> const &boxMin, std::array<double, 3> const &boxMax,
+  OctreeNodeWrapper(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax,
                     int unsigned const treeSplitThreshold, double const interactionLength,
                     double const cellSizeFactor) {
     _pointer = std::make_unique<OctreeLeafNode<Particle>>(boxMin, boxMax, nullptr, treeSplitThreshold,

--- a/src/autopas/containers/octree/OctreeNodeWrapper.h
+++ b/src/autopas/containers/octree/OctreeNodeWrapper.h
@@ -250,7 +250,8 @@ class OctreeNodeWrapper : public ParticleCell<Particle> {
    * @param max The maximum coordinate in 3D space of the query area
    * @return A set of all leaf nodes that are in the query region
    */
-  std::set<OctreeLeafNode<Particle> *> getLeavesInRange(std::array<double, 3> min, std::array<double, 3> max) {
+  std::set<OctreeLeafNode<Particle> *> getLeavesInRange(const std::array<double, 3> &min,
+                                                        const std::array<double, 3> &max) {
     return _pointer->getLeavesInRange(min, max);
   }
 

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -73,7 +73,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
    * @param clusterSize Number of particles per cluster.
    * @param loadEstimator load estimation algorithm for balanced traversals.
    */
-  VerletClusterLists(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, double cutoff,
+  VerletClusterLists(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax, double cutoff,
                      double skinPerTimestep, unsigned int rebuildFrequency, size_t clusterSize,
                      LoadEstimatorOption loadEstimator = LoadEstimatorOption::none)
       : ParticleContainerInterface<Particle>(),

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -945,7 +945,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
    * @param towersPerDim The number of towers in each dimension.
    * @return the 1D index for the given tower grid coordinates of a tower.
    */
-  static size_t towerIndex2DTo1D(const size_t x, const size_t y, const std::array<size_t, 2> towersPerDim) {
+  static size_t towerIndex2DTo1D(const size_t x, const size_t y, const std::array<size_t, 2> &towersPerDim) {
     return x + y * towersPerDim[0];
   }
 

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -376,10 +376,10 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
         this->getNumberOfParticles(), boxSizeWithHalo, _clusterSize);
     auto towersPerDim =
         internal::VerletClusterListsRebuilder<Particle>::calculateTowersPerDim(boxSizeWithHalo, 1.0 / towerSideLength);
-    std::array<double, 3> towerSize = {towerSideLength, towerSideLength,
+    const std::array<double, 3> towerSize = {towerSideLength, towerSideLength,
 
-                                       this->getHaloBoxMax()[2] - this->getHaloBoxMin()[2]};
-    std::array<unsigned long, 3> towerDimensions = {towersPerDim[0], towersPerDim[1], 1};
+                                             this->getHaloBoxMax()[2] - this->getHaloBoxMin()[2]};
+    const std::array<unsigned long, 3> towerDimensions = {towersPerDim[0], towersPerDim[1], 1};
     return TraversalSelectorInfo(towerDimensions, this->getInteractionLength(), towerSize, _clusterSize);
   }
 
@@ -861,12 +861,12 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
     if (_towersPerDim[0] == 0) {
       return {_boxMin, _boxMax};
     }
-    std::array<double, 3> boxMin{
+    const std::array<double, 3> boxMin{
         _haloBoxMin[0] + _towerSideLength * static_cast<double>(index2D[0]),
         _haloBoxMin[1] + _towerSideLength * static_cast<double>(index2D[1]),
         _haloBoxMin[2],
     };
-    std::array<double, 3> boxMax{
+    const std::array<double, 3> boxMax{
         boxMin[0] + _towerSideLength,
         boxMin[1] + _towerSideLength,
         _haloBoxMax[2],

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -38,7 +38,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    * @param cellSizeFactor cell size factor relative to cutoff. Verlet lists are only implemented for values >= 1.0
    * (smaller values are set to 1.0).
    */
-  VerletListsLinkedBase(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
+  VerletListsLinkedBase(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax, const double cutoff,
                         const double skinPerTimestep, const unsigned int rebuildFrequency,
                         const std::set<TraversalOption> &applicableTraversals, const double cellSizeFactor)
       : _linkedCells(boxMin, boxMax, cutoff, skinPerTimestep, rebuildFrequency, std::max(1.0, cellSizeFactor)) {

--- a/src/autopas/containers/verletListsCellBased/varVerletLists/VarVerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/varVerletLists/VarVerletLists.h
@@ -31,7 +31,7 @@ class VarVerletLists : public VerletListsLinkedBase<Particle> {
    * @param rebuildFrequency The rebuild Frequency.
    * @param cellSizeFactor cell size factor relative to cutoff
    */
-  VarVerletLists(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
+  VarVerletLists(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax, const double cutoff,
                  const double skinPerTimestep, const unsigned int rebuildFrequency, const double cellSizeFactor = 1.0)
       : VerletListsLinkedBase<Particle>(boxMin, boxMax, cutoff, skinPerTimestep, rebuildFrequency,
                                         compatibleTraversals::allVarVLAsBuildCompatibleTraversals(), cellSizeFactor),

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -58,7 +58,7 @@ class VerletLists : public VerletListsLinkedBase<Particle> {
    * @param buildVerletListType Specifies how the verlet list should be build, see BuildVerletListType
    * @param cellSizeFactor cell size factor ralative to cutoff
    */
-  VerletLists(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
+  VerletLists(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax, const double cutoff,
               const double skinPerTimestep, const unsigned int rebuildFrequency,
               const BuildVerletListType buildVerletListType = BuildVerletListType::VerletSoA,
               const double cellSizeFactor = 1.0)

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
@@ -50,7 +50,7 @@ class VerletListsCells : public VerletListsLinkedBase<Particle> {
    * @param loadEstimator load estimation algorithm for balanced traversals
    * @param buildType data layout of the particles which are used to generate the neighbor lists
    */
-  VerletListsCells(const std::array<double, 3> boxMin, const std::array<double, 3> boxMax, const double cutoff,
+  VerletListsCells(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax, const double cutoff,
                    const double skinPerTimestep = 0, const unsigned int rebuildFrequency = 2,
                    const double cellSizeFactor = 1.0,
                    const LoadEstimatorOption loadEstimator = LoadEstimatorOption::squaredParticlesPerCell,

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCCellPairC08CellHandler.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCCellPairC08CellHandler.h
@@ -50,7 +50,7 @@ class VLCCellPairC08CellHandler : public LCC08CellHandler<ParticleCell, Pairwise
   void processCellListsC08(VLCCellPairNeighborList<typename ParticleCell::ParticleType> &neighborList,
                            unsigned long cellIndex, PairwiseFunctor *pairwiseFunctor, DataLayoutOption::Value layout,
                            SoA<typename ParticleCell::ParticleType::SoAArraysType> *soa,
-                           std::array<unsigned long, 3> dims) {
+                           const std::array<unsigned long, 3> &dims) {
     const auto &aosNeighborList = neighborList.getAoSNeighborList();
     const auto &soaNeighborList = neighborList.getSoANeighborList();
     const auto &globalToLocalIndex = neighborList.getGlobalToLocalMap();

--- a/src/autopas/molecularDynamics/MoleculeLJ.h
+++ b/src/autopas/molecularDynamics/MoleculeLJ.h
@@ -28,7 +28,7 @@ class MoleculeLJ final : public Particle {
    * @param moleculeId Id of the molecule.
    * @param typeId TypeId of the molecule.
    */
-  explicit MoleculeLJ(std::array<floatType, 3> pos, std::array<floatType, 3> v, unsigned long moleculeId,
+  explicit MoleculeLJ(const std::array<floatType, 3> &pos, const std::array<floatType, 3> &v, unsigned long moleculeId,
                       unsigned long typeId = 0)
       : Particle(pos, v, moleculeId), _typeId(typeId) {}
 
@@ -167,7 +167,7 @@ class MoleculeLJ final : public Particle {
    * Get the old force.
    * @return
    */
-  [[nodiscard]] std::array<double, 3> getOldF() const { return _oldF; }
+  [[nodiscard]] const std::array<double, 3> &getOldF() const { return _oldF; }
 
   /**
    * Set old force.

--- a/src/autopas/particles/ParticleBase.h
+++ b/src/autopas/particles/ParticleBase.h
@@ -39,7 +39,7 @@ class ParticleBase {
    * @param v Velocity of the particle.
    * @param id Id of the particle.
    */
-  ParticleBase(std::array<double, 3> r, std::array<double, 3> v, idType id)
+  ParticleBase(const std::array<double, 3> &r, const std::array<double, 3> &v, idType id)
       : _r(r), _v(v), _f({0.0, 0.0, 0.0}), _id(id) {}
 
   /**

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -66,11 +66,11 @@ class AutoTuner {
    * @param rebuildFrequency The rebuild frequency this AutoPas instance uses.
    * @param outputSuffix Suffix for all output files produced by this class.
    */
-  AutoTuner(std::array<double, 3> boxMin, std::array<double, 3> boxMax, double cutoff, double verletSkinPerTimestep,
-            unsigned int verletClusterSize, std::unique_ptr<TuningStrategyInterface> tuningStrategy,
-            double MPITuningMaxDifferenceForBucket, double MPITuningWeightForMaxDensity,
-            SelectorStrategyOption selectorStrategy, unsigned int tuningInterval, unsigned int maxSamples,
-            unsigned int rebuildFrequency, const std::string &outputSuffix = "")
+  AutoTuner(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax, double cutoff,
+            double verletSkinPerTimestep, unsigned int verletClusterSize,
+            std::unique_ptr<TuningStrategyInterface> tuningStrategy, double MPITuningMaxDifferenceForBucket,
+            double MPITuningWeightForMaxDensity, SelectorStrategyOption selectorStrategy, unsigned int tuningInterval,
+            unsigned int maxSamples, unsigned int rebuildFrequency, const std::string &outputSuffix = "")
       : _selectorStrategy(selectorStrategy),
         _tuningStrategy(std::move(tuningStrategy)),
         _tuningInterval(tuningInterval),

--- a/src/autopas/sph/SPHKernels.h
+++ b/src/autopas/sph/SPHKernels.h
@@ -35,7 +35,7 @@ class SPHKernels {
    * @param h relative kernel support radius
    * @return value of the kernel function
    */
-  static inline double W(const std::array<double, 3> dr, const double h) {
+  static inline double W(const std::array<double, 3> &dr, const double h) {
     const double dr2 = autopas::utils::ArrayMath::dot(dr, dr);
     return W(dr2, h);
   }
@@ -73,7 +73,7 @@ class SPHKernels {
    * @param h kernel support radius
    * @return gradient of W evaluated at dr and h
    */
-  static inline std::array<double, 3> gradW(const std::array<double, 3> dr, const double h) {
+  static inline std::array<double, 3> gradW(const std::array<double, 3> &dr, const double h) {
     using namespace autopas::utils::ArrayMath::literals;
 
     const double H = kernelSupportRadius * h;

--- a/src/autopas/sph/SPHParticle.h
+++ b/src/autopas/sph/SPHParticle.h
@@ -43,7 +43,7 @@ class SPHParticle : public autopas::Particle {
    * @param v velocity of the particle
    * @param id id of the particle. This id should be unique
    */
-  SPHParticle(std::array<double, 3> r, std::array<double, 3> v, unsigned long id)
+  SPHParticle(const std::array<double, 3> &r, const std::array<double, 3> &v, unsigned long id)
       : autopas::Particle(r, v, id),
         _density(0.),
         _pressure(0.),
@@ -68,7 +68,8 @@ class SPHParticle : public autopas::Particle {
    * @param smth smoothing length of the particle
    * @param snds speed of sound (SouND Speed)
    */
-  SPHParticle(std::array<double, 3> r, std::array<double, 3> v, unsigned long id, double mass, double smth, double snds)
+  SPHParticle(const std::array<double, 3> &r, const std::array<double, 3> &v, unsigned long id, double mass, double smth,
+              double snds)
       : autopas::Particle(r, v, id),
         _density(0.),
         _pressure(0.),
@@ -268,13 +269,13 @@ class SPHParticle : public autopas::Particle {
    * Getter for velocity at half-time step (leapfrog)
    * @return
    */
-  std::array<double, 3> getVel_half() const { return _vel_half; }
+  const std::array<double, 3> &getVel_half() const { return _vel_half; }
 
   /**
    * Setter for velocity at half-time step (leapfrog)
    * @param vel_half
    */
-  void setVel_half(std::array<double, 3> vel_half) { SPHParticle::_vel_half = vel_half; }
+  void setVel_half(const std::array<double, 3> &vel_half) { SPHParticle::_vel_half = vel_half; }
 
   /**
    * Getter for energy at half-time step (leapfrog)

--- a/src/autopas/sph/SPHParticle.h
+++ b/src/autopas/sph/SPHParticle.h
@@ -68,8 +68,8 @@ class SPHParticle : public autopas::Particle {
    * @param smth smoothing length of the particle
    * @param snds speed of sound (SouND Speed)
    */
-  SPHParticle(const std::array<double, 3> &r, const std::array<double, 3> &v, unsigned long id, double mass, double smth,
-              double snds)
+  SPHParticle(const std::array<double, 3> &r, const std::array<double, 3> &v, unsigned long id, double mass,
+              double smth, double snds)
       : autopas::Particle(r, v, id),
         _density(0.),
         _pressure(0.),

--- a/src/autopas/utils/SimilarityFunctions.h
+++ b/src/autopas/utils/SimilarityFunctions.h
@@ -26,8 +26,8 @@ namespace autopas::utils {
  */
 template <class Container>
 std::pair<double, double> calculateHomogeneityAndMaxDensity(const Container &container,
-                                                            const std::array<double, 3> startCorner,
-                                                            const std::array<double, 3> endCorner) {
+                                                            const std::array<double, 3> &startCorner,
+                                                            const std::array<double, 3> &endCorner) {
   unsigned int numberOfParticles = static_cast<unsigned int>(container.getNumberOfParticles());
   autopas::AutoPas_MPI_Allreduce(AUTOPAS_MPI_IN_PLACE, &numberOfParticles, 1, AUTOPAS_MPI_UNSIGNED_INT, AUTOPAS_MPI_SUM,
                                  AUTOPAS_MPI_COMM_WORLD);

--- a/src/autopas/utils/SoA.h
+++ b/src/autopas/utils/SoA.h
@@ -122,7 +122,7 @@ class SoA {
    * @param values
    */
   template <int... attributes, size_t N = sizeof...(attributes)>
-  inline void writeMultiple(size_t particleId, std::array<double, N> values) {
+  inline void writeMultiple(size_t particleId, const std::array<double, N> &values) {
     write_impl<attributes...>(particleId, values);
   }
 

--- a/src/autopas/utils/logging/OctreeLogger.h
+++ b/src/autopas/utils/logging/OctreeLogger.h
@@ -356,8 +356,8 @@ class OctreeLogger {
    * @param node An octree node to obtain the box minimum and maximum coordinates from
    */
   static void outBoxCoordinatesJSON(FILE *out, OctreeNodeInterface<Particle> *node) {
-    std::array<double, 3> min = node->getBoxMin();
-    std::array<double, 3> max = node->getBoxMax();
+    const auto min = node->getBoxMin();
+    const auto max = node->getBoxMax();
     outLocationArrayJSON(out, min, max);
   }
 

--- a/src/autopas/utils/logging/OctreeLogger.h
+++ b/src/autopas/utils/logging/OctreeLogger.h
@@ -342,7 +342,7 @@ class OctreeLogger {
    * @param min The minimum coordinate
    * @param max The maximum coordinate
    */
-  static void outLocationArrayJSON(FILE *out, std::array<double, 3> min, std::array<double, 3> max) {
+  static void outLocationArrayJSON(FILE *out, const std::array<double, 3> &min, const std::array<double, 3> &max) {
     fputc('[', out);
     out3(out, min[0], min[1], min[2]);
     fputc(',', out);

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.cpp
@@ -206,7 +206,7 @@ TEST_P(VerletListsTest, testVerletListBuildHalo) {
 }
 
 template <class Container, class Particle>
-bool moveUpdateAndExpectEqual(Container &container, Particle &particle, std::array<double, 3> newPosition) {
+bool moveUpdateAndExpectEqual(Container &container, Particle &particle, const std::array<double, 3> &newPosition) {
   particle.setR(newPosition);
   bool updated = container.updateHaloParticle(particle);
   if (updated) {

--- a/tests/testAutopas/tests/particles/myMoleculeTest.cpp
+++ b/tests/testAutopas/tests/particles/myMoleculeTest.cpp
@@ -13,7 +13,7 @@ using namespace autopas;
 class MyMolecule : public Particle {
  public:
   MyMolecule() : Particle(), _myvar(0) {}
-  MyMolecule(std::array<double, 3> r, std::array<double, 3> v, unsigned long i, int myvar)
+  MyMolecule(const std::array<double, 3> &r, const std::array<double, 3> &v, unsigned long i, int myvar)
       : Particle(r, v, i), _myvar(myvar) {}
   void print() {
     std::cout << "Molecule with position: ";


### PR DESCRIPTION
# Description

- [x] add some missing `const`
- [x] remove unnecessary `const`
- [x] pass `const &` instead of copies
- [x] return `const &` instead of copies
- [x] `const` west > east `const`

Checked for:
- [x] std::array<double, 3>
- [x] std::vector<*>

This PR doesn't noticeably affect performance but it's a bunch of clean-ups that are long overdue.