### PR TITLE
Fix Region Iterators

### DIFF
--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -1201,6 +1201,8 @@ bool LogicHandler<Particle>::iteratePairwisePipeline(Functor *functor) {
     }
     ++_stepsSinceLastListRebuild;
 
+    _containerSelector.getCurrentContainer().setStepsSinceLastRebuild(_stepsSinceLastListRebuild);
+
     _autoTuner.bumpIterationCounters();
     ++_iteration;
   }

--- a/src/autopas/containers/CellBasedParticleContainer.h
+++ b/src/autopas/containers/CellBasedParticleContainer.h
@@ -31,7 +31,8 @@ class CellBasedParticleContainer : public ParticleContainerInterface<typename Pa
    * @param boxMin
    * @param boxMax
    * @param cutoff
-   * @param skin
+   * @param skinPerTimestep
+   * @param rebuildFrequency
    */
   CellBasedParticleContainer(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax,
                              const double cutoff, double skinPerTimestep, unsigned int rebuildFrequency)

--- a/src/autopas/containers/CellBasedParticleContainer.h
+++ b/src/autopas/containers/CellBasedParticleContainer.h
@@ -23,6 +23,8 @@ namespace autopas {
  */
 template <class ParticleCell>
 class CellBasedParticleContainer : public ParticleContainerInterface<typename ParticleCell::ParticleType> {
+  using Particle = typename ParticleCell::ParticleType;
+
  public:
   /**
    * Constructor of CellBasedParticleContainer
@@ -32,8 +34,13 @@ class CellBasedParticleContainer : public ParticleContainerInterface<typename Pa
    * @param skin
    */
   CellBasedParticleContainer(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax,
-                             const double cutoff, const double skin)
-      : _cells(), _boxMin(boxMin), _boxMax(boxMax), _cutoff(cutoff), _skin(skin) {}
+                             const double cutoff, double skinPerTimestep, unsigned int rebuildFrequency)
+      : ParticleContainerInterface<Particle>(skinPerTimestep),
+        _cells(),
+        _boxMin(boxMin),
+        _boxMax(boxMax),
+        _cutoff(cutoff),
+        _skin(skinPerTimestep * rebuildFrequency) {}
 
   /**
    * Destructor of CellBasedParticleContainer.

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -293,6 +293,7 @@ class ParticleContainerInterface {
 
   /**
    * Set the number of time-steps since last neighbor list rebuild
+   * @param stepsSinceLastRebuild steps since last neighbor list rebuild
    */
   virtual void setStepsSinceLastRebuild(size_t stepsSinceLastRebuild) {
     _stepsSinceLastRebuild = stepsSinceLastRebuild;

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -283,6 +283,12 @@ class ParticleContainerInterface {
    */
   [[nodiscard]] virtual double getVerletSkin() const = 0;
 
+  [[nodiscard]] virtual size_t getStepsSinceLastRebuild() const { return _stepsSinceLastRebuild; }
+
+  virtual void setStepsSinceLastRebuild(size_t stepsSinceLastRebuild) {
+    _stepsSinceLastRebuild = stepsSinceLastRebuild;
+  }
+
   /**
    * Return the interaction length (cutoff+skin) of the container.
    * @return interaction length
@@ -403,6 +409,9 @@ class ParticleContainerInterface {
    * @return True if the given indices still point to a new particle.
    */
   virtual bool deleteParticle(size_t cellIndex, size_t particleIndex) = 0;
+
+ protected:
+  size_t _stepsSinceLastRebuild{0};
 };
 
 }  // namespace autopas

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -49,6 +49,7 @@ class ParticleContainerInterface {
 
   /**
    * Constructor
+   * @param skinPerTimestep Skin distance a particle is allowed to move in one time-step.
    */
   ParticleContainerInterface(double skinPerTimestep) : _skinPerTimestep(skinPerTimestep) {}
 

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -48,9 +48,9 @@ class ParticleContainerInterface {
   virtual CellType getParticleCellTypeEnum() const = 0;
 
   /**
-   * Default constructor
+   * Constructor
    */
-  ParticleContainerInterface() = default;
+  ParticleContainerInterface(double skinPerTimestep) : _skinPerTimestep(skinPerTimestep) {}
 
   /**
    * Destructor of ParticleContainerInterface.
@@ -427,6 +427,11 @@ class ParticleContainerInterface {
    * be 0
    */
   size_t _stepsSinceLastRebuild{0};
+
+  /**
+   * Skin distance a particle is allowed to move in one time-step.
+   */
+  double _skinPerTimestep;
 };
 
 }  // namespace autopas

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -283,8 +283,17 @@ class ParticleContainerInterface {
    */
   [[nodiscard]] virtual double getVerletSkin() const = 0;
 
+  /**
+   * Return the number of time-steps since last neighbor list rebuild
+   * @note: The value has to be set by setStepsSinceLastRebuild() from outside the container. Otherwise this will always
+   * return 0
+   * @return steps since last rebuild
+   */
   [[nodiscard]] virtual size_t getStepsSinceLastRebuild() const { return _stepsSinceLastRebuild; }
 
+  /**
+   * Set the number of time-steps since last neighbor list rebuild
+   */
   virtual void setStepsSinceLastRebuild(size_t stepsSinceLastRebuild) {
     _stepsSinceLastRebuild = stepsSinceLastRebuild;
   }
@@ -411,6 +420,11 @@ class ParticleContainerInterface {
   virtual bool deleteParticle(size_t cellIndex, size_t particleIndex) = 0;
 
  protected:
+  /**
+   * Stores the number of time-steps since last neighbor list rebuild
+   * @note: The value has to be set by setStepsSinceLastRebuild() from outside the container. Otherwise this will always
+   * be 0
+   */
   size_t _stepsSinceLastRebuild{0};
 };
 

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -55,7 +55,7 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
    */
   DirectSum(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax, double cutoff,
             double skinPerTimestep, unsigned int verletRebuildFrequency)
-      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep * verletRebuildFrequency),
+      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep, verletRebuildFrequency),
         _cellBorderFlagManager() {
     this->_cells.resize(2);
   }

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -557,8 +557,14 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
    */
   autopas::LoadEstimatorOption _loadEstimator;
 
