### PR TITLE
Bugfix for race condition in VCL

### DIFF
--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -181,12 +181,12 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
    * @param p The particle to add.
    */
   void addParticleImpl(const Particle &p) override {
-    _isValid = ValidityState::invalid;
+    _isValid.store(ValidityState::invalid, std::memory_order::memory_order_relaxed);
     _particlesToAdd[autopas_get_thread_num()].push_back(p);
   }
 
   void addHaloParticleImpl(const Particle &haloParticle) override {
-    _isValid = ValidityState::invalid;
+    _isValid.store(ValidityState::invalid, std::memory_order::memory_order_relaxed);
     Particle copy = haloParticle;
     copy.setOwnershipState(OwnershipState::halo);
     _particlesToAdd[autopas_get_thread_num()].push_back(copy);
@@ -257,7 +257,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
       }
     }
     if (deletedSomething) {
-      _isValid = ValidityState::invalid;
+      _isValid.store(ValidityState::invalid, std::memory_order::memory_order_relaxed);
     }
   }
 
@@ -378,7 +378,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
         }
       }
     }
-    _isValid = ValidityState::invalid;
+    _isValid.store(ValidityState::invalid, std::memory_order::memory_order_relaxed);
     return invalidParticles;
   }
 
@@ -1074,7 +1074,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
   [[nodiscard]] double getInteractionLength() const override { return _cutoff + _skinPerTimestep * _rebuildFrequency; }
 
   void deleteAllParticles() override {
-    _isValid = ValidityState::invalid;
+    _isValid.store(ValidityState::invalid, std::memory_order::memory_order_relaxed);
     std::for_each(_particlesToAdd.begin(), _particlesToAdd.end(), [](auto &buffer) { buffer.clear(); });
     std::for_each(_towers.begin(), _towers.end(), [](auto &tower) { tower.clear(); });
   }
@@ -1102,7 +1102,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
         _builder->rebuildTowersAndClusters();
 
     _towerSideLengthReciprocal = 1 / _towerSideLength;
