### PR TITLE
Option for sorting threshold

### DIFF
--- a/examples/md-flexible/input/AllOptions.yaml
+++ b/examples/md-flexible/input/AllOptions.yaml
@@ -18,6 +18,7 @@ box-min                              :  [-1.75, -1.75, -1.75]
 box-max                              :  [7.25, 7.25, 7.25]
 cell-size                            :  [1]
 deltaT                               :  0.000001
+sorting-threshold                    :  8
 iterations                           :  10
 boundary-type                        :  [periodic, periodic, periodic]
 subdivide-dimension                  :  [true, true, true]

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -134,6 +134,7 @@ Simulation::Simulation(const MDFlexConfig &configuration,
   _autoPasContainer->setVerletSkinPerTimestep(_configuration.verletSkinRadiusPerTimestep.value);
   _autoPasContainer->setAcquisitionFunction(_configuration.acquisitionFunctionOption.value);
   _autoPasContainer->setUseTuningLogger(_configuration.useTuningLogger.value);
+  _autoPasContainer->setSortingThreshold(_configuration.sortingThreshold.value);
   int rank{};
   autopas::AutoPas_MPI_Comm_rank(AUTOPAS_MPI_COMM_WORLD, &rank);
   const auto *fillerBeforeSuffix =

--- a/examples/md-flexible/src/configuration/CLIParser.cpp
+++ b/examples/md-flexible/src/configuration/CLIParser.cpp
@@ -55,6 +55,7 @@ MDFlexParser::exitCodes MDFlexParser::CLIParser::parseInput(int argc, char **arg
       config.cutoff,
       config.dataLayoutOptions,
       config.deltaT,
+      config.sortingThreshold,
       config.distributionMean,
       config.distributionStdDev,
       config.dontCreateEndConfig,
@@ -206,7 +207,16 @@ MDFlexParser::exitCodes MDFlexParser::CLIParser::parseInput(int argc, char **arg
         try {
           config.deltaT.value = stod(strArg);
         } catch (const exception &) {
-          cerr << "Error parsing epsilon value: " << optarg << endl;
+          cerr << "Error parsing deltaT value: " << optarg << endl;
+          displayHelp = true;
+        }
+        break;
+      }
+      case decltype(config.sortingThreshold)::getoptChar: {
+        try {
+          config.sortingThreshold.value = stoul(strArg);
+        } catch (const exception &) {
+          cerr << "Error parsing value for sorting-threshold: " << optarg << endl;
           displayHelp = true;
         }
         break;

--- a/examples/md-flexible/src/configuration/MDFlexConfig.cpp
+++ b/examples/md-flexible/src/configuration/MDFlexConfig.cpp
@@ -308,6 +308,7 @@ std::string MDFlexConfig::to_string() const {
   printOption(boxMax);
   printOption(cellSizeFactors);
   printOption(deltaT);
+  printOption(sortingThreshold);
   // simulation length is either dictated by tuning phases or iterations
   if (tuningPhases.value > 0) {
     printOption(tuningPhases);

--- a/examples/md-flexible/src/configuration/MDFlexConfig.h
+++ b/examples/md-flexible/src/configuration/MDFlexConfig.h
@@ -491,6 +491,18 @@ class MDFlexConfig {
   MDFlexOption<double, __LINE__> deltaT{0.001, "deltaT", true,
                                         "Length of a timestep. Set to 0 to deactivate time integration."};
 
+  /**
+   * sortingThreshold
+   * This value is used in traversal that use the CellFunctor. If the sum of the number of particles in two cells is
+   * greater or equal to that value, the CellFunctor creates a sorted view of the particles to avoid unnecessary
+   * distance checks.
+   */
+  MDFlexOption<size_t, __LINE__> sortingThreshold{
+      8, "sorting-threshold", true,
+      "Threshold for traversals that use the CellFunctor to start sorting. If the sum of the number of particles in "
+      "two cells is greater or equal to that value, the CellFunctor creates a sorted view of the particles to avoid "
+      "unnecessary distance checks."};
+
   // Options for additional Object Generation on command line
   /**
    * boxLength

--- a/examples/md-flexible/src/configuration/YamlParser.cpp
+++ b/examples/md-flexible/src/configuration/YamlParser.cpp
@@ -717,8 +717,8 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         description = config.thermostatInterval.description;
         try {
           config.thermostatInterval.value = node[key][config.thermostatInterval.name].as<size_t>();
-          if (config.thermostatInterval.value <= 1) {
-            throw std::runtime_error("thermostatInterval has to be > 0!");
+          if (config.thermostatInterval.value < 1) {
+            throw std::runtime_error("thermostatInterval has to be > 0");
           }
         } catch (const std::exception &e) {
           errors.push_back(makeErrorMsg(mark, key, e.what(), expected, description));

--- a/examples/md-flexible/src/configuration/YamlParser.cpp
+++ b/examples/md-flexible/src/configuration/YamlParser.cpp
@@ -274,6 +274,11 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         description = config.deltaT.description;
 
         config.deltaT.value = node[key].as<double>();
+      } else if (key == config.sortingThreshold.name) {
+        expected = "Unsigned Integer >= 0.";
+        description = config.sortingThreshold.description;
+
+        config.sortingThreshold.value = node[key].as<size_t>();
       } else if (key == config.traversalOptions.name) {
         expected = "YAML-sequence of possible values.";
         description = config.traversalOptions.description;

--- a/src/autopas/AutoPasDecl.h
+++ b/src/autopas/AutoPasDecl.h
@@ -1067,8 +1067,7 @@ class AutoPas {
    */
   std::string _outputSuffix{""};
   /**
-   * description
-   *
+   * Number of particles in two cells from which sorting should be performed for traversal that use the CellFunctor
    */
   size_t _sortingThreshold{8};
   /**

--- a/src/autopas/AutoPasDecl.h
+++ b/src/autopas/AutoPasDecl.h
@@ -977,6 +977,20 @@ class AutoPas {
    */
   const std::string &getRuleFileName() const { return _tuningStrategyFactoryInfo.ruleFileName; }
 
+  /**
+   * Set the sorting-threshold for traversals that use the CellFunctor
+   * If the sum of the number of particles in two cells is greater or equal to that value, the CellFunctor creates a
+   * sorted view of the particles to avoid unnecessary distance checks.
+   * @param sortingThreshold Sum of the number of particles in two cells from which sorting should be enabled
+   */
+  void setSortingThreshold(size_t sortingThreshold) { _sortingThreshold = sortingThreshold; }
+
+  /**
+   * Get the sorting-threshold for traversals that use the CellFunctor
+   * @return sorting-threshold
+   */
+  size_t getSortingThreshold() const { return _sortingThreshold; }
+
  private:
   autopas::ParticleContainerInterface<Particle> &getContainer();
 
@@ -1052,6 +1066,11 @@ class AutoPas {
    * This is useful when multiple instances of AutoPas exist, especially in an MPI context.
    */
   std::string _outputSuffix{""};
+  /**
+   * description
+   *
+   */
+  size_t _sortingThreshold{8};
   /**
    * Helper function to reduce code duplication for all forms of addParticle while minimizing overhead through loops.
    * Triggers reserve() and provides a parallel loop with deliberate scheduling.

--- a/src/autopas/AutoPasImpl.h
+++ b/src/autopas/AutoPasImpl.h
@@ -109,6 +109,7 @@ void AutoPas<Particle>::init() {
   _autoTuner = std::make_unique<autopas::AutoTuner>(tuningStrategies, searchSpace, _autoTunerInfo,
                                                     _verletRebuildFrequency, _outputSuffix);
 
+  _logicHandlerInfo.sortingThreshold = _sortingThreshold;
   _logicHandler = std::make_unique<std::remove_reference_t<decltype(*_logicHandler)>>(
       *_autoTuner, _logicHandlerInfo, _verletRebuildFrequency, _outputSuffix);
 }

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -58,6 +58,7 @@ class LogicHandler {
         _haloParticleBuffer(autopas_get_max_threads()),
         _containerSelector(logicHandlerInfo.boxMin, logicHandlerInfo.boxMax, logicHandlerInfo.cutoff),
         _verletClusterSize(logicHandlerInfo.verletClusterSize),
+        _sortingThreshold(logicHandlerInfo.sortingThreshold),
         _iterationLogger(outputSuffix),
         _bufferLocks(std::max(2, autopas::autopas_get_max_threads())) {
     using namespace autopas::utils::ArrayMath::literals;
@@ -706,6 +707,11 @@ class LogicHandler {
   unsigned int _verletClusterSize;
 
   /**
+   * Number of particles in two cells from which sorting should be performed for traversal that use the CellFunctor
+   */
+  size_t _sortingThreshold;
+
+  /**
    * Reference to the AutoTuner that owns the container, ...
    */
   autopas::AutoTuner &_autoTuner;
@@ -1085,6 +1091,14 @@ std::tuple<Configuration, std::unique_ptr<TraversalInterface>, bool> LogicHandle
               TraversalSelector<std::decay_t<decltype(particleCellDummy)>>::template generateTraversal<Functor>(
                   configuration.traversal, functor, container.getTraversalSelectorInfo(), configuration.dataLayout,
                   configuration.newton3);
+
+          // set sortingThreshold of the traversal if it can be casted to a CellPairTraversal and uses the CellFunctor
+          if (auto *cellPairTraversalPtr =
+                  dynamic_cast<autopas::CellPairTraversal<std::decay_t<decltype(particleCellDummy)>> *>(
+                      traversalPtr.get())) {
+            cellPairTraversalPtr->setSortingThreshold(_sortingThreshold);
+          }
+
           if (traversalPtr->isApplicable()) {
             return std::optional{std::move(traversalPtr)};
           } else {
@@ -1234,6 +1248,14 @@ std::tuple<std::optional<std::unique_ptr<TraversalInterface>>, bool> LogicHandle
         auto traversalPtr =
             TraversalSelector<std::decay_t<decltype(particleCellDummy)>>::template generateTraversal<PairwiseFunctor>(
                 conf.traversal, pairwiseFunctor, traversalInfo, conf.dataLayout, conf.newton3);
+
+        // set sortingThreshold of the traversal if it can be casted to a CellPairTraversal and uses the CellFunctor
+        if (auto *cellPairTraversalPtr =
+                dynamic_cast<autopas::CellPairTraversal<std::decay_t<decltype(particleCellDummy)>> *>(
+                    traversalPtr.get())) {
+          cellPairTraversalPtr->setSortingThreshold(_sortingThreshold);
+        }
+
         if (traversalPtr->isApplicable()) {
           return std::optional{std::move(traversalPtr)};
         } else {

--- a/src/autopas/LogicHandlerInfo.h
+++ b/src/autopas/LogicHandlerInfo.h
@@ -35,5 +35,9 @@ class LogicHandlerInfo {
    * Number of particles in a cluster to use in VCL.
    */
   unsigned int verletClusterSize{4};
+  /**
+   * Number of particles in two cells from which sorting should be performed for traversal that use the CellFunctor
+   */
+  size_t sortingThreshold{8};
 };
 }  // namespace autopas

--- a/src/autopas/containers/cellPairTraversals/CellPairTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/CellPairTraversal.h
@@ -41,14 +41,6 @@ class CellPairTraversal : public TraversalInterface {
   virtual void setCellsToTraverse(std::vector<ParticleCell> &cells) { _cells = &cells; }
 
   /**
-   * Sets a boolean value that indicates whether the CellFunctor should apply sorting or not. This value only affects
-   * traversals that use the CellFunctor.
-   *
-   * @param useSorting If the CellFunctor should apply sorting when processing cells
-   */
-  virtual void setUseSorting(bool useSorting) = 0;
-
-  /**
    * Set the sorting-threshold for traversals that use the CellFunctor
    * If the sum of the number of particles in two cells is greater or equal to that value, the CellFunctor creates a
    * sorted view of the particles to avoid unnecessary distance checks.

--- a/src/autopas/containers/cellPairTraversals/CellPairTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/CellPairTraversal.h
@@ -48,6 +48,14 @@ class CellPairTraversal : public TraversalInterface {
    */
   virtual void setUseSorting(bool useSorting) = 0;
 
+  /**
+   * Set the sorting-threshold for traversals that use the CellFunctor
+   * If the sum of the number of particles in two cells is greater or equal to that value, the CellFunctor creates a
+   * sorted view of the particles to avoid unnecessary distance checks.
+   * @param sortingThreshold Sum of the number of particles in two cells from which sorting should be enabled
+   */
+  virtual void setSortingThreshold(size_t sortingThreshold) = 0;
+
  protected:
   /**
    * The dimensions of the cellblock.

--- a/src/autopas/containers/directSum/traversals/DSSequentialTraversal.h
+++ b/src/autopas/containers/directSum/traversals/DSSequentialTraversal.h
@@ -70,6 +70,11 @@ class DSSequentialTraversal : public CellPairTraversal<ParticleCell>, public DST
    */
   void setUseSorting(bool useSorting) override { _cellFunctor.setUseSorting(useSorting); }
 
+  /**
+   * @copydoc autopas::CellPairTraversal::setSortingThreshold()
+   */
+  void setSortingThreshold(size_t sortingThreshold) override { _cellFunctor.setSortingThreshold(sortingThreshold); }
+
  private:
   /**
    * CellFunctor to be used for the traversal defining the interaction between two cells.

--- a/src/autopas/containers/directSum/traversals/DSSequentialTraversal.h
+++ b/src/autopas/containers/directSum/traversals/DSSequentialTraversal.h
@@ -66,11 +66,6 @@ class DSSequentialTraversal : public CellPairTraversal<ParticleCell>, public DST
   void traverseParticlePairs() override;
 
   /**
-   * @copydoc autopas::CellPairTraversal::setUseSorting()
-   */
-  void setUseSorting(bool useSorting) override { _cellFunctor.setUseSorting(useSorting); }
-
-  /**
    * @copydoc autopas::CellPairTraversal::setSortingThreshold()
    */
   void setSortingThreshold(size_t sortingThreshold) override { _cellFunctor.setSortingThreshold(sortingThreshold); }

--- a/src/autopas/containers/linkedCells/traversals/LCC01Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC01Traversal.h
@@ -135,6 +135,11 @@ class LCC01Traversal
    */
   void setUseSorting(bool useSorting) override { _cellFunctor.setUseSorting(useSorting); }
 
+  /**
+   * @copydoc autopas::CellPairTraversal::setSortingThreshold()
+   */
+  void setSortingThreshold(size_t sortingThreshold) override { _cellFunctor.setSortingThreshold(sortingThreshold); }
+
  private:
   /**
    * Computes all interactions between the base

--- a/src/autopas/containers/linkedCells/traversals/LCC01Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC01Traversal.h
@@ -131,11 +131,6 @@ class LCC01Traversal
   }
 
   /**
-   * @copydoc autopas::CellPairTraversal::setUseSorting()
-   */
-  void setUseSorting(bool useSorting) override { _cellFunctor.setUseSorting(useSorting); }
-
-  /**
    * @copydoc autopas::CellPairTraversal::setSortingThreshold()
    */
   void setSortingThreshold(size_t sortingThreshold) override { _cellFunctor.setSortingThreshold(sortingThreshold); }

--- a/src/autopas/containers/linkedCells/traversals/LCC04CombinedSoATraversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC04CombinedSoATraversal.h
@@ -63,12 +63,6 @@ class LCC04CombinedSoATraversal : public C04BasedTraversal<ParticleCell, Pairwis
   }
 
   /**
-   * @copydoc autopas::CellPairTraversal::setUseSorting()
-   * This traversal does not use the CellFunctor, so the function has no effect here
-   */
-  void setUseSorting(bool useSorting) override {}
-
-  /**
    * @copydoc autopas::CellPairTraversal::setSortingThreshold()
    * This traversal does not use the CellFunctor, so the function has no effect here
    */

--- a/src/autopas/containers/linkedCells/traversals/LCC04CombinedSoATraversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC04CombinedSoATraversal.h
@@ -68,6 +68,12 @@ class LCC04CombinedSoATraversal : public C04BasedTraversal<ParticleCell, Pairwis
    */
   void setUseSorting(bool useSorting) override {}
 
+  /**
+   * @copydoc autopas::CellPairTraversal::setSortingThreshold()
+   * This traversal does not use the CellFunctor, so the function has no effect here
+   */
+  void setSortingThreshold(size_t sortingThreshold) override {}
+
  private:
   LCC04SoACellHandler<ParticleCell, PairwiseFunctor, dataLayout, useNewton3> _cellHandler;
 };

--- a/src/autopas/containers/linkedCells/traversals/LCC04HCPTraversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC04HCPTraversal.h
@@ -68,6 +68,11 @@ class LCC04HCPTraversal : public C08BasedTraversal<ParticleCell, PairwiseFunctor
    */
   void setUseSorting(bool useSorting) override { _cellHandler.setUseSorting(useSorting); }
 
+  /**
+   * @copydoc autopas::CellPairTraversal::setSortingThreshold()
+   */
+  void setSortingThreshold(size_t sortingThreshold) override { _cellHandler.setSortingThreshold(sortingThreshold); }
+
  private:
   void traverseSingleColor(std::vector<ParticleCell> &cells, int color);
 

--- a/src/autopas/containers/linkedCells/traversals/LCC04HCPTraversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC04HCPTraversal.h
@@ -64,11 +64,6 @@ class LCC04HCPTraversal : public C08BasedTraversal<ParticleCell, PairwiseFunctor
   }
 
   /**
-   * @copydoc autopas::CellPairTraversal::setUseSorting()
-   */
-  void setUseSorting(bool useSorting) override { _cellHandler.setUseSorting(useSorting); }
-
-  /**
    * @copydoc autopas::CellPairTraversal::setSortingThreshold()
    */
   void setSortingThreshold(size_t sortingThreshold) override { _cellHandler.setSortingThreshold(sortingThreshold); }

--- a/src/autopas/containers/linkedCells/traversals/LCC04Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC04Traversal.h
@@ -75,6 +75,11 @@ class LCC04Traversal : public C08BasedTraversal<ParticleCell, PairwiseFunctor, d
    */
   void setUseSorting(bool useSorting) override { _cellHandler.setUseSorting(useSorting); }
 
+  /**
+   * @copydoc autopas::CellPairTraversal::setSortingThreshold()
+   */
+  void setSortingThreshold(size_t sortingThreshold) override { _cellHandler.setSortingThreshold(sortingThreshold); }
+
  private:
   void traverseSingleColor(std::vector<ParticleCell> &cells, int color);
 

--- a/src/autopas/containers/linkedCells/traversals/LCC04Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC04Traversal.h
@@ -71,11 +71,6 @@ class LCC04Traversal : public C08BasedTraversal<ParticleCell, PairwiseFunctor, d
   }
 
   /**
-   * @copydoc autopas::CellPairTraversal::setUseSorting()
-   */
-  void setUseSorting(bool useSorting) override { _cellHandler.setUseSorting(useSorting); }
-
-  /**
    * @copydoc autopas::CellPairTraversal::setSortingThreshold()
    */
   void setSortingThreshold(size_t sortingThreshold) override { _cellHandler.setSortingThreshold(sortingThreshold); }

--- a/src/autopas/containers/linkedCells/traversals/LCC08CellHandler.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC08CellHandler.h
@@ -58,11 +58,6 @@ class LCC08CellHandler {
   void processBaseCell(std::vector<ParticleCell> &cells, unsigned long baseIndex);
 
   /**
-   * @copydoc autopas::CellPairTraversal::setUseSorting()
-   */
-  void setUseSorting(bool useSorting) { _cellFunctor.setUseSorting(useSorting); }
-
-  /**
    * @copydoc autopas::CellPairTraversal::setSortingThreshold()
    */
   void setSortingThreshold(size_t sortingThreshold) { _cellFunctor.setSortingThreshold(sortingThreshold); }

--- a/src/autopas/containers/linkedCells/traversals/LCC08CellHandler.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC08CellHandler.h
@@ -62,6 +62,11 @@ class LCC08CellHandler {
    */
   void setUseSorting(bool useSorting) { _cellFunctor.setUseSorting(useSorting); }
 
+  /**
+   * @copydoc autopas::CellPairTraversal::setSortingThreshold()
+   */
+  void setSortingThreshold(size_t sortingThreshold) { _cellFunctor.setSortingThreshold(sortingThreshold); }
+
  protected:
   /**
    * Pair sets for processBaseCell().

--- a/src/autopas/containers/linkedCells/traversals/LCC08Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC08Traversal.h
@@ -59,11 +59,6 @@ class LCC08Traversal : public C08BasedTraversal<ParticleCell, PairwiseFunctor, d
   [[nodiscard]] bool isApplicable() const override { return true; }
 
   /**
-   * @copydoc autopas::CellPairTraversal::setUseSorting()
-   */
-  void setUseSorting(bool useSorting) override { _cellHandler.setUseSorting(useSorting); }
-
-  /**
    * @copydoc autopas::CellPairTraversal::setSortingThreshold()
    */
   void setSortingThreshold(size_t sortingThreshold) override { _cellHandler.setSortingThreshold(sortingThreshold); }

--- a/src/autopas/containers/linkedCells/traversals/LCC08Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC08Traversal.h
@@ -63,6 +63,11 @@ class LCC08Traversal : public C08BasedTraversal<ParticleCell, PairwiseFunctor, d
    */
   void setUseSorting(bool useSorting) override { _cellHandler.setUseSorting(useSorting); }
 
+  /**
+   * @copydoc autopas::CellPairTraversal::setSortingThreshold()
+   */
+  void setSortingThreshold(size_t sortingThreshold) override { _cellHandler.setSortingThreshold(sortingThreshold); }
+
  private:
   LCC08CellHandler<ParticleCell, PairwiseFunctor, dataLayout, useNewton3> _cellHandler;
 };

--- a/src/autopas/containers/linkedCells/traversals/LCC18Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC18Traversal.h
@@ -76,11 +76,6 @@ class LCC18Traversal : public C18BasedTraversal<ParticleCell, PairwiseFunctor, d
   [[nodiscard]] bool getUseNewton3() const override { return useNewton3; }
 
   /**
-   * @copydoc autopas::CellPairTraversal::setUseSorting()
-   */
-  void setUseSorting(bool useSorting) override { _cellFunctor.setUseSorting(useSorting); }
-
-  /**
    * @copydoc autopas::CellPairTraversal::setSortingThreshold()
    */
   void setSortingThreshold(size_t sortingThreshold) override { _cellFunctor.setSortingThreshold(sortingThreshold); }

--- a/src/autopas/containers/linkedCells/traversals/LCC18Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC18Traversal.h
@@ -80,6 +80,11 @@ class LCC18Traversal : public C18BasedTraversal<ParticleCell, PairwiseFunctor, d
    */
   void setUseSorting(bool useSorting) override { _cellFunctor.setUseSorting(useSorting); }
 
+  /**
+   * @copydoc autopas::CellPairTraversal::setSortingThreshold()
+   */
+  void setSortingThreshold(size_t sortingThreshold) override { _cellFunctor.setSortingThreshold(sortingThreshold); }
+
  private:
   /**
    * Computes pairs used in processBaseCell()

--- a/src/autopas/containers/linkedCells/traversals/LCSlicedBalancedTraversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCSlicedBalancedTraversal.h
@@ -61,11 +61,6 @@ class LCSlicedBalancedTraversal
   [[nodiscard]] TraversalOption getTraversalType() const override { return TraversalOption::lc_sliced_balanced; }
 
   /**
-   * @copydoc autopas::CellPairTraversal::setUseSorting()
-   */
-  void setUseSorting(bool useSorting) override { _cellHandler.setUseSorting(useSorting); }
-
-  /**
    * @copydoc autopas::CellPairTraversal::setSortingThreshold()
    */
   void setSortingThreshold(size_t sortingThreshold) override { _cellHandler.setSortingThreshold(sortingThreshold); }

--- a/src/autopas/containers/linkedCells/traversals/LCSlicedBalancedTraversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCSlicedBalancedTraversal.h
@@ -65,6 +65,11 @@ class LCSlicedBalancedTraversal
    */
   void setUseSorting(bool useSorting) override { _cellHandler.setUseSorting(useSorting); }
 
+  /**
+   * @copydoc autopas::CellPairTraversal::setSortingThreshold()
+   */
+  void setSortingThreshold(size_t sortingThreshold) override { _cellHandler.setSortingThreshold(sortingThreshold); }
+
  private:
   LCC08CellHandler<ParticleCell, PairwiseFunctor, dataLayout, useNewton3> _cellHandler;
 };

--- a/src/autopas/containers/linkedCells/traversals/LCSlicedC02Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCSlicedC02Traversal.h
@@ -62,6 +62,11 @@ class LCSlicedC02Traversal
    */
   void setUseSorting(bool useSorting) override { _cellHandler.setUseSorting(useSorting); }
 
+  /**
+   * @copydoc autopas::CellPairTraversal::setSortingThreshold()
+   */
+  void setSortingThreshold(size_t sortingThreshold) override { _cellHandler.setSortingThreshold(sortingThreshold); }
+
  private:
   LCC08CellHandler<ParticleCell, PairwiseFunctor, dataLayout, useNewton3> _cellHandler;
 };

--- a/src/autopas/containers/linkedCells/traversals/LCSlicedC02Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCSlicedC02Traversal.h
@@ -58,11 +58,6 @@ class LCSlicedC02Traversal
   [[nodiscard]] TraversalOption getTraversalType() const override { return TraversalOption::lc_sliced_c02; }
 
   /**
-   * @copydoc autopas::CellPairTraversal::setUseSorting()
-   */
-  void setUseSorting(bool useSorting) override { _cellHandler.setUseSorting(useSorting); }
-
-  /**
    * @copydoc autopas::CellPairTraversal::setSortingThreshold()
    */
   void setSortingThreshold(size_t sortingThreshold) override { _cellHandler.setSortingThreshold(sortingThreshold); }

--- a/src/autopas/containers/linkedCells/traversals/LCSlicedTraversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCSlicedTraversal.h
@@ -63,6 +63,11 @@ class LCSlicedTraversal : public SlicedLockBasedTraversal<ParticleCell, Pairwise
    */
   void setUseSorting(bool useSorting) override { _cellHandler.setUseSorting(useSorting); }
 
+  /**
+   * @copydoc autopas::CellPairTraversal::setSortingThreshold()
+   */
+  void setSortingThreshold(size_t sortingThreshold) override { _cellHandler.setSortingThreshold(sortingThreshold); }
+
  private:
   LCC08CellHandler<ParticleCell, PairwiseFunctor, dataLayout, useNewton3> _cellHandler;
 };

--- a/src/autopas/containers/linkedCells/traversals/LCSlicedTraversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCSlicedTraversal.h
@@ -59,11 +59,6 @@ class LCSlicedTraversal : public SlicedLockBasedTraversal<ParticleCell, Pairwise
   [[nodiscard]] TraversalOption getTraversalType() const override { return TraversalOption::lc_sliced; }
 
   /**
-   * @copydoc autopas::CellPairTraversal::setUseSorting()
-   */
-  void setUseSorting(bool useSorting) override { _cellHandler.setUseSorting(useSorting); }
-
-  /**
    * @copydoc autopas::CellPairTraversal::setSortingThreshold()
    */
   void setSortingThreshold(size_t sortingThreshold) override { _cellHandler.setSortingThreshold(sortingThreshold); }

--- a/src/autopas/containers/octree/traversals/OTC01Traversal.h
+++ b/src/autopas/containers/octree/traversals/OTC01Traversal.h
@@ -106,11 +106,6 @@ class OTC01Traversal : public CellPairTraversal<OctreeLeafNode<Particle>>,
   }
 
   /**
-   * @copydoc autopas::CellPairTraversal::setUseSorting()
-   */
-  void setUseSorting(bool useSorting) override { _cellFunctor.setUseSorting(useSorting); }
-
-  /**
    * @copydoc autopas::CellPairTraversal::setSortingThreshold()
    */
   void setSortingThreshold(size_t sortingThreshold) override { _cellFunctor.setSortingThreshold(sortingThreshold); }

--- a/src/autopas/containers/octree/traversals/OTC01Traversal.h
+++ b/src/autopas/containers/octree/traversals/OTC01Traversal.h
@@ -110,6 +110,11 @@ class OTC01Traversal : public CellPairTraversal<OctreeLeafNode<Particle>>,
    */
   void setUseSorting(bool useSorting) override { _cellFunctor.setUseSorting(useSorting); }
 
+  /**
+   * @copydoc autopas::CellPairTraversal::setSortingThreshold()
+   */
+  void setSortingThreshold(size_t sortingThreshold) override { _cellFunctor.setSortingThreshold(sortingThreshold); }
+
  private:
   /**
    * CellFunctor to be used for the traversal defining the interaction between two cells.

--- a/src/autopas/containers/octree/traversals/OTC18Traversal.h
+++ b/src/autopas/containers/octree/traversals/OTC18Traversal.h
@@ -123,11 +123,6 @@ class OTC18Traversal : public CellPairTraversal<OctreeLeafNode<Particle>>,
   }
 
   /**
-   * @copydoc autopas::CellPairTraversal::setUseSorting()
-   */
-  void setUseSorting(bool useSorting) override { _cellFunctor.setUseSorting(useSorting); }
-
-  /**
    * @copydoc autopas::CellPairTraversal::setSortingThreshold()
    */
   void setSortingThreshold(size_t sortingThreshold) override { _cellFunctor.setSortingThreshold(sortingThreshold); }

--- a/src/autopas/containers/octree/traversals/OTC18Traversal.h
+++ b/src/autopas/containers/octree/traversals/OTC18Traversal.h
@@ -127,6 +127,11 @@ class OTC18Traversal : public CellPairTraversal<OctreeLeafNode<Particle>>,
    */
   void setUseSorting(bool useSorting) override { _cellFunctor.setUseSorting(useSorting); }
 
+  /**
+   * @copydoc autopas::CellPairTraversal::setSortingThreshold()
+   */
+  void setSortingThreshold(size_t sortingThreshold) override { _cellFunctor.setSortingThreshold(sortingThreshold); }
+
  private:
   /**
    * CellFunctor to be used for the traversal defining the interaction between two cells.

--- a/src/autopas/containers/verletClusterLists/traversals/VCLC06Traversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VCLC06Traversal.h
@@ -110,6 +110,12 @@ class VCLC06Traversal : public CBasedTraversal<ParticleCell, PairwiseFunctor, da
    */
   void setUseSorting(bool useSorting) override {}
 
+  /**
+   * @copydoc autopas::CellPairTraversal::setSortingThreshold()
+   * This traversal does not use the CellFunctor, so the function has no effect here
+   */
+  void setSortingThreshold(size_t sortingThreshold) override {}
+
  private:
   PairwiseFunctor *_functor;
   internal::VCLClusterFunctor<Particle, PairwiseFunctor, dataLayout, useNewton3> _clusterFunctor;

--- a/src/autopas/containers/verletClusterLists/traversals/VCLC06Traversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VCLC06Traversal.h
@@ -105,12 +105,6 @@ class VCLC06Traversal : public CBasedTraversal<ParticleCell, PairwiseFunctor, da
   }
 
   /**
-   * @copydoc autopas::CellPairTraversal::setUseSorting()
-   * This traversal does not use the CellFunctor, so the function has no effect here
-   */
-  void setUseSorting(bool useSorting) override {}
-
-  /**
    * @copydoc autopas::CellPairTraversal::setSortingThreshold()
    * This traversal does not use the CellFunctor, so the function has no effect here
    */

--- a/src/autopas/containers/verletClusterLists/traversals/VCLSlicedBalancedTraversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VCLSlicedBalancedTraversal.h
@@ -85,12 +85,6 @@ class VCLSlicedBalancedTraversal
   }
 
   /**
-   * @copydoc autopas::CellPairTraversal::setUseSorting()
-   * This traversal does not use the CellFunctor, so the function has no effect here
-   */
-  void setUseSorting(bool useSorting) override {}
-
-  /**
    * @copydoc autopas::CellPairTraversal::setSortingThreshold()
    * This traversal does not use the CellFunctor, so the function has no effect here
    */

