### PR TITLE
Less Halo Halo Interactions

### DIFF
--- a/src/autopas/pairwiseFunctors/CellFunctor.h
+++ b/src/autopas/pairwiseFunctors/CellFunctor.h
@@ -208,10 +208,8 @@ void CellFunctor<Particle, ParticleCell, ParticleFunctor, DataLayout, useNewton3
     }
   } else {
     for (auto cellIter1 = cell.begin(); cellIter1 != cell.end(); ++cellIter1) {
-      auto &[p1Projection, p1] = *cellIter1;
       for (auto cellIter2 = std::next(cellIter1); cellIter2 != cell.end(); ++cellIter2) {
-        auto &[p2Projection, p2] = *cellIter2;
-        interactParticles(p1, p2);
+        interactParticles(*cellIter1, *cellIter2);
       }
     }
   }
@@ -234,8 +232,8 @@ void CellFunctor<Particle, ParticleCell, ParticleFunctor, DataLayout, useNewton3
       }
     }
   } else {
-    for (auto &[p1Projection, p1] : cell1) {
-      for (auto &[p2Projection, p2] : cell2) {
+    for (auto &p1 : cell1) {
+      for (auto &p2 : cell2) {
         _functor->AoSFunctor(p1, p2, true);
       }
     }

--- a/src/autopas/pairwiseFunctors/CellFunctor.h
+++ b/src/autopas/pairwiseFunctors/CellFunctor.h
@@ -19,12 +19,12 @@ namespace autopas::internal {
  * @tparam Particle
  * @tparam ParticleCell
  * @tparam ParticleFunctor the functor which
- * @tparam DataLayout the DataLayout to be used
+ * @tparam dataLayout the dataLayout to be used
  * @tparam useNewton3
  * @tparam bidirectional if no newton3 is used processCellPair(cell1, cell2) should also handle processCellPair(cell2,
  * cell1)
  */
-template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutOption::Value DataLayout,
+template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutOption::Value dataLayout,
           bool useNewton3 = true, bool bidirectional = true>
 class CellFunctor {
  public:
@@ -52,6 +52,29 @@ class CellFunctor {
    */
   void processCellPair(ParticleCell &cell1, ParticleCell &cell2,
                        const std::array<double, 3> &sortingDirection = {0., 0., 0.});
+
+  /**
+   * Getter
+   * @return
+   */
+  DataLayoutOption::Value getDataLayout() const {
+    return dataLayout;
+  }
+
+  /**
+   * Getter
+   * @return
+   */
+  bool getNewton3() const {
+    return useNewton3;
+  }
+
+  /**
+   * Getter
+   */
+  bool getBidirectional() const {
+    return bidirectional;
+  }
 
  private:
   /**
@@ -104,12 +127,12 @@ class CellFunctor {
   constexpr static unsigned long _startSorting = std::numeric_limits<unsigned long>::max();
 };
 
-template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutOption::Value DataLayout,
+template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutOption::Value dataLayout,
           bool useNewton3, bool bidirectional>
-void CellFunctor<Particle, ParticleCell, ParticleFunctor, DataLayout, useNewton3, bidirectional>::processCell(
+void CellFunctor<Particle, ParticleCell, ParticleFunctor, dataLayout, useNewton3, bidirectional>::processCell(
     ParticleCell &cell) {
-  if ((DataLayout == DataLayoutOption::soa and cell._particleSoABuffer.size() == 0) or
-      (DataLayout == DataLayoutOption::aos and cell.size() == 0)) {
+  if ((dataLayout == DataLayoutOption::soa and cell._particleSoABuffer.size() == 0) or
+      (dataLayout == DataLayoutOption::aos and cell.size() == 0)) {
     return;
   }
 
@@ -119,7 +142,7 @@ void CellFunctor<Particle, ParticleCell, ParticleFunctor, DataLayout, useNewton3
     return;
   }
 
-  switch (DataLayout) {
+  switch (dataLayout) {
     case DataLayoutOption::aos:
       processCellAoS<useNewton3>(cell);
       break;
@@ -133,14 +156,14 @@ void CellFunctor<Particle, ParticleCell, ParticleFunctor, DataLayout, useNewton3
   }
 }
 
-template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutOption::Value DataLayout,
+template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutOption::Value dataLayout,
           bool useNewton3, bool bidirectional>
-void CellFunctor<Particle, ParticleCell, ParticleFunctor, DataLayout, useNewton3, bidirectional>::processCellPair(
+void CellFunctor<Particle, ParticleCell, ParticleFunctor, dataLayout, useNewton3, bidirectional>::processCellPair(
 
     ParticleCell &cell1, ParticleCell &cell2, const std::array<double, 3> &sortingDirection) {
-  if ((DataLayout == DataLayoutOption::soa and
+  if ((dataLayout == DataLayoutOption::soa and
        (cell1._particleSoABuffer.size() == 0 and cell2._particleSoABuffer.size() == 0)) or
-      (DataLayout == DataLayoutOption::aos and (cell1.size() == 0 and cell2.size() == 0))) {
+      (dataLayout == DataLayoutOption::aos and (cell1.size() == 0 and cell2.size() == 0))) {
     return;
   }
 
@@ -154,7 +177,7 @@ void CellFunctor<Particle, ParticleCell, ParticleFunctor, DataLayout, useNewton3
     return;
   }
 
-  switch (DataLayout) {
+  switch (dataLayout) {
     case DataLayoutOption::aos:
       if constexpr (useNewton3) {
         processCellPairAoSN3(cell1, cell2, sortingDirection);
@@ -172,10 +195,10 @@ void CellFunctor<Particle, ParticleCell, ParticleFunctor, DataLayout, useNewton3
   }
 }
 
-template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutOption::Value DataLayout,
+template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutOption::Value dataLayout,
           bool useNewton3, bool bidirectional>
 template <bool newton3>
-void CellFunctor<Particle, ParticleCell, ParticleFunctor, DataLayout, useNewton3, bidirectional>::processCellAoS(
+void CellFunctor<Particle, ParticleCell, ParticleFunctor, dataLayout, useNewton3, bidirectional>::processCellAoS(
     ParticleCell &cell) {
   // helper function
   const auto interactParticles = [&](auto &p1, auto &p2) {
@@ -217,9 +240,9 @@ void CellFunctor<Particle, ParticleCell, ParticleFunctor, DataLayout, useNewton3
   }
 }
 
-template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutOption::Value DataLayout,
+template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutOption::Value dataLayout,
           bool useNewton3, bool bidirectional>
-void CellFunctor<Particle, ParticleCell, ParticleFunctor, DataLayout, useNewton3, bidirectional>::processCellPairAoSN3(
+void CellFunctor<Particle, ParticleCell, ParticleFunctor, dataLayout, useNewton3, bidirectional>::processCellPairAoSN3(
     ParticleCell &cell1, ParticleCell &cell2, const std::array<double, 3> &sortingDirection) {
   if (cell1.size() + cell2.size() > _startSorting and sortingDirection != std::array<double, 3>{0., 0., 0.}) {
     SortedCellView<Particle, ParticleCell> cell1Sorted(cell1, sortingDirection);
@@ -242,9 +265,9 @@ void CellFunctor<Particle, ParticleCell, ParticleFunctor, DataLayout, useNewton3
   }
 }
 
-template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutOption::Value DataLayout,
+template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutOption::Value dataLayout,
           bool useNewton3, bool bidirectional>
-void CellFunctor<Particle, ParticleCell, ParticleFunctor, DataLayout, useNewton3,
+void CellFunctor<Particle, ParticleCell, ParticleFunctor, dataLayout, useNewton3,
                  bidirectional>::processCellPairAoSNoN3(ParticleCell &cell1, ParticleCell &cell2,
                                                         const std::array<double, 3> &sortingDirection) {
   // helper function
@@ -278,16 +301,16 @@ void CellFunctor<Particle, ParticleCell, ParticleFunctor, DataLayout, useNewton3
   }
 }
 
-template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutOption::Value DataLayout,
+template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutOption::Value dataLayout,
           bool useNewton3, bool bidirectional>
-void CellFunctor<Particle, ParticleCell, ParticleFunctor, DataLayout, useNewton3, bidirectional>::processCellPairSoAN3(
+void CellFunctor<Particle, ParticleCell, ParticleFunctor, dataLayout, useNewton3, bidirectional>::processCellPairSoAN3(
     ParticleCell &cell1, ParticleCell &cell2) {
   _functor->SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, true);
 }
 
-template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutOption::Value DataLayout,
+template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutOption::Value dataLayout,
           bool useNewton3, bool bidirectional>
-void CellFunctor<Particle, ParticleCell, ParticleFunctor, DataLayout, useNewton3,
+void CellFunctor<Particle, ParticleCell, ParticleFunctor, dataLayout, useNewton3,
                  bidirectional>::processCellPairSoANoN3(ParticleCell &cell1, ParticleCell &cell2) {
   _functor->SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, false);
   if constexpr (bidirectional) {
@@ -295,16 +318,16 @@ void CellFunctor<Particle, ParticleCell, ParticleFunctor, DataLayout, useNewton3
   }
 }
 
-template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutOption::Value DataLayout,
+template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutOption::Value dataLayout,
           bool useNewton3, bool bidirectional>
-void CellFunctor<Particle, ParticleCell, ParticleFunctor, DataLayout, useNewton3, bidirectional>::processCellSoAN3(
+void CellFunctor<Particle, ParticleCell, ParticleFunctor, dataLayout, useNewton3, bidirectional>::processCellSoAN3(
     ParticleCell &cell) {
   _functor->SoAFunctorSingle(cell._particleSoABuffer, true);
 }
 
-template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutOption::Value DataLayout,
+template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutOption::Value dataLayout,
           bool useNewton3, bool bidirectional>
-void CellFunctor<Particle, ParticleCell, ParticleFunctor, DataLayout, useNewton3, bidirectional>::processCellSoANoN3(
+void CellFunctor<Particle, ParticleCell, ParticleFunctor, dataLayout, useNewton3, bidirectional>::processCellSoANoN3(
     ParticleCell &cell) {
   _functor->SoAFunctorSingle(cell._particleSoABuffer, false);  // the functor has to enable this...
 }

--- a/src/autopas/pairwiseFunctors/CellFunctor.h
+++ b/src/autopas/pairwiseFunctors/CellFunctor.h
@@ -208,7 +208,9 @@ void CellFunctor<Particle, ParticleCell, ParticleFunctor, DataLayout, useNewton3
     }
   } else {
     for (auto cellIter1 = cell.begin(); cellIter1 != cell.end(); ++cellIter1) {
-      for (auto cellIter2 = std::next(cellIter1); cellIter2 != cell.end(); ++cellIter2) {
+      auto cellIter2 = cellIter1;
+      ++cellIter2;
+      for (; cellIter2 != cell.end(); ++cellIter2) {
         interactParticles(*cellIter1, *cellIter2);
       }
     }

--- a/src/autopas/pairwiseFunctors/CellFunctor.h
+++ b/src/autopas/pairwiseFunctors/CellFunctor.h
@@ -57,18 +57,19 @@ class CellFunctor {
    * Getter
    * @return
    */
-  DataLayoutOption::Value getDataLayout() const { return dataLayout; }
+  [[nodiscard]] DataLayoutOption::Value getDataLayout() const { return dataLayout; }
 
   /**
    * Getter
    * @return
    */
-  bool getNewton3() const { return useNewton3; }
+  [[nodiscard]] bool getNewton3() const { return useNewton3; }
 
   /**
    * Getter
+   * @return
    */
-  bool getBidirectional() const { return bidirectional; }
+  [[nodiscard]] bool getBidirectional() const { return bidirectional; }
 
  private:
   /**

--- a/src/autopas/pairwiseFunctors/CellFunctor.h
+++ b/src/autopas/pairwiseFunctors/CellFunctor.h
@@ -57,24 +57,18 @@ class CellFunctor {
    * Getter
    * @return
    */
-  DataLayoutOption::Value getDataLayout() const {
-    return dataLayout;
-  }
+  DataLayoutOption::Value getDataLayout() const { return dataLayout; }
 
   /**
    * Getter
    * @return
    */
-  bool getNewton3() const {
-    return useNewton3;
-  }
+  bool getNewton3() const { return useNewton3; }
 
   /**
    * Getter
    */
-  bool getBidirectional() const {
-    return bidirectional;
-  }
+  bool getBidirectional() const { return bidirectional; }
 
  private:
   /**

--- a/src/autopas/particles/OwnershipState.h
+++ b/src/autopas/particles/OwnershipState.h
@@ -58,7 +58,7 @@ enum class OwnershipState : int64_t {
  * @param b second operand
  * @return a & b
  */
-const inline OwnershipState operator&(const OwnershipState a, const OwnershipState b) {
+inline OwnershipState operator&(const OwnershipState a, const OwnershipState b) {
   return static_cast<OwnershipState>(static_cast<int64_t>(a) & static_cast<int64_t>(b));
 }
 
@@ -68,16 +68,16 @@ const inline OwnershipState operator&(const OwnershipState a, const OwnershipSta
  * @param b second operand
  * @return a | b
  */
-const inline OwnershipState operator|(const OwnershipState a, const OwnershipState b) {
+inline OwnershipState operator|(const OwnershipState a, const OwnershipState b) {
   return static_cast<OwnershipState>(static_cast<int64_t>(a) | static_cast<int64_t>(b));
 }
 
 /**
- * Returnes the int64_t value of a given OwnershipState
+ * Returns the int64_t value of a given OwnershipState
  *
  * @param a OwnershipState
  * @return const int64_t value of a given OwnershipState
  */
-const inline int64_t toInt64(const OwnershipState a) { return static_cast<int64_t>(a); }
+inline int64_t toInt64(const OwnershipState a) { return static_cast<int64_t>(a); }
 
 }  // namespace autopas

--- a/src/autopas/particles/OwnershipState.h
+++ b/src/autopas/particles/OwnershipState.h
@@ -28,6 +28,34 @@ enum class OwnershipState : int64_t {
 };
 
 /**
+ * Bitwise AND operator for OwnershipState
+ * @param a first operand
+ * @param b second operand
+ * @return a & b
+ */
+constexpr OwnershipState operator&(const OwnershipState a, const OwnershipState b) {
+  return static_cast<OwnershipState>(static_cast<int64_t>(a) & static_cast<int64_t>(b));
+}
+
+/**
+ * Bitwise OR operator for OwnershipState
+ * @param a first operand
+ * @param b second operand
+ * @return a | b
+ */
+constexpr OwnershipState operator|(const OwnershipState a, const OwnershipState b) {
+  return static_cast<OwnershipState>(static_cast<int64_t>(a) | static_cast<int64_t>(b));
+}
+
+/**
+ * Returns the int64_t value of a given OwnershipState
+ *
+ * @param a OwnershipState
+ * @return const int64_t value of a given OwnershipState
+ */
+constexpr int64_t toInt64(const OwnershipState a) { return static_cast<int64_t>(a); }
+
+/**
  * Insertion operator for OwnershipState.
  * This function enables passing ownershipState to an ostream via `<<`.
  * @param os
@@ -51,33 +79,4 @@ enum class OwnershipState : int64_t {
   }
   return os;
 }
-
-/**
- * Bitwise AND operator for OwnershipState
- * @param a first operand
- * @param b second operand
- * @return a & b
- */
-inline OwnershipState operator&(const OwnershipState a, const OwnershipState b) {
-  return static_cast<OwnershipState>(static_cast<int64_t>(a) & static_cast<int64_t>(b));
-}
-
-/**
- * Bitwise OR operator for OwnershipState
- * @param a first operand
- * @param b second operand
- * @return a | b
- */
-inline OwnershipState operator|(const OwnershipState a, const OwnershipState b) {
-  return static_cast<OwnershipState>(static_cast<int64_t>(a) | static_cast<int64_t>(b));
-}
-
-/**
- * Returns the int64_t value of a given OwnershipState
- *
- * @param a OwnershipState
- * @return const int64_t value of a given OwnershipState
- */
-inline int64_t toInt64(const OwnershipState a) { return static_cast<int64_t>(a); }
-
 }  // namespace autopas

--- a/tests/testAutopas/tests/pairwiseFunctors/CellFunctorTest.cpp
+++ b/tests/testAutopas/tests/pairwiseFunctors/CellFunctorTest.cpp
@@ -185,19 +185,20 @@ TYPED_TEST_P(CellFunctorTest, testOwnedAndHaloCellInteractionPair) {
 
           CellFunctorType cellFunctor(&ljFunctor, cutoff);
 
-          const auto &[forceCellA, forceCellB] = ownedHaloInteractionHelper<CellFunctorType>(
+          const auto &[forceParticleA, forceParticleB] = ownedHaloInteractionHelper<CellFunctorType>(
               cellFunctor, ownershipParticleA, ownershipParticleB, ownershipCellA, ownerShipStateCellB,
               cellFunctor.getDataLayout(), ljFunctor, false);
 
           ljFunctor.endTraversal(cellFunctor.getNewton3());
 
+          // EXPECTATIONS
           if (ownershipCellA == halo and ownerShipStateCellB == halo) {
-            EXPECT_NEAR(forceCellA, 0, 1e-13)
+            EXPECT_EQ(forceParticleA, 0)
                 << "Particle in Cell1 is experiencing force with both cells containing only halo particles."
                    "\nCell1: "
                 << ownershipCellA << "\nCell2: " << ownerShipStateCellB << "\nParticle in Cell1: " << ownershipParticleA
                 << "\nParticle in Cell2: " << ownershipParticleB;
-            EXPECT_NEAR(forceCellB, 0, 1e-13)
+            EXPECT_EQ(forceParticleB, 0)
                 << "Particle in Cell2 is experiencing force with with both cells containing only halo particles."
                    "\nCell1: "
                 << ownershipCellA << "\nCell2: " << ownerShipStateCellB << "\nParticle in Cell1: " << ownershipParticleA
@@ -205,23 +206,23 @@ TYPED_TEST_P(CellFunctorTest, testOwnedAndHaloCellInteractionPair) {
           } else if (ownershipCellA == halo and (not cellFunctor.getNewton3()) and
                      (not cellFunctor.getBidirectional())) {
             // if cell1 is halo, and NoN3 and no bidirectional we can skip the interaction
-            EXPECT_NEAR(forceCellA, 0, 1e-13)
-                << "Particle in Cell1 is experiencing force with "
-                   "OwnershipState halo, no newton3 and bidirectional off."
-                   "\nCell1: "
-                << ownershipCellA << "\nCell2: " << ownerShipStateCellB << "\nParticle in Cell1: " << ownershipParticleA
-                << "\nParticle in Cell2: " << ownershipParticleB;
+            EXPECT_EQ(forceParticleA, 0) << "Particle in Cell1 is experiencing force with "
+                                            "OwnershipState halo, no newton3 and bidirectional off."
+                                            "\nCell1: "
+                                         << ownershipCellA << "\nCell2: " << ownerShipStateCellB
+                                         << "\nParticle in Cell1: " << ownershipParticleA
+                                         << "\nParticle in Cell2: " << ownershipParticleB;
           } else {
             // in all other cases we expect force on particle in Cell1
-            EXPECT_TRUE(forceCellA > 0) << "Particle in Cell1 does not experience force."
-                                           "\nCell1: "
-                                        << ownershipCellA << "\nCell2: " << ownerShipStateCellB
-                                        << "\nParticle in Cell1: " << ownershipParticleA
-                                        << "\nParticle in Cell2: " << ownershipParticleB;
+            EXPECT_GT(forceParticleA, 0) << "Particle in Cell1 does not experience force."
+                                            "\nCell1: "
+                                         << ownershipCellA << "\nCell2: " << ownerShipStateCellB
+                                         << "\nParticle in Cell1: " << ownershipParticleA
+                                         << "\nParticle in Cell2: " << ownershipParticleB;
 
             // if bidirectional or newton3=true we expect also force on particle in Cell2
             if ((cellFunctor.getBidirectional() or cellFunctor.getNewton3()) and containsOwned(ownershipParticleB)) {
-              EXPECT_TRUE(forceCellB > 0)
+              EXPECT_GT(forceParticleB, 0)
                   << "Particle in Cell2 does not experience force."
                      "\nCell1: "
                   << ownershipCellA << "\nCell2: " << ownerShipStateCellB
@@ -270,34 +271,35 @@ TYPED_TEST_P(CellFunctorTest, testOwnedAndHaloCellInteractionSingle) {
 
         CellFunctorType cellFunctor(&ljFunctor, cutoff);
 
-        const auto &[forceCellA, forceCellB] = ownedHaloInteractionHelper<CellFunctorType>(
+        const auto &[forceParticleA, forceParticleB] = ownedHaloInteractionHelper<CellFunctorType>(
             cellFunctor, ownershipParticleA, ownershipParticleB, ownershipCellA, ownershipCellA,
             cellFunctor.getDataLayout(), ljFunctor, true);
 
         ljFunctor.endTraversal(cellFunctor.getNewton3());
 
+        // EXPECTATIONS
         if (ownershipCellA == halo) {
-          EXPECT_NEAR(forceCellA, 0, 1e-13) << "Particle 1 is experiencing force."
-                                               "\nCell1: "
-                                            << ownershipCellA << "\nParticle 1 in Cell1: " << ownershipParticleA
-                                            << "\nParticle 2 in Cell1: " << ownershipParticleB;
-          EXPECT_NEAR(forceCellB, 0, 1e-13) << "Particle 2 is experiencing force."
-                                               "\nCell1: "
-                                            << ownershipCellA << "\nParticle 1 in Cell1: " << ownershipParticleA
-                                            << "\nParticle 2 in Cell1: " << ownershipParticleB;
+          EXPECT_EQ(forceParticleA, 0) << "Particle 1 is experiencing force."
+                                          "\nCell1: "
+                                       << ownershipCellA << "\nParticle 1 in Cell1: " << ownershipParticleA
+                                       << "\nParticle 2 in Cell1: " << ownershipParticleB;
+          EXPECT_EQ(forceParticleB, 0) << "Particle 2 is experiencing force."
+                                          "\nCell1: "
+                                       << ownershipCellA << "\nParticle 1 in Cell1: " << ownershipParticleA
+                                       << "\nParticle 2 in Cell1: " << ownershipParticleB;
         } else {
           // in all other cases we expect force on particle in Cell1
-          EXPECT_TRUE(forceCellA > 0) << "Particle 1 in Cell1 does not experience force."
-                                         "\nCell1: "
-                                      << ownershipCellA << "\nParticle 1 in Cell1: " << ownershipParticleA
-                                      << "\nParticle 2 in Cell1: " << ownershipParticleB;
+          EXPECT_GT(forceParticleA, 0) << "Particle 1 in Cell1 does not experience force."
+                                          "\nCell1: "
+                                       << ownershipCellA << "\nParticle 1 in Cell1: " << ownershipParticleA
+                                       << "\nParticle 2 in Cell1: " << ownershipParticleB;
 
           // if bidirectional or newton3=true we expect also force on particle in Cell2
           if ((cellFunctor.getBidirectional() or cellFunctor.getNewton3()) and containsOwned(ownershipParticleB)) {
-            EXPECT_TRUE(forceCellB > 0) << "Particle 2 does not experience force."
-                                           "\nCell1: "
-                                        << ownershipCellA << "\nParticle 1 in Cell1: " << ownershipParticleA
-                                        << "\nParticle 2 in Cell1: " << ownershipParticleB;
+            EXPECT_GT(forceParticleB, 0) << "Particle 2 does not experience force."
+                                            "\nCell1: "
+                                         << ownershipCellA << "\nParticle 1 in Cell1: " << ownershipParticleA
+                                         << "\nParticle 2 in Cell1: " << ownershipParticleB;
           }
         }
       }

--- a/tests/testAutopas/tests/pairwiseFunctors/CellFunctorTest.cpp
+++ b/tests/testAutopas/tests/pairwiseFunctors/CellFunctorTest.cpp
@@ -12,71 +12,76 @@
  *
  */
 using CellFTestingTypes = ::testing::Types<
-    std::pair<autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
-                                             autopas::DataLayoutOption::aos, false, false>,
-              CellFunctorWrapper<autopas::DataLayoutOption::aos, false, false>>,
-    std::pair<autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
-                                             autopas::DataLayoutOption::aos, false, true>,
-              CellFunctorWrapper<autopas::DataLayoutOption::aos, false, true>>,
-    std::pair<autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
-                                             autopas::DataLayoutOption::aos, true, false>,
-              CellFunctorWrapper<autopas::DataLayoutOption::aos, true, false>>,
-    std::pair<autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
-                                             autopas::DataLayoutOption::aos, true, true>,
-              CellFunctorWrapper<autopas::DataLayoutOption::aos, true, true>>,
-    std::pair<autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
-                                             autopas::DataLayoutOption::soa, false, false>,
-              CellFunctorWrapper<autopas::DataLayoutOption::soa, false, false>>,
-    std::pair<autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
-                                             autopas::DataLayoutOption::soa, false, true>,
-              CellFunctorWrapper<autopas::DataLayoutOption::soa, false, true>>,
-    std::pair<autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
-                                             autopas::DataLayoutOption::soa, true, false>,
-              CellFunctorWrapper<autopas::DataLayoutOption::soa, true, false>>,
-    std::pair<autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
-                                             autopas::DataLayoutOption::soa, true, true>,
-              CellFunctorWrapper<autopas::DataLayoutOption::soa, true, true>>>;
+    autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
+                                   autopas::DataLayoutOption::aos, false, false>,
+    autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
+                                   autopas::DataLayoutOption::aos, false, true>,
+    autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
+                                   autopas::DataLayoutOption::aos, true, false>,
+    autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
+                                   autopas::DataLayoutOption::aos, true, true>,
+    autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
+                                   autopas::DataLayoutOption::soa, false, false>,
+    autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
+                                   autopas::DataLayoutOption::soa, false, true>,
+    autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
+                                   autopas::DataLayoutOption::soa, true, false>,
+    autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
+                                   autopas::DataLayoutOption::soa, true, true>>;
+
+/**
+ * Helper function for readability
+ * @param ownershipState
+ * @return True if the passed ownership state contains the bit for "owned".
+ */
+bool containsOwned(autopas::OwnershipState ownershipState) {
+  return static_cast<bool>(ownershipState & autopas::OwnershipState::owned);
+}
 
 /**
  * Helper for testOwnedAndHaloCellInteractionPair andtestOwnedAndHaloCellInteractionSingle that creates particles and
- * cells with given OwnershipStates, executes CellFunctor::processCellPair or CellFunctor::processCell and returnes the
+ * cells with given OwnershipStates, executes CellFunctor::processCellPair or CellFunctor::processCell and returns the
  * calculated forces on particles.
  *
  * @tparam T The type of CellFunctor
  * @param cellFunctor
- * @param osp1 OwnershipState for particle 1 (for testOwnedAndHaloCellInteractionPair this partile is in cell 1)
- * @param osp2 OwnershipState for particle 2 (for testOwnedAndHaloCellInteractionPair this partile is in cell 2)
- * @param osc1 OwnershipState for cell 1 (for testOwnedAndHaloCellInteractionSingle both particles are in this cell)
- * @param osc2 OwnershipState for cell 2 (only used in testOwnedAndHaloCellInteractionPair)
+ * @param ownershipParticle1 OwnershipState for particle 1 (for testOwnedAndHaloCellInteractionPair this particle is in
+ * cell 1)
+ * @param ownershipParticle2 OwnershipState for particle 2 (for testOwnedAndHaloCellInteractionPair this particle is in
+ * cell 2)
+ * @param ownershipCell1 OwnershipState for cell 1 (for testOwnedAndHaloCellInteractionSingle both particles are in this
+ * cell)
+ * @param ownershipCell2 OwnershipState for cell 2 (only used in testOwnedAndHaloCellInteractionPair)
  * @param dataLayout AoS or SoA
  * @param ljFunctor The functor to evaluate forces
  * @param singleCell boolean if called from testOwnedAndHaloCellInteractionPair (false) or from
  * testOwnedAndHaloCellInteractionSingle (true)
- * @return std::tuple<double, double>
+ * @return The force in X direction of the first particle in the first and second cell. In the single cell case
+ * the same force is returned twice. std::tuple<f0[0], f1[0]>
  */
 template <class T>
-std::tuple<double, double> ownedHaloInteractionHelper(T &cellFunctor, const autopas::OwnershipState osp1,
-                                                      const autopas::OwnershipState osp2,
-                                                      const autopas::OwnershipState osc1,
-                                                      const autopas::OwnershipState osc2,
+std::tuple<double, double> ownedHaloInteractionHelper(T &cellFunctor, const autopas::OwnershipState ownershipParticle1,
+                                                      const autopas::OwnershipState ownershipParticle2,
+                                                      const autopas::OwnershipState ownershipCell1,
+                                                      const autopas::OwnershipState ownershipCell2,
                                                       const autopas::DataLayoutOption dataLayout,
                                                       mdLib::LJFunctor<Molecule> &ljFunctor, bool singleCell) {
   // create two particles
   Molecule p1({0.6, 0.5, 0.5}, {0., 0., 0.}, 0);
-  p1.setOwnershipState(osp1);
+  p1.setOwnershipState(ownershipParticle1);
 
   Molecule p2({1.4, 0.5, 0.5}, {0., 0., 0.}, 1);
-  p2.setOwnershipState(osp2);
+  p2.setOwnershipState(ownershipParticle2);
 
   // create cells
   autopas::FullParticleCell<Molecule> cell1({1., 1., 1.});
   autopas::FullParticleCell<Molecule> cell2({1., 1., 1.});
 
-  cell1.setPossibleParticleOwnerships(osc1);
+  cell1.setPossibleParticleOwnerships(ownershipCell1);
   cell1.addParticle(p1);
 
   if (not singleCell) {
-    cell2.setPossibleParticleOwnerships(osc2);
+    cell2.setPossibleParticleOwnerships(ownershipCell2);
     cell2.addParticle(p2);
   } else {
     cell1.addParticle(p2);
@@ -109,7 +114,7 @@ std::tuple<double, double> ownedHaloInteractionHelper(T &cellFunctor, const auto
   }
 }
 
-TYPED_TEST_CASE_P(CellFunctorTest);
+TYPED_TEST_SUITE_P(CellFunctorTest);
 
 /**
  * Tests if pure halo-halo cell interactions or interactions between a halo cell and any other cell with newton3==false
@@ -118,72 +123,69 @@ TYPED_TEST_CASE_P(CellFunctorTest);
  *
  */
 TYPED_TEST_P(CellFunctorTest, testOwnedAndHaloCellInteractionPair) {
-  const double cutoff = 1.;
-  const double sigma = 1.;
-  const double epsilon = 1.;
+  using CellFunctorType = TypeParam;
 
-  using CellFT = typename TypeParam::first_type;
-  using CFWT = typename TypeParam::second_type;
+  constexpr double cutoff = 1.;
+  constexpr double sigma = 1.;
+  constexpr double epsilon = 1.;
 
-  for (auto ownerShipStateA : {autopas::OwnershipState::owned, autopas::OwnershipState::halo}) {
-    for (auto ownerShipStateB : {autopas::OwnershipState::owned, autopas::OwnershipState::halo}) {
-      for (auto ownerShipStateCellA :
-           {ownerShipStateA, (autopas::OwnershipState::owned | autopas::OwnershipState::halo)}) {
-        for (auto ownerShipStateCellB :
-             {ownerShipStateB, (autopas::OwnershipState::owned | autopas::OwnershipState::halo)}) {
+  // shorthands for readability
+  constexpr autopas::OwnershipState owned = autopas::OwnershipState::owned;
+  constexpr autopas::OwnershipState halo = autopas::OwnershipState::halo;
+  constexpr autopas::OwnershipState ownedOrHalo = autopas::OwnershipState::owned | autopas::OwnershipState::halo;
+
+  for (const auto ownershipParticleA : {owned, halo}) {
+    for (const auto ownershipParticleB : {owned, halo}) {
+      for (const auto ownershipCellA : {ownershipParticleA, ownedOrHalo}) {
+        for (const auto ownerShipStateCellB : {ownershipParticleB, ownedOrHalo}) {
           mdLib::LJFunctor<Molecule> ljFunctor(cutoff);
           ljFunctor.setParticleProperties(sigma, epsilon);
 
           ljFunctor.initTraversal();
 
-          CellFT cellFunctor(&ljFunctor, cutoff);
-          CFWT cfw;
+          CellFunctorType cellFunctor(&ljFunctor, cutoff);
 
-          std::tuple<double, double> result =
-              ownedHaloInteractionHelper<CellFT>(cellFunctor, ownerShipStateA, ownerShipStateB, ownerShipStateCellA,
-                                                 ownerShipStateCellB, cfw.dataLayoutV, ljFunctor, false);
+          const auto &[forceCellA, forceCellB] = ownedHaloInteractionHelper<CellFunctorType>(
+              cellFunctor, ownershipParticleA, ownershipParticleB, ownershipCellA, ownerShipStateCellB,
+              cellFunctor.getDataLayout(), ljFunctor, false);
 
-          ljFunctor.endTraversal(cfw.useNewton3V);
+          ljFunctor.endTraversal(cellFunctor.getNewton3());
 
-          if (ownerShipStateCellA == autopas::OwnershipState::halo and
-              ownerShipStateCellB == autopas::OwnershipState::halo) {
-            EXPECT_NEAR(std::get<0>(result), 0, 1e-13)
-                << "Particle in Cell1 is experiencing force with both cells containing only halo particles. "
-                   "OwnershipState of Cell1: "
-                << ownerShipStateCellA << ", OwnershipState of Cell2: " << ownerShipStateCellB
-                << ", OwnershipState of Particle in Cell1: " << ownerShipStateA
-                << ", OwnershipState of Particle in Cell2: " << ownerShipStateB;
-            EXPECT_NEAR(std::get<1>(result), 0, 1e-13)
-                << "Particle in Cell2 is experiencing force with with both cells containing only halo particles. "
-                   "OwnershipState of Cell1: "
-                << ownerShipStateCellA << ", OwnershipState of Cell2: " << ownerShipStateCellB
-                << ", OwnershipState of Particle in Cell1: " << ownerShipStateA
-                << ", OwnershipState of Particle in Cell2: " << ownerShipStateB;
-          } else if (ownerShipStateCellA == autopas::OwnershipState::halo and (not cfw.useNewton3V) and
-                     (not cfw.bidirectionalV)) {
+          if (ownershipCellA == halo and ownerShipStateCellB == halo) {
+            EXPECT_NEAR(forceCellA, 0, 1e-13)
+                << "Particle in Cell1 is experiencing force with both cells containing only halo particles."
+                   "\nCell1: "
+                << ownershipCellA << "\nCell2: " << ownerShipStateCellB << "\nParticle in Cell1: " << ownershipParticleA
+                << "\nParticle in Cell2: " << ownershipParticleB;
+            EXPECT_NEAR(forceCellB, 0, 1e-13)
+                << "Particle in Cell2 is experiencing force with with both cells containing only halo particles."
+                   "\nCell1: "
+                << ownershipCellA << "\nCell2: " << ownerShipStateCellB << "\nParticle in Cell1: " << ownershipParticleA
+                << "\nParticle in Cell2: " << ownershipParticleB;
+          } else if (ownershipCellA == halo and (not cellFunctor.getNewton3()) and
+                     (not cellFunctor.getBidirectional())) {
             // if cell1 is halo, and NoN3 and no bidirectional we can skip the interaction
-            EXPECT_NEAR(std::get<0>(result), 0, 1e-13)
+            EXPECT_NEAR(forceCellA, 0, 1e-13)
                 << "Particle in Cell1 is experiencing force with "
-                   "OwnershipState halo, no newton3 and bidirectional off. "
-                   "OwnershipState of Cell1: "
-                << ownerShipStateCellA << ", OwnershipState of Cell2: " << ownerShipStateCellB
-                << ", OwnershipState of Particle in Cell1: " << ownerShipStateA
-                << ", OwnershipState of Particle in Cell2: " << ownerShipStateB;
+                   "OwnershipState halo, no newton3 and bidirectional off."
+                   "\nCell1: "
+                << ownershipCellA << "\nCell2: " << ownerShipStateCellB << "\nParticle in Cell1: " << ownershipParticleA
+                << "\nParticle in Cell2: " << ownershipParticleB;
           } else {
             // in all other cases we expect force on particle in Cell1
-            EXPECT_TRUE(std::get<0>(result) > 0)
-                << "Particle in Cell1 does not experience force. OwnershipState of Cell1: " << ownerShipStateCellA
-                << ", OwnershipState of Cell2: " << ownerShipStateCellB
-                << ", OwnershipState of Particle in Cell1: " << ownerShipStateA
-                << ", OwnershipState of Particle in Cell2: " << ownerShipStateB;
+            EXPECT_TRUE(forceCellA > 0) << "Particle in Cell1 does not experience force."
+                                           "\nCell1: "
+                                        << ownershipCellA << "\nCell2: " << ownerShipStateCellB
+                                        << "\nParticle in Cell1: " << ownershipParticleA
+                                        << "\nParticle in Cell2: " << ownershipParticleB;
 
             // if bidirectional or newton3=true we expect also force on particle in Cell2
-            if (cfw.bidirectionalV or cfw.useNewton3V) {
-              EXPECT_TRUE(std::get<1>(result) > 0)
-                  << "Particle in Cell2 does not experience force. OwnershipState of Cell1: " << ownerShipStateCellA
-                  << ", OwnershipState of Cell2: " << ownerShipStateCellB
-                  << ", OwnershipState of Particle in Cell1: " << ownerShipStateA
-                  << ", OwnershipState of Particle in Cell2: " << ownerShipStateB;
+            if ((cellFunctor.getBidirectional() or cellFunctor.getNewton3()) and containsOwned(ownershipParticleB)) {
+              EXPECT_TRUE(forceCellB > 0)
+                  << "Particle in Cell2 does not experience force."
+                     "\nCell1: "
+                  << ownershipCellA << "\nCell2: " << ownerShipStateCellB
+                  << "\nParticle in Cell1: " << ownershipParticleA << "\nParticle in Cell2: " << ownershipParticleB;
             }
           }
         }
@@ -198,24 +200,25 @@ TYPED_TEST_P(CellFunctorTest, testOwnedAndHaloCellInteractionPair) {
  *
  */
 TYPED_TEST_P(CellFunctorTest, testOwnedAndHaloCellInteractionSingle) {
-  const double cutoff = 1.;
-  const double sigma = 1.;
-  const double epsilon = 1.;
+  using CellFunctorType = TypeParam;
 
-  using CellFT = typename TypeParam::first_type;
-  using CFWT = typename TypeParam::second_type;
+  constexpr double cutoff = 1.;
+  constexpr double sigma = 1.;
+  constexpr double epsilon = 1.;
 
-  for (auto ownerShipStateA : {autopas::OwnershipState::owned, autopas::OwnershipState::halo}) {
-    for (auto ownerShipStateB : {autopas::OwnershipState::owned, autopas::OwnershipState::halo}) {
-      for (auto ownerShipStateCellA :
-           {ownerShipStateA, (autopas::OwnershipState::owned | autopas::OwnershipState::halo)}) {
-        // skip unapplicable cases
-        if (ownerShipStateCellA == autopas::OwnershipState::owned and
-            ownerShipStateB == autopas::OwnershipState::halo) {
+  // shorthands for readability
+  constexpr autopas::OwnershipState owned = autopas::OwnershipState::owned;
+  constexpr autopas::OwnershipState halo = autopas::OwnershipState::halo;
+  constexpr autopas::OwnershipState ownedOrHalo = autopas::OwnershipState::owned | autopas::OwnershipState::halo;
+
+  for (const auto ownershipParticleA : {owned, halo}) {
+    for (const auto ownershipParticleB : {owned, halo}) {
+      for (const auto ownershipCellA : {ownershipParticleA, ownedOrHalo}) {
+        // skip inapplicable cases
+        if (ownershipCellA == owned and ownershipParticleB == halo) {
           continue;
         }
-        if (ownerShipStateCellA == autopas::OwnershipState::halo and
-            ownerShipStateB == autopas::OwnershipState::owned) {
+        if (ownershipCellA == halo and ownershipParticleB == owned) {
           continue;
         }
 
@@ -224,37 +227,36 @@ TYPED_TEST_P(CellFunctorTest, testOwnedAndHaloCellInteractionSingle) {
 
         ljFunctor.initTraversal();
 
-        CellFT cellFunctor(&ljFunctor, cutoff);
-        CFWT cfw;
+        CellFunctorType cellFunctor(&ljFunctor, cutoff);
 
-        std::tuple<double, double> result =
-            ownedHaloInteractionHelper<CellFT>(cellFunctor, ownerShipStateA, ownerShipStateB, ownerShipStateCellA,
-                                               ownerShipStateCellA, cfw.dataLayoutV, ljFunctor, true);
+        const auto &[forceCellA, forceCellB] = ownedHaloInteractionHelper<CellFunctorType>(
+            cellFunctor, ownershipParticleA, ownershipParticleB, ownershipCellA, ownershipCellA,
+            cellFunctor.getDataLayout(), ljFunctor, true);
 
-        ljFunctor.endTraversal(cfw.useNewton3V);
+        ljFunctor.endTraversal(cellFunctor.getNewton3());
 
-        if (ownerShipStateCellA == autopas::OwnershipState::halo) {
-          EXPECT_NEAR(std::get<0>(result), 0, 1e-13)
-              << "Particle 1 is experiencing force. OwnershipState of Cell1: " << ownerShipStateCellA
-              << ", OwnershipState of Particle 1 in Cell1: " << ownerShipStateA
-              << ", OwnershipState of Particle 2 in Cell1: " << ownerShipStateB;
-          EXPECT_NEAR(std::get<1>(result), 0, 1e-13)
-              << "Particle 2 is experiencing force. OwnershipState of Cell1: " << ownerShipStateCellA
-              << ", OwnershipState of Particle 1 in Cell1: " << ownerShipStateA
-              << ", OwnershipState of Particle 2 in Cell1: " << ownerShipStateB;
+        if (ownershipCellA == halo) {
+          EXPECT_NEAR(forceCellA, 0, 1e-13) << "Particle 1 is experiencing force."
+                                               "\nCell1: "
+                                            << ownershipCellA << "\nParticle 1 in Cell1: " << ownershipParticleA
+                                            << "\nParticle 2 in Cell1: " << ownershipParticleB;
+          EXPECT_NEAR(forceCellB, 0, 1e-13) << "Particle 2 is experiencing force."
+                                               "\nCell1: "
+                                            << ownershipCellA << "\nParticle 1 in Cell1: " << ownershipParticleA
+                                            << "\nParticle 2 in Cell1: " << ownershipParticleB;
         } else {
           // in all other cases we expect force on particle in Cell1
-          EXPECT_TRUE(std::get<0>(result) > 0)
-              << "Particle 1 in Cell1 does not experience force. OwnershipState of Cell1: " << ownerShipStateCellA
-              << ", OwnershipState of Particle 1 in Cell1: " << ownerShipStateA
-              << ", OwnershipState of Particle 2 in Cell1: " << ownerShipStateB;
+          EXPECT_TRUE(forceCellA > 0) << "Particle 1 in Cell1 does not experience force."
+                                         "\nCell1: "
+                                      << ownershipCellA << "\nParticle 1 in Cell1: " << ownershipParticleA
+                                      << "\nParticle 2 in Cell1: " << ownershipParticleB;
 
           // if bidirectional or newton3=true we expect also force on particle in Cell2
-          if (cfw.bidirectionalV or cfw.useNewton3V) {
-            EXPECT_TRUE(std::get<1>(result) > 0)
-                << "Particle 2 does not experience force. OwnershipState of Cell1: " << ownerShipStateCellA
-                << ", OwnershipState of Particle 1 in Cell1: " << ownerShipStateA
-                << ", OwnershipState of Particle 2 in Cell1: " << ownerShipStateB;
+          if ((cellFunctor.getBidirectional() or cellFunctor.getNewton3()) and containsOwned(ownershipParticleB)) {
+            EXPECT_TRUE(forceCellB > 0) << "Particle 2 does not experience force."
+                                           "\nCell1: "
+                                        << ownershipCellA << "\nParticle 1 in Cell1: " << ownershipParticleA
+                                        << "\nParticle 2 in Cell1: " << ownershipParticleB;
           }
         }
       }
@@ -262,5 +264,6 @@ TYPED_TEST_P(CellFunctorTest, testOwnedAndHaloCellInteractionSingle) {
   }
 }
 
-REGISTER_TYPED_TEST_CASE_P(CellFunctorTest, testOwnedAndHaloCellInteractionPair, testOwnedAndHaloCellInteractionSingle);
-INSTANTIATE_TYPED_TEST_CASE_P(TypedTest, CellFunctorTest, CellFTestingTypes);
+REGISTER_TYPED_TEST_SUITE_P(CellFunctorTest, testOwnedAndHaloCellInteractionPair,
+                            testOwnedAndHaloCellInteractionSingle);
+INSTANTIATE_TYPED_TEST_SUITE_P(TypedTest, CellFunctorTest, CellFTestingTypes);

--- a/tests/testAutopas/tests/pairwiseFunctors/CellFunctorTest.cpp
+++ b/tests/testAutopas/tests/pairwiseFunctors/CellFunctorTest.cpp
@@ -6,28 +6,65 @@
 
 #include "CellFunctorTest.h"
 
+// Type aliases via inheritance for more readable test names (using declarations do not work for this)
+struct CellFunctor_AoS_NoN3_NoBi
+    : public autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
+                                            autopas::DataLayoutOption::aos, false, false> {
+  CellFunctor_AoS_NoN3_NoBi(mdLib::LJFunctor<Molecule> *f, const double sortingCutoff)
+      : CellFunctor(f, sortingCutoff) {}
+};
+struct CellFunctor_AoS_NoN3_Bi
+    : public autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
+                                            autopas::DataLayoutOption::aos, false, true> {
+  CellFunctor_AoS_NoN3_Bi(mdLib::LJFunctor<Molecule> *f, const double sortingCutoff) : CellFunctor(f, sortingCutoff) {}
+};
+struct CellFunctor_AoS_N3_NoBi
+    : public autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
+                                            autopas::DataLayoutOption::aos, true, false> {
+  CellFunctor_AoS_N3_NoBi(mdLib::LJFunctor<Molecule> *f, const double sortingCutoff) : CellFunctor(f, sortingCutoff) {}
+};
+struct CellFunctor_AoS_N3_Bi
+    : public autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
+                                            autopas::DataLayoutOption::aos, true, true> {
+  CellFunctor_AoS_N3_Bi(mdLib::LJFunctor<Molecule> *f, const double sortingCutoff) : CellFunctor(f, sortingCutoff) {}
+};
+struct CellFunctor_SoA_NoN3_NoBi
+    : public autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
+                                            autopas::DataLayoutOption::soa, false, false> {
+  CellFunctor_SoA_NoN3_NoBi(mdLib::LJFunctor<Molecule> *f, const double sortingCutoff)
+      : CellFunctor(f, sortingCutoff) {}
+};
+struct CellFunctor_SoA_NoN3_Bi
+    : public autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
+                                            autopas::DataLayoutOption::soa, false, true> {
+  CellFunctor_SoA_NoN3_Bi(mdLib::LJFunctor<Molecule> *f, const double sortingCutoff) : CellFunctor(f, sortingCutoff) {}
+};
+struct CellFunctor_SoA_N3_NoBi
+    : public autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
+                                            autopas::DataLayoutOption::soa, true, false> {
+  CellFunctor_SoA_N3_NoBi(mdLib::LJFunctor<Molecule> *f, const double sortingCutoff) : CellFunctor(f, sortingCutoff) {}
+};
+struct CellFunctor_SoA_N3_Bi
+    : public autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
+                                            autopas::DataLayoutOption::soa, true, true> {
+  CellFunctor_SoA_N3_Bi(mdLib::LJFunctor<Molecule> *f, const double sortingCutoff) : CellFunctor(f, sortingCutoff) {}
+};
+
 /**
  * All relevant CellFunctor configurations which are used to instantiate the typed test cases
  * testOwnedAndHaloCellInteractionPair and testOwnedAndHaloCellInteractionSingle
  *
  */
-using CellFTestingTypes = ::testing::Types<
-    autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
-                                   autopas::DataLayoutOption::aos, false, false>,
-    autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
-                                   autopas::DataLayoutOption::aos, false, true>,
-    autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
-                                   autopas::DataLayoutOption::aos, true, false>,
-    autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
-                                   autopas::DataLayoutOption::aos, true, true>,
-    autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
-                                   autopas::DataLayoutOption::soa, false, false>,
-    autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
-                                   autopas::DataLayoutOption::soa, false, true>,
-    autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
-                                   autopas::DataLayoutOption::soa, true, false>,
-    autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>, mdLib::LJFunctor<Molecule>,
-                                   autopas::DataLayoutOption::soa, true, true>>;
+// clang-format off
+using CellFTestingTypes = ::testing::Types<CellFunctor_AoS_NoN3_NoBi,
+                                           CellFunctor_AoS_NoN3_Bi,
+                                           CellFunctor_AoS_N3_NoBi,
+                                           CellFunctor_AoS_N3_Bi,
+                                           CellFunctor_SoA_NoN3_NoBi,
+                                           CellFunctor_SoA_NoN3_Bi,
+                                           CellFunctor_SoA_N3_NoBi,
+                                           CellFunctor_SoA_N3_Bi>;
+// clang-format on
 
 /**
  * Helper function for readability

--- a/tests/testAutopas/tests/pairwiseFunctors/CellFunctorTest.cpp
+++ b/tests/testAutopas/tests/pairwiseFunctors/CellFunctorTest.cpp
@@ -288,12 +288,13 @@ TYPED_TEST_P(CellFunctorTest, testOwnedAndHaloCellInteractionSingle) {
                                        << ownershipCellA << "\nParticle 1 in Cell1: " << ownershipParticleA
                                        << "\nParticle 2 in Cell1: " << ownershipParticleB;
         } else {
-          // in all other cases we expect force on particle in Cell1
-          EXPECT_GT(forceParticleA, 0) << "Particle 1 in Cell1 does not experience force."
-                                          "\nCell1: "
-                                       << ownershipCellA << "\nParticle 1 in Cell1: " << ownershipParticleA
-                                       << "\nParticle 2 in Cell1: " << ownershipParticleB;
-
+          // in all other cases we expect force on particle A in Cell1 as long as it is owned.
+          if (containsOwned(ownershipParticleA)) {
+            EXPECT_GT(forceParticleA, 0) << "Particle 1 in Cell1 does not experience force."
+                                            "\nCell1: "
+                                         << ownershipCellA << "\nParticle 1 in Cell1: " << ownershipParticleA
+                                         << "\nParticle 2 in Cell1: " << ownershipParticleB;
+          }
           // if bidirectional or newton3=true we expect also force on particle in Cell2
           if ((cellFunctor.getBidirectional() or cellFunctor.getNewton3()) and containsOwned(ownershipParticleB)) {
             EXPECT_GT(forceParticleB, 0) << "Particle 2 does not experience force."

--- a/tests/testAutopas/tests/pairwiseFunctors/CellFunctorTest.cpp
+++ b/tests/testAutopas/tests/pairwiseFunctors/CellFunctorTest.cpp
@@ -154,10 +154,12 @@ std::tuple<double, double> ownedHaloInteractionHelper(T &cellFunctor, const auto
 TYPED_TEST_SUITE_P(CellFunctorTest);
 
 /**
- * Tests if pure halo-halo cell interactions or interactions between a halo cell and any other cell with newton3==false
- * and bidirection==false are skipped in the CellFunctor (no forces are calculated). Tests if all other interactions
- * result in force calculations.
  *
+ * Tests if the cell functor skips the cell interactions:
+ *  - halo <-> halo
+ *  - halo  -> any
+ *
+ * All other interaction combinations should be applied.
  */
 TYPED_TEST_P(CellFunctorTest, testOwnedAndHaloCellInteractionPair) {
   using CellFunctorType = TypeParam;
@@ -171,6 +173,7 @@ TYPED_TEST_P(CellFunctorTest, testOwnedAndHaloCellInteractionPair) {
   constexpr autopas::OwnershipState halo = autopas::OwnershipState::halo;
   constexpr autopas::OwnershipState ownedOrHalo = autopas::OwnershipState::owned | autopas::OwnershipState::halo;
 
+  // Test all reasonable combinations of owned / halo particles and cells
   for (const auto ownershipParticleA : {owned, halo}) {
     for (const auto ownershipParticleB : {owned, halo}) {
       for (const auto ownershipCellA : {ownershipParticleA, ownedOrHalo}) {
@@ -232,8 +235,8 @@ TYPED_TEST_P(CellFunctorTest, testOwnedAndHaloCellInteractionPair) {
 }
 
 /**
- * Tests if force calculation is skipped in the CellFunctor with a pure halo cell. Checks if force calculations are done
- * for a cell that can contain owned particles.
+ * Tests if force calculation is skipped in the CellFunctor with a pure halo cell. Checks if force calculations are
+ * done for a cell that can contain owned particles.
  *
  */
 TYPED_TEST_P(CellFunctorTest, testOwnedAndHaloCellInteractionSingle) {
@@ -248,6 +251,7 @@ TYPED_TEST_P(CellFunctorTest, testOwnedAndHaloCellInteractionSingle) {
   constexpr autopas::OwnershipState halo = autopas::OwnershipState::halo;
   constexpr autopas::OwnershipState ownedOrHalo = autopas::OwnershipState::owned | autopas::OwnershipState::halo;
 
+  // Test all reasonable combinations of owned / halo particles and cells
   for (const auto ownershipParticleA : {owned, halo}) {
     for (const auto ownershipParticleB : {owned, halo}) {
       for (const auto ownershipCellA : {ownershipParticleA, ownedOrHalo}) {

--- a/tests/testAutopas/tests/pairwiseFunctors/CellFunctorTest.h
+++ b/tests/testAutopas/tests/pairwiseFunctors/CellFunctorTest.h
@@ -13,19 +13,6 @@
 #include "testingHelpers/LJPotential.h"
 #include "testingHelpers/commonTypedefs.h"
 
-/**
- * Helper struct to get access to template parameters
- */
-template <autopas::DataLayoutOption::Value dataLayout, bool useNewton3, bool bidirectional>
-struct CellFunctorWrapper {
-  using CellFT = autopas::internal::CellFunctor<Molecule, autopas::FullParticleCell<Molecule>,
-                                                mdLib::LJFunctor<Molecule>, dataLayout, useNewton3, bidirectional>;
-
-  static const autopas::DataLayoutOption::Value dataLayoutV = dataLayout;
-  static const bool useNewton3V = useNewton3;
-  static const bool bidirectionalV = bidirectional;
-};
-
 template <typename T>
 class CellFunctorTest : public AutoPasTestBase {
  public:


### PR DESCRIPTION
# Description

All containers do too many unnecessary halo-halo interactions. This PR tries to lower the amount of these interactions. A complete elimination seems too much effort at this point but anything that can be ignored due to knowledge about the layout of the domain and container should be ignored.

## Related Pull Requests

- only possible thanks to #745

## ~Resolved Issues~

# How Has This Been Tested?

- [x] Existing unit tests, especially those that compare containers to calculate the correct potentials and globals.
- [x] Update CellFunctorTest expectations.
