### PR TITLE
Fixing LJFunctorSVE

### DIFF
--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -626,7 +626,7 @@ T Simulation::applyWithChosenFunctor(F f) {
     }
     case MDFlexConfig::FunctorOption::lj12_6_SVE: {
 #if defined(MD_FLEXIBLE_FUNCTOR_SVE) && defined(__ARM_FEATURE_SVE)
-      return f(autopas::LJFunctorSVE<ParticleType, true, true> functor{cutoff, particlePropertiesLibrary});
+      return f(autopas::LJFunctorSVE<ParticleType, true, true>{cutoff, particlePropertiesLibrary});
 #else
       throw std::runtime_error(
           "MD-Flexible was not compiled with support for LJFunctor SVE. Activate it via `cmake "

--- a/src/autopas/molecularDynamics/LJFunctorSVE.h
+++ b/src/autopas/molecularDynamics/LJFunctorSVE.h
@@ -157,11 +157,6 @@ class LJFunctorSVE
       double upot = epsilon24 * lj12m6 + shift6;
 
       const int threadnum = autopas_get_thread_num();
-      // for non-newton3 the division is in the post-processing step.
-      if (newton3) {
-        upot *= 0.5;
-        virial *= (double)0.5;
-      }
       if (i.isOwned()) {
         if (newton3) {
           _aosThreadData[threadnum].upotSumN3 += upot * 0.5;

--- a/src/autopas/molecularDynamics/LJFunctorSVE.h
+++ b/src/autopas/molecularDynamics/LJFunctorSVE.h
@@ -261,7 +261,7 @@ class LJFunctorSVE
         pg_3 = svwhilelt_b64(j_3, i);
         pg_4 = svwhilelt_b64(j_4, i);
 
-        SoAKernel<newton3, false>(j, ownedStatePtr[i] == OwnershipState::owned,
+        SoAKernel<true, false>(j, ownedStatePtr[i] == OwnershipState::owned,
                                   reinterpret_cast<const int64_t *>(ownedStatePtr), x1, y1, z1, xptr, yptr, zptr, fxptr,
                                   fyptr, fzptr, &typeIDptr[i], typeIDptr, fxacc, fyacc, fzacc, virialSumX, virialSumY,
                                   virialSumZ, upotSum, pg_1, svundef_u64(), pg_2, svundef_u64(), pg_3, svundef_u64(),

--- a/src/autopas/molecularDynamics/LJFunctorSVE.h
+++ b/src/autopas/molecularDynamics/LJFunctorSVE.h
@@ -262,10 +262,10 @@ class LJFunctorSVE
         pg_4 = svwhilelt_b64(j_4, i);
 
         SoAKernel<true, false>(j, ownedStatePtr[i] == OwnershipState::owned,
-                                  reinterpret_cast<const int64_t *>(ownedStatePtr), x1, y1, z1, xptr, yptr, zptr, fxptr,
-                                  fyptr, fzptr, &typeIDptr[i], typeIDptr, fxacc, fyacc, fzacc, virialSumX, virialSumY,
-                                  virialSumZ, upotSum, pg_1, svundef_u64(), pg_2, svundef_u64(), pg_3, svundef_u64(),
-                                  pg_4, svundef_u64());
+                               reinterpret_cast<const int64_t *>(ownedStatePtr), x1, y1, z1, xptr, yptr, zptr, fxptr,
+                               fyptr, fzptr, &typeIDptr[i], typeIDptr, fxacc, fyacc, fzacc, virialSumX, virialSumY,
+                               virialSumZ, upotSum, pg_1, svundef_u64(), pg_2, svundef_u64(), pg_3, svundef_u64(), pg_4,
+                               svundef_u64());
       }
 
       fxptr[i] += svaddv(svptrue_b64(), fxacc);

--- a/tests/testAutopas/tests/molecularDynamics/LJFunctorSVETest.cpp
+++ b/tests/testAutopas/tests/molecularDynamics/LJFunctorSVETest.cpp
@@ -345,9 +345,8 @@ void LJFunctorSVETest::testLJFunctorVSLJFunctorSVEAoS(bool newton3, bool doDelet
   EXPECT_NEAR(ljFunctorSVE.getUpot(), ljFunctorNoSVE.getUpot(), tolerance) << "global uPot";
   EXPECT_NEAR(ljFunctorSVE.getVirial(), ljFunctorNoSVE.getVirial(), tolerance) << "global virial";
 }
-* /
 
-    TEST_P(LJFunctorSVETest, testLJFunctorVSLJFunctorSVEAoS) {
+TEST_P(LJFunctorSVETest, testLJFunctorVSLJFunctorSVEAoS) {
   auto [newton3, doDeleteSomeParticle] = GetParam();
   testLJFunctorVSLJFunctorSVEAoS(newton3, doDeleteSomeParticle);
 }


### PR DESCRIPTION
# Description

- SVE functor now compiles with two minor fixes.
- SVE AoS functor correctly calculates globals now
- SVE SoA functor single correctly applies forces by always calling the SoAKernel with newton3=true.



## Resolved Issues

- [x] fixes #762 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Existing SVE tests run on HSU ARM Minicluster and pass. These were run with the Google test filter `*SVE*` (I assume all SVE related tests include `SVE`)