--- a/src/autopas/containers/verletClusterLists/traversals/VCLSlicedBalancedTraversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VCLSlicedBalancedTraversal.h
@@ -89,5 +89,11 @@ class VCLSlicedBalancedTraversal
    * This traversal does not use the CellFunctor, so the function has no effect here
    */
   void setUseSorting(bool useSorting) override {}
+
+  /**
+   * @copydoc autopas::CellPairTraversal::setSortingThreshold()
+   * This traversal does not use the CellFunctor, so the function has no effect here
+   */
+  void setSortingThreshold(size_t sortingThreshold) override {}
 };
 }  // namespace autopas

--- a/src/autopas/containers/verletClusterLists/traversals/VCLSlicedC02Traversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VCLSlicedC02Traversal.h
@@ -85,12 +85,6 @@ class VCLSlicedC02Traversal
   }
 
   /**
-   * @copydoc autopas::CellPairTraversal::setUseSorting()
-   * This traversal does not use the CellFunctor, so the function has no effect here
-   */
-  void setUseSorting(bool useSorting) override {}
-
-  /**
    * @copydoc autopas::CellPairTraversal::setSortingThreshold()
    * This traversal does not use the CellFunctor, so the function has no effect here
    */

--- a/src/autopas/containers/verletClusterLists/traversals/VCLSlicedC02Traversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VCLSlicedC02Traversal.h
@@ -89,5 +89,11 @@ class VCLSlicedC02Traversal
    * This traversal does not use the CellFunctor, so the function has no effect here
    */
   void setUseSorting(bool useSorting) override {}
