### PR TITLE
Rename static_array_cast

### DIFF
--- a/examples/md-flexible/src/configuration/objects/CubeGrid.h
+++ b/examples/md-flexible/src/configuration/objects/CubeGrid.h
@@ -68,7 +68,7 @@ class CubeGrid : public Object {
   [[nodiscard]] std::array<double, 3> getBoxMax() const override {
     using namespace autopas::utils::ArrayMath::literals;
 
-    const auto particlesPerDimDouble = autopas::utils::ArrayUtils::static_cast_array<double>(_particlesPerDim);
+    const auto particlesPerDimDouble = autopas::utils::ArrayUtils::static_cast_copy_array<double>(_particlesPerDim);
     // subtract one because the first particle is at bottomLeftCorner
     const auto particlesPerDimSubOne = particlesPerDimDouble - 1.;
     const auto lastParticleRelative = particlesPerDimSubOne * _particleSpacing;

--- a/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
@@ -144,7 +144,7 @@ TEST_F(RegularGridDecompositionTest, testGetLocalDomain) {
   const auto decomposition = domainDecomposition->getDecomposition();
 
   const std::array<double, 3> expectedLocalBoxExtend =
-      globalBoxExtend / autopas::utils::ArrayUtils::static_cast_array<double>(decomposition);
+      globalBoxExtend / autopas::utils::ArrayUtils::static_cast_copy_array<double>(decomposition);
   // make sure expectations make sense
   ASSERT_THAT(expectedLocalBoxExtend, ::testing::Each(::testing::Gt(1e-10)));
 

--- a/src/autopas/containers/linkedCells/traversals/LCC01Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC01Traversal.h
@@ -207,7 +207,7 @@ inline void LCC01Traversal<ParticleCell, PairwiseFunctor, dataLayout, useNewton3
         const double distSquare = utils::ArrayMath::dot(pos, pos);
         if (distSquare <= interactionLengthSquare) {
           const long currentOffset = utils::ThreeDimensionalMapping::threeToOneD(
-              x, y, z, utils::ArrayUtils::static_cast_array<long>(this->_cellsPerDimension));
+              x, y, z, utils::ArrayUtils::static_cast_copy_array<long>(this->_cellsPerDimension));
           const bool containCurrentOffset =
               std::any_of(_cellOffsets[x + this->_overlap[0]].cbegin(), _cellOffsets[x + this->_overlap[0]].cend(),
                           [currentOffset](const auto &e) { return e.first == currentOffset; });
@@ -216,7 +216,7 @@ inline void LCC01Traversal<ParticleCell, PairwiseFunctor, dataLayout, useNewton3
           }
           for (long ix = x; ix <= std::abs(x); ++ix) {
             const long offset = utils::ThreeDimensionalMapping::threeToOneD(
-                ix, y, z, utils::ArrayUtils::static_cast_array<long>(this->_cellsPerDimension));
+                ix, y, z, utils::ArrayUtils::static_cast_copy_array<long>(this->_cellsPerDimension));
             const size_t index = ix + this->_overlap[0];
             if (y == 0l and z == 0l) {
               // make sure center of slice is always at the beginning

--- a/src/autopas/containers/linkedCells/traversals/LCC04HCPTraversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC04HCPTraversal.h
@@ -44,7 +44,8 @@ class LCC04HCPTraversal : public C08BasedTraversal<ParticleCell, PairwiseFunctor
       : C08BasedTraversal<ParticleCell, PairwiseFunctor, dataLayout, useNewton3>(dims, pairwiseFunctor,
                                                                                  interactionLength, cellLength),
         _cellHandler(pairwiseFunctor, this->_cellsPerDimension, interactionLength, cellLength, this->_overlap),
-        _end(utils::ArrayMath::subScalar(utils::ArrayUtils::static_cast_array<long>(this->_cellsPerDimension), 1l)) {}
+        _end(utils::ArrayMath::subScalar(utils::ArrayUtils::static_cast_copy_array<long>(this->_cellsPerDimension),
+                                         1l)) {}
 
   void traverseParticlePairs() override;
 
@@ -77,7 +78,7 @@ void LCC04HCPTraversal<ParticleCell, PairwiseFunctor, dataLayout, useNewton3>::p
     std::vector<ParticleCell> &cells, const std::array<long, 3> &base3DIndex) {
   using utils::ThreeDimensionalMapping::threeToOneD;
   std::array<long, 3> index{};
-  const std::array<long, 3> signedDims = utils::ArrayUtils::static_cast_array<long>(this->_cellsPerDimension);
+  const std::array<long, 3> signedDims = utils::ArrayUtils::static_cast_copy_array<long>(this->_cellsPerDimension);
 
   // go through the six cells
   for (long z = 0; z < 3; ++z) {

--- a/src/autopas/containers/linkedCells/traversals/LCC04Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC04Traversal.h
@@ -46,7 +46,8 @@ class LCC04Traversal : public C08BasedTraversal<ParticleCell, PairwiseFunctor, d
                                                                                  interactionLength, cellLength),
         _cellOffsets32Pack(computeOffsets32Pack()),
         _cellHandler(pairwiseFunctor, this->_cellsPerDimension, interactionLength, cellLength, this->_overlap),
-        _end(utils::ArrayMath::subScalar(utils::ArrayUtils::static_cast_array<long>(this->_cellsPerDimension), 1l)) {}
+        _end(utils::ArrayMath::subScalar(utils::ArrayUtils::static_cast_copy_array<long>(this->_cellsPerDimension),
+                                         1l)) {}
 
   void traverseParticlePairs() override;
 
@@ -149,7 +150,7 @@ void LCC04Traversal<ParticleCell, PairwiseFunctor, dataLayout, useNewton3>::proc
     std::vector<ParticleCell> &cells, const std::array<long, 3> &base3DIndex) {
   using utils::ThreeDimensionalMapping::threeToOneD;
   std::array<long, 3> index;
-  const std::array<long, 3> signedDims = utils::ArrayUtils::static_cast_array<long>(this->_cellsPerDimension);
+  const std::array<long, 3> signedDims = utils::ArrayUtils::static_cast_copy_array<long>(this->_cellsPerDimension);
 
   for (auto Offset32Pack : _cellOffsets32Pack) {
     // compute 3D index

--- a/src/autopas/containers/linkedCells/traversals/LCC18Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC18Traversal.h
@@ -111,7 +111,7 @@ class LCC18Traversal : public C18BasedTraversal<ParticleCell, PairwiseFunctor, d
 template <class ParticleCell, class PairwiseFunctor, DataLayoutOption::Value dataLayout, bool useNewton3>
 inline void LCC18Traversal<ParticleCell, PairwiseFunctor, dataLayout, useNewton3>::computeOffsets() {
   _cellOffsets.resize(2 * this->_overlap[1] + 1, std::vector<offsetArray_t>(2 * this->_overlap[0] + 1));
-  const std::array<long, 3> _overlap_s = utils::ArrayUtils::static_cast_array<long>(this->_overlap);
+  const std::array<long, 3> _overlap_s = utils::ArrayUtils::static_cast_copy_array<long>(this->_overlap);
 
   const auto interactionLengthSquare(this->_interactionLength * this->_interactionLength);
 
@@ -119,7 +119,7 @@ inline void LCC18Traversal<ParticleCell, PairwiseFunctor, dataLayout, useNewton3
     for (long y = -_overlap_s[1]; y <= _overlap_s[1]; ++y) {
       for (long x = -_overlap_s[0]; x <= _overlap_s[0]; ++x) {
         const long offset = utils::ThreeDimensionalMapping::threeToOneD(
-            x, y, z, utils::ArrayUtils::static_cast_array<long>(this->_cellsPerDimension));
+            x, y, z, utils::ArrayUtils::static_cast_copy_array<long>(this->_cellsPerDimension));
 
         if (offset < 0l) {
           continue;

--- a/src/autopas/selectors/AutoTuner.h
+++ b/src/autopas/selectors/AutoTuner.h
@@ -90,7 +90,7 @@ class AutoTuner {
         _tuningDataLogger(maxSamples, outputSuffix) {
     using namespace autopas::utils::ArrayMath::literals;
     using autopas::utils::ArrayMath::ceil;
-    using autopas::utils::ArrayUtils::static_cast_array;
+    using autopas::utils::ArrayUtils::static_cast_copy_array;
 
     // initialize locks needed for remainder traversal
     const auto boxLength = boxMax - boxMin;
@@ -222,10 +222,10 @@ class AutoTuner {
   void initSpacialLocks(const std::array<double, 3> &boxLength, double interactionLengthInv) {
     using namespace autopas::utils::ArrayMath::literals;
     using autopas::utils::ArrayMath::ceil;
-    using autopas::utils::ArrayUtils::static_cast_array;
+    using autopas::utils::ArrayUtils::static_cast_copy_array;
 
     // one lock per interaction length + one for each halo region
-    const auto locksPerDim = static_cast_array<size_t>(ceil(boxLength * interactionLengthInv) + 2.);
+    const auto locksPerDim = static_cast_copy_array<size_t>(ceil(boxLength * interactionLengthInv) + 2.);
     _spacialLocks.resize(locksPerDim[0]);
     for (auto &lockVecVec : _spacialLocks) {
       lockVecVec.resize(locksPerDim[1]);
@@ -541,7 +541,7 @@ void AutoTuner<Particle>::doRemainderTraversal(PairwiseFunctor *f, T containerPt
                                                std::vector<FullParticleCell<Particle>> &particleBuffers,
                                                std::vector<FullParticleCell<Particle>> &haloParticleBuffers) {
   using namespace autopas::utils::ArrayMath::literals;
-  using autopas::utils::ArrayUtils::static_cast_array;
+  using autopas::utils::ArrayUtils::static_cast_copy_array;
 
   // Sanity check. If this is violated feel free to add some logic here that adapts the number of locks.
   if (_bufferLocks.size() < particleBuffers.size()) {
@@ -583,7 +583,7 @@ void AutoTuner<Particle>::doRemainderTraversal(PairwiseFunctor *f, T containerPt
         const auto max = pos + cutoff;
         staticTypedContainerPtr->forEachInRegion(
             [&](auto &p2) {
-              const auto lockCoords = static_cast_array<size_t>((p2.getR() - haloBoxMin) * interactionLengthInv);
+              const auto lockCoords = static_cast_copy_array<size_t>((p2.getR() - haloBoxMin) * interactionLengthInv);
               if constexpr (newton3) {
                 const std::lock_guard<std::mutex> lock(*_spacialLocks[lockCoords[0]][lockCoords[1]][lockCoords[2]]);
                 f->AoSFunctor(p1, p2, true);
@@ -606,7 +606,7 @@ void AutoTuner<Particle>::doRemainderTraversal(PairwiseFunctor *f, T containerPt
         const auto max = pos + cutoff;
         staticTypedContainerPtr->forEachInRegion(
             [&](auto &p2) {
-              const auto lockCoords = static_cast_array<size_t>((p2.getR() - haloBoxMin) * interactionLengthInv);
+              const auto lockCoords = static_cast_copy_array<size_t>((p2.getR() - haloBoxMin) * interactionLengthInv);
               // No need to apply anything to p1halo
               //   -> AoSFunctor(p1, p2, false) not needed as it neither adds force nor Upot (potential energy)
               //   -> newton3 argument needed for correct globals

--- a/src/autopas/utils/ArrayUtils.h
+++ b/src/autopas/utils/ArrayUtils.h
@@ -66,6 +66,11 @@ struct is_container {
 
 /**
  * Creates a new array by performing an element-wise static_cast<>.
+ *
+ * @note This function returns a new copy of the array with the desired type!
+ *
+ * Even though this is implemented to copy the array, compilers optimize this away: https://gcc.godbolt.org/z/6dav1PEGP
+ *
  * @tparam output_t Output type.
  * @tparam input_t Input type.
  * @tparam SIZE Size of the array.
@@ -73,7 +78,7 @@ struct is_container {
  * @return Array of type std::array<output_t, SIZE>.
  */
 template <class output_t, class input_t, std::size_t SIZE>
-[[nodiscard]] constexpr std::array<output_t, SIZE> static_cast_array(const std::array<input_t, SIZE> &a) {
+[[nodiscard]] constexpr std::array<output_t, SIZE> static_cast_copy_array(const std::array<input_t, SIZE> &a) {
   std::array<output_t, SIZE> result{};
   for (std::size_t d = 0; d < SIZE; ++d) {
     result[d] = static_cast<output_t>(a[d]);

--- a/tests/testAutopas/tests/utils/ArrayUtilsTest.cpp
+++ b/tests/testAutopas/tests/utils/ArrayUtilsTest.cpp
@@ -12,16 +12,16 @@
 
 using namespace autopas;
 
-TEST(ArrayUtilsTest, teststatic_cast_array) {
+TEST(ArrayUtilsTest, teststatic_cast_copy_array) {
   {
     std::array<long, 3> in({1l, 2l, 3l});
-    auto out = utils::ArrayUtils::static_cast_array<unsigned long>(in);
+    auto out = utils::ArrayUtils::static_cast_copy_array<unsigned long>(in);
     static_assert(std::is_same<decltype(out), std::array<unsigned long, 3>>::value, "Type mismatch");
   }
 
   {
     std::array<long, 3> in({1l, 2l, 3l});
-    auto out = utils::ArrayUtils::static_cast_array<double>(in);
+    auto out = utils::ArrayUtils::static_cast_copy_array<double>(in);
     static_assert(std::is_same<decltype(out), std::array<double, 3>>::value, "Type mismatch");
   }
 }


### PR DESCRIPTION
# Description

Minor update that:
- [x] Renames `static_array_cast` to `static_array_copy_cast` to highlight that this function returns a copy.
- [x] Extend doc to explain the reasoning.