-    _isValid = ValidityState::cellsValidListsInvalid;
+    _isValid.store(ValidityState::cellsValidListsInvalid, std::memory_order::memory_order_relaxed);
     for (auto &tower : _towers) {
       tower.setParticleDeletionObserver(this);
     }

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -398,95 +398,33 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
   }
 
   /**
-   * Helper function for begin() and getRegionIterator() to check if the passed additionalVectors are empty
-   *
-   * @tparam modifiable
-   * @tparam regionIter
-   * @param additionalVectors
-   * @return true iff all passed vectors are empty
-   * @return false iff at least one buffer from the passed vectors is not empty
-   */
-  template <bool modifiable, bool regionIter>
-  bool additionalVectorsEmpty(
-      typename ContainerIterator<Particle, modifiable, regionIter>::ParticleVecType *additionalVectors) const {
-    if (additionalVectors) {
-      for (const auto &buffer : *additionalVectors) {
-        if (not buffer->empty()) {
-          return false;
-        }
-      }
-    }
-    return true;
-  }
-
-  /**
-   * Helper function for begin() and getRegionIterator() that merges all buffers from _particlesToAdd into a single
-   * buffer
-   *
-   * @tparam regionIter
-   * @param additionalVectorsToPass
-   */
-  template <bool regionIter>
-  void appendBuffersFromParticlesToAdd(
-      typename ContainerIterator<Particle, true, regionIter>::ParticleVecType &additionalVectorsToPass) {
-    additionalVectorsToPass.reserve(_particlesToAdd.size());
-    for (auto &vec : _particlesToAdd) {
-      additionalVectorsToPass.push_back(&vec);
-    }
-  }
-
-  /**
-   * Helper function for begin() and getRegionIterator() that merges all buffers from _particlesToAdd into a single
-   * buffer
-   * note: const version
-   * @tparam regionIter
-   * @param additionalVectorsToPass
-   */
-  template <bool regionIter>
-  void appendBuffersFromParticlesToAdd(
-      typename ContainerIterator<Particle, false, regionIter>::ParticleVecType &additionalVectorsToPass) const {
-    additionalVectorsToPass.reserve(_particlesToAdd.size());
-    for (auto &vec : _particlesToAdd) {
-      additionalVectorsToPass.push_back(&vec);
-    }
-  }
-
-  /**
    * @copydoc autopas::ParticleContainerInterface::begin()
    */
   [[nodiscard]] ContainerIterator<Particle, true, false> begin(
       IteratorBehavior behavior = autopas::IteratorBehavior::ownedOrHalo,
       typename ContainerIterator<Particle, true, false>::ParticleVecType *additionalVectors = nullptr) override {
-    // first check if _particlesToAdd is empty and if additionalVectors are empty
-    const bool pToAddEmpty = particlesToAddEmpty();
-    const bool addVectorsEmpty = additionalVectorsEmpty<true, false>(additionalVectors);
-
-    // if both of them contain particles something went wrong. _particlesToAdd should only contain particles in a
-    // rebuild iteration and additionalVectors should only contain particles in non-rebuild iterations
-    if (not pToAddEmpty and not addVectorsEmpty) {
-      autopas::utils::ExceptionHandler::exception(
-          "VerletClusterLists::begin(): Additional vectors are not empty and also_particlesToAdd isn't empty! "
-          "_particlesToAdd should only contain particles in a rebuild iteration and additionalVectors should only "
-          "contain particles in non-rebuild iterations.");
-    }
-
-    typename ContainerIterator<Particle, true, false>::ParticleVecType additionalVectorsToPass;
-    if (not pToAddEmpty) {
-      // _particlesToAdd only contains particles if the container is invalid
-      if (_isValid != ValidityState::invalid) {
+    if (_isValid != ValidityState::invalid) {
+      if (not particlesToAddEmpty()) {
         autopas::utils::ExceptionHandler::exception(
             "VerletClusterLists::begin(): Error: particle container is valid, but _particlesToAdd isn't empty!");
       }
-
+      // If the particles are sorted into the towers, we can simply use the iteration over towers.
+      return ContainerIterator<Particle, true, false>(*this, behavior, additionalVectors);
+    } else {
       // if the particles are not sorted into the towers, we have to also iterate over _particlesToAdd.
       // store all pointers in a temporary which is passed to the ParticleIterator constructor.
-      appendBuffersFromParticlesToAdd<false>(additionalVectorsToPass);
+      typename ContainerIterator<Particle, true, false>::ParticleVecType additionalVectorsTmp;
+      if (not additionalVectorsEmpty<true, false>(additionalVectors)) {
+        additionalVectorsTmp.reserve(_particlesToAdd.size() + additionalVectors->size());
+        additionalVectorsTmp.insert(additionalVectorsTmp.end(), additionalVectors->begin(), additionalVectors->end());
+      } else {
+        additionalVectorsTmp.reserve(_particlesToAdd.size());
+      }
+      for (auto &vec : _particlesToAdd) {
+        additionalVectorsTmp.push_back(&vec);
+      }
+      return ContainerIterator<Particle, true, false>(*this, behavior, &additionalVectorsTmp);
     }
-
-    // pToAddEmpty we are in anon-rebuild-iteration and can simply pass additionalVectors, which saves buffer
-    // allocations
-    return ContainerIterator<Particle, true, false>(*this, behavior,
-                                                    pToAddEmpty ? additionalVectors : &additionalVectorsToPass);
   }
 
   /**
@@ -496,35 +434,28 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
   [[nodiscard]] ContainerIterator<Particle, false, false> begin(
       IteratorBehavior behavior = autopas::IteratorBehavior::ownedOrHalo,
       typename ContainerIterator<Particle, false, false>::ParticleVecType *additionalVectors = nullptr) const override {
-    const bool pToAddEmpty = particlesToAddEmpty();
-    const bool addVectorsEmpty = additionalVectorsEmpty<false, false>(additionalVectors);
-
-    // if both of them contain particles something went wrong. _particlesToAdd should only contain particles in a
-    // rebuild iteration and additionalVectors should only contain particles in non-rebuild iterations
-    if (not pToAddEmpty and not addVectorsEmpty) {
-      autopas::utils::ExceptionHandler::exception(
-          "VerletClusterLists::begin() const: Additional vectors are not empty and also_particlesToAdd isn't empty! "
-          "_particlesToAdd should only contain particles in a rebuild iteration and additionalVectors should only "
-          "contain particles in non-rebuild iterations.");
-    }
-
-    typename ContainerIterator<Particle, false, false>::ParticleVecType additionalVectorsToPass;
-    if (not pToAddEmpty) {
-      // _particlesToAdd only contains particles if the container is invalid
-      if (_isValid != ValidityState::invalid) {
+    if (_isValid != ValidityState::invalid) {
+      if (not particlesToAddEmpty()) {
         autopas::utils::ExceptionHandler::exception(
             "VerletClusterLists::begin() const: Error: particle container is valid, but _particlesToAdd isn't empty!");
       }
-
+      // If the particles are sorted into the towers, we can simply use the iteration over towers.
+      return ContainerIterator<Particle, false, false>(*this, behavior, additionalVectors);
+    } else {
       // if the particles are not sorted into the towers, we have to also iterate over _particlesToAdd.
       // store all pointers in a temporary which is passed to the ParticleIterator constructor.
-      appendBuffersFromParticlesToAdd<false>(additionalVectorsToPass);
+      typename ContainerIterator<Particle, false, false>::ParticleVecType additionalVectorsTmp;
+      if (not additionalVectorsEmpty<false, false>(additionalVectors)) {
+        additionalVectorsTmp.reserve(_particlesToAdd.size() + additionalVectors->size());
+        additionalVectorsTmp.insert(additionalVectorsTmp.end(), additionalVectors->begin(), additionalVectors->end());
+      } else {
+        additionalVectorsTmp.reserve(_particlesToAdd.size());
+      }
+      for (auto &vec : _particlesToAdd) {
+        additionalVectorsTmp.push_back(&vec);
+      }
+      return ContainerIterator<Particle, false, false>(*this, behavior, &additionalVectorsTmp);
     }
-
-    // pToAddEmpty we are in anon-rebuild-iteration and can simply pass additionalVectors, which saves buffer
-    // allocations
-    return ContainerIterator<Particle, false, false>(*this, behavior,
-                                                     pToAddEmpty ? additionalVectors : &additionalVectorsToPass);
   }
 
   /**
@@ -631,38 +562,29 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
   [[nodiscard]] ContainerIterator<Particle, true, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner, IteratorBehavior behavior,
       typename ContainerIterator<Particle, true, true>::ParticleVecType *additionalVectors) override {
-    // first check if _particlesToAdd is empty and if additionalVectors are empty
-    const bool pToAddEmpty = particlesToAddEmpty();
-    const bool addVectorsEmpty = additionalVectorsEmpty<true, true>(additionalVectors);
-
-    // if both of them contain particles something went wrong. _particlesToAdd should only contain particles in a
-    // rebuild iteration and additionalVectors should only contain particles in non-rebuild iterations
-    if (not pToAddEmpty and not addVectorsEmpty) {
-      autopas::utils::ExceptionHandler::exception(
-          "VerletClusterLists::getRegionIterator(): Additional vectors are not empty and also_particlesToAdd isn't "
-          "empty! "
-          "_particlesToAdd should only contain particles in a rebuild iteration and additionalVectors should only "
-          "contain particles in non-rebuild iterations.");
-    }
-
-    typename ContainerIterator<Particle, true, true>::ParticleVecType additionalVectorsToPass;
-    if (not pToAddEmpty) {
-      // _particlesToAdd only contains particles if the container is invalid
-      if (_isValid != ValidityState::invalid) {
+    if (_isValid != ValidityState::invalid) {
+      if (not particlesToAddEmpty()) {
         autopas::utils::ExceptionHandler::exception(
-            "VerletClusterLists::getRegionIterator(): Error: particle container is valid, but _particlesToAdd isn't "
-            "empty!");
+            "VerletClusterLists::getRegionIterator(): Error: particle container is valid, but _particlesToAdd "
+            "isn't empty!");
       }
-
+      // If the particles are sorted into the towers, we can simply use the iteration over towers.
+      return ContainerIterator<Particle, true, true>(*this, behavior, additionalVectors, lowerCorner, higherCorner);
+    } else {
       // if the particles are not sorted into the towers, we have to also iterate over _particlesToAdd.
       // store all pointers in a temporary which is passed to the ParticleIterator constructor.
-      appendBuffersFromParticlesToAdd<true>(additionalVectorsToPass);
+      typename ContainerIterator<Particle, true, true>::ParticleVecType additionalVectorsTmp;
+      if (not additionalVectorsEmpty<true, true>(additionalVectors)) {
+        additionalVectorsTmp.reserve(_particlesToAdd.size() + additionalVectors->size());
+        additionalVectorsTmp.insert(additionalVectorsTmp.end(), additionalVectors->begin(), additionalVectors->end());
+      } else {
+        additionalVectorsTmp.reserve(_particlesToAdd.size());
+      }
+      for (auto &vec : _particlesToAdd) {
+        additionalVectorsTmp.push_back(&vec);
+      }
+      return ContainerIterator<Particle, true, true>(*this, behavior, &additionalVectorsTmp, lowerCorner, higherCorner);
     }
-
-    // pToAddEmpty we are in anon-rebuild-iteration and can simply pass additionalVectors, which saves buffer
-    // allocations
-    return ContainerIterator<Particle, true, true>(
-        *this, behavior, pToAddEmpty ? additionalVectors : &additionalVectorsToPass, lowerCorner, higherCorner);
   }
 
   /**
@@ -672,38 +594,30 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
   [[nodiscard]] ContainerIterator<Particle, false, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner, IteratorBehavior behavior,
       typename ContainerIterator<Particle, false, true>::ParticleVecType *additionalVectors) const override {
-    // first check if _particlesToAdd is empty and if additionalVectors are empty
-    const bool pToAddEmpty = particlesToAddEmpty();
-    const bool addVectorsEmpty = additionalVectorsEmpty<false, true>(additionalVectors);
-
-    // if both of them contain particles something went wrong. _particlesToAdd should only contain particles in a
-    // rebuild iteration and additionalVectors should only contain particles in non-rebuild iterations
-    if (not pToAddEmpty and not addVectorsEmpty) {
-      autopas::utils::ExceptionHandler::exception(
-          "VerletClusterLists::getRegionIterator() const: Additional vectors are not empty and also_particlesToAdd "
-          "isn't empty! "
-          "_particlesToAdd should only contain particles in a rebuild iteration and additionalVectors should only "
-          "contain particles in non-rebuild iterations.");
-    }
-
-    typename ContainerIterator<Particle, false, true>::ParticleVecType additionalVectorsToPass;
-    if (not pToAddEmpty) {
-      // _particlesToAdd only contains particles if the container is invalid
-      if (_isValid != ValidityState::invalid) {
+    if (_isValid != ValidityState::invalid) {
+      if (not particlesToAddEmpty()) {
         autopas::utils::ExceptionHandler::exception(
             "VerletClusterLists::getRegionIterator() const: Error: particle container is valid, but _particlesToAdd "
             "isn't empty!");
       }
-
+      // If the particles are sorted into the towers, we can simply use the iteration over towers.
+      return ContainerIterator<Particle, false, true>(*this, behavior, additionalVectors, lowerCorner, higherCorner);
+    } else {
       // if the particles are not sorted into the towers, we have to also iterate over _particlesToAdd.
       // store all pointers in a temporary which is passed to the ParticleIterator constructor.
-      appendBuffersFromParticlesToAdd<true>(additionalVectorsToPass);
+      typename ContainerIterator<Particle, false, true>::ParticleVecType additionalVectorsTmp;
+      if (not additionalVectorsEmpty<false, true>(additionalVectors)) {
+        additionalVectorsTmp.reserve(_particlesToAdd.size() + additionalVectors->size());
+        additionalVectorsTmp.insert(additionalVectorsTmp.end(), additionalVectors->begin(), additionalVectors->end());
+      } else {
+        additionalVectorsTmp.reserve(_particlesToAdd.size());
+      }
+      for (auto &vec : _particlesToAdd) {
+        additionalVectorsTmp.push_back(&vec);
+      }
+      return ContainerIterator<Particle, false, true>(*this, behavior, &additionalVectorsTmp, lowerCorner,
+                                                      higherCorner);
     }
-
-    // pToAddEmpty we are in anon-rebuild-iteration and can simply pass additionalVectors, which saves buffer
-    // allocations
-    return ContainerIterator<Particle, false, true>(
-        *this, behavior, pToAddEmpty ? additionalVectors : &additionalVectorsToPass, lowerCorner, higherCorner);
   }
 
   /**
@@ -1454,6 +1368,28 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
     for (auto &threadBuffer : _particlesToAdd) {
       if (not threadBuffer.empty()) {
         return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Helper function for begin() and getRegionIterator() to check if the passed additionalVectors are empty
+   *
+   * @tparam modifiable
+   * @tparam regionIter
+   * @param additionalVectors
+   * @return true iff all passed vectors are empty
+   * @return false iff at least one buffer from the passed vectors is not empty
+   */
+  template <bool modifiable, bool regionIter>
+  bool additionalVectorsEmpty(
+      typename ContainerIterator<Particle, modifiable, regionIter>::ParticleVecType *additionalVectors) const {
+    if (additionalVectors) {
+      for (const auto &buffer : *additionalVectors) {
+        if (not buffer->empty()) {
+          return false;
+        }
       }
     }
     return true;

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -413,17 +413,18 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
     } else {
       // if the particles are not sorted into the towers, we have to also iterate over _particlesToAdd.
       // store all pointers in a temporary which is passed to the ParticleIterator constructor.
-      typename ContainerIterator<Particle, true, false>::ParticleVecType additionalVectorsTmp;
+      typename ContainerIterator<Particle, true, false>::ParticleVecType additionalVectorsToPass;
       if (not additionalVectorsEmpty<true, false>(additionalVectors)) {
-        additionalVectorsTmp.reserve(_particlesToAdd.size() + additionalVectors->size());
-        additionalVectorsTmp.insert(additionalVectorsTmp.end(), additionalVectors->begin(), additionalVectors->end());
+        additionalVectorsToPass.reserve(_particlesToAdd.size() + additionalVectors->size());
+        additionalVectorsToPass.insert(additionalVectorsToPass.end(), additionalVectors->begin(),
+                                       additionalVectors->end());
       } else {
-        additionalVectorsTmp.reserve(_particlesToAdd.size());
+        additionalVectorsToPass.reserve(_particlesToAdd.size());
       }
       for (auto &vec : _particlesToAdd) {
-        additionalVectorsTmp.push_back(&vec);
+        additionalVectorsToPass.push_back(&vec);
       }
-      return ContainerIterator<Particle, true, false>(*this, behavior, &additionalVectorsTmp);
+      return ContainerIterator<Particle, true, false>(*this, behavior, &additionalVectorsToPass);
     }
   }
 
@@ -444,17 +445,18 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
     } else {
       // if the particles are not sorted into the towers, we have to also iterate over _particlesToAdd.
       // store all pointers in a temporary which is passed to the ParticleIterator constructor.
-      typename ContainerIterator<Particle, false, false>::ParticleVecType additionalVectorsTmp;
+      typename ContainerIterator<Particle, false, false>::ParticleVecType additionalVectorsToPass;
       if (not additionalVectorsEmpty<false, false>(additionalVectors)) {
-        additionalVectorsTmp.reserve(_particlesToAdd.size() + additionalVectors->size());
-        additionalVectorsTmp.insert(additionalVectorsTmp.end(), additionalVectors->begin(), additionalVectors->end());
+        additionalVectorsToPass.reserve(_particlesToAdd.size() + additionalVectors->size());
+        additionalVectorsToPass.insert(additionalVectorsToPass.end(), additionalVectors->begin(),
+                                       additionalVectors->end());
       } else {
-        additionalVectorsTmp.reserve(_particlesToAdd.size());
+        additionalVectorsToPass.reserve(_particlesToAdd.size());
       }
       for (auto &vec : _particlesToAdd) {
-        additionalVectorsTmp.push_back(&vec);
+        additionalVectorsToPass.push_back(&vec);
       }
-      return ContainerIterator<Particle, false, false>(*this, behavior, &additionalVectorsTmp);
+      return ContainerIterator<Particle, false, false>(*this, behavior, &additionalVectorsToPass);
     }
   }
 
