### PR TITLE
Separate DocTagChecker Workflow

### DIFF
--- a/.github/workflows/DocTagChecker.yaml
+++ b/.github/workflows/DocTagChecker.yaml
@@ -1,0 +1,27 @@
+# Workflow for generating, checking, and deploying our doxygen documentation.
+name: DocTagChecker
+
+# This Workflow can only run on PRs.
+on:
+  pull_request:
+
+# abort old runs if a new one is started
+concurrency:
+  group: ${{ github.head_ref }}-DocTagChecker
+  cancel-in-progress: true
+
+jobs:
+  DocTagCheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check for missing userdoc updates
+        uses: AutoPas/DocTagChecker@main
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          userDocsDirs: docs/userdoc
+          recurseUserDocDirs: true
+          docFileExtensions: md
+          # c++ files and cmake files
+          srcFileExtensions: cpp h txt cmake

--- a/.github/workflows/TestSuites.yaml
+++ b/.github/workflows/TestSuites.yaml
@@ -1,14 +1,12 @@
 # Workflow for unit tests
 name: CI
 
-# Controls when the action will run.
+# This Workflow is triggered by any PR or a direct push to master.
 on:
   push:
-    # pushes to master
     branches: [ master ]
   pull_request:
-    # PRs to master
-    # branches: [ master ]
+
 # abort old runs if a new one is started
 concurrency:
   group: ${{ github.head_ref }}-tests

--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -15,21 +15,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  DocTagCheck:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Check for missing userdoc updates
-        uses: AutoPas/DocTagChecker@main
-        with:
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
-          userDocsDirs: docs/userdoc
-          recurseUserDocDirs: true
-          docFileExtensions: md
-          # c++ files and cmake files
-          srcFileExtensions: cpp h txt cmake
-
   DoxygenCheck:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -1,14 +1,12 @@
 # Workflow for generating, checking, and deploying our doxygen documentation.
 name: Doxygen
 
-# Controls when the action will run.
+# This Workflow is triggered by any PR or a direct push to master.
 on:
   push:
-    # pushes to master
     branches: [ master ]
   pull_request:
-    # PRs to master
-    # branches: [ master ]
+
 # abort old runs if a new one is started
 concurrency:
   group: ${{ github.head_ref }}-doxygen


### PR DESCRIPTION
# Description

## Problem
Currently, DocTagChecker is a job in the Doxygen workflow. This is a problem, because this workflow is also triggered on pushes to master which doesn't make sense for DocTagChecker.
The result is that it appears as if our pipeline crashes on master.

## Solution
Move DocTagChecker to separate workflow with more restrictive triggers.

## Related Pull Requests

- DocTagChecker was introduced here: #809 

## ~Resolved Issues~

# How Has This Been Tested?

See status of checks here