+
+  /**
+   * @copydoc autopas::CellPairTraversal::setSortingThreshold()
+   * This traversal does not use the CellFunctor, so the function has no effect here
+   */
+  void setSortingThreshold(size_t sortingThreshold) override {}
 };
 }  // namespace autopas

--- a/src/autopas/containers/verletClusterLists/traversals/VCLSlicedTraversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VCLSlicedTraversal.h
@@ -89,5 +89,11 @@ class VCLSlicedTraversal
    * This traversal does not use the CellFunctor, so the function has no effect here
    */
   void setUseSorting(bool useSorting) override {}
+
+  /**
+   * @copydoc autopas::CellPairTraversal::setSortingThreshold()
+   * This traversal does not use the CellFunctor, so the function has no effect here
+   */
+  void setSortingThreshold(size_t sortingThreshold) override {}
 };
 }  // namespace autopas

--- a/src/autopas/containers/verletClusterLists/traversals/VCLSlicedTraversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VCLSlicedTraversal.h
@@ -85,12 +85,6 @@ class VCLSlicedTraversal
   }
 
   /**
-   * @copydoc autopas::CellPairTraversal::setUseSorting()
-   * This traversal does not use the CellFunctor, so the function has no effect here
-   */
-  void setUseSorting(bool useSorting) override {}
-
-  /**
    * @copydoc autopas::CellPairTraversal::setSortingThreshold()
    * This traversal does not use the CellFunctor, so the function has no effect here
    */

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCC01Traversal.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCC01Traversal.h
@@ -67,12 +67,6 @@ class VLCC01Traversal : public C01BasedTraversal<ParticleCell, PairwiseFunctor, 
   [[nodiscard]] bool getUseNewton3() const override { return useNewton3; }
 
   /**
-   * @copydoc autopas::CellPairTraversal::setUseSorting()
-   * This traversal does not use the CellFunctor, so the function has no effect here
-   */
-  void setUseSorting(bool useSorting) override {}
-
-  /**
    * @copydoc autopas::CellPairTraversal::setSortingThreshold()
    * This traversal does not use the CellFunctor, so the function has no effect here
    */

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCC01Traversal.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCC01Traversal.h
@@ -72,6 +72,12 @@ class VLCC01Traversal : public C01BasedTraversal<ParticleCell, PairwiseFunctor, 
    */
   void setUseSorting(bool useSorting) override {}
 