+  /**
+   * Skin distance a particle is allowed to move in one time-step.
+   */
   double _skinPerTimestep;
 
+  /**
+   * Frequency of container rebuild.
+   */
   unsigned int _rebuildFrequency;
 };
 

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -62,10 +62,9 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
   LinkedCells(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax, const double cutoff,
               const double skinPerTimestep, const unsigned int rebuildFrequency, const double cellSizeFactor = 1.0,
               LoadEstimatorOption loadEstimator = LoadEstimatorOption::squaredParticlesPerCell)
-      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep * rebuildFrequency),
+      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep, rebuildFrequency),
         _cellBlock(this->_cells, boxMin, boxMax, cutoff + skinPerTimestep * rebuildFrequency, cellSizeFactor),
-        _loadEstimator(loadEstimator),
-        _skinPerTimestep(skinPerTimestep) {}
+        _loadEstimator(loadEstimator) {}
 
   [[nodiscard]] ContainerOption getContainerType() const override { return ContainerOption::linkedCells; }
 
@@ -247,15 +246,19 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
                                                                const std::array<double, 3> &boxMax) const {
     using namespace autopas::utils::ArrayMath::literals;
 
+    std::array<double, 3> boxMinWithSafetyMargin = boxMin;
+    std::array<double, 3> boxMaxWithSafetyMargin = boxMax;
+    if constexpr (regionIter) {
+      // We extend the search box for cells here since particles might have moved
+      boxMinWithSafetyMargin -= (this->_skinPerTimestep * static_cast<double>(this->getStepsSinceLastRebuild()));
+      boxMaxWithSafetyMargin +=
+          boxMax + (this->_skinPerTimestep * static_cast<double>(this->getStepsSinceLastRebuild()));
+    }
+
     // first and last relevant cell index
     const auto [startCellIndex, endCellIndex] = [&]() -> std::tuple<size_t, size_t> {
       if constexpr (regionIter) {
         // We extend the search box for cells here since particles might have moved
-        const auto boxMinWithSafetyMargin =
-            boxMin - (_skinPerTimestep * static_cast<double>(this->getStepsSinceLastRebuild()));
-        const auto boxMaxWithSafetyMargin =
-            boxMax + (_skinPerTimestep * static_cast<double>(this->getStepsSinceLastRebuild()));
-
         return {_cellBlock.get1DIndexOfPosition(boxMinWithSafetyMargin),
                 _cellBlock.get1DIndexOfPosition(boxMaxWithSafetyMargin)};
       } else {
@@ -284,7 +287,8 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
             this->_cells[cellIndex][particleIndex], iteratorBehavior, boxMin, boxMax)) {
       // either advance them to something interesting or invalidate them.
       std::tie(cellIndex, particleIndex) =
-          advanceIteratorIndices<regionIter>(cellIndex, particleIndex, iteratorBehavior, boxMin, boxMax, endCellIndex);
+          advanceIteratorIndices<regionIter>(cellIndex, particleIndex, iteratorBehavior, boxMin, boxMax,
+                                             boxMinWithSafetyMargin, boxMaxWithSafetyMargin, endCellIndex);
     }
 
     // shortcut if the given index doesn't exist
@@ -494,10 +498,10 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
    * @return tuple<cellIndex, particleIndex>
    */
   template <bool regionIter>
-  std::tuple<size_t, size_t> advanceIteratorIndices(size_t cellIndex, size_t particleIndex,
-                                                    IteratorBehavior iteratorBehavior,
-                                                    const std::array<double, 3> &boxMin,
-                                                    const std::array<double, 3> &boxMax, size_t endCellIndex) const {
+  std::tuple<size_t, size_t> advanceIteratorIndices(
+      size_t cellIndex, size_t particleIndex, IteratorBehavior iteratorBehavior, const std::array<double, 3> &boxMin,
+      const std::array<double, 3> &boxMax, std::array<double, 3> boxMinWithSafetyMargin,
+      std::array<double, 3> boxMaxWithSafetyMargin, size_t endCellIndex) const {
     // Finding the indices for the next particle
     const size_t stride = (iteratorBehavior & IteratorBehavior::forceSequential) ? 1 : autopas_get_num_threads();
 
@@ -509,15 +513,11 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
           (iteratorBehavior & IteratorBehavior::halo and _cellBlock.cellCanContainHaloParticles(cellIndex));
       if constexpr (regionIter) {
         // short circuit if already false
-        // TODO: should we remove the if isRelevant here, since a cell with a different ownership-state could contain a
-        // moved particle with another ownership state?
         if (isRelevant) {
           // is the cell in the region?
           const auto [cellLowCorner, cellHighCorner] = _cellBlock.getCellBoundingBox(cellIndex);
-          // particles can move over cell borders. Calculate the volume this cell's particles can be.
-          const auto cellLowCornerSkin = utils::ArrayMath::subScalar(cellLowCorner, this->getVerletSkin() * 0.5);
-          const auto cellHighCornerSkin = utils::ArrayMath::addScalar(cellHighCorner, this->getVerletSkin() * 0.5);
-          isRelevant = utils::boxesOverlap(cellLowCornerSkin, cellHighCornerSkin, boxMin, boxMax);
+          isRelevant =
+              utils::boxesOverlap(cellLowCorner, cellHighCorner, boxMinWithSafetyMargin, boxMaxWithSafetyMargin);
         }
       }
       return isRelevant;
@@ -557,11 +557,6 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
    * load estimation algorithm for balanced traversals.
    */
   autopas::LoadEstimatorOption _loadEstimator;
-
-  /**
-   * Skin distance a particle is allowed to move in one time-step.
-   */
-  double _skinPerTimestep;
 };
 
 }  // namespace autopas

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -492,8 +492,10 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
    * @param cellIndex
    * @param particleIndex
    * @param iteratorBehavior
-   * @param boxMin
-   * @param boxMax
+   * @param boxMin The actual search box min
+   * @param boxMax The actual search box max
+   * @param boxMinWithSafetyMargin Search box min that includes a surrounding of skinPerTimestep * stepsSinceLastRebuild
+   * @param boxMaxWithSafetyMargin Search box max that includes a surrounding of skinPerTimestep * stepsSinceLastRebuild
    * @param endCellIndex Last relevant cell index
    * @return tuple<cellIndex, particleIndex>
    */

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -252,8 +252,13 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
     const auto [startCellIndex, endCellIndex] = [&]() -> std::tuple<size_t, size_t> {
       if constexpr (regionIter) {
         // if particles might have moved extend search box for cells here
-        const auto boxMinWithSafetyMargin = boxMin - (_skinPerTimestep * _rebuildFrequency);
-        const auto boxMaxWithSafetyMargin = boxMax + (_skinPerTimestep * _rebuildFrequency);
+        // const auto boxMinWithSafetyMargin = boxMin - (_skinPerTimestep * _rebuildFrequency);
+        // const auto boxMaxWithSafetyMargin = boxMax + (_skinPerTimestep * _rebuildFrequency);
+
+        const auto boxMinWithSafetyMargin =
+            boxMin - (_skinPerTimestep * static_cast<double>(this->getStepsSinceLastRebuild()));
+        const auto boxMaxWithSafetyMargin =
+            boxMax + (_skinPerTimestep * static_cast<double>(this->getStepsSinceLastRebuild()));
 
         return {_cellBlock.get1DIndexOfPosition(boxMinWithSafetyMargin),
                 _cellBlock.get1DIndexOfPosition(boxMaxWithSafetyMargin)};

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -65,8 +65,7 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
       : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep * rebuildFrequency),
         _cellBlock(this->_cells, boxMin, boxMax, cutoff + skinPerTimestep * rebuildFrequency, cellSizeFactor),
         _loadEstimator(loadEstimator),
-        _skinPerTimestep(skinPerTimestep),
-        _rebuildFrequency(rebuildFrequency) {}
+        _skinPerTimestep(skinPerTimestep) {}
 
   [[nodiscard]] ContainerOption getContainerType() const override { return ContainerOption::linkedCells; }
 
@@ -251,10 +250,7 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
     // first and last relevant cell index
     const auto [startCellIndex, endCellIndex] = [&]() -> std::tuple<size_t, size_t> {
       if constexpr (regionIter) {
-        // if particles might have moved extend search box for cells here
-        // const auto boxMinWithSafetyMargin = boxMin - (_skinPerTimestep * _rebuildFrequency);
-        // const auto boxMaxWithSafetyMargin = boxMax + (_skinPerTimestep * _rebuildFrequency);
-
+        // We extend the search box for cells here since particles might have moved
         const auto boxMinWithSafetyMargin =
             boxMin - (_skinPerTimestep * static_cast<double>(this->getStepsSinceLastRebuild()));
         const auto boxMaxWithSafetyMargin =
@@ -566,11 +562,6 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
    * Skin distance a particle is allowed to move in one time-step.
    */
   double _skinPerTimestep;
-
-  /**
-   * Frequency of container rebuild.
-   */
-  unsigned int _rebuildFrequency;
 };
 
 }  // namespace autopas

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -247,6 +247,8 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
     // first and last relevant cell index
     const auto [startCellIndex, endCellIndex] = [&]() -> std::tuple<size_t, size_t> {
       if constexpr (regionIter) {
+        // if particles might have moved extend search box for cells here
+        // TODO
         return {_cellBlock.get1DIndexOfPosition(boxMin), _cellBlock.get1DIndexOfPosition(boxMax)};
       } else {
         if (not(iteratorBehavior & IteratorBehavior::halo)) {

--- a/src/autopas/containers/linkedCells/LinkedCellsReferences.h
+++ b/src/autopas/containers/linkedCells/LinkedCellsReferences.h
@@ -540,8 +540,10 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
    * @param cellIndex
    * @param particleIndex
    * @param iteratorBehavior
-   * @param boxMin
-   * @param boxMax
+   * @param boxMin The actual search box min
+   * @param boxMax The actual search box max
+   * @param boxMinWithSafetyMargin Search box min that includes a surrounding of skinPerTimestep * stepsSinceLastRebuild
+   * @param boxMaxWithSafetyMargin Search box max that includes a surrounding of skinPerTimestep * stepsSinceLastRebuild
    * @param endCellIndex Last relevant cell index
    * @return tuple<cellIndex, particleIndex>
    */

--- a/src/autopas/containers/octree/Octree.h
+++ b/src/autopas/containers/octree/Octree.h
@@ -320,7 +320,11 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
   }
 
   /**
-   * @copydoc ParticleContainerInterface::deleteParticle()
+   * Deletes the given particle as long as this does not compromise the validity of the container.
+   * If this is not possible the particle is just marked as deleted.
+   * @note This function might be implemented via swap-delete and is thus not completely thread safe.
+   * @param particle Reference to the particle that is to be deleted.
+   * @return True if the given pointer still points to a new particle.
    */
   bool deleteParticle(Particle &particle) override {
     if (particle.isOwned()) {
@@ -334,7 +338,12 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
   }
 
   /**
-   * @copydoc ParticleContainerInterface::deleteParticle()
+   * Deletes the particle at the given index positions as long as this does not compromise the validity of the
+   * container. If this is not possible the particle is just marked as deleted. If the positions do not exist the
+   * behavior is undefined.
+   * @param cellIndex
+   * @param particleIndex
+   * @return True if the given indices still point to a new particle.
    */
   bool deleteParticle(size_t cellIndex, size_t particleIndex) override {
     auto [cellIndexVector, cell] = getLeafCellByIndex(cellIndex);

--- a/src/autopas/containers/octree/Octree.h
+++ b/src/autopas/containers/octree/Octree.h
@@ -74,8 +74,7 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
   Octree(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax, const double cutoff,
          const double skinPerTimestep, const unsigned int rebuildFrequency, const double cellSizeFactor)
       : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep * rebuildFrequency),
-        _skinPerTimestep(skinPerTimestep),
-        _rebuildFrequency(rebuildFrequency) {
+        _skinPerTimestep(skinPerTimestep) {
     using namespace autopas::utils::ArrayMath::literals;
 
     // @todo Obtain this from a configuration, reported in https://github.com/AutoPas/AutoPas/issues/624
@@ -234,10 +233,6 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
                                                                    const std::array<double, 3> &boxMin,
                                                                    const std::array<double, 3> &boxMax) const {
     using namespace autopas::utils::ArrayMath::literals;
-
-    // do we need that here actually?
-    const auto boxMinWithSafetyMargin = boxMin - (_skinPerTimestep * _rebuildFrequency);
-    const auto boxMaxWithSafetyMargin = boxMax + (_skinPerTimestep * _rebuildFrequency);
 
     // FIXME think about parallelism.
     // This `if` currently disables it but should be replaced with logic that determines the start index.
@@ -590,11 +585,15 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
    */
   OctreeLogger<Particle> logger;
 
+  /**
+   * The verlet skin
+   */
   double skin;
 
+  /**
+   * Skin distance a particle is allowed to move in one time-step.
+   */
   double _skinPerTimestep;
-
-  unsigned int _rebuildFrequency;
 };
 
 }  // namespace autopas

--- a/src/autopas/containers/octree/Octree.h
+++ b/src/autopas/containers/octree/Octree.h
@@ -320,11 +320,7 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
   }
 
   /**
-   * Deletes the given particle as long as this does not compromise the validity of the container.
-   * If this is not possible the particle is just marked as deleted.
-   * @note This function might be implemented via swap-delete and is thus not completely thread safe.
-   * @param particle Reference to the particle that is to be deleted.
-   * @return True if the given pointer still points to a new particle.
+   * @copydoc ParticleContainerInterface::deleteParticle()
    */
   bool deleteParticle(Particle &particle) override {
     if (particle.isOwned()) {
@@ -337,14 +333,6 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
     }
   }
 
-  /**
-   * Deletes the particle at the given index positions as long as this does not compromise the validity of the
-   * container. If this is not possible the particle is just marked as deleted. If the positions do not exist the
-   * behavior is undefined.
-   * @param cellIndex
-   * @param particleIndex
-   * @return True if the given indices still point to a new particle.
-   */
   bool deleteParticle(size_t cellIndex, size_t particleIndex) override {
     auto [cellIndexVector, cell] = getLeafCellByIndex(cellIndex);
     auto &particleVec = cell->_particles;

--- a/src/autopas/containers/octree/Octree.h
+++ b/src/autopas/containers/octree/Octree.h
@@ -73,8 +73,7 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
    */
   Octree(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax, const double cutoff,
          const double skinPerTimestep, const unsigned int rebuildFrequency, const double cellSizeFactor)
-      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep * rebuildFrequency),
-        _skinPerTimestep(skinPerTimestep) {
+      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep * rebuildFrequency) {
     using namespace autopas::utils::ArrayMath::literals;
 
     // @todo Obtain this from a configuration, reported in https://github.com/AutoPas/AutoPas/issues/624
@@ -232,8 +231,6 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
                                                                    IteratorBehavior iteratorBehavior,
                                                                    const std::array<double, 3> &boxMin,
                                                                    const std::array<double, 3> &boxMax) const {
-    using namespace autopas::utils::ArrayMath::literals;
-
     // FIXME think about parallelism.
     // This `if` currently disables it but should be replaced with logic that determines the start index.
     if (autopas_get_thread_num() > 0 and not(iteratorBehavior & IteratorBehavior::forceSequential)) {
@@ -585,15 +582,7 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
    */
   OctreeLogger<Particle> logger;
 
-  /**
-   * The verlet skin
-   */
   double skin;
-
-  /**
-   * Skin distance a particle is allowed to move in one time-step.
-   */
-  double _skinPerTimestep;
 };
 
 }  // namespace autopas

--- a/src/autopas/containers/octree/Octree.h
+++ b/src/autopas/containers/octree/Octree.h
@@ -340,24 +340,36 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
     return particleIndex < particleVec.size();
   }
 
+  /**
+   * @copydoc ParticleContainerInterface::begin()
+   */
   [[nodiscard]] ContainerIterator<Particle, true, false> begin(
       IteratorBehavior behavior,
       typename ContainerIterator<Particle, true, false>::ParticleVecType *additionalVectors = nullptr) override {
     return ContainerIterator<Particle, true, false>(*this, behavior, additionalVectors);
   }
 
+  /**
+   * @copydoc ParticleContainerInterface::begin()
+   */
   [[nodiscard]] ContainerIterator<Particle, false, false> begin(
       IteratorBehavior behavior,
       typename ContainerIterator<Particle, false, false>::ParticleVecType *additionalVectors = nullptr) const override {
     return ContainerIterator<Particle, false, false>(*this, behavior, additionalVectors);
   }
 
+  /**
+   * @copydoc ParticleContainerInterface::getRegionIterator()
+   */
   [[nodiscard]] ContainerIterator<Particle, true, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner, IteratorBehavior behavior,
       typename ContainerIterator<Particle, true, true>::ParticleVecType *additionalVectors = nullptr) override {
     return ContainerIterator<Particle, true, true>(*this, behavior, additionalVectors, lowerCorner, higherCorner);
   }
 
+  /**
+   * @copydoc ParticleContainerInterface::getRegionIterator()
+   */
   [[nodiscard]] ContainerIterator<Particle, false, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner, IteratorBehavior behavior,
       typename ContainerIterator<Particle, false, true>::ParticleVecType *additionalVectors = nullptr) const override {

--- a/src/autopas/containers/octree/Octree.h
+++ b/src/autopas/containers/octree/Octree.h
@@ -475,8 +475,10 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
    * @param currentCellPtr
    * @param particleIndex
    * @param iteratorBehavior
-   * @param boxMin
-   * @param boxMax
+   * @param boxMin The actual search box min
+   * @param boxMax The actual search box max
+   * @param boxMinWithSafetyMargin Search box min that includes a surrounding of skinPerTimestep * stepsSinceLastRebuild
+   * @param boxMaxWithSafetyMargin Search box max that includes a surrounding of skinPerTimestep * stepsSinceLastRebuild
    * @return tuple<nextLeafCell, nextParticleIndex>
    */
   template <bool regionIter>

--- a/src/autopas/containers/octree/Octree.h
+++ b/src/autopas/containers/octree/Octree.h
@@ -73,7 +73,9 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
    */
   Octree(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax, const double cutoff,
          const double skinPerTimestep, const unsigned int rebuildFrequency, const double cellSizeFactor)
-      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep * rebuildFrequency) {
+      : CellBasedParticleContainer<ParticleCell>(boxMin, boxMax, cutoff, skinPerTimestep * rebuildFrequency),
+        _skinPerTimestep(skinPerTimestep),
+        _rebuildFrequency(rebuildFrequency) {
     using namespace autopas::utils::ArrayMath::literals;
 
     // @todo Obtain this from a configuration, reported in https://github.com/AutoPas/AutoPas/issues/624
@@ -231,6 +233,12 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
                                                                    IteratorBehavior iteratorBehavior,
                                                                    const std::array<double, 3> &boxMin,
                                                                    const std::array<double, 3> &boxMax) const {
+    using namespace autopas::utils::ArrayMath::literals;
+
+    // do we need that here actually?
+    const auto boxMinWithSafetyMargin = boxMin - (_skinPerTimestep * _rebuildFrequency);
+    const auto boxMaxWithSafetyMargin = boxMax + (_skinPerTimestep * _rebuildFrequency);
+
     // FIXME think about parallelism.
     // This `if` currently disables it but should be replaced with logic that determines the start index.
     if (autopas_get_thread_num() > 0 and not(iteratorBehavior & IteratorBehavior::forceSequential)) {
@@ -583,6 +591,10 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
   OctreeLogger<Particle> logger;
 
   double skin;
+
+  double _skinPerTimestep;
+
+  unsigned int _rebuildFrequency;
 };
 
 }  // namespace autopas

--- a/src/autopas/containers/octree/Octree.h
+++ b/src/autopas/containers/octree/Octree.h
@@ -319,6 +319,9 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
     return {currentCellIndex, dynamic_cast<OctreeLeafNode<Particle> *>(currentCell)};
   }
 
+  /**
+   * @copydoc ParticleContainerInterface::deleteParticle()
+   */
   bool deleteParticle(Particle &particle) override {
     if (particle.isOwned()) {
       return this->_cells[CellTypes::OWNED].deleteParticle(particle);
@@ -330,6 +333,9 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
     }
   }
 
+  /**
+   * @copydoc ParticleContainerInterface::deleteParticle()
+   */
   bool deleteParticle(size_t cellIndex, size_t particleIndex) override {
     auto [cellIndexVector, cell] = getLeafCellByIndex(cellIndex);
     auto &particleVec = cell->_particles;

--- a/src/autopas/containers/verletClusterLists/ClusterTowerBlock2D.h
+++ b/src/autopas/containers/verletClusterLists/ClusterTowerBlock2D.h
@@ -193,9 +193,12 @@ class ClusterTowerBlock2D : public CellBorderAndFlagManager {
     if (_towersPerDim[0] == 0) {
       return {_boxMin, _boxMax};
     }
+    // towerBoxMin[0/1] does NOT start at _haloBoxMin[0/1] because the halo towers might extend beyond the halo box.
     const std::array<double, 3> towerBoxMin{
-        _haloBoxMin[0] + _towerSideLength[0] * static_cast<double>(index2D[0]),
-        _haloBoxMin[1] + _towerSideLength[1] * static_cast<double>(index2D[1]),
+        _boxMin[0] - _towerSideLength[0] * _numTowersPerInteractionLength +
+            _towerSideLength[0] * static_cast<double>(index2D[0]),
+        _boxMin[1] - _towerSideLength[1] * _numTowersPerInteractionLength +
+            _towerSideLength[1] * static_cast<double>(index2D[1]),
         _haloBoxMin[2],
     };
     const std::array<double, 3> towerBoxMax{

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -1163,8 +1163,10 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
    * @param cellIndex
    * @param particleIndex
    * @param iteratorBehavior
-   * @param boxMin
-   * @param boxMax
+   * @param boxMin The actual search box min
+   * @param boxMax The actual search box max
+   * @param boxMinWithSafetyMargin Search box min that includes a surrounding of skinPerTimestep * stepsSinceLastRebuild
+   * @param boxMaxWithSafetyMargin Search box max that includes a surrounding of skinPerTimestep * stepsSinceLastRebuild
    * @param endCellIndex
    * @return tuple<cellIndex, particleIndex>
    */

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -295,7 +295,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
     // first and last relevant cell index
     const auto [startCellIndex, endCellIndex] = [&]() -> std::tuple<size_t, size_t> {
       if constexpr (regionIter) {
-        // if particles might have moved extend search box here
+        // We extend the search box for cells here since particles might have moved
         const auto boxMinWithSafetyMargin =
             boxMin - (_skinPerTimestep * static_cast<double>(this->getStepsSinceLastRebuild()));
         const auto boxMaxWithSafetyMargin =

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -285,6 +285,8 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
                                                                IteratorBehavior iteratorBehavior,
                                                                const std::array<double, 3> &boxMin,
                                                                const std::array<double, 3> &boxMax) const {
+    using namespace autopas::utils::ArrayMath::literals;
+
     // in this context cell == tower
     // catching the edge case that towers are not yet built -> Iterator jumps to additional vectors
     if (_towerBlock.empty()) {
@@ -294,7 +296,11 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
     // first and last relevant cell index
     const auto [startCellIndex, endCellIndex] = [&]() -> std::tuple<size_t, size_t> {
       if constexpr (regionIter) {
-        return {_towerBlock.getTowerIndex1DAtPosition(boxMin), _towerBlock.getTowerIndex1DAtPosition(boxMax)};
+        // if particles might have moved extend search box here
+        const auto boxMinWithSafetyMargin = boxMin - (_skinPerTimestep * _rebuildFrequency);
+        const auto boxMaxWithSafetyMargin = boxMax + (_skinPerTimestep * _rebuildFrequency);
+        return {_towerBlock.getTowerIndex1DAtPosition(boxMinWithSafetyMargin),
+                _towerBlock.getTowerIndex1DAtPosition(boxMaxWithSafetyMargin)};
       } else {
         if (not(iteratorBehavior & IteratorBehavior::halo)) {
           // only potentially owned region

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -52,6 +52,11 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    */
   CellType getParticleCellTypeEnum() const override { return _linkedCells.getParticleCellTypeEnum(); };
 
+  void setStepsSinceLastRebuild(size_t stepsSinceLastRebuild) override {
+    this->_stepsSinceLastRebuild = stepsSinceLastRebuild;
+    _linkedCells.setStepsSinceLastRebuild(stepsSinceLastRebuild);
+  }
+
   void reserve(size_t numParticles, size_t numParticlesHaloEstimate) override {
     _linkedCells.reserve(numParticles, numParticlesHaloEstimate);
   }
@@ -139,7 +144,8 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
                                                                IteratorBehavior iteratorBehavior,
                                                                const std::array<double, 3> &boxMin,
                                                                const std::array<double, 3> &boxMax) const {
-    return _linkedCells.getParticle(cellIndex, particleIndex, iteratorBehavior, boxMin, boxMax);
+    return _linkedCells.template getParticleImpl<regionIter>(cellIndex, particleIndex, iteratorBehavior, boxMin,
+                                                             boxMax);
   }
 
   bool deleteParticle(Particle &particle) override {

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -54,6 +54,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
 
   /**
    * Set the number of time-steps since last neighbor list rebuild
+   * @param stepsSinceLastRebuild steps since last neighbor list rebuild
    */
   void setStepsSinceLastRebuild(size_t stepsSinceLastRebuild) override {
     this->_stepsSinceLastRebuild = stepsSinceLastRebuild;

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -52,6 +52,9 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    */
   CellType getParticleCellTypeEnum() const override { return _linkedCells.getParticleCellTypeEnum(); };
 
+  /**
+   * Set the number of time-steps since last neighbor list rebuild
+   */
   void setStepsSinceLastRebuild(size_t stepsSinceLastRebuild) override {
     this->_stepsSinceLastRebuild = stepsSinceLastRebuild;
     _linkedCells.setStepsSinceLastRebuild(stepsSinceLastRebuild);

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -41,7 +41,8 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
   VerletListsLinkedBase(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax, const double cutoff,
                         const double skinPerTimestep, const unsigned int rebuildFrequency,
                         const std::set<TraversalOption> &applicableTraversals, const double cellSizeFactor)
-      : _linkedCells(boxMin, boxMax, cutoff, skinPerTimestep, rebuildFrequency, std::max(1.0, cellSizeFactor)) {
+      : ParticleContainerInterface<Particle>(skinPerTimestep),
+        _linkedCells(boxMin, boxMax, cutoff, skinPerTimestep, rebuildFrequency, std::max(1.0, cellSizeFactor)) {
     if (cellSizeFactor < 1.0) {
       AutoPasLog(DEBUG, "VerletListsLinkedBase: CellSizeFactor smaller 1 detected. Set to 1.");
     }

--- a/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
@@ -248,7 +248,7 @@ TEST_P(RegionParticleIteratorTestTwo, testParticleMisplacement) {
 
     // this creates the positions (min + offset) and (max - offset) and positions mirrored at min and max (along one
     // dimension)
-    auto generateInteresting1DPositions = [&](double min, double max) -> auto{
+    auto generateInteresting1DPositions = [&](double min, double max) -> auto {
       return std::array<std::tuple<double, double>, numParticles1DTotal>{
           {{min + offset, min - offset}, {(max - min) / 2.0, (max - min) / 2.0}, {max - offset, max + offset}}};
     };
@@ -268,15 +268,15 @@ TEST_P(RegionParticleIteratorTestTwo, testParticleMisplacement) {
             // this ensures that a value that is closer than offset to the floored integer, is floored to the next
             // smaller integer
             auto getFlooredValue = [offset](double value) {
-              return ((value - floor(value) < (offset - margin)) && (value - floor(value) >= 0)) ? floor(value - 1)
-                                                                                                 : floor(value);
+              return ((value - floor(value) < (offset - margin)) and (value - floor(value) >= 0)) ? floor(value - 1)
+                                                                                                  : floor(value);
             };
 
             // this ensures that a value that is closer than offset to the ceiled integer, is ceiled to the next greater
             // integer
             auto getCeiledValue = [offset](double value) {
-              return ((ceil(value) - value < (offset - margin)) && (ceil(value) - value >= 0)) ? ceil(value + 1)
-                                                                                               : ceil(value);
+              return ((ceil(value) - value < (offset - margin)) and (ceil(value) - value >= 0)) ? ceil(value + 1)
+                                                                                                : ceil(value);
             };
 
             // store corresponding search boxes for particles and mirrored versions. Note: we add a small margin to the

--- a/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
@@ -226,7 +226,7 @@ TEST_F(RegionParticleIteratorTestOne, testForceSequential) {
 TEST_P(RegionParticleIteratorTestTwo, testParticleMisplacement) {
   using namespace autopas::utils::ArrayMath::literals;
 
-  auto [containerOption, behavior] = GetParam();
+  auto containerOption = GetParam();
 
   autopas::AutoPas<Molecule> autoPas{};
   // Get a 10x10x10 box
@@ -317,8 +317,7 @@ TEST_P(RegionParticleIteratorTestTwo, testParticleMisplacement) {
   auto testRegion = [&](const std::array<double, 3> &min, const std::array<double, 3> &max, size_t exptectedID,
                         const std::string &context) {
     size_t numParticlesFound = 0;
-    for (auto iter = autoPas.getRegionIterator(min, max, autopas::IteratorBehavior::ownedOrHalo); iter.isValid();
-         ++iter) {
+    for (auto iter = autoPas.getRegionIterator(min, max, autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
       ++numParticlesFound;
       EXPECT_EQ(iter->getID(), exptectedID) << "There should only be one particle with ID 0.\n" << context;
     }
@@ -352,7 +351,5 @@ TEST_P(RegionParticleIteratorTestTwo, testParticleMisplacement) {
   }
 }
 
-INSTANTIATE_TEST_SUITE_P(Generated, RegionParticleIteratorTestTwo,
-                         Combine(ValuesIn(getTestableContainerOptions()),
-                                 ValuesIn(autopas::IteratorBehavior::getMostOptions())),
+INSTANTIATE_TEST_SUITE_P(Generated, RegionParticleIteratorTestTwo, ValuesIn(getTestableContainerOptions()),
                          RegionParticleIteratorTestTwo::PrintToStringParamName());

--- a/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
@@ -246,8 +246,7 @@ TEST_F(RegionParticleIteratorTest, testParticleMisplacement) {
   auto testRegion = [&](const std::array<double, 3> &min, const std::array<double, 3> &max,
                         const std::string &context) {
     size_t numParticlesFound = 0;
-    for (auto iter = autoPas.getRegionIterator(min, max, autopas::IteratorBehavior::owned); iter.isValid();
-         ++iter) {
+    for (auto iter = autoPas.getRegionIterator(min, max, autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
       ++numParticlesFound;
       EXPECT_EQ(iter->getID(), 0) << "There should only be one particle with ID 0.\n" << context;
     }

--- a/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
@@ -272,7 +272,7 @@ TEST_P(RegionParticleIteratorTestTwo, testParticleMisplacement) {
   autoPas.begin(autopas::IteratorBehavior::ownedOrHalo)->setR(posEnd);
 
   const auto p = autoPas.begin(autopas::IteratorBehavior::ownedOrHalo)->getR();
-  //std::cout << "Test: " << p[0] << ", " << p[1] << ", " << p[2] << std::endl;
+  // std::cout << "Test: " << p[0] << ", " << p[1] << ", " << p[2] << std::endl;
 
   testRegion(searchBoxEnd.min, searchBoxEnd.max, "After particle was moved.");
 }

--- a/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
@@ -246,7 +246,7 @@ TEST_F(RegionParticleIteratorTest, testParticleMisplacement) {
   auto testRegion = [&](const std::array<double, 3> &min, const std::array<double, 3> &max,
                         const std::string &context) {
     size_t numParticlesFound = 0;
-    for (auto iter = autoPas.getRegionIterator(min, max, autopas::IteratorBehavior::ownedOrHalo); iter.isValid();
+    for (auto iter = autoPas.getRegionIterator(min, max, autopas::IteratorBehavior::owned); iter.isValid();
          ++iter) {
       ++numParticlesFound;
       EXPECT_EQ(iter->getID(), 0) << "There should only be one particle with ID 0.\n" << context;
@@ -260,6 +260,6 @@ TEST_F(RegionParticleIteratorTest, testParticleMisplacement) {
   testRegion(searchBoxStart.min, searchBoxStart.max, "Before particle is moved.");
 
   // Move the particle outside the data structure element (for LC: cell) where it is currently stored
-  autoPas.begin(autopas::IteratorBehavior::ownedOrHalo)->setR(posEnd);
+  autoPas.begin(autopas::IteratorBehavior::owned)->setR(posEnd);
   testRegion(searchBoxEnd.min, searchBoxEnd.max, "After particle was moved.");
 }

--- a/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
@@ -248,7 +248,7 @@ TEST_P(RegionParticleIteratorTestTwo, testParticleMisplacement) {
 
     // this creates the positions (min + offset) and (max - offset) and positions mirrored at min and max (along one
     // dimension)
-    auto generateInteresting1DPositions = [&](double min, double max) -> auto {
+    auto generateInteresting1DPositions = [&](double min, double max) -> auto{
       return std::array<std::tuple<double, double>, numParticles1DTotal>{
           {{min + offset, min - offset}, {(max - min) / 2.0, (max - min) / 2.0}, {max - offset, max + offset}}};
     };

--- a/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.h
+++ b/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.h
@@ -12,10 +12,25 @@
 #include "autopas/options/ContainerOption.h"
 #include "autopas/options/IteratorBehavior.h"
 
-using testingTuple = std::tuple<autopas::ContainerOption, double /*cell size factor*/, bool /*testConstIterators*/,
-                                bool /*priorForceCalc*/, autopas::IteratorBehavior>;
+using testingTupleOne = std::tuple<autopas::ContainerOption, double /*cell size factor*/, bool /*testConstIterators*/,
+                                   bool /*priorForceCalc*/, autopas::IteratorBehavior>;
 
-class RegionParticleIteratorTest : public AutoPasTestBase, public ::testing::WithParamInterface<testingTuple> {
+using testingTupleTwo = std::tuple<autopas::ContainerOption, autopas::IteratorBehavior>;
+
+class RegionParticleIteratorTestBase : public AutoPasTestBase {
+ protected:
+  /**
+   * Initialize the given AutoPas object with the default values for this test class.
+   * @tparam AutoPasT
+   * @param autoPas
+   * @return tuple {haloBoxMin, haloBoxMax}
+   */
+  template <class AutoPasT>
+  auto defaultInit(AutoPasT &autoPas, const autopas::ContainerOption &containerOption, double cellSizeFactor);
+};
+
+class RegionParticleIteratorTestOne : public RegionParticleIteratorTestBase,
+                                      public ::testing::WithParamInterface<testingTupleOne> {
  public:
   struct PrintToStringParamName {
     template <class ParamType>
@@ -33,13 +48,21 @@ class RegionParticleIteratorTest : public AutoPasTestBase, public ::testing::Wit
       return str;
     }
   };
+};
 
-  /**
-   * Initialize the given AutoPas object with the default values for this test class.
-   * @tparam AutoPasT
-   * @param autoPas
-   * @return tuple {haloBoxMin, haloBoxMax}
-   */
-  template <class AutoPasT>
-  auto defaultInit(AutoPasT &autoPas, const autopas::ContainerOption &containerOption, double cellSizeFactor);
+class RegionParticleIteratorTestTwo : public RegionParticleIteratorTestBase,
+                                      public ::testing::WithParamInterface<testingTupleTwo> {
+ public:
+  struct PrintToStringParamName {
+    template <class ParamType>
+    std::string operator()(const testing::TestParamInfo<ParamType> &info) const {
+      auto [containerOption, behavior] = static_cast<ParamType>(info.param);
+      std::string str;
+      str += containerOption.to_string() + "_";
+      str += "_" + behavior.to_string();
+      std::replace(str.begin(), str.end(), '-', '_');
+      std::replace(str.begin(), str.end(), '.', '_');
+      return str;
+    }
+  };
 };

--- a/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.h
+++ b/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.h
@@ -15,8 +15,6 @@
 using testingTupleOne = std::tuple<autopas::ContainerOption, double /*cell size factor*/, bool /*testConstIterators*/,
                                    bool /*priorForceCalc*/, autopas::IteratorBehavior>;
 
-using testingTupleTwo = std::tuple<autopas::ContainerOption, autopas::IteratorBehavior>;
-
 class RegionParticleIteratorTestBase : public AutoPasTestBase {
  protected:
   /**
@@ -51,15 +49,14 @@ class RegionParticleIteratorTestOne : public RegionParticleIteratorTestBase,
 };
 
 class RegionParticleIteratorTestTwo : public RegionParticleIteratorTestBase,
-                                      public ::testing::WithParamInterface<testingTupleTwo> {
+                                      public ::testing::WithParamInterface<autopas::ContainerOption> {
  public:
   struct PrintToStringParamName {
     template <class ParamType>
     std::string operator()(const testing::TestParamInfo<ParamType> &info) const {
-      auto [containerOption, behavior] = static_cast<ParamType>(info.param);
+      auto containerOption = static_cast<ParamType>(info.param);
       std::string str;
       str += containerOption.to_string() + "_";
-      str += "_" + behavior.to_string();
       std::replace(str.begin(), str.end(), '-', '_');
       std::replace(str.begin(), str.end(), '.', '_');
       return str;


### PR DESCRIPTION
# Description

Region iterators do not consider particles that are in the region but are stored in cells that are completely outside the region. This affects all containers.

# Todo
- [x] pass timesteps since last rebuild somehow to containers
- [x] performance measurements

## Related Pull Requests

- noticed in #826 

## ~Resolved Issues~

## Performance
The following scenario with 179800 particles was used for the performance comparison with 8 HW threads:

```
./md-flexible --container LinkedCells --functor Lennard-Jones-AVX2 --traversal lc_c01 --newton3 disabled --data-layout AoS --verlet-rebuild-frequency 10 --verlet-skin-radius-per-timestep 0.025 --cutoff 2.5 --cell-size 1 --deltaT 0.001 --iterations 2000 --boundary-type reflective --fastParticlesThrow true --particle-generator closest --box-length 50 --particle-spacing 1.0 --no-progress-bar true
```

Since `getRegionIterator` is called in `updateContainer` and `reflectParticlesAtBoundaries`, the times were measured here. In this scenario, around 12500 particles are iterated by the `regionIterator` at boundaries in one timestep in `reflectParticlesAtBoundaries`.

The following table contains the times of 5 measurements in each case.

|                              | New regionIterator ([61a9789](https://github.com/AutoPas/AutoPas/pull/830/commits/61a978946ed9ff45a8f1a1455cb377a0dc326a7c))                         | avg | master ([2545a53](https://github.com/AutoPas/AutoPas/commit/2545a538de175046cf2bcd589eed98e75f9ac8be))                                 | avg |
|------------------------------|----------------------------------------|-----|----------------------------------------|-----|
| `updateContainer`              | 1.945s, 1.938s, 1.941s, 1.956s, 1.939s | 1.9438s | 1.953s, 1.945s, 1.946s, 1.953s, 1.951s | 1.9496s |
| `reflectParticlesAtBoundaries` | 9.716s, 9.723s, 9.677s, 9.726s, 9.735s | 9.7154s | 9.241s, 9.231s, 9.218s, 9.265s, 9.248s | 9.2406s


# How Has This Been Tested?

A new `regionIterator` test (`RegionParticleIteratorTest::testParticleMisplacement`) has been implemented for all containers. This test checks whether particles that have moved beyond the boundaries of a data structure element but are still stored in the old data structure element are found. This test works on the assumption that the halo box is in a new data structure element (cell, tower, ...).
Particles are placed close to the boundaries within the simulation box. The particles are then moved slightly outside the simulation box without updating the data structure. It is checked whether the particles are still found with a region that no longer includes the old data structure element in which the particles are still stored.

- [x] New region iterator test (for all containers)

