### PR TITLE
Nicer Links in Docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,3 @@
-
 # Contributing to AutoPas
 
 **Thanks for contributing to AutoPas!** 
@@ -9,7 +8,7 @@ Please keep in mind the following notes while working.
 ### General Notes
 * Cpp standard: C++17. If there is a piece of code, which could be done better using a newer standard, please add a comment like `@todo C++20` including the alternative version of the code.
 * Pointers: Always use smart pointers when you are managing memory. Don't use `new` or `delete`.
-* OpenMP: Use AutoPas wrapper functions for OpenMP (`src/autopas/utils/WrapOpenMP.h`) instead of OpenMP functions to allow building without enabled OpenMP.
+* OpenMP: Use AutoPas wrapper functions for OpenMP from [`WrapOpenMP.h`](/src/autopas/utils/WrapOpenMP.h) instead of native OpenMP functions to allow building without enabled OpenMP.
 * `#pragma once` instead of header guards.
 * `#include` of files from within AutoPas shall be given with the full path (starting with `autopas/`) and using `""`. 
 * `constexpr` instead of `#define`. Use it wherever possible.
@@ -106,82 +105,83 @@ Possible log levels are:`trace`, `debug`, `info`, `warn`, `err`, `critical`, `of
 
 ### Adding a new Traversal
 * Create a new traversal class under `src/autopas/containers/[Container]/traversals` for the container the traversal is intended.
-* Think about inheriting from a similar traversal. At least derive your new traversal from `src/autopas/containers/cellPairTraversals/TraversalInterface.h`.
-* Go to `src/autopas/options/TraversalOption.h`.
+* Think about inheriting from a similar traversal. At least derive your new traversal from [`TraversalInterface`](/src/autopas/containers/TraversalInterface.h).
+* Go to [`TraversalOption`](/src/autopas/options/TraversalOption.h).
   * Add a new enum in `TraversalOption::Value`.
   * Add a new string representation in the `map` of `TraversalOption::getOptionNames()`.
-* Add the enum to every compatible container in `src/autopas/containers/CompatibleTraversals.h`.
+* Add the enum to every compatible container in [`CompatibleTraversals`](/src/autopas/containers/CompatibleTraversals.h).
   * If applicability of the traversal is restricted, add your new enum to any of the functions that return sets of restricted traversals (E.g. `CompatibleTraversals::allTraversalsSupportingOnlySoA()`).
-* Add a case for the new traversal in `src/autopas/tuning/selectors/TraversalSelector.h::generateTraversal()`.
+* Add a case for the new traversal in [`TraversalSelector::generateTraversal()`](/src/autopas/tuning/selectors/TraversalSelector.h).
 * Check that the new option is working in the md-flexible example.
-* Adapt unit tests (e.g. expected number of iterations in `tests/testAutopas/tests/tuning/AutoTunerTest.cpp::testAllConfigurations()` and `OptionTest::parseTraversalOptionsTest`).
+* Adapt unit tests (e.g. expected number of iterations in [`AutoTunerTest::testAllConfigurations()`](/tests/testAutopas/tests/tuning/AutoTunerTest.cpp) and [`OptionTest::parseTraversalOptionsTest`](/tests/testAutopas/tests/options/OptionTest.h)).
 * Add new unit tests for your traversal.
-* Regenerate the `RuleLanguage.g4` via the `generateRuleLanguage.sh` script, both located in `src/autopas/tuning/tuningStrategy/ruleBasedTuning`
+* Regenerate the `RuleLanguage.g4` via the `generateRuleLanguage.sh` script, both located in [`ruleBasedTuning`](/src/autopas/tuning/tuningStrategy/ruleBasedTuning).
 
 ### Adding a new Container
-* Create a new container class under `src/autopas/containers/`.
-* Derive your new container from `src/autopas/containers/ParticleContainerInterface.h` or a more similar one.
-* Go to `src/autopas/options/ContainerOption.h`.
+* Create a new container class under [`src/autopas/containers/`](/src/autopas/containers/).
+* Derive your new container from [`ParticleContainerInterface`](/src/autopas/containers/ParticleContainerInterface.h) or a more similar one.
+* Go to [`ContainerOption`](/src/autopas/options/ContainerOption.h).
   * Add a new enum in `ContainerOption::Value`.
   * Add a new string representation in the `map` of `ContainerOption::getOptionNames()`.
-* Create a new set of compatible traversals in `src/autopas/containers/CompatibleTraversals.h`.
-* Create a new `case` statement in `src/autopas/utils/StaticContainerSelector.h`.
-* Add a case for the new container in `src/autopas/tuning/selectors/ContainerSelector.h::generateContainer()`.
+* Create a new set of compatible traversals in [`CompatibleTraversals`](/src/autopas/containers/CompatibleTraversals.h).
+* Create a new `case` statement in [`StaticContainerSelector`](/src/autopas/utils/StaticContainerSelector.h).
+* Add a case for the new container in [`ContainerSelector::generateContainer()`](/src/autopas/tuning/selectors/ContainerSelector.h).
 * Check that the new option is working in the md-flexible example.
-* Adapt unit tests (e.g. expected number of iterations in `tests/testAutopas/tests/tuning/AutoTunerTest.cpp::testAllConfigurations()` and `StringUtilsTest::parseContainerOptionsTest`).
+* Adapt unit tests (e.g. expected number of iterations in [`AutoTunerTest::testAllConfigurations()`](/tests/testAutopas/tests/tuning/AutoTunerTest.cpp) and [`StringUtilsTest::parseContainerOptionsTest`](/tests/testAutopas/tests/utils/StringUtilsTest.cpp)).
 * Add new unit tests for your container.
-* Regenerate the `RuleLanguage.g4` via the `generateRuleLanguage.sh` script, both located in `src/autopas/tuning/tuningStrategy/ruleBasedTuning`
+* Regenerate the `RuleLanguage.g4` via the `generateRuleLanguage.sh` script, both located in [`ruleBasedTuning`](/src/autopas/tuning/tuningStrategy/ruleBasedTuning).
 
 ### Adding a new Tuning Strategy
-* Create a new tuning strategy class under `src/autopas/tuning/tuningStrategy`.
-* Derive your new strategy from `src/autopas/tuning/tuningStrategy/TuningStrategyInterface.h` or a more similar one.
-* Go to `src/autopas/options/TuningStrategyOption.h`.
+* Create a new tuning strategy class under [`src/autopas/tuning/tuningStrategy`](/src/autopas/tuning/tuningStrategy).
+* Derive your new strategy from [`TuningStrategyInterface`](/src/autopas/tuning/tuningStrategy/TuningStrategyInterface.h) or a more similar one.
+* Go to [`TuningStrategyOption`](/src/autopas/options/TuningStrategyOption.h).
   * Add a new enum in `TuningStrategyOption::Value`.
   * Add a new string representation in the `map` of `TuningStrategyOption::getOptionNames()`.
-* In `src/autopas/tuning/tuningStrategy/TuningStrategyFactory.cpp::generateTuningStrategy()`:
+* In [`TuningStrategyFactory::generateTuningStrategy()`](/src/autopas/tuning/tuningStrategy/TuningStrategyFactory.cpp):
   * Add a `case` for the new strategy.
   * If the new strategy handles communication between processes itself, make sure to not wrap it in the lower `mpiStrategyOption`-switch.
 * Check that the new option is working in the md-flexible example.
 * Add new unit tests for your strategy.
 
 ### Adding a new Option
-* If applicable add a new setter to `src/autopas/AutoPas.h` (this is required for tunable options).
+* If applicable add a new setter to [`AutoPas`](/src/autopas/AutoPas.h) (this is required for tunable options).
 * Check that the new option is added to the md-flexible example. Parser and main.
-* Global options, which are represented by an enum, should be defined in an additional file in `src/autopas/options`.
-* Inherit from `src/autopas/options/Option.h`. This will also generate functions for conversion from and to strings.
-* Add new unit tests for your option, mainly in `tests/testAutopas/tests/options/OptionTest.cpp`.
+* Global options, which are represented by an enum, should be defined in an additional file in [`src/autopas/options`](/src/autopas/options).
+* Inherit from [`Option`](/src/autopas/options/Option.h). This will also generate functions for conversion from and to strings.
+* Add new unit tests for your option, mainly in [`OptionTest`](/tests/testAutopas/tests/options/OptionTest.cpp).
 * Also add the new option to md-flexible! 
-  * Add the option in `examples/md-flexible/src/parsing/MDFlexConfig.h`
-  * Add it to `MDFlexConfig::to_string`
-  * Parse it in `examples/md-flexible/src/parsing/CLIParser.cpp` (in `CLIParser::parseInput()`: Add it to `relevantOptions` and switch)
-  * Parse it in `examples/md-flexible/src/configuration/YamlParser.cpp`
-  * If applicable, pass the option value to AutoPas in `Simulation::Simulation()`
-  * Make sure that the description is parsable by `CLIParser::createZSHCompletionFile()`
+  * Add the option in [`MDFlexConfig`](/examples/md-flexible/src/parsing/MDFlexConfig.h).
+  * Add it to [`MDFlexConfig::to_string`](/examples/md-flexible/src/parsing/MDFlexConfig.h).
+  * Parse it in [`CLIParser`](/examples/md-flexible/src/parsing/CLIParser.cpp).
+  * In [`CLIParser::parseInput()`](/examples/md-flexible/src/parsing/CLIParser.cpp) add it to `relevantOptions` and switch.
+  * Parse it in [`YamlParser`](/examples/md-flexible/src/configuration/YamlParser.cpp).
+  * If applicable, pass the option value to AutoPas in [`Simulation::Simulation()`](/examples/md-flexible/src/Simulation.cpp).
+  * Make sure that the description is parsable by [`CLIParser::createZSHCompletionFile()`](/examples/md-flexible/src/configuration/CLIParser.cpp).
 
 ### Making an Option tunable
-* If not already done, add a new setter to `src/autopas/AutoPasDecl.h`.
-* Add your option to `src/autopas/tuning/Configuration.h` and adjust constructors, comparison operators and ConfigHash function accordingly.
+* If not already done, add a new setter to [`src/autopas/AutoPasDecl.h`](/src/autopas/AutoPasDecl.h).
+* Add your option to [`Configuration`](/src/autopas/tuning/Configuration.h) and adjust constructors, comparison operators and ConfigHash function accordingly.
 * Adjust the individual tuning strategies accordingly; the exact implementation will depend on the purpose of your option, but some general advice is:
   * Depending on your new option, it might make sense for some tuning strategies to merge it with another option to avoid sparse dimensions.
-  * Make sure it is added to the search spaces that is passed to the `AutoTuner` in `AutoPas::init()`
-  * For bayesian based tuning strategies your option will also have to be integrated into `FeatureVector` and `FeatureVectorEncoder`.
-  * Extend `FeatureVectorEncoder` by modifying `setAllowedOptions()`, `convertToTunable()` and `convertFromTunable()`. If the new option wasn't merged with another one you may have to add a new index to `DiscreteIndices` or `ContinuousIndices`
-  * Make sure to declare your option by calling `configureTuningParameter()` in `ActiveHarmony::resetHarmony()`.
-* In `src/autopas/utils/AutoPasConfigurationCommunicator.h/.cpp`:
+  * Make sure it is added to the search spaces that is passed to the [`AutoTuner`](/src/autopas/tuning/AutoTuner.cpp) in `AutoPas::init()`
+  * For Bayesian based tuning strategies your option will also have to be integrated into [`FeatureVector`](/src/autopas/tuning/utils/FeatureVector.h) and [`FeatureVectorEncoder`](/src/autopas/tuning/utils/FeatureVectorEncoder.h).
+  * Extend [`FeatureVectorEncoder`](/src/autopas/tuning/utils/FeatureVectorEncoder.h) by modifying `setAllowedOptions()`, `convertToTunable()` and `convertFromTunable()`. If the new option wasn't merged with another one you may have to add a new index to `DiscreteIndices` or `ContinuousIndices`
+  * Make sure to declare your option by calling `configureTuningParameter()` in [`ActiveHarmony::resetHarmony()`](/src/autopas/tuning/tuningStrategy/ActiveHarmony.cpp).
+* In [`AutoPasConfigurationCommunicator`](/src/autopas/utils/AutoPasConfigurationCommunicator.h):
   * Change the size and (de-)serialization of SerializedConfiguration
   * Add the new option to all appropriate functions and adjust their functioning respectively.
-* In `src/autopas/utils/ConfigurationAndRankIteratorHandler.h/.cpp`:
+* In [`ConfigurationAndRankIteratorHandler`](/src/autopas/utils/ConfigurationAndRankIteratorHandler.h):
   * Add the new option wherever appropriate.
   * If the new options depends on others, implement it similarly to traversals, containers, and load estimators.
 * Adjust any tests that are affected by these changes. The following tests will definitely require changes:
-  * `tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.{h,cpp}`
-  * `tests/testAutopas/tests/tuning/AutoTunerTest.cpp`
-  * `tests/testAutopas/tests/tuning/FeatureVectorTest.cpp`
-  * Tests for the individual tuning strategies. See files in `tests/testAutopas/tests/tuning/tuningStrategy/`.
+  * [`AutoPasInterfaceTest`](/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp)
+  * [`AutoTunerTest`](/tests/testAutopas/tests/tuning/AutoTunerTest.cpp)
+  * [`FeatureVectorTest`](/tests/testAutopas/tests/tuning/FeatureVectorTest.cpp)
+  * Tests for the individual tuning strategies. See files in [`tests/testAutopas/tests/tuning/tuningStrategy/`](/tests/testAutopas/tests/tuning/tuningStrategy/).
 
 ### Rule Based Tuning and Antlr
 Whenever any option is added that is part of the tuning procedure, it has to be added to the Antlr parsing logic and grammar.
-To update the grammar, simply run `src/autopas/tuning/tuningStrategy/ruleBasedTuning/generateRuleLanguage.sh` and overwrite the old `src/autopas/tuning/tuningStrategy/ruleBasedTuning/RuleLangugage.g4` file.
+To update the grammar, simply run [`generateRuleLanguage.sh`](/src/autopas/tuning/tuningStrategy/ruleBasedTuning/generateRuleLanguage.sh) and overwrite the old [`RuleLangugage.g4`](/src/autopas/tuning/tuningStrategy/ruleBasedTuning/RuleLangugage.g4) file.
 To update the parser, the easiest way to do this is via the CLion plugin for Antlr4. Just right-click the g4 file -> 'Configure ANTLR' (Output directory, input grammar file, namespace `autopas_generated_rule_syntax`, language) and then right click the g4 again -> 'Generate ANTLR Recognizer'. Don't forget to apply clang-format afterward.
 
 **WARNING** The CLion plugin and Antlr version must match!. For example for Antlr version 4.9.1 the plugin version 1.16 is needed, otherwise incompatible parser code is generated. See [Antlr plugin's GitHub page](https://github.com/antlr/intellij-plugin-v4/releases) for what is compatible and get the plugin's binary from the [jetbrains plugin webpage](https://plugins.jetbrains.com/plugin/7358-antlr-v4/versions).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -115,7 +115,7 @@ Possible log levels are:`trace`, `debug`, `info`, `warn`, `err`, `critical`, `of
 * Check that the new option is working in the md-flexible example.
 * Adapt unit tests (e.g. expected number of iterations in [`AutoTunerTest::testAllConfigurations()`](/tests/testAutopas/tests/tuning/AutoTunerTest.cpp) and [`OptionTest::parseTraversalOptionsTest`](/tests/testAutopas/tests/options/OptionTest.h)).
 * Add new unit tests for your traversal.