+  /**
+   * @copydoc autopas::CellPairTraversal::setSortingThreshold()
+   * This traversal does not use the CellFunctor, so the function has no effect here
+   */
+  void setSortingThreshold(size_t sortingThreshold) override {}
+
  private:
   PairwiseFunctor *_functor;
 };

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCC18Traversal.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCC18Traversal.h
@@ -76,6 +76,12 @@ class VLCC18Traversal : public C18BasedTraversal<ParticleCell, PairwiseFunctor, 
    */
   void setUseSorting(bool useSorting) override {}
 
+  /**
+   * @copydoc autopas::CellPairTraversal::setSortingThreshold()
+   * This traversal does not use the CellFunctor, so the function has no effect here
+   */
+  void setSortingThreshold(size_t sortingThreshold) override {}
+
  private:
   PairwiseFunctor *_functor;
 };

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCC18Traversal.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCC18Traversal.h
@@ -71,12 +71,6 @@ class VLCC18Traversal : public C18BasedTraversal<ParticleCell, PairwiseFunctor, 
   [[nodiscard]] bool getUseNewton3() const override { return useNewton3; }
 
   /**
-   * @copydoc autopas::CellPairTraversal::setUseSorting()
-   * This traversal does not use the CellFunctor, so the function has no effect here
-   */
-  void setUseSorting(bool useSorting) override {}
-
-  /**
    * @copydoc autopas::CellPairTraversal::setSortingThreshold()
    * This traversal does not use the CellFunctor, so the function has no effect here
    */

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCCellPairC08Traversal.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCCellPairC08Traversal.h
@@ -55,12 +55,6 @@ class VLCCellPairC08Traversal : public C08BasedTraversal<ParticleCell, PairwiseF
   [[nodiscard]] TraversalOption getTraversalType() const override { return TraversalOption::vlp_c08; }
 
   /**
-   * @copydoc autopas::CellPairTraversal::setUseSorting()
-   * This traversal does not use the CellFunctor, so the function has no effect here
-   */
-  void setUseSorting(bool useSorting) override {}
-
-  /**
    * @copydoc autopas::CellPairTraversal::setSortingThreshold()
    * This traversal does not use the CellFunctor, so the function has no effect here
    */

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCCellPairC08Traversal.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCCellPairC08Traversal.h
@@ -60,6 +60,12 @@ class VLCCellPairC08Traversal : public C08BasedTraversal<ParticleCell, PairwiseF
    */
   void setUseSorting(bool useSorting) override {}
 
