### PR TITLE
Unreverse buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ The default parameter is `ownedOrHalo`, which is also used for range-based for l
 
 Analogously to `begin()`, `cbegin()` is also defined, which guarantees to return a `const_iterator`.
 
-Iterators are not guaranteed to be valid after particle insertion. 
+Iterators are not guaranteed to be valid after particle insertion (see [Issue #766](https://github.com/AutoPas/AutoPas/issues/766) for details).
 However, particle deletion while iterating is supported via `autoPas.deleteParticle(iterator)`. 
 After deletion the `++` operator has to be called:
 ```cpp

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -347,6 +347,9 @@ class LogicHandler {
                               static_cast<bool>(behavior & IteratorBehavior::halo) * _haloParticleBuffer.size());
     if (behavior & IteratorBehavior::owned) {
       for (auto &buffer : _particleBuffer) {
+        // Don't insert empty buffers. This also means that we won't pick up particles added during iterating if they
+        // go to the buffers. But since we wouldn't pick them up if they go into the container to a cell that the
+        // iterators already passed this is unsupported anyways.
         if (not buffer.isEmpty()) {
           additionalVectors.push_back(&(buffer._particles));
         }

--- a/src/autopas/iterators/ContainerIterator.h
+++ b/src/autopas/iterators/ContainerIterator.h
@@ -326,11 +326,7 @@ class ContainerIterator {
       // if getParticle told us that the container doesn't have a particle in the first vector for our thread...
       if (_currentParticle == nullptr and not _additionalVectors.empty()) {
         // determine which additional vector this thread should start to iterate
-        // we invert the assignment of threads to additional vectors because if there are more threads than cells
-        // these surplus threads can then directly start with the additional vectors
-        _currentVectorIndex = (_behavior & IteratorBehavior::forceSequential)
-                                  ? 0
-                                  : autopas_get_num_threads() - 1 - autopas_get_thread_num();
+        _currentVectorIndex = (_behavior & IteratorBehavior::forceSequential) ? 0 : autopas_get_thread_num();
         _currentParticleIndex = 0;
         _iteratingAdditionalVectors = true;
       } else {

--- a/tests/testAutopas/tests/iterators/ContainerIteratorTest.h
+++ b/tests/testAutopas/tests/iterators/ContainerIteratorTest.h
@@ -13,11 +13,7 @@
 #include "autopas/options/ContainerOption.h"
 #include "autopas/options/IteratorBehavior.h"
 
-using testingTuple =
-    std::tuple<autopas::ContainerOption, double /*cell size factor*/, bool /*regionIterator (true) or regular (false)*/,
-               bool /*testConstIterators*/, bool /*priorForceCalc*/, autopas::IteratorBehavior>;
-
-class ContainerIteratorTest : public testing::Test, public ::testing::WithParamInterface<testingTuple> {
+class ContainerIteratorTestBase : public testing::Test {
  public:
   struct PrintToStringParamName {
     template <class ParamType>
@@ -44,7 +40,7 @@ class ContainerIteratorTest : public testing::Test, public ::testing::WithParamI
    * @return tuple {haloBoxMin, haloBoxMax}
    */
   template <typename AutoPasT>
-  auto defaultInit(AutoPasT &autoPas, autopas::ContainerOption &containerOption, double cellSizeFactor);
+  auto defaultInit(AutoPasT &autoPas, const autopas::ContainerOption &containerOption, double cellSizeFactor);
 
   /**
    * Deletes all particles whose ID matches the given Predicate.
@@ -61,3 +57,14 @@ class ContainerIteratorTest : public testing::Test, public ::testing::WithParamI
   auto deleteParticles(AutoPasT &autopas, F predicate, bool useRegionIterator,
                        const autopas::IteratorBehavior &behavior);
 };
+
+using testingTuple =
+    std::tuple<autopas::ContainerOption, double /*cell size factor*/, bool /*regionIterator (true) or regular (false)*/,
+               bool /*testConstIterators*/, bool /*priorForceCalc*/, autopas::IteratorBehavior>;
+class ContainerIteratorTest : public ContainerIteratorTestBase, public ::testing::WithParamInterface<testingTuple> {};
+
+class ContainerIteratorTestNonConst : public ContainerIteratorTestBase,
+                                      public ::testing::WithParamInterface<testingTuple> {};
+
+class ContainerIteratorTestNonConstOwned : public ContainerIteratorTestBase,
+                                           public ::testing::WithParamInterface<testingTuple> {};

--- a/tests/testAutopas/tests/iterators/IteratorTestHelper.h
+++ b/tests/testAutopas/tests/iterators/IteratorTestHelper.h
@@ -119,7 +119,7 @@ auto fillContainerAroundBoundary(AutoPasT &autoPas) {
 
 /**
  * Creates a grid of particles in the given AutoPas object.
- * Grid width is `sparsity * ( boxLength / ((cutoff + skin) * cellSizeFactor) )`.
+ * The grid width is `sparsity * cellLength`
  * E.g., for a sparsity of 1, 1 particle is inserted for every cell. For a sparsity of .5, 8 particles are inserted.
  * The lower corner of the grid is offset from boxMin by half the grid width in every dimension.
  * This way there should be one particle in every third Linked Cells cell.


### PR DESCRIPTION
# Description

Reversing the assignment of buffers to iterators during iteration caused race conditions.

## Related Pull Requests

- bug introduced here: #712

## ~Resolved Issues~

No issue was created.

# How Has This Been Tested?

- [x] New unit test `ContainerIteratorTestNonConstOwned::addParticlesWhileIterating`
- [x] ls1 Simulation that previously crashed doesn't crash anymore.