-* Regenerate the `RuleLanguage.g4` via the `generateRuleLanguage.sh` script, both located in [`ruleBasedTuning`](/src/autopas/tuning/tuningStrategy/ruleBasedTuning).
+* Regenerate the [`RuleLanguage.g4`](/src/autopas/tuning/tuningStrategy/ruleBasedTuning/RuleLanguage.g4) via the [`generateRuleLanguage.sh`](/src/autopas/tuning/tuningStrategy/ruleBasedTuning/generateRuleLanguage.sh) script, both located in [`ruleBasedTuning`](/src/autopas/tuning/tuningStrategy/ruleBasedTuning).
 
 ### Adding a new Container
 * Create a new container class under [`src/autopas/containers/`](/src/autopas/containers/).
@@ -129,7 +129,7 @@ Possible log levels are:`trace`, `debug`, `info`, `warn`, `err`, `critical`, `of
 * Check that the new option is working in the md-flexible example.
 * Adapt unit tests (e.g. expected number of iterations in [`AutoTunerTest::testAllConfigurations()`](/tests/testAutopas/tests/tuning/AutoTunerTest.cpp) and [`StringUtilsTest::parseContainerOptionsTest`](/tests/testAutopas/tests/utils/StringUtilsTest.cpp)).
 * Add new unit tests for your container.
-* Regenerate the `RuleLanguage.g4` via the `generateRuleLanguage.sh` script, both located in [`ruleBasedTuning`](/src/autopas/tuning/tuningStrategy/ruleBasedTuning).
+* Regenerate the [`RuleLanguage.g4`](/src/autopas/tuning/tuningStrategy/ruleBasedTuning/RuleLanguage.g4) via the [`generateRuleLanguage.sh`](/src/autopas/tuning/tuningStrategy/ruleBasedTuning/generateRuleLanguage.sh) script, both located in [`ruleBasedTuning`](/src/autopas/tuning/tuningStrategy/ruleBasedTuning).
 
 ### Adding a new Tuning Strategy
 * Create a new tuning strategy class under [`src/autopas/tuning/tuningStrategy`](/src/autopas/tuning/tuningStrategy).
@@ -150,10 +150,10 @@ Possible log levels are:`trace`, `debug`, `info`, `warn`, `err`, `critical`, `of
 * Inherit from [`Option`](/src/autopas/options/Option.h). This will also generate functions for conversion from and to strings.
 * Add new unit tests for your option, mainly in [`OptionTest`](/tests/testAutopas/tests/options/OptionTest.cpp).
 * Also add the new option to md-flexible! 
