### PR TITLE
Add loadEstimatorOptions to Relevant Options

### DIFF
--- a/examples/md-flexible/src/configuration/CLIParser.cpp
+++ b/examples/md-flexible/src/configuration/CLIParser.cpp
@@ -68,6 +68,7 @@ MDFlexParser::exitCodes MDFlexParser::CLIParser::parseInput(int argc, char **arg
       config.iterations,
       config.loadBalancer,
       config.loadBalancingInterval,
+      config.loadEstimatorOptions,
       config.logFileName,
       config.logLevel,
       config.maxTuningPhasesWithoutTest,


### PR DESCRIPTION
# Description

`loadEstimatorOptions` was missing from `MDFlexConfig::relevantOptions`. Thus it was not included in zsh completions and help messages.
