### PR TITLE
Remove unnecessary buffer allocations in VCL

### DIFF
--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -183,7 +183,8 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
   }
 
   /**
-   * Adds the given particle to the container. rebuildVerletLists() has to be called to have it actually sorted in.
+   * Adds the given particle to the container. rebuildTowersAndClusters() has to be called to have it actually sorted
+   * in.
    * @param p The particle to add.
    */
   void addParticleImpl(const Particle &p) override {
@@ -490,6 +491,8 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
       createIteratorFromParticlesToAdd<false>(additionalVectorsToPass);
     }
 
+    // pToAddEmpty we are in anon-rebuild-iteration and can simply pass additionalVectors, which saves buffer
+    // allocations
     return ContainerIterator<Particle, true, false>(*this, behavior,
                                                     pToAddEmpty ? additionalVectors : &additionalVectorsToPass);
   }
@@ -526,6 +529,8 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
       createIteratorFromParticlesToAdd<false>(additionalVectorsToPass);
     }
 
+    // pToAddEmpty we are in anon-rebuild-iteration and can simply pass additionalVectors, which saves buffer
+    // allocations
     return ContainerIterator<Particle, false, false>(*this, behavior,
                                                      pToAddEmpty ? additionalVectors : &additionalVectorsToPass);
   }
@@ -662,6 +667,8 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
       createIteratorFromParticlesToAdd<true>(additionalVectorsToPass);
     }
 
+    // pToAddEmpty we are in anon-rebuild-iteration and can simply pass additionalVectors, which saves buffer
+    // allocations
     return ContainerIterator<Particle, true, true>(
         *this, behavior, pToAddEmpty ? additionalVectors : &additionalVectorsToPass, lowerCorner, higherCorner);
   }
@@ -701,6 +708,8 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
       createIteratorFromParticlesToAdd<true>(additionalVectorsToPass);
     }
 