@@ -573,17 +575,19 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
     } else {
       // if the particles are not sorted into the towers, we have to also iterate over _particlesToAdd.
       // store all pointers in a temporary which is passed to the ParticleIterator constructor.
-      typename ContainerIterator<Particle, true, true>::ParticleVecType additionalVectorsTmp;
+      typename ContainerIterator<Particle, true, true>::ParticleVecType additionalVectorsToPass;
       if (not additionalVectorsEmpty<true, true>(additionalVectors)) {
-        additionalVectorsTmp.reserve(_particlesToAdd.size() + additionalVectors->size());
-        additionalVectorsTmp.insert(additionalVectorsTmp.end(), additionalVectors->begin(), additionalVectors->end());
+        additionalVectorsToPass.reserve(_particlesToAdd.size() + additionalVectors->size());
+        additionalVectorsToPass.insert(additionalVectorsToPass.end(), additionalVectors->begin(),
+                                       additionalVectors->end());
       } else {
-        additionalVectorsTmp.reserve(_particlesToAdd.size());
+        additionalVectorsToPass.reserve(_particlesToAdd.size());
       }
       for (auto &vec : _particlesToAdd) {
-        additionalVectorsTmp.push_back(&vec);
+        additionalVectorsToPass.push_back(&vec);
       }
-      return ContainerIterator<Particle, true, true>(*this, behavior, &additionalVectorsTmp, lowerCorner, higherCorner);
+      return ContainerIterator<Particle, true, true>(*this, behavior, &additionalVectorsToPass, lowerCorner,
+                                                     higherCorner);
     }
   }
 
