### PR TITLE
LinkedCellsReferencesFix

### DIFF
--- a/src/autopas/containers/linkedCells/LinkedCellsReferences.h
+++ b/src/autopas/containers/linkedCells/LinkedCellsReferences.h
@@ -351,11 +351,11 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
       }
     }
 
-    // we have to remove halo particles after the above for-loop since removing halo particles changes the undelying
+    // we have to remove halo particles after the above for-loop since removing halo particles changes the underlying
     // datastructure (_particleList) which invalidates the references in the cells.
     // Note: removing halo particles before the loop and do a call to updateDirtyParticleReferences() right after won't
     // work since there are owned particles in _particleList which fall into the halo area (they are not yet filtered
-    // out by the above loop) and can therfore not added to halo cells during particle insert in
+    // out by the above loop) and can therefore not added to halo cells during particle insert in
     // updateDirtyParticleReferences()
     this->deleteHaloParticles();
 

--- a/src/autopas/containers/linkedCells/LinkedCellsReferences.h
+++ b/src/autopas/containers/linkedCells/LinkedCellsReferences.h
@@ -294,7 +294,7 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
     std::vector<ParticleType> invalidParticles;
 
     // for exception handling in parallel region
-    bool exceptionCatched{false};
+    bool exceptionCaught{false};
     std::string exceptionMsg{""};
 
 #ifdef AUTOPAS_OPENMP
@@ -337,7 +337,7 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
       // the barrier is needed because iterators are not thread safe w.r.t. addParticle()
 
       // this loop is executed for every thread and thus parallel. Don't use #pragma omp for here!
-      // addParticle might throw. Set exceptionCatched to true, so we can handle that after the OpenMP region
+      // addParticle might throw. Set exceptionCaught to true, so we can handle that after the OpenMP region
       try {
         for (auto &&p : myInvalidParticles) {
           // if not in halo
@@ -348,7 +348,7 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
           }
         }
       } catch (const std::exception &e) {
-        exceptionCatched = true;
+        exceptionCaught = true;
 #ifdef AUTOPAS_OPENMP
 #pragma omp critical
 #endif
@@ -364,7 +364,7 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
       }
     }
 
