### PR TITLE
OpenMP Wrapper Macro

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Please keep in mind the following notes while working.
 ### General Notes
 * Cpp standard: C++17. If there is a piece of code, which could be done better using a newer standard, please add a comment like `@todo C++20` including the alternative version of the code.
 * Pointers: Always use smart pointers when you are managing memory. Don't use `new` or `delete`.
-* OpenMP: Use AutoPas wrapper functions for OpenMP (`src/autopas/utils/WrapOpenMP.h`) instead of OpenMP functions to allow building without enabled OpenMP.
+* OpenMP: Use AutoPas wrapper functions and macros for OpenMP (`src/autopas/utils/WrapOpenMP.h`) instead of OpenMP functions to allow building without enabled OpenMP.
 * `#pragma once` instead of header guards.
 * `#include` of files from within AutoPas shall be given with the full path (starting with `autopas/`) and using `""`. 
 * `constexpr` instead of `#define`. Use it wherever possible.

--- a/.github/workflows/TestSuites.yaml
+++ b/.github/workflows/TestSuites.yaml
@@ -53,6 +53,9 @@ jobs:
           ! grep '#include <autopas' **/*.{h,cpp}
           # prohibit 'typedef' to force 'using'
           ! grep --word-regexp 'typedef' **/*.{h,cpp}
+          # prohibit old usage of AUTOPAS_OPENMP
+          ! grep '#ifdef AUTOPAS_OPENMP'  **/*.{h,cpp}
+          ! grep '#if defined.AUTOPAS_OPENMP'  **/*.{h,cpp}
 
   MatrixJob:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Iterators to iterate over particle are provided.
 The particle can be accesses using `iter->` or `*iter`.
 When created inside a OpenMP parallel region, work is automatically spread over all threads.
 ```cpp
-#pragma omp parallel
+AUTOPAS_OPENMP(parallel)
 for(auto iter = autoPas.begin(); iter.isValid(); ++iter) {
   // user code:
   auto position = iter->getR();
@@ -168,7 +168,7 @@ for(auto iter = autoPas.begin(); iter.isValid(); ++iter) {
 ```
 For convenience the `end()` method is also implemented for the AutoPas class so you might also use range-based for loops:
 ```cpp
-#pragma omp parallel
+AUTOPAS_OPENMP(parallel)
 for(auto& particle : autoPas) {
   // user code:
   auto position = particle.getR();
@@ -177,7 +177,7 @@ for(auto& particle : autoPas) {
 
 To iterate over a subset of particles, the `getRegionIterator(lowCorner, highCorner)` method can be used:
 ```cpp