@@ -605,17 +609,18 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
     } else {
       // if the particles are not sorted into the towers, we have to also iterate over _particlesToAdd.
       // store all pointers in a temporary which is passed to the ParticleIterator constructor.
-      typename ContainerIterator<Particle, false, true>::ParticleVecType additionalVectorsTmp;
+      typename ContainerIterator<Particle, false, true>::ParticleVecType additionalVectorsToPass;
       if (not additionalVectorsEmpty<false, true>(additionalVectors)) {
-        additionalVectorsTmp.reserve(_particlesToAdd.size() + additionalVectors->size());
-        additionalVectorsTmp.insert(additionalVectorsTmp.end(), additionalVectors->begin(), additionalVectors->end());
+        additionalVectorsToPass.reserve(_particlesToAdd.size() + additionalVectors->size());
+        additionalVectorsToPass.insert(additionalVectorsToPass.end(), additionalVectors->begin(),
+                                       additionalVectors->end());
       } else {
-        additionalVectorsTmp.reserve(_particlesToAdd.size());
+        additionalVectorsToPass.reserve(_particlesToAdd.size());
       }
       for (auto &vec : _particlesToAdd) {
-        additionalVectorsTmp.push_back(&vec);
+        additionalVectorsToPass.push_back(&vec);
       }
-      return ContainerIterator<Particle, false, true>(*this, behavior, &additionalVectorsTmp, lowerCorner,
+      return ContainerIterator<Particle, false, true>(*this, behavior, &additionalVectorsToPass, lowerCorner,
                                                       higherCorner);
     }
   }

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -1338,11 +1338,12 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
   std::vector<std::vector<Particle>> _particlesToAdd;
 
   /**
-   * Checks if there are particles in at least one thread buffer of _particlesToAdd.
-   * @return true iff all thread buffer are empty.
+   * Checks if there are particles in the buffers of _particlesToAdd.
+   * @param bufferID the buffer ID to check for emptiness. If bufferID == -1, all buffers are checked
+   * @return true if all buffers are empty or if one of the specified buffers is empty.
    */
