### PR TITLE
Fix CellBlock3D::getCellBoundingBox()

### DIFF
--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -458,8 +458,8 @@ inline std::pair<std::array<double, 3>, std::array<double, 3>> CellBlock3D<Parti
 
     boxmax[d] = boxmin[d] + this->_cellLength[d];
 
-    // This must not be an else to the if block above.
-    // If the above is true, this can also be true if there is e.g. only one cell
+    // This must not be an else to the if block above as both cases can be true.
+    // e.g. if there is only one cell
     if (index3d[d] == this->_cellsPerDimensionWithHalo[d] - _cellsPerInteractionLength - 1) {
       boxmax[d] = _boxMax[d];
     } else if (index3d[d] == this->_cellsPerDimensionWithHalo[d] - 1) {

--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -447,16 +447,18 @@ inline std::pair<std::array<double, 3>, std::array<double, 3>> CellBlock3D<Parti
   for (int d = 0; d < 3; d++) {
     // defaults
     boxmin[d] = index3d[d] * this->_cellLength[d] + _haloBoxMin[d];
-    boxmax[d] = (index3d[d] + 1) * this->_cellLength[d] + _haloBoxMin[d];
 
-    // stupid rounding errors. Make sure that the lower corner is set correctly!
+    // stupid rounding errors. Snap values to the exact box values.
     if (index3d[d] == 0) {
       boxmin[d] = _haloBoxMin[d];
-      boxmax[d] = this->_cellLength[d];
     } else if (index3d[d] == _cellsPerInteractionLength) {
+      // Case: we are at the lower boundary of the non-halo box
       boxmin[d] = _boxMin[d];
     }
-    // no else, as this might ALSO be 1
+
+    boxmax[d] = boxmin[d] + this->_cellLength[d];
+
+    // This is not an else to the if block above, if there is only one cell
     if (index3d[d] == this->_cellsPerDimensionWithHalo[d] - _cellsPerInteractionLength - 1) {
       boxmax[d] = _boxMax[d];
     } else if (index3d[d] == this->_cellsPerDimensionWithHalo[d] - 1) {

--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -458,7 +458,8 @@ inline std::pair<std::array<double, 3>, std::array<double, 3>> CellBlock3D<Parti
 
     boxmax[d] = boxmin[d] + this->_cellLength[d];
 
-    // This is not an else to the if block above, if there is only one cell
+    // This must not be an else to the if block above.
+    // If the above is true, this can also be true if there is e.g. only one cell
     if (index3d[d] == this->_cellsPerDimensionWithHalo[d] - _cellsPerInteractionLength - 1) {
       boxmax[d] = _boxMax[d];
     } else if (index3d[d] == this->_cellsPerDimensionWithHalo[d] - 1) {

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -328,7 +328,7 @@ class ParticleContainerInterface {
    * @param cellIndex Index of the cell the particle is located in.
    * @param particleIndex Particle index within the cell.
    * @param iteratorBehavior Which ownership states should be considered for the next particle.
-   * @return Pointer to the particle and its indices.
+   * @return Pointer to the particle and its indices. tuple<Particle*, cellIndex, particleIndex>
    * If a index pair is given that does not exist but is also not beyond the last cell, the next fitting particle shall
    * be returned.
    * Example: If [4,2] does not exist, [5,1] shall be returned

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -322,7 +322,6 @@ class ParticleContainerInterface {
    * even exist.
    * The only guarantee is that the indices {0,0} yield the first particle in the container that satisfies the iterator
    * requirements.
-
    *
    * @note This function should handle any offsets if used in a parallel iterator.
    *
@@ -331,8 +330,9 @@ class ParticleContainerInterface {
    * @param iteratorBehavior Which ownership states should be considered for the next particle.
    * @return Pointer to the particle and its indices.
    * If a index pair is given that does not exist but is also not beyond the last cell, the next fitting particle shall
-   * be returned. Example: If [4,2] does not exist, [5,1] shall be returned (or whatever is the next particle that
-   * fulfills the iterator requirements).
+   * be returned.
+   * Example: If [4,2] does not exist, [5,1] shall be returned
+   * (or whatever is the next particle that fulfills the iterator requirements).
    * If there is no next fitting particle {nullptr, 0, 0} is returned.
    */
   virtual std::tuple<const Particle *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,

--- a/tests/testAutopas/tests/containers/CellBlock3DTest.cpp
+++ b/tests/testAutopas/tests/containers/CellBlock3DTest.cpp
@@ -221,6 +221,6 @@ TEST_F(CellBlock3DTest, testGetCellBoundingBox) {
   testCellBoundingBox({cellsPerDimensionWithHalo - 2, cellsPerDimensionWithHalo - 2, cellsPerDimensionWithHalo - 2},
                       boxMax - desiredCellLength, boxMax);
   // last cell in the halo box
-  testCellBoundingBox({cellsPerDimensionWithHalo - 1, cellsPerDimensionWithHalo - 1, cellsPerDimensionWithHalo - 1}, boxMax,
-                      boxMax + desiredCellLength);
+  testCellBoundingBox({cellsPerDimensionWithHalo - 1, cellsPerDimensionWithHalo - 1, cellsPerDimensionWithHalo - 1},
+                      boxMax, boxMax + desiredCellLength);
 }


### PR DESCRIPTION
# Description

Fixes the value clamping in `CellBlock3D::getCellBoundingBox()` when we calculate the bounding box of a cell at the lower edge of the domain.

- [x] Fixed bug
- [x] Adapted some tangentially related documentation.

## ~Related Pull Requests~

## ~Resolved Issues~

## Additional Context

- This caused the particle duplication bug in ls1 because particles were not found by the `LeavingParticleCollector`. Thus during the update, some halos were not removed and their corresponding owned partners were placed right on top of them.
- *Why was this not an issue before?* Not sure. I think when I rewrote the Iterators in #712 I started using `CellBlock3D::getCellBoundingBox()` significantly more than it was used previously. Later when I rewrote `LeavingParticleCollector` in #792 this was used even more, especially around domain borders. So maybe we just didn't use the function for these edge cases before? Seems like another important argument for introducing test coverage -> #807 

# How Has This Been Tested?

- [x] fixed bug in ls1
- [x] New unit tests