+  /**
+   * @copydoc autopas::CellPairTraversal::setSortingThreshold()
+   * This traversal does not use the CellFunctor, so the function has no effect here
+   */
+  void setSortingThreshold(size_t sortingThreshold) override {}
+
  private:
   PairwiseFunctor *_functor;
   VLCCellPairC08CellHandler<ParticleCell, PairwiseFunctor, dataLayout, useNewton3> _cellHandler;

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCSlicedBalancedTraversal.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCSlicedBalancedTraversal.h
@@ -77,12 +77,6 @@ class VLCSlicedBalancedTraversal
   }
 
   /**
-   * @copydoc autopas::CellPairTraversal::setUseSorting()
-   * This traversal does not use the CellFunctor, so the function has no effect here
-   */
-  void setUseSorting(bool useSorting) override {}
-
-  /**
    * @copydoc autopas::CellPairTraversal::setSortingThreshold()
    * This traversal does not use the CellFunctor, so the function has no effect here
    */

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCSlicedBalancedTraversal.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCSlicedBalancedTraversal.h
@@ -82,6 +82,12 @@ class VLCSlicedBalancedTraversal
    */
   void setUseSorting(bool useSorting) override {}
 
+  /**
+   * @copydoc autopas::CellPairTraversal::setSortingThreshold()
+   * This traversal does not use the CellFunctor, so the function has no effect here
+   */
+  void setSortingThreshold(size_t sortingThreshold) override {}
+
  private:
   PairwiseFunctor *_functor;
 };

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCSlicedC02Traversal.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCSlicedC02Traversal.h
@@ -75,12 +75,6 @@ class VLCSlicedC02Traversal
   }
 
   /**
-   * @copydoc autopas::CellPairTraversal::setUseSorting()
-   * This traversal does not use the CellFunctor, so the function has no effect here
-   */
-  void setUseSorting(bool useSorting) override {}
-
-  /**
    * @copydoc autopas::CellPairTraversal::setSortingThreshold()
    * This traversal does not use the CellFunctor, so the function has no effect here
    */

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCSlicedC02Traversal.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCSlicedC02Traversal.h
@@ -80,6 +80,12 @@ class VLCSlicedC02Traversal
    */
   void setUseSorting(bool useSorting) override {}
 
