### PR TITLE
correct md-flex log level output in endconfig

### DIFF
--- a/examples/md-flexible/input/AllOptions.yaml
+++ b/examples/md-flexible/input/AllOptions.yaml
@@ -1,3 +1,4 @@
+# This file contains all possible options that a yaml input file for md-flexible can have. For the meaning of individual options ./md-flexible --help can be called, or MDFlexConfig.h can be looked up.
 container                            :  [DirectSum, LinkedCells, LinkedCellsReferences, VarVerletListsAsBuild, VerletClusterLists, VerletLists, VerletListsCells, PairwiseVerletLists]
 verlet-rebuild-frequency             :  20
 verlet-skin-radius-per-timestep      :  0.01

--- a/examples/md-flexible/src/configuration/MDFlexConfig.cpp
+++ b/examples/md-flexible/src/configuration/MDFlexConfig.cpp
@@ -318,7 +318,8 @@ std::string MDFlexConfig::to_string() const {
     printOption(checkpointfile);
   }
 
-  printOption(logLevel);
+  os << setw(valueOffset) << left << logLevel.name << ":  " << spdlog::level::to_string_view(logLevel.value).data()
+     << endl;
 
   os << setw(valueOffset) << left << dontMeasureFlops.name << ":  " << (not dontMeasureFlops.value) << endl;
   os << setw(valueOffset) << left << dontCreateEndConfig.name << ":  " << (not dontCreateEndConfig.value) << endl;


### PR DESCRIPTION
# Description

- The md-flex end-config has so far printed in integer value for the log level. Now a string representation is printed.
- Comment for AllOptions.yaml added, which points to the description of parameters

## Resolved Issues

- If an end-config is used as input, the correct log level from the end-config-yaml is used.
- fixes #706

# How Has This Been Tested?

All existing tests
