### PR TITLE
Fix generated yaml files

### DIFF
--- a/examples/md-flexible/src/configuration/MDFlexConfig.cpp
+++ b/examples/md-flexible/src/configuration/MDFlexConfig.cpp
@@ -221,9 +221,9 @@ std::string MDFlexConfig::to_string() const {
   };
 
 #if MD_FLEXIBLE_MODE == MULTISITE
-  os << "Running multi-site MD simulation.\n" << endl;
+  os << "# Running multi-site MD simulation.\n" << endl;
 #else
-  os << "Running single-site MD simulation.\n" << endl;
+  os << "# Running single-site MD simulation.\n" << endl;
 #endif
 
   printOption(containerOptions);

--- a/examples/md-flexible/src/configuration/objects/Object.h
+++ b/examples/md-flexible/src/configuration/objects/Object.h
@@ -99,14 +99,10 @@ class Object {
    */
   [[nodiscard]] virtual std::string to_string() const {
     std::ostringstream output;
-#if MD_FLEXIBLE_MODE == MULTISITE
-    const auto typeName = "molecule-id";
-#else
-    const auto typeName = "site-id";
-#endif
     output << std::setw(_valueOffset) << std::left << "velocity"
            << ":  " << autopas::utils::ArrayUtils::to_string(_velocity) << std::endl;
-    output << std::setw(_valueOffset) << std::left << typeName << ":  " << _typeId << std::endl;
+    output << std::setw(_valueOffset) << std::left << "particle-type-id"
+           << ":  " << _typeId << std::endl;
     return output.str();
   };
 


### PR DESCRIPTION
# Description

Running the generated `yaml` files does not work. This PR reolves this.

- [x] put a `#` in front of the comment at the top
- [x] There is no tag `site-type`, instead it is always `particle-type-id`

## Related Pull Requests

- Changes introduced here: #682 

# How Has This Been Tested?

```bash
./md-flexible                                     # this generates a yaml file
./md-flexible --yaml-filename MDFlex_end_*.yaml   # this call should not fail
```