-    if (exceptionCatched) {
+    if (exceptionCaught) {
       throw autopas::utils::ExceptionHandler::AutoPasException(exceptionMsg);
     }
 

--- a/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
@@ -11,37 +11,75 @@ TYPED_TEST_SUITE_P(LinkedCellsTest);
 TYPED_TEST_P(LinkedCellsTest, testUpdateContainer) {
   decltype(this->_linkedCells) linkedCells({0., 0., 0.}, {3., 3., 3.}, 1., 0., 1.);
 
+  // create owned particles
   autopas::Particle p1({0.5, 0.5, 0.5}, {0, 0, 0}, 0);
   autopas::Particle p2({1.5, 1.5, 1.5}, {0, 0, 0}, 1);
   autopas::Particle p3({1.6, 1.5, 1.5}, {0, 0, 0}, 2);
   autopas::Particle p4({2.5, 1.5, 1.5}, {0, 0, 0}, 3);
   autopas::Particle p5({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
 
+  // These are going to be halo particles
+  autopas::Particle p6({-0.5, 1.5, 1.5}, {0, 0, 0}, 5);
+  autopas::Particle p7({3.5, 1.5, 1.5}, {0, 0, 0}, 6);
+  autopas::Particle p8({1.5, -0.5, 1.5}, {0, 0, 0}, 7);
+  autopas::Particle p9({1.5, 1.5, -0.5}, {0, 0, 0}, 8);
+
+  // we insert owned and halo particles alternating. This way we can check if references are updated correctly when
+  // using LinkedCellsReferences
   linkedCells.addParticle(p1);
+  linkedCells.addHaloParticle(p6);
   linkedCells.addParticle(p2);
+  linkedCells.addHaloParticle(p7);
   linkedCells.addParticle(p3);
+  linkedCells.addHaloParticle(p8);
   linkedCells.addParticle(p4);
+  linkedCells.addHaloParticle(p9);
   linkedCells.addParticle(p5);
 
-  this->checkParticleIDsInCells(linkedCells, {{31ul, {0}}, {62ul, {1, 2}}, {63ul, {3}}, {93ul, {4}}}, true, __LINE__);
+  this->checkParticleIDsInCells(linkedCells,
+                                {{12ul, {{8, autopas::OwnershipState::halo}}},
+                                 {31ul, {{0, autopas::OwnershipState::owned}}},
+                                 {52ul, {{7, autopas::OwnershipState::halo}}},
+                                 {60ul, {{5, autopas::OwnershipState::halo}}},
+                                 {62ul, {{1, autopas::OwnershipState::owned}, {2, autopas::OwnershipState::owned}}},
+                                 {63ul, {{3, autopas::OwnershipState::owned}}},
+                                 {64ul, {{6, autopas::OwnershipState::halo}}},
+                                 {93ul, {{4, autopas::OwnershipState::owned}}}},
+                                true, __LINE__);
 
-  // new locations for particles
+  // // new locations for owned particles
   linkedCells.getCells()[31].begin()->setR({1.5, 0.5, 0.5});
   linkedCells.getCells()[62].begin()->setR({2.5, 1.5, 0.5});
   linkedCells.getCells()[63].begin()->setR({-0.5, -0.5, -0.5});
   linkedCells.getCells()[93].begin()->setR({1.6, 0.5, 0.5});
 
-  auto invalidParticles = linkedCells.updateContainer(this->_keepListsValid);
+  std::vector<Particle> invalidParticles;
+  EXPECT_NO_THROW(invalidParticles = linkedCells.updateContainer(this->_keepListsValid));
 
   ASSERT_EQ(invalidParticles.size(), 1);
   EXPECT_EQ(invalidParticles[0].getID(), 3);
 
   if (this->_keepListsValid) {
     // if the lists are kept valid, particles are NOT moved between cells!
-    this->checkParticleIDsInCells(linkedCells, {{31ul, {0}}, {62ul, {1, 2}}, {93ul, {4}}}, true, __LINE__);
+    // halo particles should now be dummies
+    // particle 3 should be a leaving particle and therefore a dummy
+    this->checkParticleIDsInCells(linkedCells,
+                                  {{12ul, {{8, autopas::OwnershipState::dummy}}},
+                                   {31ul, {{0, autopas::OwnershipState::owned}}},
+                                   {52ul, {{7, autopas::OwnershipState::dummy}}},
+                                   {60ul, {{5, autopas::OwnershipState::dummy}}},
+                                   {62ul, {{1, autopas::OwnershipState::owned}, {2, autopas::OwnershipState::owned}}},
+                                   {63ul, {{3, autopas::OwnershipState::dummy}}},
+                                   {64ul, {{6, autopas::OwnershipState::dummy}}},
+                                   {93ul, {{4, autopas::OwnershipState::owned}}}},
+                                  true, __LINE__);
   } else {
     // if the lists are not kept valid, particles should be moved between cells, so update the cells!
-    this->checkParticleIDsInCells(linkedCells, {{32ul, {0, 4}}, {38ul, {1}}, {62ul, {2}}},
+    // halo particles should be removed by updateContainer() at this point
+    this->checkParticleIDsInCells(linkedCells,
+                                  {{32ul, {{0, autopas::OwnershipState::owned}, {4, autopas::OwnershipState::owned}}},
+                                   {38ul, {{1, autopas::OwnershipState::owned}}},
+                                   {62ul, {{2, autopas::OwnershipState::owned}}}},
                                   false /*here, we do not know the order!*/, __LINE__);
   }
 }

--- a/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.h
@@ -45,7 +45,7 @@ void LinkedCellsTest<TestingType>::checkParticleIDsInCells(
     if (auto iter = expectedParticleIDsInCells.find(i); iter != expectedParticleIDsInCells.end()) {
       auto expectedParticles = iter->second;
       auto expectedNumParticles = expectedParticles.size();
-      ASSERT_EQ(linkedCells.getCells()[i].size(), expectedNumParticles) << "i is " << i << "called from line: " << line;
+      ASSERT_EQ(linkedCells.getCells()[i].size(), expectedNumParticles) << "called from line: " << line;
 
       std::vector<std::tuple<int, autopas::OwnershipState>> foundParticles;
       {

--- a/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.h
@@ -30,32 +30,35 @@ class LinkedCellsTest : public AutoPasTestBase {
 
   void checkParticleIDsInCells(
       LinkedCellsType &linkedCells,
-      std::map<unsigned long /*cellID*/, std::vector<int> /*particleIDs*/> expectedParticleIDsInCells, bool ordered,
-      int line);
+      std::map<unsigned long /*cellID*/, std::vector<std::tuple<int, autopas::OwnershipState>> /*particleIDs*/>
+          expectedParticleIDsInCells,
+      bool ordered, int line);
 };
 
 template <class TestingType>
 void LinkedCellsTest<TestingType>::checkParticleIDsInCells(
-    LinkedCellsType &linkedCells, std::map<unsigned long, std::vector<int>> expectedParticleIDsInCells, bool ordered,
-    int line) {
+    LinkedCellsType &linkedCells,
+    std::map<unsigned long, std::vector<std::tuple<int, autopas::OwnershipState>>> expectedParticleIDsInCells,
+    bool ordered, int line) {
   // check particles are where we expect them to be (and nothing else)
   for (size_t i = 0; i < linkedCells.getCells().size(); ++i) {
     if (auto iter = expectedParticleIDsInCells.find(i); iter != expectedParticleIDsInCells.end()) {
-      auto expectedIDs = iter->second;
-      auto expectedNumParticles = expectedIDs.size();
-      ASSERT_EQ(linkedCells.getCells()[i].size(), expectedNumParticles) << "called from line: " << line;
+      auto expectedParticles = iter->second;
+      auto expectedNumParticles = expectedParticles.size();
+      ASSERT_EQ(linkedCells.getCells()[i].size(), expectedNumParticles) << "i is " << i << "called from line: " << line;
 
-      std::vector<int> foundIDs;
+      std::vector<std::tuple<int, autopas::OwnershipState>> foundParticles;
       {
         auto pIter = linkedCells.getCells()[i].begin();
         for (int j = 0; j < expectedNumParticles; ++j, ++pIter) {
-          foundIDs.push_back(pIter->getID());
+          foundParticles.push_back({pIter->getID(), pIter->getOwnershipState()});
         }
       }
       if (ordered) {
-        EXPECT_THAT(foundIDs, testing::ElementsAreArray(expectedIDs)) << "called from line: " << line;
+        EXPECT_THAT(foundParticles, testing::ElementsAreArray(expectedParticles)) << "called from line: " << line;
       } else {
-        EXPECT_THAT(foundIDs, testing::UnorderedElementsAreArray(expectedIDs)) << "called from line: " << line;
+        EXPECT_THAT(foundParticles, testing::UnorderedElementsAreArray(expectedParticles))
+            << "called from line: " << line;
       }
     } else {
       bool isEmpty = linkedCells.getCells()[i].isEmpty();


### PR DESCRIPTION
# Description

This PR should fix the bug described in #791.

In `LinkedCellsReferences::updateContainer()`, the halo particles were deleted with `deleteHaloParticles()` before all leaving particles were detected. This function deletes all halo particles in the data structure that stores the actual particles (`_particleList`). However, as a result, the references in the cells that point to the particles in `_particleList` are no longer correct. 
One solution would be to make a call to `updateDirtyParticleReferences()` directly after deleting the halo particles. However, since `_particleList` contains owned particles that have already been moved to the halo area, an exception is thrown when assigning the particles to the halo cells. So the simplest solution is to first run the loop that filters out all leaving particles and then call `deleteHaloParticles()`.

## Resolved Issues

- [x] fixes #791

# How Has This Been Tested?

- [x] All existing tests
- [x] The md-flexible scenario from #791
- [x] Testcase that checks correctness of references after updating the container: The `LinkedCellsTest` test was adjusted, so that wrong references after removing or inserting particles are detected. Therefore owned and halo particles are added alternating  to the container. After `updateContainer` it is checked that references still point to the expected particles. Also the `OwnershipState` of particles is checked.