+    // pToAddEmpty we are in anon-rebuild-iteration and can simply pass additionalVectors, which saves buffer
+    // allocations
     return ContainerIterator<Particle, false, true>(
         *this, behavior, pToAddEmpty ? additionalVectors : &additionalVectorsToPass, lowerCorner, higherCorner);
   }

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -39,20 +39,13 @@ namespace autopas {
  * the same buffer structure. In principle, moving the particles directly into one of the towers would be possible,
  * since particles are moved from LogicHandler to VCL only in a rebuild iteration. However, storing the particles in a
  * tower (e.g. tower0) is only possible very inefficiently, since several threads would write to this buffer at the same
- * time.
- * Hypotetic solution suggestion, if storing the particles in one of the towers (e.g. tower0) can be solved
- * efficiently: Check in addParticleImpl() and addHaloParticleImpl() if the container is valid. If yes, then copy all
- * particles from tower0 into a temporary buffer, execute clear() on the tower and then paste the particles from the
- * temporary buffer back into tower0 (makes sure that the tower is not broken by inserting further particles). Set the
- * container status to invalid. Then addParticleImpl() and addHaloParticleImpl() can store incoming particles in tower0.
- * Since there are more logic steps executed before the actual rebuild, it is necessary to return not a region iterator
- * in getRegionIterator() if the container-status is invalid, but a "normal" iterator, which iterates over all buffers,
- * so that also the added particles in tower0 are considered. For reduceInRegion() and forEachInRegion() we would have
- * to iterate over tower0 in addition to the tower in the region. The _particlesToAdd buffer structure could then be
- * removed completely.
+ * time. Even if we could add the particles to tower0 efficiently, there are still problems in getRegionIterator(),
+ * because this function is executed between the addition of particles and the actual rebuild. getRegionIterator()
+ * expects that all particles are already sorted correctly into the towers (if we do not use _particlesToAdd).
+ *
  * In the current solution, we can make use of the fact that _particlesToAdd only contains particles in a
  * rebuild-iteration and the additionalVectors only contain particles in a non-rebuild-iteration. This means that we can
- * save expensive buffer allocations in begin() and getRegionIterator() in valid container-status iterations, ba just
+ * save expensive buffer allocations in begin() and getRegionIterator() in valid container-status iterations, by just
  * passing the additionalVectors instead of concatenating them with _particlesToAdd.
  *
  * @note See VerletClusterListsRebuilder for the layout of the towers and clusters.

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -416,9 +416,8 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
   template <bool modifiable, bool regionIter>
   bool additionalVectorsEmpty(
       typename ContainerIterator<Particle, modifiable, regionIter>::ParticleVecType *additionalVectors) const {
-    bool addVectorsEmpty = true;
     if (additionalVectors) {
-      for (auto &buffer : *additionalVectors) {
+      for (const auto &buffer : *additionalVectors) {
         if (not buffer->empty()) {
           return false;
         }
@@ -428,14 +427,14 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
   }
 
   /**
-   * Helper function for begin() and getRegionIterator() that creates a ContainerIterator from all particles in
-   * _particlesToAdd
+   * Helper function for begin() and getRegionIterator() that merges all buffers from _particlesToAdd into a single
+   * buffer
    *
    * @tparam regionIter
    * @param additionalVectorsToPass
    */
   template <bool regionIter>
-  void createIteratorFromParticlesToAdd(
+  void appendBuffersFromParticlesToAdd(
       typename ContainerIterator<Particle, true, regionIter>::ParticleVecType &additionalVectorsToPass) {
     additionalVectorsToPass.reserve(_particlesToAdd.size());
     for (auto &vec : _particlesToAdd) {
@@ -444,14 +443,14 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
   }
 
   /**
-   * Helper function for begin() and getRegionIterator() that creates a ContainerIterator from all particles in
-   * _particlesToAdd
+   * Helper function for begin() and getRegionIterator() that merges all buffers from _particlesToAdd into a single
+   * buffer
    * note: const version
    * @tparam regionIter
    * @param additionalVectorsToPass
    */
   template <bool regionIter>
-  void createIteratorFromParticlesToAdd(
+  void appendBuffersFromParticlesToAdd(
       typename ContainerIterator<Particle, false, regionIter>::ParticleVecType &additionalVectorsToPass) const {
     additionalVectorsToPass.reserve(_particlesToAdd.size());
     for (auto &vec : _particlesToAdd) {
@@ -488,7 +487,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
 
       // if the particles are not sorted into the towers, we have to also iterate over _particlesToAdd.
       // store all pointers in a temporary which is passed to the ParticleIterator constructor.
-      createIteratorFromParticlesToAdd<false>(additionalVectorsToPass);
+      appendBuffersFromParticlesToAdd<false>(additionalVectorsToPass);
     }
 
     // pToAddEmpty we are in anon-rebuild-iteration and can simply pass additionalVectors, which saves buffer
@@ -526,7 +525,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
 
       // if the particles are not sorted into the towers, we have to also iterate over _particlesToAdd.
       // store all pointers in a temporary which is passed to the ParticleIterator constructor.
-      createIteratorFromParticlesToAdd<false>(additionalVectorsToPass);
+      appendBuffersFromParticlesToAdd<false>(additionalVectorsToPass);
     }
 
     // pToAddEmpty we are in anon-rebuild-iteration and can simply pass additionalVectors, which saves buffer
@@ -664,7 +663,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
 
       // if the particles are not sorted into the towers, we have to also iterate over _particlesToAdd.
       // store all pointers in a temporary which is passed to the ParticleIterator constructor.
-      createIteratorFromParticlesToAdd<true>(additionalVectorsToPass);
+      appendBuffersFromParticlesToAdd<true>(additionalVectorsToPass);
     }
 
     // pToAddEmpty we are in anon-rebuild-iteration and can simply pass additionalVectors, which saves buffer
@@ -705,7 +704,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
 
       // if the particles are not sorted into the towers, we have to also iterate over _particlesToAdd.
       // store all pointers in a temporary which is passed to the ParticleIterator constructor.
-      createIteratorFromParticlesToAdd<true>(additionalVectorsToPass);
+      appendBuffersFromParticlesToAdd<true>(additionalVectorsToPass);
     }
 
     // pToAddEmpty we are in anon-rebuild-iteration and can simply pass additionalVectors, which saves buffer


### PR DESCRIPTION
# Description

- Some buffer allocations in the begin() and getRegionIterator() functions could be removed since _particlesToAdd contains only particles in rebuild iterations. So in all non-rebuild iterations the additionalVectors can be passed directly to the ContainerIterator without concatenating them with _particlesToAdd.
- Description added why it is (at the moment) necessary to keep the _particlesToAdd buffer-structure for VCL.

## Resolved Issues

- [x] solves the problem of memory allocations mentioned in #734

# How Has This Been Tested?

- All existing tests