-  * Add the option in [`MDFlexConfig`](/examples/md-flexible/src/parsing/MDFlexConfig.h).
-  * Add it to [`MDFlexConfig::to_string`](/examples/md-flexible/src/parsing/MDFlexConfig.h).
-  * Parse it in [`CLIParser`](/examples/md-flexible/src/parsing/CLIParser.cpp).
-  * In [`CLIParser::parseInput()`](/examples/md-flexible/src/parsing/CLIParser.cpp) add it to `relevantOptions` and switch.
+  * Add the option in [`MDFlexConfig`](/examples/md-flexible/src/configuration/MDFlexConfig.h).
+  * Add it to [`MDFlexConfig::to_string`](/examples/md-flexible/src/configuration/MDFlexConfig.h).
+  * Parse it in [`CLIParser`](/examples/md-flexible/src/configuration/CLIParser.cpp).
+  * In [`CLIParser::parseInput()`](/examples/md-flexible/src/configuration/CLIParser.cpp) add it to `relevantOptions` and switch.
   * Parse it in [`YamlParser`](/examples/md-flexible/src/configuration/YamlParser.cpp).
   * If applicable, pass the option value to AutoPas in [`Simulation::Simulation()`](/examples/md-flexible/src/Simulation.cpp).
   * Make sure that the description is parsable by [`CLIParser::createZSHCompletionFile()`](/examples/md-flexible/src/configuration/CLIParser.cpp).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -176,7 +176,7 @@ Possible log levels are:`trace`, `debug`, `info`, `warn`, `err`, `critical`, `of
 * Adjust any tests that are affected by these changes. The following tests will definitely require changes:
   * [`AutoPasInterfaceTest`](/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.cpp)
   * [`AutoTunerTest`](/tests/testAutopas/tests/tuning/AutoTunerTest.cpp)
-  * [`FeatureVectorTest`](/tests/testAutopas/tests/tuning/FeatureVectorTest.cpp)
+  * [`FeatureVectorTest`](/tests/testAutopas/tests/tuning/utils/FeatureVectorTest.cpp)
   * Tests for the individual tuning strategies. See files in [`tests/testAutopas/tests/tuning/tuningStrategy/`](/tests/testAutopas/tests/tuning/tuningStrategy/).
 
 ### Rule Based Tuning and Antlr

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ As AutoPas is only a library, it is not able to run simulations by itself.
 We have, however, included a few example proxy applications in the **examples** directory.
 The examples include:
 * [md-flexible](https://github.com/AutoPas/AutoPas/blob/master/examples/md-flexible): Molecular dynamics simulations with single centered Lennard-Jones particles.
-* Smoothed particle hydrodynamics simulations
+* [Smoothed particle hydrodynamics simulations](https://github.com/AutoPas/AutoPas/blob/master/examples/sph)
 
 ## Using AutoPas
 Steps to using AutoPas in your particle simulation program:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # ![AutoPas](https://raw.githubusercontent.com/AutoPas/AutoPas/master/docs/graphics/AutoPasLogo_Large.svg "Title")
 
 AutoPas is a node-level auto-tuned particle simulation library developed
@@ -116,9 +115,9 @@ Steps to using AutoPas in your particle simulation program:
 
 ### Custom Particles
 First you will need to define a particle class which will be passed to AutoPas as template Argument.
-For that we provide some basic Particle classes defined in `applicationLibrary/molecularDynamics/molecularDynamicsLibrary` or `applicationLibrary/sph/SPHLibrary` 
+For that we provide some basic Particle classes defined in [`molecularDynamicsLibrary`](applicationLibrary/molecularDynamics/molecularDynamicsLibrary) or [`SPHLibrary`](applicationLibrary/sph/SPHLibrary) 
 that you can use either directly or you can write your own Particle class by inheriting from one of the provided
-classes or from `autopas::Particle`.
+classes or from [`autopas::ParticleBase`](src/autopas/particles/ParticleBase.h).
 
 Important parts to implement:
 * `enum AttributeNames`
@@ -137,7 +136,7 @@ Important parts to implement:
 
 #### Usage
 Each functor is applied to AutoPas via:
-```bash
+```cpp
 autoPas.iteratePairwise(&myFunctor);
 ```
 