+  /**
+   * @copydoc autopas::CellPairTraversal::setSortingThreshold()
+   * This traversal does not use the CellFunctor, so the function has no effect here
+   */
+  void setSortingThreshold(size_t sortingThreshold) override {}
+
  private:
   PairwiseFunctor *_functor;
 };

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCSlicedTraversal.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCSlicedTraversal.h
@@ -85,6 +85,12 @@ class VLCSlicedTraversal
    */
   void setUseSorting(bool useSorting) override {}
 
+  /**
+   * @copydoc autopas::CellPairTraversal::setSortingThreshold()
+   * This traversal does not use the CellFunctor, so the function has no effect here
+   */
+  void setSortingThreshold(size_t sortingThreshold) override {}
+
  private:
   PairwiseFunctor *_functor;
 };

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCSlicedTraversal.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCSlicedTraversal.h
@@ -80,12 +80,6 @@ class VLCSlicedTraversal
   }
 
   /**
-   * @copydoc autopas::CellPairTraversal::setUseSorting()
-   * This traversal does not use the CellFunctor, so the function has no effect here
-   */
-  void setUseSorting(bool useSorting) override {}
-
-  /**
    * @copydoc autopas::CellPairTraversal::setSortingThreshold()
    * This traversal does not use the CellFunctor, so the function has no effect here
    */

