### PR TITLE
Parallelize LeavingParticleCollector

### DIFF
--- a/examples/md-flexible/src/TimeDiscretization.cpp
+++ b/examples/md-flexible/src/TimeDiscretization.cpp
@@ -32,17 +32,19 @@ void calculatePositionsAndResetForces(autopas::AutoPas<ParticleType> &autoPasCon
     v *= deltaT;
     f *= (deltaT * deltaT / (2 * m));
     const auto displacement = v + f;
-    // sanity check that particles are not too fast for the Verlet skin technique.
-    // If this condition is violated once this is not necessarily an error. Only if the total distance traveled over
-    // the whole rebuild frequency is farther than the skin we lose interactions.
-    const auto distanceMovedSquared = dot(displacement, displacement);
-    if (distanceMovedSquared > maxAllowedDistanceMovedSquared) {
+    // sanity check that particles are not too fast for the Verlet skin technique. Only makes sense if skin > 0.
+    if (maxAllowedDistanceMoved > 0) {
+      // If this condition is violated once this is not necessarily an error. Only if the total distance traveled over
+      // the whole rebuild frequency is farther than the skin we lose interactions.
+      const auto distanceMovedSquared = dot(displacement, displacement);
+      if (distanceMovedSquared > maxAllowedDistanceMovedSquared) {
 #pragma omp critical
-      std::cerr << "A particle moved farther than verletSkinPerTimestep/2: " << std::sqrt(distanceMovedSquared) << " > "
-                << autoPasContainer.getVerletSkinPerTimestep() << "/2 = " << maxAllowedDistanceMoved << "\n"
-                << *iter << "\nNew Position: " << iter->getR() + displacement << std::endl;
-      if (fastParticlesThrow) {
-        throwException = true;
+        std::cerr << "A particle moved farther than verletSkinPerTimestep/2: " << std::sqrt(distanceMovedSquared)
+                  << " > " << autoPasContainer.getVerletSkinPerTimestep() << "/2 = " << maxAllowedDistanceMoved << "\n"
+                  << *iter << "\nNew Position: " << iter->getR() + displacement << std::endl;
+        if (fastParticlesThrow) {
+          throwException = true;
+        }
       }
     }
     iter->addR(displacement);

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -260,6 +260,7 @@ void RegularGridDecomposition::exchangeMigratingParticles(AutoPasType &autoPasCo
       sendAndReceiveParticlesLeftAndRight(_particlesForLeftNeighbor, _particlesForRightNeighbor,
                                           _receivedParticlesBuffer, leftNeighbor, rightNeighbor);
 #ifdef AUTOPAS_OPENMP
+// custom openmp reduction to concatenate all local vectors to one at the end of a parallel region
 #pragma omp declare reduction(vecMergeParticle : std::remove_reference_t<decltype(emigrants)> : omp_out.insert(omp_out.end(), omp_in.begin(), omp_in.end()))
 // make sure each buffer gets filled equally while not inducing scheduling overhead
 #pragma omp parallel for reduction(vecMergeParticle \

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -111,7 +111,7 @@ class LogicHandler {
         }
         buffer.clear();
       } else {
-        for (auto iter = buffer.begin(); iter != buffer.end();) {
+        for (auto iter = buffer.begin(); iter < buffer.end();) {
           auto &p = *iter;
 
           auto fastRemoveP = [&]() {
@@ -124,7 +124,9 @@ class LogicHandler {
             // We remove dummies!
             fastRemoveP();
           }
-          if (utils::notInBox(p.getR(), boxMin, boxMax)) {
+          // if p was a dummy a new particle might now be at the memory location of p so we need to check that.
+          // We also just might have deleted the last particle in the buffer in that case the inBox check is meaningless
+          if (not buffer.empty() and utils::notInBox(p.getR(), boxMin, boxMax)) {
             leavingBufferParticles.push_back(p);
             fastRemoveP();
           } else {

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -124,6 +124,8 @@ class LogicHandler {
           if (p.isDummy()) {
             // We remove dummies!
             fastRemoveP();
+            // In case we swapped a dummy here, don't increment the iterator and do another iteration to check again.
+            continue;
           }
           // if p was a dummy a new particle might now be at the memory location of p so we need to check that.
           // We also just might have deleted the last particle in the buffer in that case the inBox check is meaningless

--- a/src/autopas/containers/LeavingParticleCollector.h
+++ b/src/autopas/containers/LeavingParticleCollector.h
@@ -64,6 +64,7 @@ std::vector<typename ContainerType::ParticleType> collectParticlesAndMarkNonOwne
 
   std::vector<typename ContainerType::ParticleType> leavingParticles{};
 #ifdef AUTOPAS_OPENMP
+  // custom openmp reduction to concatenate all local vectors to one at the end of a parallel region
 #pragma omp declare reduction(vecMergeParticle : std::vector<typename ContainerType::ParticleType> : omp_out.insert(omp_out.end(), omp_in.begin(), omp_in.end()))
   // this has to be a `parallel` and not `parallel for` because we are actually interested in parallelizing the inner
   // loops without having a barrier between outer loop iterations.

--- a/src/autopas/containers/LeavingParticleCollector.h
+++ b/src/autopas/containers/LeavingParticleCollector.h
@@ -28,12 +28,14 @@ std::vector<typename ContainerType::ParticleType> collectParticlesAndMarkNonOwne
   using namespace autopas::utils::ArrayMath::literals;
 
   const auto interactionLength = container.getInteractionLength();
-  const auto skin = container.getVerletSkin();
   const auto containerDimensions = container.getBoxMax() - container.getBoxMin();
   const auto lowerHaloCorner = container.getBoxMin() - interactionLength;
   const auto upperHaloCorner = container.getBoxMax() + interactionLength;
-  const auto lowerInnerCorner = container.getBoxMin() + skin;
-  const auto upperInnerCorner = container.getBoxMax() - skin;
+  // We need to extend these boundaries into the container because we need to find particles that are stored in the
+  // container but have since moved out. Extending by skin is not enough since we are interested in particles that have
+  // travelled beyond that and skin can be 0.
+  const auto lowerInnerCorner = container.getBoxMin() + interactionLength;
+  const auto upperInnerCorner = container.getBoxMax() - interactionLength;
 
   // volumes describing the halo regions on the six faces of the cuboid shaped container.
   const std::array<std::tuple<decltype(lowerHaloCorner), decltype(upperHaloCorner)>, 6> haloVolumes{{

--- a/src/autopas/containers/LeavingParticleCollector.h
+++ b/src/autopas/containers/LeavingParticleCollector.h
@@ -31,8 +31,8 @@ std::vector<typename ContainerType::ParticleType> collectParticlesAndMarkNonOwne
   const auto containerDimensions = container.getBoxMax() - container.getBoxMin();
   const auto lowerHaloCorner = container.getBoxMin() - upperBoundForMisplacement;
   const auto upperHaloCorner = container.getBoxMax() + upperBoundForMisplacement;
-  // We need to extend these boundaries into the container because we need to find particles that are stored in the
-  // container but have since moved out. Extending by skin is not enough since we are interested in particles that have
+  // We need to extend these boundaries into the container because we need to include cells that still hold particles,
+  // which now have left the cells region towards the outside of the container.
   // travelled beyond that and skin can be 0.
   const auto lowerInnerCorner = container.getBoxMin() + upperBoundForMisplacement;
   const auto upperInnerCorner = container.getBoxMax() - upperBoundForMisplacement;

--- a/src/autopas/containers/LeavingParticleCollector.h
+++ b/src/autopas/containers/LeavingParticleCollector.h
@@ -58,12 +58,14 @@ std::vector<typename ContainerType::ParticleType> collectParticlesAndMarkNonOwne
   }};
 
   std::vector<typename ContainerType::ParticleType> leavingParticles{};
+#ifdef AUTOPAS_OPENMP
 #pragma omp declare reduction(vecMergeParticle : std::vector<typename ContainerType::ParticleType> : omp_out.insert(omp_out.end(), omp_in.begin(), omp_in.end()))
   // this has to be a `parallel` and not `parallel for` because we are actually interested in parallelizing the inner
   // loops without having a barrier between outer loop iterations.
   // The way this works is that all threads iterate the outer loop but due to the way the iterators are parallelized,
   // each thread only picks its iterations of the inner loops, hence nothing is done multiple times.
 #pragma omp parallel reduction(vecMergeParticle : leavingParticles)
+#endif
   for (const auto &[regionStart, regionEnd] : haloVolumes) {
     for (auto iter = container.getRegionIterator(regionStart, regionEnd, autopas::IteratorBehavior::ownedOrHalo);
          iter.isValid(); ++iter) {

--- a/src/autopas/containers/LeavingParticleCollector.h
+++ b/src/autopas/containers/LeavingParticleCollector.h
@@ -38,22 +38,27 @@ std::vector<typename ContainerType::ParticleType> collectParticlesAndMarkNonOwne
   const auto upperInnerCorner = container.getBoxMax() - upperBoundForMisplacement;
 
   // volumes describing the halo regions on the six faces of the cuboid shaped container.
+  // The total volume can be thought of as:
+  // 6 faces
+  // 8 corners
+  // 12 edges
+  // These 26 pieces are combined to six volumes, the minimal number to cover it with region iterators.
   const std::array<std::tuple<decltype(lowerHaloCorner), decltype(upperHaloCorner)>, 6> haloVolumes{{
-      // left + lower edge
+      // left face + edge shared by left and bottom faces
       {{lowerHaloCorner[0], lowerInnerCorner[1], lowerHaloCorner[2]},
        {lowerInnerCorner[0], upperInnerCorner[1], upperInnerCorner[2]}},
-      // right + upper edge
+      // right face + edge shared by right and upper faces
       {{upperInnerCorner[0], lowerInnerCorner[1], lowerInnerCorner[2]},
        {upperHaloCorner[0], upperInnerCorner[1], upperHaloCorner[2]}},
-      // top + left edge
+      // top face + edge shared by left and top faces
       {{lowerHaloCorner[0], lowerInnerCorner[1], upperInnerCorner[2]},
        {upperInnerCorner[0], upperInnerCorner[1], upperHaloCorner[2]}},
-      // bottom + right edge
+      // bottom face + edge shared by right and bottom faces
       {{lowerInnerCorner[0], lowerInnerCorner[1], lowerHaloCorner[2]},
        {upperHaloCorner[0], upperInnerCorner[1], lowerInnerCorner[2]}},
-      // front with all edges and corners
+      // front face with the all adjacent four edges and four corners
       {lowerHaloCorner, {upperHaloCorner[0], lowerInnerCorner[1], upperHaloCorner[2]}},
-      // back with all edges and corners
+      // back face with the all adjacent four edges and four corners
       {{lowerHaloCorner[0], upperInnerCorner[1], lowerHaloCorner[2]}, upperHaloCorner},
   }};
 

--- a/src/autopas/containers/LeavingParticleCollector.h
+++ b/src/autopas/containers/LeavingParticleCollector.h
@@ -11,11 +11,10 @@
 #include "autopas/particles/OwnershipState.h"
 #include "autopas/utils/inBox.h"
 
-namespace autopas {
 /**
  * Namespace to collect leaving particles from a container.
  */
-namespace LeavingParticleCollector {
+namespace autopas::LeavingParticleCollector {
 /**
  * Collects leaving particles and marks halo particles as dummy.
  * @note This function does not move or actually delete any particles!
@@ -34,7 +33,7 @@ std::vector<typename ContainerType::ParticleType> collectParticlesAndMarkNonOwne
       // Mark halo particles for deletion
       if (iter->isHalo()) {
         iter->setOwnershipState(OwnershipState::dummy);
-      // Collect leaving particles and mark them for deletion
+        // Collect leaving particles and mark them for deletion
       } else if (not utils::inBox(iter->getR(), container.getBoxMin(), container.getBoxMax())) {
         leavingParticles.push_back(*iter);
         iter->setOwnershipState(OwnershipState::dummy);
@@ -43,5 +42,4 @@ std::vector<typename ContainerType::ParticleType> collectParticlesAndMarkNonOwne
   }
   return leavingParticles;
 }
-}  // namespace LeavingParticleCollector
-}  // namespace autopas
+}  // namespace autopas::LeavingParticleCollector

--- a/src/autopas/containers/LeavingParticleCollector.h
+++ b/src/autopas/containers/LeavingParticleCollector.h
@@ -27,15 +27,15 @@ template <class ContainerType>
 std::vector<typename ContainerType::ParticleType> collectParticlesAndMarkNonOwnedAsDummy(ContainerType &container) {
   using namespace autopas::utils::ArrayMath::literals;
 
-  const auto interactionLength = container.getInteractionLength();
+  const auto upperBoundForMisplacement = container.getCutoff();
   const auto containerDimensions = container.getBoxMax() - container.getBoxMin();
-  const auto lowerHaloCorner = container.getBoxMin() - interactionLength;
-  const auto upperHaloCorner = container.getBoxMax() + interactionLength;
+  const auto lowerHaloCorner = container.getBoxMin() - upperBoundForMisplacement;
+  const auto upperHaloCorner = container.getBoxMax() + upperBoundForMisplacement;
   // We need to extend these boundaries into the container because we need to find particles that are stored in the
   // container but have since moved out. Extending by skin is not enough since we are interested in particles that have
   // travelled beyond that and skin can be 0.
-  const auto lowerInnerCorner = container.getBoxMin() + interactionLength;
-  const auto upperInnerCorner = container.getBoxMax() - interactionLength;
+  const auto lowerInnerCorner = container.getBoxMin() + upperBoundForMisplacement;
+  const auto upperInnerCorner = container.getBoxMax() - upperBoundForMisplacement;
 
   // volumes describing the halo regions on the six faces of the cuboid shaped container.
   const std::array<std::tuple<decltype(lowerHaloCorner), decltype(upperHaloCorner)>, 6> haloVolumes{{

--- a/src/autopas/containers/LeavingParticleCollector.h
+++ b/src/autopas/containers/LeavingParticleCollector.h
@@ -36,20 +36,23 @@ std::vector<typename ContainerType::ParticleType> collectParticlesAndMarkNonOwne
   const auto upperInnerCorner = container.getBoxMax() - skin;
 
   // volumes describing the halo regions on the six faces of the cuboid shaped container.
-  // FIXME: currently the corners and edges overlap.
   const std::array<std::tuple<decltype(lowerHaloCorner), decltype(upperHaloCorner)>, 6> haloVolumes{{
-      // left
-      {lowerHaloCorner, {upperHaloCorner[0] - containerDimensions[0], upperHaloCorner[1], upperHaloCorner[2]}},
-      // right
-      {{lowerHaloCorner[0] + containerDimensions[0], lowerHaloCorner[1], lowerHaloCorner[2]}, upperHaloCorner},
-      // top
-      {lowerHaloCorner, {upperHaloCorner[0], upperHaloCorner[1] - containerDimensions[1], upperHaloCorner[2]}},
-      // bottom
-      {{lowerHaloCorner[0], lowerHaloCorner[1] + containerDimensions[1], lowerHaloCorner[2]}, upperHaloCorner},
-      // front
-      {lowerHaloCorner, {upperHaloCorner[0], upperHaloCorner[1], upperHaloCorner[2] - containerDimensions[2]}},
-      // back
-      {{lowerHaloCorner[0], lowerHaloCorner[1], lowerHaloCorner[2] + containerDimensions[2]}, upperHaloCorner},
+      // left + lower edge
+      {{lowerHaloCorner[0], lowerInnerCorner[1], lowerHaloCorner[2]},
+       {lowerInnerCorner[0], upperInnerCorner[1], upperInnerCorner[2]}},
+      // right + upper edge
+      {{upperInnerCorner[0], lowerInnerCorner[1], lowerInnerCorner[2]},
+       {upperHaloCorner[0], upperInnerCorner[1], upperHaloCorner[2]}},
+      // top + left edge
+      {{lowerHaloCorner[0], lowerInnerCorner[1], upperInnerCorner[2]},
+       {upperInnerCorner[0], upperInnerCorner[1], upperHaloCorner[2]}},
+      // bottom + right edge
+      {{lowerInnerCorner[0], lowerInnerCorner[1], lowerHaloCorner[2]},
+       {upperHaloCorner[0], upperInnerCorner[1], lowerInnerCorner[2]}},
+      // front with all edges and corners
+      {lowerHaloCorner, {upperHaloCorner[0], lowerInnerCorner[1], upperHaloCorner[2]}},
+      // back with all edges and corners
+      {{lowerHaloCorner[0], upperInnerCorner[1], lowerHaloCorner[2]}, upperHaloCorner},
   }};
 
   std::vector<typename ContainerType::ParticleType> leavingParticles{};

--- a/src/autopas/containers/LeavingParticleCollector.h
+++ b/src/autopas/containers/LeavingParticleCollector.h
@@ -9,6 +9,7 @@
 
 #include "autopas/options/IteratorBehavior.h"
 #include "autopas/particles/OwnershipState.h"
+#include "autopas/utils/ArrayMath.h"
 #include "autopas/utils/inBox.h"
 
 /**
@@ -21,15 +22,46 @@ namespace autopas::LeavingParticleCollector {
  * @tparam ContainerType The type of the container.
  * @param container The container from which particles should be collected.
  * @return Returns a vector of leaving particles.
- * @todo: do not iterate over all particles, but only over boundary
  */
 template <class ContainerType>
 std::vector<typename ContainerType::ParticleType> collectParticlesAndMarkNonOwnedAsDummy(ContainerType &container) {
+  using namespace autopas::utils::ArrayMath::literals;
+
+  const auto interactionLength = container.getInteractionLength();
+  const auto skin = container.getVerletSkin();
+  const auto containerDimensions = container.getBoxMax() - container.getBoxMin();
+  const auto lowerHaloCorner = container.getBoxMin() - interactionLength;
+  const auto upperHaloCorner = container.getBoxMax() + interactionLength;
+  const auto lowerInnerCorner = container.getBoxMin() + skin;
+  const auto upperInnerCorner = container.getBoxMax() - skin;
+
+  // volumes describing the halo regions on the six faces of the cuboid shaped container.
+  // FIXME: currently the corners and edges overlap.
+  const std::array<std::tuple<decltype(lowerHaloCorner), decltype(upperHaloCorner)>, 6> haloVolumes{{
+      // left
+      {lowerHaloCorner, {upperHaloCorner[0] - containerDimensions[0], upperHaloCorner[1], upperHaloCorner[2]}},
+      // right
+      {{lowerHaloCorner[0] + containerDimensions[0], lowerHaloCorner[1], lowerHaloCorner[2]}, upperHaloCorner},
+      // top
+      {lowerHaloCorner, {upperHaloCorner[0], upperHaloCorner[1] - containerDimensions[1], upperHaloCorner[2]}},
+      // bottom
+      {{lowerHaloCorner[0], lowerHaloCorner[1] + containerDimensions[1], lowerHaloCorner[2]}, upperHaloCorner},
+      // front
+      {lowerHaloCorner, {upperHaloCorner[0], upperHaloCorner[1], upperHaloCorner[2] - containerDimensions[2]}},
+      // back
+      {{lowerHaloCorner[0], lowerHaloCorner[1], lowerHaloCorner[2] + containerDimensions[2]}, upperHaloCorner},
+  }};
+
   std::vector<typename ContainerType::ParticleType> leavingParticles{};
 #pragma omp declare reduction(vecMergeParticle : std::vector<typename ContainerType::ParticleType> : omp_out.insert(omp_out.end(), omp_in.begin(), omp_in.end()))
+  // this has to be a `parallel` and not `parallel for` because we are actually interested in parallelizing the inner
+  // loops without having a barrier between outer loop iterations.
+  // The way this works is that all threads iterate the outer loop but due to the way the iterators are parallelized,
+  // each thread only picks its iterations of the inner loops, hence nothing is done multiple times.
 #pragma omp parallel reduction(vecMergeParticle : leavingParticles)
-  {
-    for (auto iter = container.begin(autopas::IteratorBehavior::ownedOrHalo); iter.isValid(); ++iter) {
+  for (const auto &[regionStart, regionEnd] : haloVolumes) {
+    for (auto iter = container.getRegionIterator(regionStart, regionEnd, autopas::IteratorBehavior::ownedOrHalo);
+         iter.isValid(); ++iter) {
       // Mark halo particles for deletion
       if (iter->isHalo()) {
         iter->setOwnershipState(OwnershipState::dummy);

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -202,13 +202,14 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
 
   [[nodiscard]] ContainerIterator<ParticleType, true, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner, IteratorBehavior behavior,
-      typename ContainerIterator<ParticleType, true, true>::ParticleVecType *additionalVectors) override {
+      typename ContainerIterator<ParticleType, true, true>::ParticleVecType *additionalVectors = nullptr) override {
     return ContainerIterator<ParticleType, true, true>(*this, behavior, additionalVectors, lowerCorner, higherCorner);
   }
 
   [[nodiscard]] ContainerIterator<ParticleType, false, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner, IteratorBehavior behavior,
-      typename ContainerIterator<ParticleType, false, true>::ParticleVecType *additionalVectors) const override {
+      typename ContainerIterator<ParticleType, false, true>::ParticleVecType *additionalVectors =
+          nullptr) const override {
     return ContainerIterator<ParticleType, false, true>(*this, behavior, additionalVectors, lowerCorner, higherCorner);
   }
 

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -372,13 +372,14 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
 
   [[nodiscard]] ContainerIterator<ParticleType, true, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner, IteratorBehavior behavior,
-      typename ContainerIterator<ParticleType, true, true>::ParticleVecType *additionalVectors) override {
+      typename ContainerIterator<ParticleType, true, true>::ParticleVecType *additionalVectors = nullptr) override {
     return ContainerIterator<ParticleType, true, true>(*this, behavior, additionalVectors, lowerCorner, higherCorner);
   }
 
   [[nodiscard]] ContainerIterator<ParticleType, false, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner, IteratorBehavior behavior,
-      typename ContainerIterator<ParticleType, false, true>::ParticleVecType *additionalVectors) const override {
+      typename ContainerIterator<ParticleType, false, true>::ParticleVecType *additionalVectors =
+          nullptr) const override {
     return ContainerIterator<ParticleType, false, true>(*this, behavior, additionalVectors, lowerCorner, higherCorner);
   }
 

--- a/src/autopas/containers/linkedCells/LinkedCellsReferences.h
+++ b/src/autopas/containers/linkedCells/LinkedCellsReferences.h
@@ -34,7 +34,6 @@ namespace autopas {
  * therefore short-range interactions only need to be calculated between
  * particles in neighboring cells.
  * @tparam ParticleCell type of the ParticleCells that are used to store the particles
- * @tparam SoAArraysType type of the SoA, needed for verlet lists
  */
 template <class Particle>
 class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticleCell<Particle>> {

--- a/src/autopas/containers/linkedCells/LinkedCellsReferences.h
+++ b/src/autopas/containers/linkedCells/LinkedCellsReferences.h
@@ -412,13 +412,14 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
 
   [[nodiscard]] ContainerIterator<ParticleType, true, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner, IteratorBehavior behavior,
-      typename ContainerIterator<ParticleType, true, true>::ParticleVecType *additionalVectors) override {
+      typename ContainerIterator<ParticleType, true, true>::ParticleVecType *additionalVectors = nullptr) override {
     return ContainerIterator<ParticleType, true, true>(*this, behavior, additionalVectors, lowerCorner, higherCorner);
   }
 
   [[nodiscard]] ContainerIterator<ParticleType, false, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner, IteratorBehavior behavior,
-      typename ContainerIterator<ParticleType, false, true>::ParticleVecType *additionalVectors) const override {
+      typename ContainerIterator<ParticleType, false, true>::ParticleVecType *additionalVectors =
+          nullptr) const override {
     return ContainerIterator<ParticleType, false, true>(*this, behavior, additionalVectors, lowerCorner, higherCorner);
   }
 

--- a/src/autopas/containers/octree/Octree.h
+++ b/src/autopas/containers/octree/Octree.h
@@ -343,13 +343,13 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
 
   [[nodiscard]] ContainerIterator<Particle, true, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner, IteratorBehavior behavior,
-      typename ContainerIterator<Particle, true, true>::ParticleVecType *additionalVectors) override {
+      typename ContainerIterator<Particle, true, true>::ParticleVecType *additionalVectors = nullptr) override {
     return ContainerIterator<Particle, true, true>(*this, behavior, additionalVectors, lowerCorner, higherCorner);
   }
 
   [[nodiscard]] ContainerIterator<Particle, false, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner, IteratorBehavior behavior,
-      typename ContainerIterator<Particle, false, true>::ParticleVecType *additionalVectors) const override {
+      typename ContainerIterator<Particle, false, true>::ParticleVecType *additionalVectors = nullptr) const override {
     return ContainerIterator<Particle, false, true>(*this, behavior, additionalVectors, lowerCorner, higherCorner);
   }
 

--- a/src/autopas/containers/verletClusterLists/ClusterTowerBlock2D.h
+++ b/src/autopas/containers/verletClusterLists/ClusterTowerBlock2D.h
@@ -199,8 +199,8 @@ class ClusterTowerBlock2D : public CellBorderAndFlagManager {
         _haloBoxMin[2],
     };
     const std::array<double, 3> towerBoxMax{
-        _boxMin[0] + _towerSideLength[0],
-        _boxMin[1] + _towerSideLength[1],
+        towerBoxMin[0] + _towerSideLength[0],
+        towerBoxMin[1] + _towerSideLength[1],
         _haloBoxMax[2],
     };
     return {towerBoxMin, towerBoxMax};

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -225,12 +225,11 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
 #ifdef AUTOPAS_OPENMP
 #pragma omp parallel for reduction(|| : deletedSomething)
 #endif
-    for (size_t i = 0; i < _towerBlock.size(); ++i) {
-      auto &tower = _towerBlock[i];
+    for (auto &tower : _towerBlock) {
       const auto towerSize = tower.getNumActualParticles();
       auto numTailDummies = tower.getNumTailDummyParticles();
-      // iterate over all non-tail dummies.
-      for (size_t j = 0; j < towerSize - numTailDummies;) {
+      // iterate over all non-tail dummies. Avoid underflows.
+      for (size_t j = 0; numTailDummies < towerSize and j < towerSize - numTailDummies;) {
         if (tower[j].isHalo()) {
           // swap-"delete"
           tower[j] = tower[towerSize - 1 - numTailDummies];

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -225,7 +225,9 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
 #ifdef AUTOPAS_OPENMP
 #pragma omp parallel for reduction(|| : deletedSomething)
 #endif
-    for (auto &tower : _towerBlock) {
+    // Thanks to clang 13 this has to be a index based loop instead of a range based
+    for (size_t i = 0; i < _towerBlock.size(); ++i) {
+      auto &tower = _towerBlock[i];
       const auto towerSize = tower.getNumActualParticles();
       auto numTailDummies = tower.getNumTailDummyParticles();
       // iterate over all non-tail dummies. Avoid underflows.

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -228,7 +228,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
     // Thanks to clang 13 this has to be a index based loop instead of a range based
     for (size_t i = 0; i < _towerBlock.size(); ++i) {
       auto &tower = _towerBlock[i];
-      const auto towerSize = tower.getNumActualParticles();
+      const auto towerSize = tower.size();
       auto numTailDummies = tower.getNumTailDummyParticles();
       // iterate over all non-tail dummies. Avoid underflows.
       for (size_t j = 0; numTailDummies < towerSize and j < towerSize - numTailDummies;) {

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -364,6 +364,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
     std::vector<Particle> invalidParticles;
 
 #ifdef AUTOPAS_OPENMP
+    // custom openmp reduction to concatenate all local vectors to one at the end of a parallel region
 #pragma omp declare reduction(vecMergeParticle : std::vector<Particle> : omp_out.insert(omp_out.end(), omp_in.begin(), omp_in.end()))
 #pragma omp parallel reduction(vecMergeParticle : invalidParticles)
 #endif

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -546,7 +546,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
    */
   [[nodiscard]] ContainerIterator<Particle, true, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner, IteratorBehavior behavior,
-      typename ContainerIterator<Particle, true, true>::ParticleVecType *additionalVectors) override {
+      typename ContainerIterator<Particle, true, true>::ParticleVecType *additionalVectors = nullptr) override {
     // Note: particlesToAddEmpty() can only be called if the container status is not invalid. If the status is set to
     // invalid, we do writing operations on _particlesToAdd and can not read from from it without race conditions.
     if (_isValid != ValidityState::invalid) {
@@ -575,7 +575,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
    */
   [[nodiscard]] ContainerIterator<Particle, false, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner, IteratorBehavior behavior,
-      typename ContainerIterator<Particle, false, true>::ParticleVecType *additionalVectors) const override {
+      typename ContainerIterator<Particle, false, true>::ParticleVecType *additionalVectors = nullptr) const override {
     // Note: particlesToAddEmpty() can only be called if the container status is not invalid. If the status is set to
     // invalid, we do writing operations on _particlesToAdd and can not read from from it without race conditions.
     if (_isValid != ValidityState::invalid) {

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -229,7 +229,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    */
   [[nodiscard]] ContainerIterator<Particle, true, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner, IteratorBehavior behavior,
-      typename ContainerIterator<Particle, true, true>::ParticleVecType *additionalVectors) override {
+      typename ContainerIterator<Particle, true, true>::ParticleVecType *additionalVectors = nullptr) override {
     return _linkedCells.getRegionIterator(lowerCorner, higherCorner, behavior, additionalVectors);
   }
 
@@ -238,7 +238,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    */
   [[nodiscard]] ContainerIterator<Particle, false, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner, IteratorBehavior behavior,
-      typename ContainerIterator<Particle, false, true>::ParticleVecType *additionalVectors) const override {
+      typename ContainerIterator<Particle, false, true>::ParticleVecType *additionalVectors = nullptr) const override {
     return _linkedCells.getRegionIterator(lowerCorner, higherCorner, behavior, additionalVectors);
   }
 

--- a/src/autopas/iterators/ContainerIterator.h
+++ b/src/autopas/iterators/ContainerIterator.h
@@ -58,7 +58,7 @@ template <bool regionIter, class Particle, class Arr>
                                                         const Arr &regionMin, const Arr &regionMax) {
   // If this is a region iterator check box condition first, otherwise race conditions can occur
   // if multiple region iterator overlap and ownership state is touched.
-  // (e.g. during collection of leavein particles)
+  // (e.g. during collection of leaving particles)
   if constexpr (regionIter) {
     if (not utils::inBox(p.getR(), regionMin, regionMax)) {
       return false;

--- a/src/autopas/iterators/ContainerIterator.h
+++ b/src/autopas/iterators/ContainerIterator.h
@@ -56,24 +56,25 @@ namespace containerIteratorUtils {
 template <bool regionIter, class Particle, class Arr>
 [[nodiscard]] bool particleFulfillsIteratorRequirements(const Particle &p, IteratorBehavior behavior,
                                                         const Arr &regionMin, const Arr &regionMax) {
-  bool particleOk = false;
+  // If this is a region iterator check box condition first, otherwise race conditions can occur
+  // if multiple region iterator overlap and ownership state is touched.
+  // (e.g. during collection of leavein particles)
+  if constexpr (regionIter) {
+    if (not utils::inBox(p.getR(), regionMin, regionMax)) {
+      return false;
+    }
+  }
+
   // Check ownership
   // Dummy is not in sync with iterator behavior because it needs to be 0.
   // `a & b == b` idiom is to check a == b disregarding any bits beyond b. This is needed due to e.g. forceSequential.
   if (((behavior & IteratorBehavior::ownedOrHaloOrDummy) == IteratorBehavior::ownedOrHaloOrDummy) or
       (behavior & IteratorBehavior::dummy and p.isDummy())) {
-    particleOk = true;
+    return true;
   } else {
     // relies on both enums having the same encoding. This should be guaranteed statically in IteratorBehaviorTest!
-    particleOk = static_cast<unsigned int>(p.getOwnershipState()) & static_cast<unsigned int>(behavior);
+    return static_cast<unsigned int>(p.getOwnershipState()) & static_cast<unsigned int>(behavior);
   }
-  if constexpr (regionIter) {
-    // If this is a region iterator check if the particle is in the box.
-    if (particleOk and not utils::inBox(p.getR(), regionMin, regionMax)) {
-      particleOk = false;
-    }
-  }
-  return particleOk;
 }
 }  // namespace containerIteratorUtils
 

--- a/src/autopas/particles/OwnershipState.h
+++ b/src/autopas/particles/OwnershipState.h
@@ -58,7 +58,7 @@ enum class OwnershipState : int64_t {
  * @param b second operand
  * @return a & b
  */
-const inline OwnershipState operator&(const OwnershipState a, const OwnershipState b) {
+inline OwnershipState operator&(const OwnershipState a, const OwnershipState b) {
   return static_cast<OwnershipState>(static_cast<int64_t>(a) & static_cast<int64_t>(b));
 }
 
@@ -68,7 +68,7 @@ const inline OwnershipState operator&(const OwnershipState a, const OwnershipSta
  * @param b second operand
  * @return a | b
  */
-const inline OwnershipState operator|(const OwnershipState a, const OwnershipState b) {
+inline OwnershipState operator|(const OwnershipState a, const OwnershipState b) {
   return static_cast<OwnershipState>(static_cast<int64_t>(a) | static_cast<int64_t>(b));
 }
 
@@ -78,6 +78,6 @@ const inline OwnershipState operator|(const OwnershipState a, const OwnershipSta
  * @param a OwnershipState
  * @return const int64_t value of a given OwnershipState
  */
-const inline int64_t toInt64(const OwnershipState a) { return static_cast<int64_t>(a); }
+inline int64_t toInt64(const OwnershipState a) { return static_cast<int64_t>(a); }
 
 }  // namespace autopas

--- a/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
@@ -59,7 +59,7 @@ TYPED_TEST_P(LinkedCellsTest, testUpdateContainerCloseToBoundary) {
     }
   }
   std::set<unsigned long> movedIDs;
-  // we move particles that are close to the boundary to the outside of the container and remember the id's we moved
+  // we move particles that are close to the boundary to outside the container and remember their IDs
   for (auto iter = this->_linkedCells.begin(); iter.isValid(); ++iter) {
     for (unsigned short dim = 0; dim < 3; ++dim) {
       if (iter->getR()[dim] < 0.5) {

--- a/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
@@ -6,6 +6,8 @@
 
 #include "LinkedCellsTest.h"
 
+#include "autopas/utils/ArrayUtils.h"
+
 TYPED_TEST_SUITE_P(LinkedCellsTest);
 
 TYPED_TEST_P(LinkedCellsTest, testUpdateContainer) {
@@ -57,7 +59,7 @@ TYPED_TEST_P(LinkedCellsTest, testUpdateContainerCloseToBoundary) {
     }
   }
   std::set<unsigned long> movedIDs;
-  // we move particles that are close to the boundary to outside of the container and remember the id's we moved
+  // we move particles that are close to the boundary to the outside of the container and remember the id's we moved
   for (auto iter = this->_linkedCells.begin(); iter.isValid(); ++iter) {
     for (unsigned short dim = 0; dim < 3; ++dim) {
       if (iter->getR()[dim] < 0.5) {
@@ -78,16 +80,19 @@ TYPED_TEST_P(LinkedCellsTest, testUpdateContainerCloseToBoundary) {
 
   // now update the container!
   auto invalidParticles = this->_linkedCells.updateContainer(this->_keepListsValid);
-
   // the particles should no longer be in the inner cells!
   for (auto iter = this->_linkedCells.begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
-    EXPECT_EQ(movedIDs.count(iter->getID()), 0);
+    EXPECT_EQ(movedIDs.count(iter->getID()), 0)
+        << "Particle " << iter->getID() << " at " << autopas::utils::ArrayUtils::to_string(iter->getR())
+        << " is still in an inner cell although it was moved!";
   }
 
-  // the particles should now be inside of invalidParticles vector!
+  // the particles should now be inside the invalidParticles vector!
   EXPECT_EQ(movedIDs.size(), invalidParticles.size());
   for (auto &particle : invalidParticles) {
-    EXPECT_EQ(movedIDs.count(particle.getID()), 1);
+    EXPECT_EQ(movedIDs.count(particle.getID()), 1)
+        << "Particle " << particle.getID() << " at " << autopas::utils::ArrayUtils::to_string(particle.getR())
+        << " was not returned by updateContainer()!";
   }
 }
 
@@ -104,12 +109,13 @@ struct two_values {
 };
 
 // defines the types of _linkedCells and _keepListsValid
-using LC_true = two_values<autopas::LinkedCells<Particle>, std::true_type>;
-using LC_false = two_values<autopas::LinkedCells<Particle>, std::false_type>;
-using LCRef_true = two_values<autopas::LinkedCellsReferences<Particle>, std::true_type>;
-using LCRef_false = two_values<autopas::LinkedCellsReferences<Particle>, std::false_type>;
+struct LC_KeepListsValid : two_values<autopas::LinkedCells<Particle>, std::true_type> {};
+struct LC_DontKeepListsValid : two_values<autopas::LinkedCells<Particle>, std::false_type> {};
+struct LCRef_KeepListsValid : two_values<autopas::LinkedCellsReferences<Particle>, std::true_type> {};
+struct LCRef_DontKeepListsValid : two_values<autopas::LinkedCellsReferences<Particle>, std::false_type> {};
 
-using MyTypes = ::testing::Types<LC_true, LC_false, LCRef_true, LCRef_false>;
+using MyTypes =
+    ::testing::Types<LC_KeepListsValid, LC_DontKeepListsValid, LCRef_KeepListsValid, LCRef_DontKeepListsValid>;
 
 /// @todo c++20: replace with:
 // using MyTypes = ::testing::Types<std::tuple<autopas::LinkedCells<Particle>, std::true_type>,


### PR DESCRIPTION
# Description

- [x] merge two loops over all particles into one
- [x] parallelize this loop
- [x] change loop over all particles to region iterators over borders

## ~Related Pull Requests~

## Resolved Issues

- [x] fixes #653 
- [x] fixes #790 

# How Has This Been Tested?

Especially the following unit tests check that regions work correctly:
- [x] `testUpdateContainerCloseToBoundary()`
- [x] `md-flexible.test-sim`

- [x] Test sim with config:
```yaml
verlet-rebuild-frequency         :  15
verlet-skin-radius-per-timestep  :  0.2
selector-strategy                :  Fastest-Absolute-Value
data-layout                      :  [SoA]
traversal                        :  [lc_c08]
functor                          :  Lennard-Jones (12-6) AVX intrinsics
newton3                          :  [enabled]
cutoff                           :  2.5
cell-size                        :  [1]
deltaT                           :  0.0001
iterations                       :  50
boundary-type                    :  [periodic, periodic, periodic]
box-min                          :  [-70,-70,-70]
box-max                          :  [70, 70, 70]
Objects:
  CubeGrid:
    0:
      particles-per-dimension    :  [50, 50, 50]
      particle-spacing           :  1.4
      bottomLeftCorner           :  [0.7, 0.7, 0.7]
      velocity                   :  [1000, 0, 0]
      particle-type-id           :  0
      particle-epsilon           :  1
      particle-sigma             :  1
      particle-mass              :  1
```
Using 16 Threads on my Workstation (i7-10700) I get the following improvements:

| Version | Commit | UpdateContainer[s] |
|---------|:------:|-------------------:|
|Baseline | 7ae9a6e21cf9456cd8db99fcc8d84418d7c70ff2 | 0.174 |
| Merged loops | 82fae0d35006838bd6c8c58154fe36673529cf1e | 0.059 |
| Region Iters | e6475b0 | 0.063 |

~Seems like merged loops beat the "complicated" region iterator approach.~

- [x] Proper scenario

Falling drop from the examples folder but only linked cells on HSUper with one node and 144 threads:

| Version | Commit | UpdateContainer[s] |
|---------|:------:|-------------------:|
|Baseline | 7ae9a6e21cf9456cd8db99fcc8d84418d7c70ff2 | 6.193 |
| Merged loops | 82fae0d35006838bd6c8c58154fe36673529cf1e | 6.037 |
| Region Iters | e6475b0 | 4.441 |

=> Region iterators are better if the domain is large enough.