@@ -186,7 +185,7 @@ for(auto iter = autoPas.getRegionIterator(lowCorner, highCorner); iter != autoPa
 
 Both `begin()` and `getRegionIterator()` can also take the additional parameter `IteratorBehavior`,
 which indicates over which particles the iteration should be performed. See [autopas::IteratorBehavior
-](https://autopas.github.io/doxygen_documentation/git-master/namespaceautopas.html#a520fefd51e4555074cd16e7c3fd19c42) for possible options and details.
+](https://autopas.github.io/doxygen_documentation/git-master/classautopas_1_1options_1_1IteratorBehavior.html) for possible options and details.
 The default parameter is `ownedOrHalo`, which is also used for range-based for loops.
 
 Analogously to `begin()`, `cbegin()` is also defined, which guarantees to return a `const_iterator`.
@@ -313,7 +312,7 @@ There exist some things you have to be careful about when using multiple functor
   It is recommended, to only mark the most expensive functor as relevant.
 
 ## Developing AutoPas
-Please look at our [contribution guidelines](https://github.com/AutoPas/AutoPas/blob/master/.github/CONTRIBUTING.md).
+Please look at our [contribution guidelines](.github/CONTRIBUTING.md).
 
 For profiling the compile-time, the `cmake` option `AUTOPAS_COMPILE_TIME_PROFILING` can be turned on. This enables gcc's -`ftime-report` and clang's `-ftime-trace`. 
 It is recommended to use clang, as its output is more detailed.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ If you prefer `gdb`:
 As AutoPas is only a library, it is not able to run simulations by itself.
 We have, however, included a few example proxy applications in the **examples** directory.
 The examples include:
-* [md-flexible](examples/md-flexible): Molecular dynamics simulations with single centered Lennard-Jones particles.
+* [md-flexible](https://github.com/AutoPas/AutoPas/blob/master/examples/md-flexible): Molecular dynamics simulations with single centered Lennard-Jones particles.
 * Smoothed particle hydrodynamics simulations
 
 ## Using AutoPas
@@ -115,9 +115,9 @@ Steps to using AutoPas in your particle simulation program:
 
 ### Custom Particles
 First you will need to define a particle class which will be passed to AutoPas as template Argument.
-For that we provide some basic Particle classes defined in [`molecularDynamicsLibrary`](applicationLibrary/molecularDynamics/molecularDynamicsLibrary) or [`SPHLibrary`](applicationLibrary/sph/SPHLibrary) 
+For that we provide some basic Particle classes defined in [`molecularDynamicsLibrary`](https://github.com/AutoPas/AutoPas/blob/master/applicationLibrary/molecularDynamics/molecularDynamicsLibrary) or [`SPHLibrary`](https://github.com/AutoPas/AutoPas/blob/master/applicationLibrary/sph/SPHLibrary) 
 that you can use either directly or you can write your own Particle class by inheriting from one of the provided
-classes or from [`autopas::ParticleBase`](src/autopas/particles/ParticleBase.h).
+classes or from [`autopas::ParticleBase`](https://github.com/AutoPas/AutoPas/blob/master/src/autopas/particles/ParticleBase.h).
 
 Important parts to implement:
 * `enum AttributeNames`
@@ -312,7 +312,7 @@ There exist some things you have to be careful about when using multiple functor
   It is recommended, to only mark the most expensive functor as relevant.
 
 ## Developing AutoPas
-Please look at our [contribution guidelines](.github/CONTRIBUTING.md).
+Please look at our [contribution guidelines](https://github.com/AutoPas/AutoPas/blob/master/.github/CONTRIBUTING.md).
 
 For profiling the compile-time, the `cmake` option `AUTOPAS_COMPILE_TIME_PROFILING` can be turned on. This enables gcc's -`ftime-report` and clang's `-ftime-trace`. 
 It is recommended to use clang, as its output is more detailed.


### PR DESCRIPTION
# Description

The Problem: Links in markdown files should work both in doxygen, the doc webpage, and on github.

Internal links don't work reliably on the webpage, hence all markdown files that are directly included in doxygen directly should use https links.

Repo-abolute paths in the documentation pages
- [x] README.md
- [x] CONTRIBUTING.md