--- a/src/autopas/pairwiseFunctors/CellFunctor.h
+++ b/src/autopas/pairwiseFunctors/CellFunctor.h
@@ -61,6 +61,14 @@ class CellFunctor {
    */
   void setUseSorting(bool useSorting);
 
+  /**
+   * Set the sorting-threshold
+   * If the sum of the number of particles in two cells is greater or equal to that value, the CellFunctor creates a
+   * sorted view of the particles to avoid unnecessary distance checks.
+   * @param sortingThreshold Sum of the number of particles in two cells from which sorting should be enabled
+   */
+  void setSortingThreshold(size_t sortingThreshold);
+
  private:
   /**
    * Applies the functor to all particle pairs exploiting newtons third law of
@@ -111,10 +119,9 @@ class CellFunctor {
   bool _useSorting{true};
 
   /**
-   * Min. number of particles to start sorting.
-   * For details on the chosen threshold see: https://github.com/AutoPas/AutoPas/pull/619
+   * Min. number of particles to start sorting. This is the sum of the number of particles in two cells.
    */
-  constexpr static unsigned long _sortingThreshold = 8;
+  size_t _sortingThreshold{8};
 };
 
 template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutOption::Value DataLayout,
@@ -122,6 +129,13 @@ template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutO
 void CellFunctor<Particle, ParticleCell, ParticleFunctor, DataLayout, useNewton3, bidirectional>::setUseSorting(
     bool useSorting) {
   _useSorting = useSorting;
+}
+
+template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutOption::Value DataLayout,
+          bool useNewton3, bool bidirectional>
+void CellFunctor<Particle, ParticleCell, ParticleFunctor, DataLayout, useNewton3, bidirectional>::setSortingThreshold(
+    size_t sortingThreshold) {
+  _sortingThreshold = sortingThreshold;
 }
 
 template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutOption::Value DataLayout,

