### PR TITLE
Dont throw if energy measurement is unavailable

### DIFF
--- a/cmake/modules/autopas_antlr4cpp.cmake
+++ b/cmake/modules/autopas_antlr4cpp.cmake
@@ -69,6 +69,8 @@ ExternalProject_ADD(
         BUILD_BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/antlr4cpp/install/lib/libantlr4-runtime.a
         # point antlr4cpp to utf8cpp install dir
         CMAKE_ARGS       -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${antlr4cpp_prefix}/install -DCMAKE_CXX_FLAGS=-w -DCMAKE_PREFIX_PATH=${UTFCPP_DIR}/install
+        # make sure UUID and UTF8CPP is installed before antlr is installed
+        DEPENDS          uuid_bundled utf8cpp_bundled
         # Patch away the shared library target
         PATCH_COMMAND    sed --in-place -e /install.*shared/,+2d               runtime/CMakeLists.txt  &&
                          sed --in-place -e /set_target_properties.*shared/,+9d runtime/CMakeLists.txt  &&

--- a/src/autopas/tuning/AutoTuner.cpp
+++ b/src/autopas/tuning/AutoTuner.cpp
@@ -290,7 +290,6 @@ bool AutoTuner::initEnergy() {
     if (_tuningMetric == TuningMetricOption::energy) {
       throw utils::ExceptionHandler::AutoPasException(errMsg);
     } else {
-      AutoPasLog(WARN, "Energy Measurement not possible:\n\t{}", errMsg);
       return false;
     }
   }
@@ -307,7 +306,6 @@ bool AutoTuner::resetEnergy() {
        * very unlikely to happen, as check was performed at initialisation of autotuner
        * but may occur if permissions are changed during runtime.
        */
-      AutoPasLog(WARN, "Energy Measurement no longer possible:\n\t{}", errMsg);
       _energyMeasurementPossible = false;
       if (_tuningMetric == TuningMetricOption::energy) {
         throw utils::ExceptionHandler::AutoPasException(errMsg);
@@ -323,7 +321,6 @@ std::tuple<double, double, double, long> AutoTuner::sampleEnergy() {
   if (_energyMeasurementPossible) {
     errMsg.append(_raplMeter.sample());
     if (not errMsg.empty()) {
-      AutoPasLog(WARN, "Energy Measurement no longer possible:\n\t{}", errMsg);
       _energyMeasurementPossible = false;
       if (_tuningMetric == TuningMetricOption::energy) {
         throw utils::ExceptionHandler::AutoPasException(errMsg);

--- a/src/autopas/tuning/AutoTuner.cpp
+++ b/src/autopas/tuning/AutoTuner.cpp
@@ -290,6 +290,7 @@ bool AutoTuner::initEnergy() {
     if (_tuningMetric == TuningMetricOption::energy) {
       throw utils::ExceptionHandler::AutoPasException(errMsg);
     } else {
+      AutoPasLog(INFO, "Energy Measurement not possible on this system");
       return false;
     }
   }
@@ -306,6 +307,7 @@ bool AutoTuner::resetEnergy() {
        * very unlikely to happen, as check was performed at initialisation of autotuner
        * but may occur if permissions are changed during runtime.
        */
+      AutoPasLog(INFO, "Energy Measurement not possible on this system");
       _energyMeasurementPossible = false;
       if (_tuningMetric == TuningMetricOption::energy) {
         throw utils::ExceptionHandler::AutoPasException(errMsg);
@@ -321,6 +323,7 @@ std::tuple<double, double, double, long> AutoTuner::sampleEnergy() {
   if (_energyMeasurementPossible) {
     errMsg.append(_raplMeter.sample());
     if (not errMsg.empty()) {
+      AutoPasLog(INFO, "Energy Measurement not possible on this system");
       _energyMeasurementPossible = false;
       if (_tuningMetric == TuningMetricOption::energy) {
         throw utils::ExceptionHandler::AutoPasException(errMsg);

--- a/src/autopas/utils/RaplMeter.h
+++ b/src/autopas/utils/RaplMeter.h
@@ -26,8 +26,8 @@ class RaplMeter {
   int _psys_config, _pkg_config, _cores_config, _ram_config;
   std::vector<int> _psys_fd, _pkg_fd, _cores_fd, _ram_fd;
 
-  int open_perf_event(int type, int config, int cpu);
-  long read_perf_event(int fd);
+  int open_perf_event(int type, int config, int cpu, std::string &errMsg);
+  long read_perf_event(int fd, std::string &errMsg);
 
  public:
   ~RaplMeter();
@@ -35,18 +35,18 @@ class RaplMeter {
   /**
    *initialisation may fail, so moved out of constructor
    */
-  void init();
+  std::string init();
 
   /**
    * reset perf file descriptors to start new measurement
    */
-  void reset();
+  std::string reset();
 
   /**
    * measure power consumption since last call to reset
    * the results can be retrieved with the get_<domain>_energy() functions.
    */
-  void sample();
+  std::string sample();
 
   /**
    * returns the energy consumed by the cpu package between the last call to sample() and the preceding

--- a/src/autopas/utils/RaplMeter.h
+++ b/src/autopas/utils/RaplMeter.h
@@ -26,30 +26,31 @@ class RaplMeter {
   int _psys_config, _pkg_config, _cores_config, _ram_config;
   std::vector<int> _psys_fd, _pkg_fd, _cores_fd, _ram_fd;
 
-  int open_perf_event(int type, int config, int cpu, std::string &errMsg);
-  long read_perf_event(int fd, std::string &errMsg);
+  int open_perf_event(int type, int config, int cpu);
+  long read_perf_event(int fd);
 
  public:
   ~RaplMeter();
 
   /**
    *initialisation may fail, so moved out of constructor
+   Note: This functios returns an error message instead of throwing an exception if initialization is not possible. This
+   way debuggers don't break on the start of every autopas initialization if we are not interested in energy
+   measurement.
    @return Error message. The error is message is empty on success
    */
   std::string init();
 
   /**
    * reset perf file descriptors to start new measurement
-   * @return Error message. The error is message is empty on success
    */
-  std::string reset();
+  void reset();
 
   /**
    * measure power consumption since last call to reset
    * the results can be retrieved with the get_<domain>_energy() functions.
-   * @return Error message. The error is message is empty on success
    */
-  std::string sample();
+  void sample();
 
   /**
    * returns the energy consumed by the cpu package between the last call to sample() and the preceding

--- a/src/autopas/utils/RaplMeter.h
+++ b/src/autopas/utils/RaplMeter.h
@@ -34,17 +34,20 @@ class RaplMeter {
 
   /**
    *initialisation may fail, so moved out of constructor
+   @return Error message. The error is message is empty on success
    */
   std::string init();
 
   /**
    * reset perf file descriptors to start new measurement
+   * @return Error message. The error is message is empty on success
    */
   std::string reset();
 
   /**
    * measure power consumption since last call to reset
    * the results can be retrieved with the get_<domain>_energy() functions.
+   * @return Error message. The error is message is empty on success
    */
   std::string sample();
 


### PR DESCRIPTION
# Description

- The RaplMeter::init() does not throw exceptions if energy measurement is not available but an error string.
- ~The warnings in AutoTuner were replaced by `INFO` outputs without the error message, if energy measurement is not strictly needed.~

## Resolved Issues

- [x] fixes #773

## Additional changes
- In autopas_antlr4cpp.cmake `DEPENDS` is added again, otherwise utf8cpp might be downloaded from github in antlr's cmake files if we build for example with `make -j16`. (this was somehow removed from #780 during merge)

# How Has This Been Tested?

- [x] all existing tests