### PR TITLE
Bugfix for VCLC01BalancedTraversal

### DIFF
--- a/src/autopas/containers/verletClusterLists/traversals/VCLC01BalancedTraversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VCLC01BalancedTraversal.h
@@ -75,8 +75,7 @@ class VCLC01BalancedTraversal : public TraversalInterface, public VCLTraversalIn
         auto startIndexInTower =
             clusterCount == 0 ? clusterRange.startIndexInTower : currentTower.getFirstOwnedClusterIndex();
         for (size_t clusterIndex = startIndexInTower;
-             clusterIndex < clusterRange.numClusters and clusterCount < clusterRange.numClusters and
-             clusterIndex < currentTower.getFirstTailHaloClusterIndex();
+             clusterCount < clusterRange.numClusters and clusterIndex < currentTower.getFirstTailHaloClusterIndex();
              clusterIndex++, clusterCount++) {
           const auto isHaloCluster = clusterIndex < currentTower.getFirstOwnedClusterIndex() or
                                      clusterIndex >= currentTower.getFirstTailHaloClusterIndex();


### PR DESCRIPTION
# Description

This PR should solve a bug with the `VCLC01BalancedTraversal`.

To reproduce the bug, run the test `testAllConfigurations` with >= 6 threads using commit 06a9fd21a5219987d0bf121e79cd9a2c37bf6b3d.
The problem is the check `clusterCount < clusterRange.numClusters` in `VCLC01BalancedTraversal::traverseParticlePairs` in the parallel region:

https://github.com/AutoPas/AutoPas/blob/06a9fd21a5219987d0bf121e79cd9a2c37bf6b3d/src/autopas/containers/verletClusterLists/traversals/VCLC01BalancedTraversal.h#L77-L84

This check therefore fails if `clusterIndex`, which is initially set to `startIndexInTower`, is smaller than `clusterRange.numClusters`. This becomes a problem if a thread is assigned clusters from two towers, for example, and the `startIndex` in the first tower is already greater than `clusterRange.numClusters`.

The diagram illustrates the problem:
Thread0 is assigned C0 and C1 from Tower0. Thread1 gets C2 from Tower0 (i.e. `startIndex=2`) and C0 from Tower1 (i.e. `numClusters=2`). Accordingly, `processCluster` is never executed because the above check returns false.

![towerCluster](https://github.com/AutoPas/AutoPas/assets/121112647/bc112f3c-7423-48ea-9979-e5ff5df607ed)

However, I'm not quite sure yet whether removing the check will have any negative consequences. At first glance, it should not cause any problems, as the `numClusters` are already calculated in `VerletClusterLists::fillClusterRanges` with respect to `FirstOwnedCluster` and `FirstTailHaloCluster`. Accordingly, in `VCLC01BalancedTraversal::traverseParticlePairs` it should not be possible for the `startIndexInTower` to be above the limit for the respective thread.

# Todo
- [x] Ensure that removing the check has no negative effects / introduce a modified check

# How Has This Been Tested?
- [x] Existing tests with `OMP_NUM_THREADS=16`