--- a/src/autopas/pairwiseFunctors/CellFunctor.h
+++ b/src/autopas/pairwiseFunctors/CellFunctor.h
@@ -107,6 +107,7 @@ class CellFunctor {
 
   /**
    * Min. number of particles to start sorting. This is the sum of the number of particles in two cells.
+   * For details on the chosen default threshold see: https://github.com/AutoPas/AutoPas/pull/619
    */
   size_t _sortingThreshold{8};
 };

--- a/src/autopas/pairwiseFunctors/CellFunctor.h
+++ b/src/autopas/pairwiseFunctors/CellFunctor.h
@@ -54,14 +54,6 @@ class CellFunctor {
                        const std::array<double, 3> &sortingDirection = {0., 0., 0.});
 
   /**
-   * Sets a boolean value that indicates whether the CellFunctor should apply sorting or not.
-   * By default sorting is enabled
-   *
-   * @param useSorting If the CellFunctor should apply sorting when processing cells
-   */
-  void setUseSorting(bool useSorting);
-
-  /**
    * Set the sorting-threshold
    * If the sum of the number of particles in two cells is greater or equal to that value, the CellFunctor creates a
    * sorted view of the particles to avoid unnecessary distance checks.
@@ -114,22 +106,10 @@ class CellFunctor {
   const double _sortingCutoff;
 
   /**
-   * This value is used to switch on and off the sorting functionality of the CellFunctor. Sorting is enabled by default
-   */
-  bool _useSorting{true};
-
-  /**
    * Min. number of particles to start sorting. This is the sum of the number of particles in two cells.
    */
   size_t _sortingThreshold{8};
 };
-
-template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutOption::Value DataLayout,
-          bool useNewton3, bool bidirectional>
-void CellFunctor<Particle, ParticleCell, ParticleFunctor, DataLayout, useNewton3, bidirectional>::setUseSorting(
-    bool useSorting) {
-  _useSorting = useSorting;
-}
 
 template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutOption::Value DataLayout,
           bool useNewton3, bool bidirectional>
@@ -211,7 +191,7 @@ template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutO
 template <bool newton3>
 void CellFunctor<Particle, ParticleCell, ParticleFunctor, DataLayout, useNewton3, bidirectional>::processCellAoS(
     ParticleCell &cell) {
-  if (_useSorting and cell.size() > _sortingThreshold) {
+  if (cell.size() > _sortingThreshold) {
     SortedCellView<Particle, ParticleCell> cellSorted(
         cell, utils::ArrayMath::normalize(std::array<double, 3>{1.0, 1.0, 1.0}));
 
@@ -259,8 +239,7 @@ template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutO
           bool useNewton3, bool bidirectional>
 void CellFunctor<Particle, ParticleCell, ParticleFunctor, DataLayout, useNewton3, bidirectional>::processCellPairAoSN3(
     ParticleCell &cell1, ParticleCell &cell2, const std::array<double, 3> &sortingDirection) {
-  if (_useSorting and (cell1.size() + cell2.size() > _sortingThreshold) and
-      (sortingDirection != std::array<double, 3>{0., 0., 0.})) {
+  if ((cell1.size() + cell2.size() > _sortingThreshold) and (sortingDirection != std::array<double, 3>{0., 0., 0.})) {
     SortedCellView<Particle, ParticleCell> baseSorted(cell1, sortingDirection);
     SortedCellView<Particle, ParticleCell> outerSorted(cell2, sortingDirection);
 
@@ -296,8 +275,7 @@ template <class Particle, class ParticleCell, class ParticleFunctor, DataLayoutO
 void CellFunctor<Particle, ParticleCell, ParticleFunctor, DataLayout, useNewton3,
                  bidirectional>::processCellPairAoSNoN3(ParticleCell &cell1, ParticleCell &cell2,
                                                         const std::array<double, 3> &sortingDirection) {
-  if (_useSorting and (cell1.size() + cell2.size() > _sortingThreshold) and
-      (sortingDirection != std::array<double, 3>{0., 0., 0.})) {
+  if ((cell1.size() + cell2.size() > _sortingThreshold) and (sortingDirection != std::array<double, 3>{0., 0., 0.})) {
     SortedCellView<Particle, ParticleCell> baseSorted(cell1, sortingDirection);
     SortedCellView<Particle, ParticleCell> outerSorted(cell2, sortingDirection);
 

--- a/tests/testAutopas/tests/containers/TraversalComparison.cpp
+++ b/tests/testAutopas/tests/containers/TraversalComparison.cpp
@@ -127,7 +127,7 @@ std::tuple<std::vector<std::array<double, 3>>, TraversalComparison::Globals> Tra
         // set useSorting of the traversal if it can be casted to a CellPairTraversal and uses the CellFunctor
         if (auto *cellPairTraversalPtr =
                 dynamic_cast<autopas::CellPairTraversal<decltype(particleCellDummy)> *>(traversalUniquePtr.get())) {
-          cellPairTraversalPtr->setUseSorting(useSorting);
+          cellPairTraversalPtr->setSortingThreshold(useSorting ? 8 : std::numeric_limits<size_t>::max());
         }
 
         return traversalUniquePtr;


### PR DESCRIPTION
# Description

This PR introduces a parameter for AutoPas and md-flexible to make the sorting-threshold for the `CellFunctor` configurable by the user. The default value for this parameter is set to 8.

The `setUseSorting` functionality was removed again, since this can also be done now by setting the sorting threshold to a super large value for example to disable sorting.

## Related Pull Requests

- #619

# How Has This Been Tested?

- [x] All existing tests