-  [[nodiscard]] bool particlesToAddEmpty(int threadID = -1) const {
-    if (threadID == -1) {
+  [[nodiscard]] bool particlesToAddEmpty(int bufferID = -1) const {
+    if (bufferID == -1) {
       for (auto &threadBuffer : _particlesToAdd) {
         if (not threadBuffer.empty()) {
           return false;
@@ -1350,7 +1351,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
       }
       return true;
     } else {
-      return _particlesToAdd[threadID].empty();
+      return _particlesToAdd[bufferID].empty();
     }
   }
 

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -1362,7 +1362,6 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
    *
    * @tparam VecVec Type of datastructure of additional vectors. Expected is a vector of vectors.
    * @param additionalVectors Additional vectors from LogicHandler.
-   * * @param particlesToAdd _particlesToAdd vectors from VCL.
    * @param outVec The buffer where additionalVectors + _particlesToAdd will be stored.
    */
   template <class VecVec>


### PR DESCRIPTION
# Description

It looks like the problem came from the fact that we called `particlesToAddEmpty()` in iterations with invalid container status. However, in these iterations `_particlesToAdd` is used by multiple threads, which is why races can occur. In this version, we solve this by calling `particlesToAddEmpty()` only when the container state is valid, to ensure that we don't have particles in the buffer during these iterations:

```c++
if (_isValid != ValidityState::invalid) {
// This section ensures that we do not have particles in _particlesToAdd when the container status is valid. 
// In this case we don't need to concatenate the buffers, we can just pass the additionalVectors.
      if (not particlesToAddEmpty()) {
        autopas::utils::ExceptionHandler::exception(
            "VerletClusterLists::begin(): Error: particle container is valid, but _particlesToAdd isn't empty!");
      }
      // If the particles are sorted into the towers, we can simply use the iteration over towers.
      return ContainerIterator<Particle, true, false>(*this, behavior, additionalVectors);
    } else {
    // In this case (invalid status) we concatenate additionalVectors and _particlesToAdd if additionalVectors contain particles, otherwise we just pass _particlesToAdd
 }
```

The variant to check only the buffers of the respective thread in `particlesToAddEmpty()` was tested, however, also this led to race-conditions. The problem is that the functions `begin() const`, `getRegionIterator()` and `getRegionIterator() const` are always called only by thread 0. For testing, I included an exception that throws when a thread other than T0 executes the function and used it to run example simulations (fallingDrop and explodingLiquid using only VCL), which resulted in no exception. For this reason, in `begin()` and `getRegionIterator()` we need to check all buffers in `_particlesToAdd` to see if there really are no particles in it

## Related Pull Requests

- https://github.com/AutoPas/AutoPas/pull/742

## Resolved Issues

- [x] fixes #756
- [x] fixes #755

# How Has This Been Tested?
- All existing tests with current master ([8299124](https://github.com/AutoPas/AutoPas/commit/829912490c798c2eff623e9da1f645ed8b97754e) )
- All tests that failed in https://github.com/AutoPas/AutoPas/commit/3df9b768a61b8217682bc329ef757b2c80327007 with Thread Sanitizers enabled using the docker container with following command:
(tested for https://github.com/AutoPas/AutoPas/commit/3df9b768a61b8217682bc329ef757b2c80327007 and current master [8299124](https://github.com/AutoPas/AutoPas/commit/829912490c798c2eff623e9da1f645ed8b97754e))
```bash
docker run -v ${PathToAutoPasRoot}:/autopas -it autopas/autopas-build-archer \
bash -c "export TSAN_OPTIONS=ignore_noninstrumented_modules=1 && cd /autopas/build
CC=clang CXX=clang++ cmake \
  -G Ninja \
  -DCCACHE=ON \
  -DCMAKE_BUILD_TYPE=Release \
  -DAUTOPAS_LOG_ALL=ON \
  -DAUTOPAS_OPENMP=ON \
  -DAUTOPAS_ENABLE_ADDRESS_SANITIZER=OFF \
  -DAUTOPAS_ENABLE_THREAD_SANITIZER=ON \
  -DAUTOPAS_INTERNODE_TUNING=OFF \
  -DMD_FLEXIBLE_USE_MPI=OFF \
  -DMD_FLEXIBLE_FUNCTOR_AUTOVEC=ON \
  -DMD_FLEXIBLE_FUNCTOR_AUTOVEC_GLOBALS=OFF \
  -DMD_FLEXIBLE_FUNCTOR_AVX=ON \
  -DMD_FLEXIBLE_FUNCTOR_SVE=OFF \
  -DAUTOPAS_ENABLE_ALLLBL=OFF \
  .. \
  && ninja runTests \
  && ctest --output-on-failure -R '^testAutopas\/Generated\/ContainerIteratorTest\.deleteParticles\/VerletClusterLists'"
```
- Example simulations (fallingDrop only with VCL and different boundary-conditions): The number of (owned) particles at the end was identical to the number at the beginning.