-#pragma omp parallel
+AUTOPAS_OPENMP(parallel)
 for(auto iter = autoPas.getRegionIterator(lowCorner, highCorner); iter != autoPas.end(); ++iter) {
   // user code:
   auto position = iter->getR();
@@ -195,7 +195,7 @@ Iterators are not guaranteed to be valid after particle insertion (see [Issue #7
 However, particle deletion while iterating is supported via `autoPas.deleteParticle(iterator)`. 
 After deletion the `++` operator has to be called:
 ```cpp
-#pragma omp parallel
+AUTOPAS_OPENMP(parallel)
 for(auto iter = autoPas.getIterator(); iter != autoPas.end(); ++iter) {
   autoPas.deleteParticle(iterator);
 }

--- a/applicationLibrary/molecularDynamics/tests/singleSiteTests/LJFunctorTestGlobals.cpp
+++ b/applicationLibrary/molecularDynamics/tests/singleSiteTests/LJFunctorTestGlobals.cpp
@@ -465,27 +465,14 @@ TYPED_TEST_P(LJFunctorTestGlobals, testAoSFunctorGlobalsOpenMPParallel) {
   std::string msg = "";
   // This is a basic check for the global calculations, by checking the handling of two particle interactions in
   // parallel. If interactions are dangerous, archer will complain.
-#if defined(AUTOPAS_OPENMP)
-// reduction for appending strings: "abc" + "def" -> "abcdef"
-#pragma omp declare reduction(stringAppend : std::string : omp_out.append(omp_in))
-
-#pragma omp parallel reduction(stringAppend : msg)
-#endif
-  {
-#if defined(AUTOPAS_OPENMP)
-#pragma omp sections
-#endif
-    {
-#if defined(AUTOPAS_OPENMP)
-#pragma omp section
-#endif
-      {
+  // reduction for appending strings: "abc" + "def" -> "abcdef"
+  AUTOPAS_OPENMP(declare reduction(stringAppend : std::string : omp_out.append(omp_in)))
+  AUTOPAS_OPENMP(parallel reduction(stringAppend : msg)) {
+    AUTOPAS_OPENMP(sections) {
+      AUTOPAS_OPENMP(section) {
         msg += this->shouldSkipIfNotImplemented([&]() { functor.AoSFunctor(p1, p2, newton3); });
       }  // pragma omp section
-#if defined(AUTOPAS_OPENMP)
-#pragma omp section
-#endif
-      {
+      AUTOPAS_OPENMP(section) {
         msg += this->shouldSkipIfNotImplemented([&]() { functor.AoSFunctor(p3, p4, newton3); });
       }  // pragma omp section
     }    // pragma omp sections

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -5,8 +5,6 @@
  */
 #include "Simulation.h"
 
-#include <autopas/utils/WrapOpenMP.h>
-
 #include <algorithm>
 
 #include "TypeDefinitions.h"
@@ -14,6 +12,7 @@
 #include "autopas/pairwiseFunctors/FlopCounterFunctor.h"
 #include "autopas/utils/SimilarityFunctions.h"
 #include "autopas/utils/WrapMPI.h"
+#include "autopas/utils/WrapOpenMP.h"
 
 // Declare the main AutoPas class and the iteratePairwise() methods with all used functors as extern template
 // instantiation. They are instantiated in the respective cpp file inside the templateInstantiations folder.

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -5,6 +5,8 @@
  */
 #include "Simulation.h"
 
+#include <autopas/utils/WrapOpenMP.h>
+
 #include <algorithm>
 
 #include "TypeDefinitions.h"

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -472,9 +472,7 @@ bool Simulation::calculatePairwiseForces() {
 }
 
 void Simulation::calculateGlobalForces(const std::array<double, 3> &globalForce) {
-#ifdef AUTOPAS_OPENMP
-#pragma omp parallel shared(_autoPasContainer)
-#endif
+  AUTOPAS_OPENMP(parallel shared(_autoPasContainer))
   for (auto particle = _autoPasContainer->begin(autopas::IteratorBehavior::owned); particle.isValid(); ++particle) {
     particle->addF(globalForce);
   }

--- a/examples/md-flexible/src/Thermostat.h
+++ b/examples/md-flexible/src/Thermostat.h
@@ -30,9 +30,7 @@ template <class AutoPasTemplate, class ParticlePropertiesLibraryTemplate>
 double calcTemperature(const AutoPasTemplate &autopas, ParticlePropertiesLibraryTemplate &particlePropertiesLibrary) {
   // kinetic energy times 2
   double kineticEnergyMul2 = 0;
-#ifdef AUTOPAS_OPENMP
-#pragma omp parallel reduction(+ : kineticEnergyMul2) default(none) shared(autopas, particlePropertiesLibrary)
-#endif
+  AUTOPAS_OPENMP(parallel reduction(+ : kineticEnergyMul2) default(none) shared(autopas, particlePropertiesLibrary))
   for (auto iter = autopas.begin(); iter.isValid(); ++iter) {
     const auto vel = iter->getV();
 #if MD_FLEXIBLE_MODE == MULTISITE
@@ -89,10 +87,7 @@ auto calcTemperatureComponent(const AutoPasTemplate &autopas,
     numParticleMap[typeID] = 0ul;
   }
 
-#ifdef AUTOPAS_OPENMP
-#pragma omp parallel
-#endif
-  {
+  AUTOPAS_OPENMP(parallel) {
     // create aggregators for each thread
     std::map<size_t, double> kineticEnergyMul2MapThread;
     std::map<size_t, size_t> numParticleMapThread;
@@ -114,10 +109,7 @@ auto calcTemperatureComponent(const AutoPasTemplate &autopas,
       numParticleMapThread.at(iter->getTypeId())++;
     }
     // manual reduction
-#ifdef AUTOPAS_OPENMP
-#pragma omp critical
-#endif
-    {
+    AUTOPAS_OPENMP(critical) {
       for (int typeID = 0; typeID < particlePropertiesLibrary.getNumberRegisteredSiteTypes(); typeID++) {
         kineticEnergyMul2Map[typeID] += kineticEnergyMul2MapThread[typeID];
         numParticleMap[typeID] += numParticleMapThread[typeID];
@@ -193,10 +185,7 @@ void addBrownianMotion(AutoPasTemplate &autopas, ParticlePropertiesLibraryTempla
 #endif
   }
 
-#ifdef AUTOPAS_OPENMP
-#pragma omp parallel default(none) shared(autopas, translationalVelocityScale, rotationalVelocityScale)
-#endif
-  {
+  AUTOPAS_OPENMP(parallel default(none) shared(autopas, translationalVelocityScale, rotationalVelocityScale)) {
     // we use a constant seed for repeatability.
     // we need one random engine and distribution per thread
     std::default_random_engine randomEngine(42 + autopas::autopas_get_thread_num());
@@ -251,9 +240,7 @@ void apply(AutoPasTemplate &autopas, ParticlePropertiesLibraryTemplate &particle
   }
 
   // Scale velocities (and angular velocities) with the scaling map
-#ifdef AUTOPAS_OPENMP
-#pragma omp parallel default(none) shared(autopas, scalingMap)
-#endif
+  AUTOPAS_OPENMP(parallel default(none) shared(autopas, scalingMap))
   for (auto iter = autopas.begin(); iter.isValid(); ++iter) {
     iter->setV(iter->getV() * scalingMap[iter->getTypeId()]);
 #if MD_FLEXIBLE_MODE == MULTISITE

--- a/examples/md-flexible/src/TimeDiscretization.cpp
+++ b/examples/md-flexible/src/TimeDiscretization.cpp
@@ -20,9 +20,7 @@ void calculatePositionsAndResetForces(autopas::AutoPas<ParticleType> &autoPasCon
 
   bool throwException = false;
 
-#ifdef AUTOPAS_OPENMP
-#pragma omp parallel reduction(|| : throwException)
-#endif
+  AUTOPAS_OPENMP(parallel reduction(|| : throwException))
   for (auto iter = autoPasContainer.begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
     const auto m = particlePropertiesLibrary.getMolMass(iter->getTypeId());
     auto v = iter->getV();
@@ -76,9 +74,7 @@ void calculateQuaternionsAndResetTorques(autopas::AutoPas<ParticleType> &autoPas
   const double tol = 1e-13;  // tolerance given in paper
   const double tolSquared = tol * tol;
 
-#ifdef AUTOPAS_OPENMP
-#pragma omp parallel
-#endif
+  AUTOPAS_OPENMP(parallel)
   for (auto iter = autoPasContainer.begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
     // Calculate Quaternions
     const auto q = iter->getQuaternion();
@@ -143,9 +139,7 @@ void calculateVelocities(autopas::AutoPas<ParticleType> &autoPasContainer,
   // helper declarations for operations with vector
   using namespace autopas::utils::ArrayMath::literals;
 
-#ifdef AUTOPAS_OPENMP
-#pragma omp parallel
-#endif
+  AUTOPAS_OPENMP(parallel)
   for (auto iter = autoPasContainer.begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
     const auto molecularMass = particlePropertiesLibrary.getMolMass(iter->getTypeId());
     const auto force = iter->getF();
@@ -163,9 +157,7 @@ void calculateAngularVelocities(autopas::AutoPas<ParticleType> &autoPasContainer
 
 #if MD_FLEXIBLE_MODE == MULTISITE
 
-#ifdef AUTOPAS_OPENMP
-#pragma omp parallel
-#endif
+  AUTOPAS_OPENMP(parallel)
   for (auto iter = autoPasContainer.begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
     const auto torqueW = iter->getTorque();
     const auto q = iter->getQuaternion();

--- a/examples/md-flexible/src/TimeDiscretization.cpp
+++ b/examples/md-flexible/src/TimeDiscretization.cpp
@@ -5,6 +5,8 @@
  */
 #include "TimeDiscretization.h"
 
+#include <autopas/utils/WrapOpenMP.h>
+
 namespace TimeDiscretization {
 
 void calculatePositionsAndResetForces(autopas::AutoPas<ParticleType> &autoPasContainer,

--- a/examples/md-flexible/src/TimeDiscretization.cpp
+++ b/examples/md-flexible/src/TimeDiscretization.cpp
@@ -5,7 +5,7 @@
  */
 #include "TimeDiscretization.h"
 
-#include <autopas/utils/WrapOpenMP.h>
+#include "autopas/utils/WrapOpenMP.h"
 
 namespace TimeDiscretization {
 

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -17,6 +17,7 @@
 #include "autopas/utils/ArrayUtils.h"
 #include "autopas/utils/Math.h"
 #include "autopas/utils/Quaternion.h"
+#include "autopas/utils/WrapOpenMP.h"
 #include "src/ParticleCommunicator.h"
 #include "src/TypeDefinitions.h"
 
@@ -259,14 +260,13 @@ void RegularGridDecomposition::exchangeMigratingParticles(AutoPasType &autoPasCo
       _receivedParticlesBuffer.clear();
       sendAndReceiveParticlesLeftAndRight(_particlesForLeftNeighbor, _particlesForRightNeighbor,
                                           _receivedParticlesBuffer, leftNeighbor, rightNeighbor);
-#ifdef AUTOPAS_OPENMP
-// custom openmp reduction to concatenate all local vectors to one at the end of a parallel region
-#pragma omp declare reduction(vecMergeParticle : std::remove_reference_t<decltype(emigrants)> : omp_out.insert(omp_out.end(), omp_in.begin(), omp_in.end()))
-// make sure each buffer gets filled equally while not inducing scheduling overhead
-#pragma omp parallel for reduction(vecMergeParticle \
-                                   : emigrants),    \
-    schedule(static, std::max(1ul, _receivedParticlesBuffer.size() / omp_get_max_threads()))
-#endif
+      // custom openmp reduction to concatenate all local vectors to one at the end of a parallel region
+      AUTOPAS_OPENMP(declare reduction(vecMergeParticle :                                                 \
+                                       std::remove_reference_t<decltype(emigrants)> :                     \
+                                           omp_out.insert(omp_out.end(), omp_in.begin(), omp_in.end())))
+      // make sure each buffer gets filled equally while not inducing scheduling overhead
+      AUTOPAS_OPENMP(parallel for reduction(vecMergeParticle : emigrants) \
+                                  schedule(static, std::max(1ul, _receivedParticlesBuffer.size() / autopas::autopas_get_max_threads())))
       // we can't use range based for loops here because clang accepts this only starting with version 11
       for (size_t i = 0; i < _receivedParticlesBuffer.size(); ++i) {
         const auto &particle = _receivedParticlesBuffer[i];

--- a/examples/md-flexible/tests/configuration/GeneratorsTest.cpp
+++ b/examples/md-flexible/tests/configuration/GeneratorsTest.cpp
@@ -6,6 +6,8 @@
 
 #include "GeneratorsTest.h"
 
+#include <autopas/utils/WrapOpenMP.h>
+
 #include "autopasTools/generators/GridGenerator.h"
 #include "autopasTools/generators/RandomGenerator.h"
 #include "src/configuration/YamlParser.h"

--- a/examples/md-flexible/tests/configuration/GeneratorsTest.cpp
+++ b/examples/md-flexible/tests/configuration/GeneratorsTest.cpp
@@ -21,9 +21,7 @@ TEST_F(GeneratorsTest, GridFillwithBoxMin) {
 
   autoPas.init();
   autopasTools::generators::GridGenerator::fillWithParticles(autoPas, {5, 5, 5}, dummy, {1, 1, 1}, boxmin);
-#ifdef AUTOPAS_OPENMP
-#pragma omp parallel
-#endif
+  AUTOPAS_OPENMP(parallel)
   for (auto iter = autoPas.begin(); iter.isValid(); ++iter) {
     EXPECT_TRUE(autopas::utils::inBox(iter->getR(), boxmin, boxmax));
   }

--- a/examples/md-flexible/tests/configuration/GeneratorsTest.cpp
+++ b/examples/md-flexible/tests/configuration/GeneratorsTest.cpp
@@ -6,8 +6,7 @@
 
 #include "GeneratorsTest.h"
 
-#include <autopas/utils/WrapOpenMP.h>
-
+#include "autopas/utils/WrapOpenMP.h"
 #include "autopasTools/generators/GridGenerator.h"
 #include "autopasTools/generators/RandomGenerator.h"
 #include "src/configuration/YamlParser.h"

--- a/src/autopas/AutoPasImpl.h
+++ b/src/autopas/AutoPasImpl.h
@@ -161,9 +161,7 @@ void AutoPas<Particle>::addParticlesAux(size_t numParticlesToAdd, size_t numHalo
                                         F loopBody) {
   reserve(getNumberOfParticles(IteratorBehavior::owned) + numParticlesToAdd,
           getNumberOfParticles(IteratorBehavior::halo) + numHalosToAdd);
-#ifdef AUTOPAS_OPENMP
-#pragma omp parallel for schedule(static, std::max(1ul, collectionSize / omp_get_max_threads()))
-#endif
+  AUTOPAS_OPENMP(parallel for schedule(static, std::max(1ul, collectionSize / omp_get_max_threads())))
   for (auto i = 0; i < collectionSize; ++i) {
     loopBody(i);
   }
@@ -185,9 +183,7 @@ template <class Collection, class F>
 void AutoPas<Particle>::addParticlesIf(Collection &&particles, F predicate) {
   std::vector<char> predicateMask(particles.size());
   int numTrue = 0;
-#ifdef AUTOPAS_OPENMP
-#pragma omp parallel for reduction(+ : numTrue)
-#endif
+  AUTOPAS_OPENMP(parallel for reduction(+ : numTrue))
   for (auto i = 0; i < particles.size(); ++i) {
     if (predicate(particles[i])) {
       predicateMask[i] = static_cast<char>(true);
@@ -244,9 +240,7 @@ template <class Collection, class F>
 void AutoPas<Particle>::addHaloParticlesIf(Collection &&particles, F predicate) {
   std::vector<char> predicateMask(particles.size());
   int numTrue = 0;
-#ifdef AUTOPAS_OPENMP
-#pragma omp parallel for reduction(+ : numTrue)
-#endif
+  AUTOPAS_OPENMP(parallel for reduction(+ : numTrue))
   for (auto i = 0; i < particles.size(); ++i) {
     if (predicate(particles[i])) {
       predicateMask[i] = static_cast<char>(true);

--- a/src/autopas/AutoPasImpl.h
+++ b/src/autopas/AutoPasImpl.h
@@ -4,6 +4,7 @@
  * LogicHandler are only forward declared.
  */
 
+#include <autopas/utils/WrapOpenMP.h>
 #pragma once
 
 #include <array>

--- a/src/autopas/AutoPasImpl.h
+++ b/src/autopas/AutoPasImpl.h
@@ -4,7 +4,6 @@
  * LogicHandler are only forward declared.
  */
 
-#include <autopas/utils/WrapOpenMP.h>
 #pragma once
 
 #include <array>
@@ -27,6 +26,7 @@
 #include "autopas/utils/CompileInfo.h"
 #include "autopas/utils/NumberInterval.h"
 #include "autopas/utils/NumberSetFinite.h"
+#include "autopas/utils/WrapOpenMP.h"
 
 namespace autopas {
 

--- a/src/autopas/CMakeLists.txt
+++ b/src/autopas/CMakeLists.txt
@@ -31,16 +31,16 @@ target_link_libraries(
         harmony
 )
 
-# Ompstuff needs to be here because autopas_OpenMP.cmake needs to run before this file to create to OpenMP
+# OpenMP stuff needs to be here because autopas_OpenMP.cmake needs to run before this file to create to OpenMP
 # target. this can be resolved by upgrading to CMake 3.13 and enforcing CMP0079.
 target_compile_definitions(
     autopas
     PUBLIC
-    $<$<BOOL:${AUTOPAS_OPENMP}>:AUTOPAS_OPENMP>
-    $<$<NOT:$<BOOL:${AUTOPAS_OPENMP}>>:EIGEN_DONT_PARALLELIZE>
-    $<$<BOOL:${AUTOPAS_INCLUDE_MPI}>:AUTOPAS_INCLUDE_MPI>
-    $<$<BOOL:${AUTOPAS_INTERNODE_TUNING}>:AUTOPAS_INTERNODE_TUNING>
-    _USE_MATH_DEFINES
+        $<$<BOOL:${AUTOPAS_OPENMP}>:AUTOPAS_USE_OPENMP>
+        $<$<NOT:$<BOOL:${AUTOPAS_OPENMP}>>:EIGEN_DONT_PARALLELIZE>
+        $<$<BOOL:${AUTOPAS_INCLUDE_MPI}>:AUTOPAS_INCLUDE_MPI>
+        $<$<BOOL:${AUTOPAS_INTERNODE_TUNING}>:AUTOPAS_INTERNODE_TUNING>
+        _USE_MATH_DEFINES
 )
 
 

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -29,6 +29,7 @@
 #include "autopas/utils/StaticCellSelector.h"
 #include "autopas/utils/StaticContainerSelector.h"
 #include "autopas/utils/Timer.h"
+#include "autopas/utils/WrapOpenMP.h"
 #include "autopas/utils/logging/IterationLogger.h"
 #include "autopas/utils/logging/Logger.h"
 #include "autopas/utils/markParticleAsDeleted.h"
@@ -966,10 +967,8 @@ void LogicHandler<Particle>::remainderHelperBufferContainer(
   const auto interactionLengthInv = 1. / container.getInteractionLength();
 
   const double cutoff = container.getCutoff();
-#ifdef AUTOPAS_OPENMP
-// one halo and particle buffer pair per thread
-#pragma omp parallel for schedule(static, 1), shared(f, _spacialLocks, haloBoxMin, interactionLengthInv)
-#endif
+  // one halo and particle buffer pair per thread
+  AUTOPAS_OPENMP(parallel for schedule(static, 1) shared(f, _spacialLocks, haloBoxMin, interactionLengthInv))
   for (int bufferId = 0; bufferId < particleBuffers.size(); ++bufferId) {
     auto &particleBuffer = particleBuffers[bufferId];
     auto &haloParticleBuffer = haloParticleBuffers[bufferId];
@@ -1028,17 +1027,12 @@ void LogicHandler<Particle>::remainderHelperBufferBuffer(PairwiseFunctor *f,
     f->SoALoader(buffer, buffer._particleSoABuffer, 0);
   }
 
-#ifdef AUTOPAS_OPENMP
-#pragma omp parallel
-#endif
-  {
+  AUTOPAS_OPENMP(parallel) {
     // For buffer interactions where bufferA == bufferB we can always enable newton3. For all interactions between
     // different buffers we turn newton3 always off, which ensures that only one thread at a time is writing to a
     // buffer. This saves expensive locks.
-#ifdef AUTOPAS_OPENMP
     // we can not use collapse here without locks, otherwise races would occur.
-#pragma omp for
-#endif
+    AUTOPAS_OPENMP(for)
     for (size_t i = 0; i < particleBuffers.size(); ++i) {
       for (size_t jj = 0; jj < particleBuffers.size(); ++jj) {
         auto *particleBufferSoAA = &particleBuffers[i]._particleSoABuffer;
@@ -1059,14 +1053,10 @@ template <bool newton3, class PairwiseFunctor>
 void LogicHandler<Particle>::remainderHelperBufferHaloBuffer(
     PairwiseFunctor *f, std::vector<FullParticleCell<Particle>> &particleBuffers,
     std::vector<FullParticleCell<Particle>> &haloParticleBuffers) {
-#ifdef AUTOPAS_OPENMP
   // Here, phase / color based parallelism turned out to be more efficient than tasks
-#pragma omp parallel
-#endif
+  AUTOPAS_OPENMP(parallel)
   for (int interactionOffset = 0; interactionOffset < haloParticleBuffers.size(); ++interactionOffset) {
-#ifdef AUTOPAS_OPENMP
-#pragma omp for
-#endif
+    AUTOPAS_OPENMP(for)
     for (size_t i = 0; i < particleBuffers.size(); ++i) {
       auto &particleBufferSoA = particleBuffers[i]._particleSoABuffer;
       auto &haloBufferSoA =

--- a/src/autopas/containers/CellBasedParticleContainer.h
+++ b/src/autopas/containers/CellBasedParticleContainer.h
@@ -13,10 +13,6 @@
 #include "autopas/containers/TraversalInterface.h"
 #include "autopas/utils/WrapOpenMP.h"
 
-#ifdef AUTOPAS_USE_OPENMP
-#include <omp.h>
-#endif
-
 namespace autopas {
 
 // consider multiple inheritance or delegation to avoid virtual call to Functor

--- a/src/autopas/containers/CellBasedParticleContainer.h
+++ b/src/autopas/containers/CellBasedParticleContainer.h
@@ -4,8 +4,6 @@
  * @date 17 Jan 2018
  * @author tchipevn
  */
-#include <autopas/utils/WrapOpenMP.h>
-
 #pragma once
 
 #include <algorithm>
@@ -13,6 +11,7 @@
 
 #include "autopas/containers/ParticleContainerInterface.h"
 #include "autopas/containers/TraversalInterface.h"
+#include "autopas/utils/WrapOpenMP.h"
 
 #ifdef AUTOPAS_USE_OPENMP
 #include <omp.h>

--- a/src/autopas/containers/CellBasedParticleContainer.h
+++ b/src/autopas/containers/CellBasedParticleContainer.h
@@ -4,6 +4,7 @@
  * @date 17 Jan 2018
  * @author tchipevn
  */
+#include <autopas/utils/WrapOpenMP.h>
 
 #pragma once
 

--- a/src/autopas/containers/LeavingParticleCollector.h
+++ b/src/autopas/containers/LeavingParticleCollector.h
@@ -10,6 +10,7 @@
 #include "autopas/options/IteratorBehavior.h"
 #include "autopas/particles/OwnershipState.h"
 #include "autopas/utils/ArrayMath.h"
+#include "autopas/utils/WrapOpenMP.h"
 #include "autopas/utils/inBox.h"
 
 /**

--- a/src/autopas/containers/LeavingParticleCollector.h
+++ b/src/autopas/containers/LeavingParticleCollector.h
@@ -63,15 +63,15 @@ std::vector<typename ContainerType::ParticleType> collectParticlesAndMarkNonOwne
   }};
 
   std::vector<typename ContainerType::ParticleType> leavingParticles{};
-#ifdef AUTOPAS_OPENMP
   // custom openmp reduction to concatenate all local vectors to one at the end of a parallel region
-#pragma omp declare reduction(vecMergeParticle : std::vector<typename ContainerType::ParticleType> : omp_out.insert(omp_out.end(), omp_in.begin(), omp_in.end()))
+  AUTOPAS_OPENMP(declare reduction(vecMergeParticle :                                                 \
+                                   std::vector<typename ContainerType::ParticleType> :                \
+                                       omp_out.insert(omp_out.end(), omp_in.begin(), omp_in.end())))
   // this has to be a `parallel` and not `parallel for` because we are actually interested in parallelizing the inner
   // loops without having a barrier between outer loop iterations.
   // The way this works is that all threads iterate the outer loop but due to the way the iterators are parallelized,
   // each thread only picks its iterations of the inner loops, hence nothing is done multiple times.
-#pragma omp parallel reduction(vecMergeParticle : leavingParticles)
-#endif
+  AUTOPAS_OPENMP(parallel reduction(vecMergeParticle : leavingParticles))
   for (const auto &[regionStart, regionEnd] : haloVolumes) {
     for (auto iter = container.getRegionIterator(regionStart, regionEnd, autopas::IteratorBehavior::ownedOrHalo);
          iter.isValid(); ++iter) {

--- a/src/autopas/containers/cellPairTraversals/CBasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/CBasedTraversal.h
@@ -57,10 +57,8 @@ class CBasedTraversal : public CellPairTraversal<ParticleCell> {
   void initTraversal() override {
     if (this->_cells) {
       auto &cells = *(this->_cells);
-#ifdef AUTOPAS_OPENMP
       /// @todo find a condition on when to use omp or when it is just overhead
-#pragma omp parallel for
-#endif
+      AUTOPAS_OPENMP(parallel for)
       for (size_t i = 0; i < cells.size(); ++i) {
         _dataLayoutConverter.loadDataLayout(cells[i]);
       }
@@ -73,10 +71,8 @@ class CBasedTraversal : public CellPairTraversal<ParticleCell> {
   void endTraversal() override {
     if (this->_cells) {
       auto &cells = *(this->_cells);
-#ifdef AUTOPAS_OPENMP
       /// @todo find a condition on when to use omp or when it is just overhead
-#pragma omp parallel for
-#endif
+      AUTOPAS_OPENMP(parallel for)
       for (size_t i = 0; i < cells.size(); ++i) {
         _dataLayoutConverter.storeDataLayout(cells[i]);
       }
@@ -134,16 +130,10 @@ inline void CBasedTraversal<ParticleCell, PairwiseFunctor, dataLayout, useNewton
     LoopBody &&loopBody, const std::array<unsigned long, 3> &end, const std::array<unsigned long, 3> &stride,
     const std::array<unsigned long, 3> &offset) {
   using namespace autopas::utils::ArrayMath::literals;
-#if defined(AUTOPAS_OPENMP)
-#pragma omp parallel
-#endif
-  {
+  AUTOPAS_OPENMP(parallel) {
     const unsigned long numColors = stride[0] * stride[1] * stride[2];
     for (unsigned long col = 0; col < numColors; ++col) {
-#if defined(AUTOPAS_OPENMP)
-#pragma omp single
-#endif
-      {
+      AUTOPAS_OPENMP(single) {
         // barrier at omp for of previous loop iteration, so fine to change it for everyone!
         notifyColorChange(col);
         // implicit barrier at end of function.
@@ -156,9 +146,7 @@ inline void CBasedTraversal<ParticleCell, PairwiseFunctor, dataLayout, useNewton
       const unsigned long end_x = end[0], end_y = end[1], end_z = end[2];
       const unsigned long stride_x = stride[0], stride_y = stride[1], stride_z = stride[2];
       if (collapseDepth == 2) {
-#if defined(AUTOPAS_OPENMP)
-#pragma omp for schedule(dynamic, 1) collapse(2)
-#endif
+        AUTOPAS_OPENMP(for schedule(dynamic, 1) collapse(2))
         for (unsigned long z = start_z; z < end_z; z += stride_z) {
           for (unsigned long y = start_y; y < end_y; y += stride_y) {
             for (unsigned long x = start_x; x < end_x; x += stride_x) {
@@ -168,9 +156,7 @@ inline void CBasedTraversal<ParticleCell, PairwiseFunctor, dataLayout, useNewton
           }
         }
       } else {
-#if defined(AUTOPAS_OPENMP)
-#pragma omp for schedule(dynamic, 1) collapse(3)
-#endif
+        AUTOPAS_OPENMP(for schedule(dynamic, 1) collapse(3))
         for (unsigned long z = start_z; z < end_z; z += stride_z) {
           for (unsigned long y = start_y; y < end_y; y += stride_y) {
             for (unsigned long x = start_x; x < end_x; x += stride_x) {

--- a/src/autopas/containers/cellPairTraversals/CBasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/CBasedTraversal.h
@@ -10,6 +10,7 @@
 #include "autopas/utils/ArrayMath.h"
 #include "autopas/utils/DataLayoutConverter.h"
 #include "autopas/utils/ThreeDimensionalMapping.h"
+#include "autopas/utils/WrapOpenMP.h"
 
 namespace autopas {
 

--- a/src/autopas/containers/cellPairTraversals/SlicedBalancedBasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/SlicedBalancedBasedTraversal.h
@@ -4,8 +4,6 @@
  * @date 24 Apr 2020
  * @author fischerv
  */
-#include <autopas/utils/WrapOpenMP.h>
-
 #pragma once
 
 #include <array>
@@ -14,6 +12,7 @@
 #include "autopas/containers/cellPairTraversals/BalancedTraversal.h"
 #include "autopas/containers/cellPairTraversals/SlicedLockBasedTraversal.h"
 #include "autopas/utils/Timer.h"
+#include "autopas/utils/WrapOpenMP.h"
 
 namespace autopas {
 

--- a/src/autopas/containers/cellPairTraversals/SlicedBalancedBasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/SlicedBalancedBasedTraversal.h
@@ -4,6 +4,7 @@
  * @date 24 Apr 2020
  * @author fischerv
  */
+#include <autopas/utils/WrapOpenMP.h>
 
 #pragma once
 

--- a/src/autopas/containers/cellPairTraversals/SlicedBalancedBasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/SlicedBalancedBasedTraversal.h
@@ -62,9 +62,7 @@ class SlicedBalancedBasedTraversal
     utils::Timer timer;
     timer.start();
     loads.resize(maxDimensionLength);
-#ifdef AUTOPAS_OPENMP
-#pragma omp parallel for schedule(static, 1)
-#endif
+    AUTOPAS_OPENMP(parallel for schedule(static, 1))
     for (auto x = 0; x < maxDimensionLength; x++) {
       std::array<unsigned long, 3> lowerCorner = {0, 0, 0};
       std::array<unsigned long, 3> upperCorner = this->_cellsPerDimension;

--- a/src/autopas/containers/cellPairTraversals/SlicedBasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/SlicedBasedTraversal.h
@@ -105,10 +105,8 @@ class SlicedBasedTraversal : public CellPairTraversal<ParticleCell> {
   void endTraversal() override {
     if (this->_cells) {
       auto &cells = *(this->_cells);
-#ifdef AUTOPAS_OPENMP
       /// @todo find a condition on when to use omp or when it is just overhead
-#pragma omp parallel for
-#endif
+      AUTOPAS_OPENMP(parallel for)
       for (size_t i = 0; i < cells.size(); ++i) {
         _dataLayoutConverter.storeDataLayout(cells[i]);
       }
@@ -128,10 +126,8 @@ class SlicedBasedTraversal : public CellPairTraversal<ParticleCell> {
   virtual void loadDataLayout() {
     if (this->_cells) {
       auto &cells = *(this->_cells);
-#ifdef AUTOPAS_OPENMP
       /// @todo find a condition on when to use omp or when it is just overhead
-#pragma omp parallel for
-#endif
+      AUTOPAS_OPENMP(parallel for)
       for (size_t i = 0; i < cells.size(); ++i) {
         _dataLayoutConverter.loadDataLayout(cells[i]);
       }

--- a/src/autopas/containers/cellPairTraversals/SlicedC02BasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/SlicedC02BasedTraversal.h
@@ -97,10 +97,8 @@ void SlicedC02BasedTraversal<ParticleCell, PairwiseFunctor, dataLayout, useNewto
   }
 
   for (size_t offset = 0; offset < 2; offset++) {
-#ifdef AUTOPAS_OPENMP
-// although every thread gets exactly one iteration (=slice) this is faster than a normal parallel region
-#pragma omp parallel for schedule(dynamic, 1)
-#endif
+    // although every thread gets exactly one iteration (=slice) this is faster than a normal parallel region
+    AUTOPAS_OPENMP(parallel for schedule(dynamic, 1))
     for (size_t slice = offset; slice < numSlices; slice += 2) {
       array<unsigned long, 3> myStartArray{0, 0, 0};
       for (size_t i = 0; i < slice; ++i) {

--- a/src/autopas/containers/cellPairTraversals/SlicedLockBasedTraversal.h
+++ b/src/autopas/containers/cellPairTraversals/SlicedLockBasedTraversal.h
@@ -92,16 +92,14 @@ void SlicedLockBasedTraversal<ParticleCell, PairwiseFunctor, dataLayout, useNewt
   timers.resize(numSlices);
   threadTimes.resize(numSlices);
 
-#ifdef AUTOPAS_OPENMP
-  // although every thread gets exactly one iteration (=slice) this is faster than a normal parallel region
-  auto numThreads = static_cast<size_t>(autopas_get_max_threads());
+#ifdef AUTOPAS_USE_OPENMP
   if (this->_dynamic) {
     omp_set_schedule(omp_sched_dynamic, 1);
   } else {
     omp_set_schedule(omp_sched_static, 1);
   }
-#pragma omp parallel for schedule(runtime) num_threads(numThreads)
 #endif
+  AUTOPAS_OPENMP(parallel for schedule(runtime))
   for (size_t slice = 0; slice < numSlices; ++slice) {
     timers[slice].start();
     array<unsigned long, 3> myStartArray{0, 0, 0};

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -156,18 +156,13 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
     this->deleteHaloParticles();
 
     std::vector<ParticleType> invalidParticles;
-#ifdef AUTOPAS_OPENMP
-#pragma omp parallel
-#endif  // AUTOPAS_OPENMP
-    {
+    AUTOPAS_OPENMP(parallel) {
       // private for each thread!
       std::vector<ParticleType> myInvalidParticles{}, myInvalidNotOwnedParticles{};
       // TODO: needs smarter heuristic than this.
       myInvalidParticles.reserve(128);
       myInvalidNotOwnedParticles.reserve(128);
-#ifdef AUTOPAS_OPENMP
-#pragma omp for
-#endif  // AUTOPAS_OPENMP
+      AUTOPAS_OPENMP(for)
       for (size_t cellId = 0; cellId < this->getCells().size(); ++cellId) {
         // Delete dummy particles of each cell.
         this->getCells()[cellId].deleteDummyParticles();
@@ -202,10 +197,7 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
           myInvalidNotOwnedParticles.push_back(p);
         }
       }
-#ifdef AUTOPAS_OPENMP
-#pragma omp critical
-#endif
-      {
+      AUTOPAS_OPENMP(critical) {
         // merge private vectors to global one.
         invalidParticles.insert(invalidParticles.end(), myInvalidNotOwnedParticles.begin(),
                                 myInvalidNotOwnedParticles.end());

--- a/src/autopas/containers/linkedCells/LinkedCellsReferences.h
+++ b/src/autopas/containers/linkedCells/LinkedCellsReferences.h
@@ -296,15 +296,10 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
     bool exceptionCaught{false};
     std::string exceptionMsg{""};
 
-#ifdef AUTOPAS_OPENMP
-#pragma omp parallel
-#endif  // AUTOPAS_OPENMP
-    {
+    AUTOPAS_OPENMP(parallel) {
       // private for each thread!
       std::vector<ParticleType> myInvalidParticles, myInvalidNotOwnedParticles;
-#ifdef AUTOPAS_OPENMP
-#pragma omp for
-#endif  // AUTOPAS_OPENMP
+      AUTOPAS_OPENMP(for)
       for (size_t cellId = 0; cellId < this->getCells().size(); ++cellId) {
         // Delete dummy particles of each cell.
         this->getCells()[cellId].deleteDummyParticles();
@@ -348,15 +343,10 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
         }
       } catch (const std::exception &e) {
         exceptionCaught = true;
-#ifdef AUTOPAS_OPENMP
-#pragma omp critical
-#endif
+        AUTOPAS_OPENMP(critical)
         exceptionMsg.append(e.what());
       }
-#ifdef AUTOPAS_OPENMP
-#pragma omp critical
-#endif
-      {
+      AUTOPAS_OPENMP(critical) {
         // merge private vectors to global one.
         invalidParticles.insert(invalidParticles.end(), myInvalidNotOwnedParticles.begin(),
                                 myInvalidNotOwnedParticles.end());

--- a/src/autopas/containers/linkedCells/traversals/LCC04HCPTraversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC04HCPTraversal.h
@@ -4,6 +4,7 @@
  * @date 30.03.2020
  */
 
+#include <autopas/utils/WrapOpenMP.h>
 #pragma once
 
 #include "autopas/containers/cellPairTraversals/C08BasedTraversal.h"

--- a/src/autopas/containers/linkedCells/traversals/LCC04HCPTraversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC04HCPTraversal.h
@@ -110,18 +110,13 @@ void LCC04HCPTraversal<ParticleCell, PairwiseFunctor, dataLayout, useNewton3>::p
 template <class ParticleCell, class PairwiseFunctor, DataLayoutOption::Value dataLayout, bool useNewton3>
 void LCC04HCPTraversal<ParticleCell, PairwiseFunctor, dataLayout, useNewton3>::traverseParticlePairs() {
   auto &cells = *(this->_cells);
-#if defined(AUTOPAS_OPENMP)
-#pragma omp parallel
-#endif
-  {
+  AUTOPAS_OPENMP(parallel) {
     for (int color = 0; color < 4; ++color) {
       traverseSingleColor(cells, color);
 
-#if defined(AUTOPAS_OPENMP)
       if (color < 3) {
-#pragma omp barrier
+        AUTOPAS_OPENMP(barrier)
       }
-#endif
     }
   }  // close parallel region
 }
@@ -169,9 +164,7 @@ void LCC04HCPTraversal<ParticleCell, PairwiseFunctor, dataLayout, useNewton3>::t
   const long startZ = startOfThisColor[2], endZ = _end[2];
 
   // iterate over cartesian grid
-#if defined(AUTOPAS_OPENMP)
-#pragma omp for schedule(dynamic, 1) collapse(3) nowait
-#endif
+  AUTOPAS_OPENMP(for schedule(dynamic, 1) collapse(3) nowait)
   for (long z = startZ; z < endZ; z += 4) {
     for (long y = startY; y < endY; y++) {
       /* color starts every 6th column again, the +4 is needed to prevent ending too early, since it

--- a/src/autopas/containers/linkedCells/traversals/LCC04HCPTraversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC04HCPTraversal.h
@@ -4,7 +4,6 @@
  * @date 30.03.2020
  */
 
-#include <autopas/utils/WrapOpenMP.h>
 #pragma once
 
 #include "autopas/containers/cellPairTraversals/C08BasedTraversal.h"
@@ -12,6 +11,7 @@
 #include "autopas/containers/linkedCells/traversals/LCTraversalInterface.h"
 #include "autopas/utils/ArrayUtils.h"
 #include "autopas/utils/ThreeDimensionalMapping.h"
+#include "autopas/utils/WrapOpenMP.h"
 
 namespace autopas {
 

--- a/src/autopas/containers/linkedCells/traversals/LCC04Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC04Traversal.h
@@ -184,18 +184,13 @@ void LCC04Traversal<ParticleCell, PairwiseFunctor, dataLayout, useNewton3>::proc
 template <class ParticleCell, class PairwiseFunctor, DataLayoutOption::Value dataLayout, bool useNewton3>
 void LCC04Traversal<ParticleCell, PairwiseFunctor, dataLayout, useNewton3>::traverseParticlePairs() {
   auto &cells = *(this->_cells);
-#if defined(AUTOPAS_OPENMP)
-#pragma omp parallel
-#endif
-  {
+  AUTOPAS_OPENMP(parallel) {
     for (int color = 0; color < 4; ++color) {
       traverseSingleColor(cells, color);
 
-#if defined(AUTOPAS_OPENMP)
       if (color < 3) {
-#pragma omp barrier
+        AUTOPAS_OPENMP(barrier)
       }
-#endif
     }
   }  // close parallel region
 }
@@ -233,11 +228,9 @@ void LCC04Traversal<ParticleCell, PairwiseFunctor, dataLayout, useNewton3>::trav
   const long startY = startOfThisColor[1], endY = _end[1];
   const long startZ = startOfThisColor[2], endZ = _end[2];
 
-// first cartesian grid
-// grids are interlinked: one grid fills the gaps in the other grid
-#if defined(AUTOPAS_OPENMP)
-#pragma omp for schedule(dynamic, 1) collapse(3) nowait
-#endif
+  // first cartesian grid
+  // grids are interlinked: one grid fills the gaps in the other grid
+  AUTOPAS_OPENMP(for schedule(dynamic, 1) collapse(3) nowait)
   for (long z = startZ; z < endZ; z += 4) {
     for (long y = startY; y < endY; y += 4) {
       for (long x = startX; x < endX; x += 4) {

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -27,6 +27,7 @@
 #include "autopas/particles/OwnershipState.h"
 #include "autopas/utils/ArrayMath.h"
 #include "autopas/utils/Timer.h"
+#include "autopas/utils/WrapOpenMP.h"
 #include "autopas/utils/inBox.h"
 #include "autopas/utils/markParticleAsDeleted.h"
 

--- a/src/autopas/containers/verletClusterLists/VerletClusterListsRebuilder.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterListsRebuilder.h
@@ -203,10 +203,7 @@ class VerletClusterListsRebuilder {
    */
   void sortParticlesIntoTowers(const std::vector<std::vector<Particle>> &particles2D) {
     const auto numVectors = particles2D.size();
-#if defined(AUTOPAS_OPENMP)
-    /// @todo: find sensible chunk size
-#pragma omp parallel for schedule(dynamic)
-#endif
+    AUTOPAS_OPENMP(parallel for schedule(dynamic))
     for (size_t index = 0; index < numVectors; index++) {
       const std::vector<Particle> &vector = particles2D[index];
       for (const auto &particle : vector) {
@@ -229,10 +226,8 @@ class VerletClusterListsRebuilder {
     const int maxTowerIndexY = _towerBlock.getTowersPerDim()[1] - 1;
     const auto numTowersPerInteractionLength = _towerBlock.getNumTowersPerInteractionLength();
     // for all towers
-#if defined(AUTOPAS_OPENMP)
     /// @todo: find sensible chunksize
-#pragma omp parallel for schedule(dynamic) collapse(2)
-#endif
+    AUTOPAS_OPENMP(parallel for schedule(dynamic) collapse(2))
     for (int towerIndexY = 0; towerIndexY <= maxTowerIndexY; towerIndexY++) {
       for (int towerIndexX = 0; towerIndexX <= maxTowerIndexX; towerIndexX++) {
         // calculate extent of interesting tower 2D indices

--- a/src/autopas/containers/verletClusterLists/VerletClusterListsRebuilder.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterListsRebuilder.h
@@ -4,6 +4,7 @@
  * @date 29.07.19
  */
 
+#include <autopas/utils/WrapOpenMP.h>
 #pragma once
 
 #include "autopas/utils/ArrayMath.h"

--- a/src/autopas/containers/verletClusterLists/VerletClusterListsRebuilder.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterListsRebuilder.h
@@ -4,11 +4,11 @@
  * @date 29.07.19
  */
 
-#include <autopas/utils/WrapOpenMP.h>
 #pragma once
 
 #include "autopas/utils/ArrayMath.h"
 #include "autopas/utils/Timer.h"
+#include "autopas/utils/WrapOpenMP.h"
 #include "autopas/utils/inBox.h"
 
 namespace autopas::internal {

--- a/src/autopas/containers/verletClusterLists/traversals/VCLC01BalancedTraversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VCLC01BalancedTraversal.h
@@ -61,10 +61,7 @@ class VCLC01BalancedTraversal : public TraversalInterface, public VCLTraversalIn
     auto &clusterThreadPartition = clusterList.getClusterThreadPartition();
 
     auto numThreads = clusterThreadPartition.size();
-#if defined(AUTOPAS_OPENMP)
-#pragma omp parallel num_threads(numThreads)
-#endif
-    {
+    AUTOPAS_OPENMP(parallel num_threads(numThreads)) {
       auto threadNum = autopas_get_thread_num();
       const auto &clusterRange = clusterThreadPartition[threadNum];
       auto &towers = *VCLTraversalInterface<Particle>::_towers;

--- a/src/autopas/containers/verletClusterLists/traversals/VCLC01BalancedTraversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VCLC01BalancedTraversal.h
@@ -4,12 +4,12 @@
  * @date 12.08.19
  */
 
-#include <autopas/utils/WrapOpenMP.h>
 #pragma once
 
 #include "autopas/containers/TraversalInterface.h"
 #include "autopas/containers/verletClusterLists/traversals/VCLClusterFunctor.h"
 #include "autopas/containers/verletClusterLists/traversals/VCLTraversalInterface.h"
+#include "autopas/utils/WrapOpenMP.h"
 
 namespace autopas {
 

--- a/src/autopas/containers/verletClusterLists/traversals/VCLC01BalancedTraversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VCLC01BalancedTraversal.h
@@ -4,6 +4,7 @@
  * @date 12.08.19
  */
 
+#include <autopas/utils/WrapOpenMP.h>
 #pragma once
 
 #include "autopas/containers/TraversalInterface.h"

--- a/src/autopas/containers/verletListsCellBased/varVerletLists/neighborLists/asBuild/VerletNeighborListAsBuild.h
+++ b/src/autopas/containers/verletListsCellBased/varVerletLists/neighborLists/asBuild/VerletNeighborListAsBuild.h
@@ -169,12 +169,8 @@ class VerletNeighborListAsBuild : public VerletNeighborListInterface<Particle>, 
     for (int color = 0; color < _numColors; color++) {
       unsigned int numThreads = _aosNeighborList[color].size();
       _soaNeighborList[color].resize(numThreads);
-#if defined(AUTOPAS_OPENMP)
-#pragma omp parallel num_threads(numThreads)
-#endif
-#if defined(AUTOPAS_OPENMP)
-#pragma omp for schedule(static)
-#endif
+      AUTOPAS_OPENMP(parallel num_threads(numThreads))
+      AUTOPAS_OPENMP(for schedule(static))
       for (unsigned int thread = 0; thread < numThreads; thread++) {
         auto &currentThreadList = _soaNeighborList[color][thread];
         currentThreadList.clear();

--- a/src/autopas/containers/verletListsCellBased/varVerletLists/traversals/VVLAsBuildTraversal.h
+++ b/src/autopas/containers/verletListsCellBased/varVerletLists/traversals/VVLAsBuildTraversal.h
@@ -102,15 +102,10 @@ void VVLAsBuildTraversal<ParticleCell, Particle, PairwiseFunctor, dataLayout, us
     VerletNeighborListAsBuild<Particle> &neighborList) {
   const auto &list = neighborList.getAoSNeighborList();
 
-#if defined(AUTOPAS_OPENMP)
-#pragma omp parallel num_threads(list[0].size())
-#endif
-  {
+  AUTOPAS_OPENMP(parallel num_threads(list[0].size())) {
     constexpr int numColors = 8;
     for (int color = 0; color < numColors; color++) {
-#if defined(AUTOPAS_OPENMP)
-#pragma omp for schedule(static)
-#endif
+      AUTOPAS_OPENMP(for schedule(static))
       for (unsigned int thread = 0; thread < list[color].size(); thread++) {
         const auto &particleToNeighborMap = list[color][thread];
         for (const auto &[particlePtr, neighborPtrList] : particleToNeighborMap) {
@@ -129,15 +124,10 @@ void VVLAsBuildTraversal<ParticleCell, Particle, PairwiseFunctor, dataLayout, us
     VerletNeighborListAsBuild<Particle> &neighborList) {
   const auto &soaNeighborList = neighborList.getSoANeighborList();
 
-#if defined(AUTOPAS_OPENMP)
-#pragma omp parallel num_threads(soaNeighborList[0].size())
-#endif
-  {
+  AUTOPAS_OPENMP(parallel num_threads(soaNeighborList[0].size())) {
     constexpr int numColors = 8;
     for (int color = 0; color < numColors; color++) {
-#if defined(AUTOPAS_OPENMP)
-#pragma omp for schedule(static)
-#endif
+      AUTOPAS_OPENMP(for schedule(static))
       for (unsigned int thread = 0; thread < soaNeighborList[color].size(); thread++) {
         const auto &threadNeighborList = soaNeighborList[color][thread];
         for (const auto &[indexFirst, neighbors] : threadNeighborList) {

--- a/src/autopas/containers/verletListsCellBased/verletLists/traversals/VLListIterationTraversal.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/traversals/VLListIterationTraversal.h
@@ -4,14 +4,13 @@
  * @date 7.4.2019
  * @author jspahl
  */
-#include <autopas/utils/WrapOpenMP.h>
-
 #pragma once
 
 #include "VLTraversalInterface.h"
 #include "autopas/containers/cellPairTraversals/CellPairTraversal.h"
 #include "autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h"
 #include "autopas/options/DataLayoutOption.h"
+#include "autopas/utils/WrapOpenMP.h"
 
 namespace autopas {
 

--- a/src/autopas/containers/verletListsCellBased/verletLists/traversals/VLListIterationTraversal.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/traversals/VLListIterationTraversal.h
@@ -40,8 +40,8 @@ class VLListIterationTraversal : public TraversalInterface, public VLTraversalIn
   [[nodiscard]] bool getUseNewton3() const override { return useNewton3; }
 
   [[nodiscard]] bool isApplicable() const override {
-    // No parallel version with N3 and no data races is available.
-    return (autopas_get_max_threads() > 1 and not useNewton3);
+    // No parallel version with N3 and no data races is available, hence no N3 is completely disabled.
+    return (not useNewton3) and (dataLayout == DataLayoutOption::aos or dataLayout == DataLayoutOption::soa);
   }
 
   void initTraversal() override {

--- a/src/autopas/containers/verletListsCellBased/verletLists/traversals/VLListIterationTraversal.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/traversals/VLListIterationTraversal.h
@@ -4,6 +4,7 @@
  * @date 7.4.2019
  * @author jspahl
  */
+#include <autopas/utils/WrapOpenMP.h>
 
 #pragma once
 

--- a/src/autopas/containers/verletListsCellBased/verletLists/traversals/VLListIterationTraversal.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/traversals/VLListIterationTraversal.h
@@ -40,7 +40,8 @@ class VLListIterationTraversal : public TraversalInterface, public VLTraversalIn
   [[nodiscard]] bool getUseNewton3() const override { return useNewton3; }
 
   [[nodiscard]] bool isApplicable() const override {
-    return (not useNewton3) and (dataLayout == DataLayoutOption::aos or dataLayout == DataLayoutOption::soa);
+    // No parallel version with N3 and no data races is available.
+    return (autopas_get_max_threads() > 1 and not useNewton3);
   }
 
   void initTraversal() override {
@@ -70,11 +71,11 @@ class VLListIterationTraversal : public TraversalInterface, public VLTraversalIn
     auto &soaNeighborLists = *(this->_soaNeighborLists);
     switch (dataLayout) {
       case DataLayoutOption::aos: {
-#if defined(AUTOPAS_OPENMP)
+        // If we use parallelization,
         if (not useNewton3) {
           size_t buckets = aosNeighborLists.bucket_count();
           /// @todo find a sensible chunk size
-#pragma omp parallel for schedule(dynamic)
+          AUTOPAS_OPENMP(parallel for schedule(dynamic))
           for (size_t bucketId = 0; bucketId < buckets; bucketId++) {
             auto endIter = aosNeighborLists.end(bucketId);
             for (auto bucketIter = aosNeighborLists.begin(bucketId); bucketIter != endIter; ++bucketIter) {
@@ -85,9 +86,7 @@ class VLListIterationTraversal : public TraversalInterface, public VLTraversalIn
               }
             }
           }
-        } else
-#endif
-        {
+        } else {
           for (auto &[particlePtr, neighborPtrList] : aosNeighborLists) {
             Particle &particle = *particlePtr;
             for (auto neighborPtr : neighborPtrList) {
@@ -100,17 +99,13 @@ class VLListIterationTraversal : public TraversalInterface, public VLTraversalIn
       }
 
       case DataLayoutOption::soa: {
-#if defined(AUTOPAS_OPENMP)
         if (not useNewton3) {
           /// @todo find a sensible chunk size
-          const size_t chunkSize = std::max(soaNeighborLists.size() / (omp_get_max_threads() * 10), 1ul);
-#pragma omp parallel for schedule(dynamic, chunkSize)
+          AUTOPAS_OPENMP(parallel for schedule(dynamic, std::max(soaNeighborLists.size() / (autopas::autopas_get_max_threads() * 10), 1ul)))
           for (size_t particleIndex = 0; particleIndex < soaNeighborLists.size(); particleIndex++) {
             _functor->SoAFunctorVerlet(_soa, particleIndex, soaNeighborLists[particleIndex], useNewton3);
           }
-        } else
-#endif
-        {
+        } else {
           // iterate over SoA
           for (size_t particleIndex = 0; particleIndex < soaNeighborLists.size(); particleIndex++) {
             _functor->SoAFunctorVerlet(_soa, particleIndex, soaNeighborLists[particleIndex], useNewton3);

--- a/src/autopas/tuning/tuningStrategy/GaussianModel/GaussianProcess.cpp
+++ b/src/autopas/tuning/tuningStrategy/GaussianModel/GaussianProcess.cpp
@@ -6,7 +6,7 @@
 
 #include "GaussianProcess.h"
 
-#include <autopas/utils/WrapOpenMP.h>
+#include "autopas/utils/WrapOpenMP.h"
 
 autopas::GaussianProcess::GaussianProcess(size_t dims, double sigma, Random &rngRef)
     : _inputs(),

--- a/src/autopas/tuning/tuningStrategy/GaussianModel/GaussianProcess.cpp
+++ b/src/autopas/tuning/tuningStrategy/GaussianModel/GaussianProcess.cpp
@@ -6,6 +6,8 @@
 
 #include "GaussianProcess.h"
 
+#include <autopas/utils/WrapOpenMP.h>
+
 autopas::GaussianProcess::GaussianProcess(size_t dims, double sigma, Random &rngRef)
     : _inputs(),
       _outputs(),

--- a/src/autopas/tuning/tuningStrategy/GaussianModel/GaussianProcess.cpp
+++ b/src/autopas/tuning/tuningStrategy/GaussianModel/GaussianProcess.cpp
@@ -229,10 +229,7 @@ void autopas::GaussianProcess::setHyperparameters(
 
   // precalculate matrices for all hyperparameters
   // @TODO find sensible chunkSize
-#ifdef AUTOPAS_OPENMP
-  const size_t chunkSize = std::max(hyperSize / (autopas_get_num_threads() * 10), 1ul);
-#pragma omp parallel for schedule(dynamic, chunkSize)
-#endif
+  AUTOPAS_OPENMP(parallel for schedule(dynamic, std::max(hyperSize / (autopas_get_num_threads() * 10), 1ul)))
   for (size_t t = 0; t < hyperSize; ++t) {
     _hypers[t].precalculate(_sigma, _inputs, _outputs);
   }

--- a/src/autopas/tuning/tuningStrategy/GaussianModel/GaussianProcess.h
+++ b/src/autopas/tuning/tuningStrategy/GaussianModel/GaussianProcess.h
@@ -16,7 +16,6 @@
 #include "autopas/utils/Math.h"
 #include "autopas/utils/NumberSet.h"
 #include "autopas/utils/Random.h"
-#include "autopas/utils/WrapOpenMP.h"
 
 namespace autopas {
 

--- a/src/autopas/utils/WrapOpenMP.h
+++ b/src/autopas/utils/WrapOpenMP.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#if defined(AUTOPAS_OPENMP)
+#if defined(AUTOPAS_USE_OPENMP)
 #include <omp.h>
 
 #include <cstddef>  // for size_t
@@ -26,7 +26,18 @@
 
 namespace autopas {
 
-#if defined(AUTOPAS_OPENMP)
+#if defined(AUTOPAS_USE_OPENMP)
+
+/**
+ * Helper macro to stringify arguments and use them as a pragma
+ * This is necessary to combine literals and arguments to a string argument for _Pragma()
+ */
+#define AUTOPAS_DO_PRAGMA(x) _Pragma(#x)
+
+/**
+ * Wrapper macro to replace "#pragma omp" that can be (de)activated.
+ */
+#define AUTOPAS_OPENMP(args) AUTOPAS_DO_PRAGMA(omp args)
 
 /**
  * Wrapper for omp_get_thread_num().
@@ -105,6 +116,11 @@ class AutoPasLock {
 #pragma omp declare reduction(vecMerge : std::vector<double> : omp_out.insert(omp_out.end(), omp_in.begin(), omp_in.end()))
 
 #else
+
+/**
+ * Empty macro to throw away OpenMP macros
+ */
+#define AUTOPAS_OPENMP(args)
 
 /**
  * Dummy for omp_set_lock() when no OpenMP is available.

--- a/src/autopas/utils/WrapOpenMP.h
+++ b/src/autopas/utils/WrapOpenMP.h
@@ -36,6 +36,9 @@ namespace autopas {
 
 /**
  * Wrapper macro to replace "#pragma omp" that can be (de)activated.
+ * @param args Anything one can pass to `#pragma omp`
+ *
+ * @note Only one argument is supported. OpenMP clauses must thus be separated by a space.
  */
 #define AUTOPAS_OPENMP(args) AUTOPAS_DO_PRAGMA(omp args)
 
@@ -118,7 +121,7 @@ class AutoPasLock {
 #else
 
 /**
- * Empty macro to throw away OpenMP macros
+ * Empty macro to throw away any arguments.
  */
 #define AUTOPAS_OPENMP(args)
 

--- a/tests/testAutopas/testingHelpers/NumThreadGuard.h
+++ b/tests/testAutopas/testingHelpers/NumThreadGuard.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef AUTOPAS_OPENMP
-#include <omp.h>
-#endif
+#include <autopas/utils/WrapOpenMP.h>
 
 /**
  * NumThreadGuard sets current number of threads to newNum and resets number of threads during destruction.
@@ -19,21 +17,14 @@ class NumThreadGuard final {
    * Construct a new NumThreadGuard object and sets current number of threads to newNum.
    * @param newNum new number of threads
    */
-  NumThreadGuard(const int newNum) {
-#ifdef AUTOPAS_OPENMP
-    numThreadsBefore = omp_get_max_threads();
-    omp_set_num_threads(newNum);
-#endif
+  explicit NumThreadGuard(const int newNum) : numThreadsBefore(autopas::autopas_get_max_threads()) {
+    autopas::autopas_set_num_threads(newNum);
   }
 
   /**
    * Destroy the NumThreadGuard object and reset number of threads.
    */
-  ~NumThreadGuard() {
-#ifdef AUTOPAS_OPENMP
-    omp_set_num_threads(numThreadsBefore);
-#endif
-  }
+  ~NumThreadGuard() { autopas::autopas_set_num_threads(numThreadsBefore); }
 
   /**
    * delete copy constructor.
@@ -47,7 +38,5 @@ class NumThreadGuard final {
   NumThreadGuard &operator=(const NumThreadGuard &) = delete;
 
  private:
-#ifdef AUTOPAS_OPENMP
   int numThreadsBefore;
-#endif
 };

--- a/tests/testAutopas/testingHelpers/NumThreadGuard.h
+++ b/tests/testAutopas/testingHelpers/NumThreadGuard.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autopas/utils/WrapOpenMP.h>
+#include "autopas/utils/WrapOpenMP.h"
 
 /**
  * NumThreadGuard sets current number of threads to newNum and resets number of threads during destruction.

--- a/tests/testAutopas/tests/ArcherShouldReportThis.cpp
+++ b/tests/testAutopas/tests/ArcherShouldReportThis.cpp
@@ -11,7 +11,7 @@
 // this test is here just to test if archer is working.
 // and is thus currently disabled.
 // remove the "DISABLED_" part to enable it again.
-#ifdef AUTOPAS_OPENMP
+#ifdef AUTOPAS_USE_OPENMP
 TEST(DISABLED_ArcherShouldReportThis, test) {
   int a[N];
   for (int i = 0; i < N; i++) {

--- a/tests/testAutopas/tests/RemainderTraversalTest.cpp
+++ b/tests/testAutopas/tests/RemainderTraversalTest.cpp
@@ -187,7 +187,7 @@ TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_particleBufferA_pa
 }
 
 // This test is not possible without OpenMP because there only exists one buffer
-#ifdef AUTOPAS_OPENMP
+#ifdef AUTOPAS_USE_OPENMP
 TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_particleBufferA_particleBufferB_NoN3) {
   NumThreadGuard threadGuard(2);
   std::vector<Molecule> particlesContainerOwned{};
@@ -285,7 +285,7 @@ TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_particleBufferA_pa
                            autopas::Newton3Option::enabled);
 }
 
-#ifdef AUTOPAS_OPENMP
+#ifdef AUTOPAS_USE_OPENMP
 TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_particleBufferA_particleBufferB_N3) {
   NumThreadGuard threadGuard(2);
   std::vector<Molecule> particlesContainerOwned{};

--- a/tests/testAutopas/tests/containers/octree/OctreeTests.cpp
+++ b/tests/testAutopas/tests/containers/octree/OctreeTests.cpp
@@ -464,7 +464,7 @@ TEST_F(OctreeTest, testAbleToSplit) {
   }
 }
 
-#if !defined(AUTOPAS_OPENMP)
+#if !defined(AUTOPAS_USE_OPENMP)
 std::pair<OctreeTest::Vector3DList, std::vector<std::tuple<unsigned long, unsigned long, double>>>
 OctreeTest::calculateForcesAndPairs(autopas::ContainerOption containerOption, autopas::TraversalOption traversalOption,
                                     autopas::DataLayoutOption dataLayoutOption, autopas::Newton3Option newton3Option,

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
@@ -320,7 +320,7 @@ TEST_F(VerletClusterListsTest, testGridAlignment) {
             expectedTowersPerDimTotal - expectedHaloWidthInTowers);
 }
 
-#if defined(AUTOPAS_OPENMP)
+#if defined(AUTOPAS_USE_OPENMP)
 TEST_F(VerletClusterListsTest, testVerletListColoringTraversalNewton3NoDataRace) {
   const std::array<double, 3> boxMin = {0, 0, 0};
   const std::array<double, 3> boxMax = {3, 3, 3};

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
@@ -6,6 +6,8 @@
 
 #include "VerletClusterListsTest.h"
 
+#include <autopas/utils/WrapOpenMP.h>
+
 #include "autopas/containers/verletClusterLists/VerletClusterLists.h"
 #include "autopas/containers/verletClusterLists/traversals/VCLC06Traversal.h"
 #include "autopas/containers/verletClusterLists/traversals/VCLClusterIterationTraversal.h"

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
@@ -6,11 +6,10 @@
 
 #include "VerletClusterListsTest.h"
 
-#include <autopas/utils/WrapOpenMP.h>
-
 #include "autopas/containers/verletClusterLists/VerletClusterLists.h"
 #include "autopas/containers/verletClusterLists/traversals/VCLC06Traversal.h"
 #include "autopas/containers/verletClusterLists/traversals/VCLClusterIterationTraversal.h"
+#include "autopas/utils/WrapOpenMP.h"
 
 using ::testing::_;
 using ::testing::AtLeast;

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.h
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.h
@@ -38,10 +38,7 @@ class CollectParticlePairsFunctor : public autopas::Functor<autopas::Particle, C
         not autopas::utils::inBox(i.getR(), _min, _max) or not autopas::utils::inBox(j.getR(), _min, _max))
       return;
 
-#if defined(AUTOPAS_OPENMP)
-#pragma omp critical
-#endif
-    {
+    AUTOPAS_OPENMP(critical) {
       _pairs.emplace_back(&i, &j);
       if (newton3) _pairs.emplace_back(&j, &i);
     };
@@ -55,7 +52,7 @@ class CollectParticlePairsFunctor : public autopas::Functor<autopas::Particle, C
   auto getParticlePairs() { return _pairs; }
 };
 
-#if defined(AUTOPAS_OPENMP)
+#if defined(AUTOPAS_USE_OPENMP)
 class CollectParticlesPerThreadFunctor : public autopas::Functor<autopas::Particle, CollectParticlesPerThreadFunctor> {
  public:
   int _currentColor{};

--- a/tests/testAutopas/tests/iterators/ContainerIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/ContainerIteratorTest.cpp
@@ -6,12 +6,11 @@
 
 #include "ContainerIteratorTest.h"
 
-#include <autopas/utils/WrapOpenMP.h>
-
 #include "IteratorTestHelper.h"
 #include "autopas/AutoPasDecl.h"
 #include "autopas/containers/CompatibleTraversals.h"
 #include "autopas/options/IteratorBehavior.h"
+#include "autopas/utils/WrapOpenMP.h"
 #include "autopasTools/generators/RandomGenerator.h"
 #include "testingHelpers/EmptyFunctor.h"
 #include "testingHelpers/commonTypedefs.h"

--- a/tests/testAutopas/tests/iterators/ContainerIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/ContainerIteratorTest.cpp
@@ -46,10 +46,7 @@ auto ContainerIteratorTestBase::deleteParticles(AutoPasT &autopas, F predicate, 
                                                 const autopas::IteratorBehavior &behavior) {
   if constexpr (not constIter) {
     IteratorTestHelper::provideIterator<false>(autopas, behavior, useRegionIterator, [&](auto &autopas, auto getIter) {
-#ifdef AUTOPAS_OPENMP
-#pragma omp parallel
-#endif
-      {
+      AUTOPAS_OPENMP(parallel) {
         for (auto iter = getIter(); iter.isValid(); ++iter) {
           const auto leID = iter->getID();
           if (predicate(leID)) {

--- a/tests/testAutopas/tests/iterators/ContainerIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/ContainerIteratorTest.cpp
@@ -6,6 +6,8 @@
 
 #include "ContainerIteratorTest.h"
 
+#include <autopas/utils/WrapOpenMP.h>
+
 #include "IteratorTestHelper.h"
 #include "autopas/AutoPasDecl.h"
 #include "autopas/containers/CompatibleTraversals.h"

--- a/tests/testAutopas/tests/iterators/IteratorTestHelper.h
+++ b/tests/testAutopas/tests/iterators/IteratorTestHelper.h
@@ -292,16 +292,14 @@ template <class AutoPasT, class FgetIter>
 void findParticles(AutoPasT &autopas, FgetIter getIter, const std::vector<size_t> &particleIDsExpected) {
   std::vector<size_t> particleIDsFound;
 
-#ifdef AUTOPAS_OPENMP
-  // aparently the version from WrapOpenMP.h can not be found
-#pragma omp declare reduction(vecMergeWorkaround : std::vector<size_t> : omp_out.insert(omp_out.end(), omp_in.begin(), omp_in.end()))
-#pragma omp parallel reduction(vecMergeWorkaround : particleIDsFound)
-#endif
-  {
-    for (auto iterator = getIter(); iterator.isValid(); ++iterator) {
-      const auto id = iterator->getID();
-      particleIDsFound.push_back(id);
-    }
+  // apparently the version from WrapOpenMP.h can not be found
+  AUTOPAS_OPENMP(declare reduction(vecMergeWorkaround :                                             \
+                                   std::vector<size_t> :                                            \
+                                       omp_out.insert(omp_out.end(), omp_in.begin(), omp_in.end())))
+  AUTOPAS_OPENMP(parallel reduction(vecMergeWorkaround : particleIDsFound))
+  for (auto iterator = getIter(); iterator.isValid(); ++iterator) {
+    const auto id = iterator->getID();
+    particleIDsFound.push_back(id);
   }
 
   // check that everything was found

--- a/tests/testAutopas/tests/iterators/ParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/ParticleIteratorTest.cpp
@@ -4,6 +4,7 @@
 // * @author F. Gratl
 // * @date 08.03.21
 // */
+#include <autopas/utils/WrapOpenMP.h>
 //
 // #include "ParticleIteratorTest.h"
 //

--- a/tests/testAutopas/tests/iterators/ParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/ParticleIteratorTest.cpp
@@ -30,9 +30,7 @@
 //  }
 //
 //  std::vector<size_t> foundParticles;
-// #ifdef AUTOPAS_OPENMP
-// #pragma omp parallel num_threads(numThreads) reduction(vecMerge : foundParticles)
-// #endif
+//  AUTOPAS_OPENMP(parallel num_threads(numThreads) reduction(vecMerge : foundParticles))
 //  {
 //    for (auto iter =
 //             ContainerIterator<Molecule, true>(&cells, 0, nullptr, IteratorBehavior::ownedOrHalo,
@@ -68,9 +66,7 @@
 //  auto data = IteratorTestHelper::generateCellsWithPattern(10, cellsToFill, numParticlesToAddPerCell);
 //
 //  int numFoundParticles = 0;
-// #ifdef AUTOPAS_OPENMP
-// #pragma omp parallel reduction(+ : numFoundParticles)
-// #endif
+//  AUTOPAS_OPENMP(parallel reduction(+ : numFoundParticles))
 //  {
 //    ContainerIterator<Molecule, FMCell, true> iter(&data);
 //    for (; iter.isValid(); ++iter, ++numFoundParticles) {
@@ -80,9 +76,7 @@
 //  ASSERT_EQ(numFoundParticles, cellsToFill.size() * numParticlesToAddPerCell);
 //
 //  numFoundParticles = 0;
-// #ifdef AUTOPAS_OPENMP
-// #pragma omp parallel reduction(+ : numFoundParticles)
-// #endif
+//  AUTOPAS_OPENMP(parallel reduction(+ : numFoundParticles))
 //  {
 //    ContainerIterator<Molecule, FMCell, true> iter(&data);
 //    for (; iter.isValid(); ++iter) {
@@ -92,7 +86,7 @@
 //  ASSERT_EQ(numFoundParticles, 0);
 //}
 //
-// #ifdef AUTOPAS_OPENMP
+// #ifdef AUTOPAS_USE_OPENMP
 // const std::vector<size_t> threadNumsToTest{1, 2, 4};
 // #else
 //// no need to test more thread counts when openmp is not enabled

--- a/tests/testAutopas/tests/iterators/ParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/ParticleIteratorTest.cpp
@@ -4,7 +4,6 @@
 // * @author F. Gratl
 // * @date 08.03.21
 // */
-#include <autopas/utils/WrapOpenMP.h>
 //
 // #include "ParticleIteratorTest.h"
 //
@@ -12,6 +11,7 @@
 // #include "autopas/containers/linkedCells/LinkedCells.h"
 // #include "autopas/iterators/ContainerIterator.h"
 // #include "autopas/options/IteratorBehavior.h"
+// #include "autopas/utils/WrapOpenMP.h"
 // #include "testingHelpers/commonTypedefs.h"
 //
 // using namespace autopas;

--- a/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
@@ -5,6 +5,8 @@
  */
 #include "RegionParticleIteratorTest.h"
 
+#include <autopas/utils/WrapOpenMP.h>
+
 #include "IteratorTestHelper.h"
 #include "autopas/AutoPasDecl.h"
 #include "testingHelpers/EmptyFunctor.h"

--- a/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
@@ -5,10 +5,9 @@
  */
 #include "RegionParticleIteratorTest.h"
 
-#include <autopas/utils/WrapOpenMP.h>
-
 #include "IteratorTestHelper.h"
 #include "autopas/AutoPasDecl.h"
+#include "autopas/utils/WrapOpenMP.h"
 #include "testingHelpers/EmptyFunctor.h"
 #include "testingHelpers/NumThreadGuard.h"
 

--- a/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
@@ -194,9 +194,7 @@ TEST_F(RegionParticleIteratorTest, testForceSequential) {
   std::vector<std::vector<size_t>> encounteredIds(numThreads);
   {
     const NumThreadGuard numThreadGuard(numThreads);
-#ifdef AUTOPAS_OPENMP
-#pragma omp parallel for
-#endif
+    AUTOPAS_OPENMP(parallel for)
     for (int t = 0; t < numThreads; ++t) {
       for (auto iter = autoPas.getRegionIterator(
                searchBoxMin, searchBoxMax,

--- a/tests/testAutopas/tests/pairwiseFunctors/FlopCounterTest.cpp
+++ b/tests/testAutopas/tests/pairwiseFunctors/FlopCounterTest.cpp
@@ -6,6 +6,8 @@
 
 #include "FlopCounterTest.h"
 
+#include <autopas/utils/WrapOpenMP.h>
+
 #include "autopas/AutoPasDecl.h"
 #include "autopas/pairwiseFunctors/FlopCounterFunctor.h"
 #include "molecularDynamicsLibrary/LJFunctor.h"

--- a/tests/testAutopas/tests/pairwiseFunctors/FlopCounterTest.cpp
+++ b/tests/testAutopas/tests/pairwiseFunctors/FlopCounterTest.cpp
@@ -6,10 +6,9 @@
 
 #include "FlopCounterTest.h"
 
-#include <autopas/utils/WrapOpenMP.h>
-
 #include "autopas/AutoPasDecl.h"
 #include "autopas/pairwiseFunctors/FlopCounterFunctor.h"
+#include "autopas/utils/WrapOpenMP.h"
 #include "molecularDynamicsLibrary/LJFunctor.h"
 #include "testingHelpers/commonTypedefs.h"
 

--- a/tests/testAutopas/tests/pairwiseFunctors/FlopCounterTest.cpp
+++ b/tests/testAutopas/tests/pairwiseFunctors/FlopCounterTest.cpp
@@ -78,21 +78,11 @@ TEST_F(FlopCounterTest, testFlopCounterAoSOpenMP) {
 
   // This is a basic check for the global calculations, by checking the handling of two particle interactions in
   // parallel. If interactions are dangerous, archer will complain.
-#if defined(AUTOPAS_OPENMP)
-#pragma omp parallel
-#endif
-  {
-#if defined(AUTOPAS_OPENMP)
-#pragma omp sections
-#endif
-    {
-#if defined(AUTOPAS_OPENMP)
-#pragma omp section
-#endif
+  AUTOPAS_OPENMP(parallel) {
+    AUTOPAS_OPENMP(sections) {
+      AUTOPAS_OPENMP(section)
       functor.AoSFunctor(p1, p2, newton3);
-#if defined(AUTOPAS_OPENMP)
-#pragma omp section
-#endif
+      AUTOPAS_OPENMP(section)
       functor.AoSFunctor(p3, p4, newton3);
     }
   }
@@ -142,49 +132,25 @@ TEST_F(FlopCounterTest, testFlopCounterSoAOpenMP) {
   // parallel. If interactions are dangerous, archer will complain.
 
   // first functors on one cell
-#if defined(AUTOPAS_OPENMP)
-#pragma omp parallel
-#endif
-  {
-#if defined(AUTOPAS_OPENMP)
-#pragma omp sections
-#endif
-    {
-#if defined(AUTOPAS_OPENMP)
-#pragma omp section
-#endif
+  AUTOPAS_OPENMP(parallel) {
+    AUTOPAS_OPENMP(sections) {
+      AUTOPAS_OPENMP(section)
       functor.SoAFunctorSingle(cell1._particleSoABuffer, newton3);
-#if defined(AUTOPAS_OPENMP)
-#pragma omp section
-#endif
+      AUTOPAS_OPENMP(section)
       functor.SoAFunctorSingle(cell2._particleSoABuffer, newton3);
-#if defined(AUTOPAS_OPENMP)
-#pragma omp section
-#endif
+      AUTOPAS_OPENMP(section)
       functor.SoAFunctorSingle(cell3._particleSoABuffer, newton3);
-#if defined(AUTOPAS_OPENMP)
-#pragma omp section
-#endif
+      AUTOPAS_OPENMP(section)
       functor.SoAFunctorSingle(cell4._particleSoABuffer, newton3);
     }
   }
 
   // functors on two cells
-#if defined(AUTOPAS_OPENMP)
-#pragma omp parallel
-#endif
-  {
-#if defined(AUTOPAS_OPENMP)
-#pragma omp sections
-#endif
-    {
-#if defined(AUTOPAS_OPENMP)
-#pragma omp section
-#endif
+  AUTOPAS_OPENMP(parallel) {
+    AUTOPAS_OPENMP(sections) {
+      AUTOPAS_OPENMP(section)
       functor.SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, newton3);
-#if defined(AUTOPAS_OPENMP)
-#pragma omp section
-#endif
+      AUTOPAS_OPENMP(section)
       functor.SoAFunctorPair(cell3._particleSoABuffer, cell4._particleSoABuffer, newton3);
     }
   }

--- a/tests/testAutopas/tests/utils/ExceptionHandlerTest.cpp
+++ b/tests/testAutopas/tests/utils/ExceptionHandlerTest.cpp
@@ -100,7 +100,7 @@ TEST_F(ExceptionHandlerTest, TestTryRethrow) {
   }
 }
 
-#ifdef AUTOPAS_OPENMP
+#ifdef AUTOPAS_USE_OPENMP
 
 #include <omp.h>
 


### PR DESCRIPTION
# Description

Whenever we do something with OpenMP macros, we need to write an ugly block of `#ifdef` to avoid potential compiler warnings about unknown pragmas when compiling without OpenMP.
Example:
```c++
#ifdef AUTOPAS_OPENMP
#pragma omp parallel reduction(+:foo)
#endif
{
  ...
}
```

I was sufficiently annoyed to introduce a new macro that wraps this away, so we can now write this significantly shorter:
```c++
AUTOPAS_OPENMP(parallel reduction(+:foo)) { 
  ...
}
```

The new pragma simply replaces `pragma omp`, so it will work for every OpenMP pragma. If we compile without OpenMP, it is replaced with nothing.

The indicator macro was renamed to provoke errors if someone uses it in the old way.

- [x] Introduces a wrapper macro for OpenMP
- [x] Rename indicator macro to `AUTOPAS_USE_OPENMP`
- [x] Refactor code base
- [x] CI check for misuse of old macro. 

## ~Related Pull Requests~

## ~Resolved Issues~

## Additional Notes
- The new macro only accepts one argument. However, OpenMP also accepts its clauses to be separated by `,` which would, in turn, split the argument to `AUTOPAS_OPENMP`. We could make `AUTOPAS_OPENMP` variadic, and then during stringification recreate the `,` but I couldn't be bothered... I'd keep it like that until a use case arises that requires this.
- Blocks can be started in the same line as the new macro :eyes:
- `clang-format` employs a different indentation for the new macro vs the old pragma. The latter was always pushed to the front of the line, while the former follows the indentation of the rest of the code.
- Why is this a valid use case for a macro?
  -> We are wrapping a pragma that wasn't debuggable in the first place.
