### PR TITLE
Fix Compilers in Makefile Projects

### DIFF
--- a/cmake/modules/autopas_antlr4cpp.cmake
+++ b/cmake/modules/autopas_antlr4cpp.cmake
@@ -22,7 +22,11 @@ if (NOT UUID_FOUND)
         BUILD_IN_SOURCE TRUE
         INSTALL_DIR "install"
         CONFIGURE_COMMAND "./configure" ${UUID_CONFIG_PARAMS}
-        BUILD_COMMAND ${MAKE_EXE}
+        # make sure make uses the same compilers as the rest of the CMake project
+        BUILD_COMMAND ${CMAKE_COMMAND} -E env
+          CC=${CMAKE_C_COMPILER}
+          CXX=${CMAKE_CXX_COMPILER}
+          ${MAKE_EXE}
     )
 
 else()

--- a/cmake/modules/autopas_harmony.cmake
+++ b/cmake/modules/autopas_harmony.cmake
@@ -24,7 +24,16 @@ ExternalProject_Add(
     CONFIGURE_COMMAND ""
     LOG_BUILD ON
     LOG_INSTALL ON
-    BUILD_COMMAND ${MAKE_EXE}
+    # make sure make uses the same compilers as the rest of the CMake project
+    BUILD_COMMAND ${CMAKE_COMMAND} -E env
+      CC=${CMAKE_C_COMPILER}
+      CXX=${CMAKE_CXX_COMPILER}
+      ${MAKE_EXE}
+    # no install step needed since we just link against the unpacked headers
+    INSTALL_COMMAND ${CMAKE_COMMAND} -E env
+      CC=${CMAKE_C_COMPILER}
+      CXX=${CMAKE_CXX_COMPILER}
+      ${MAKE_EXE} install
 )
 
 # Get GTest source and binary directories from CMake project


### PR DESCRIPTION
# Description

The problem: Some of our dependencies are makefiles (harmony, antlr). They are built via `ExternalProject_Add`. This basically just calls `make` and does not care about any CMake variables. Therefore, make falls back to the default system compiler, which can be checked when building with verbose makefiles.
So when we manually set a different compiler, e.g. clang, this can lead to parts of AutoPas being built with clang and others with GCC (which is the default almost everywhere). This can lead to problems, especially in weird github runner environments.

This PR fixes this by forcing make to use the compilers that are specified for CMake.
