### PR TITLE
Make VCL no longer discouraged and make VVL discouraged

### DIFF
--- a/src/autopas/options/ContainerOption.h
+++ b/src/autopas/options/ContainerOption.h
@@ -92,7 +92,7 @@ class ContainerOption : public Option<ContainerOption> {
    * @return
    */
   static std::set<ContainerOption> getDiscouragedOptions() {
-    return {Value::directSum, Value::linkedCellsReferences, Value::verletClusterLists, Value::octree};
+    return {Value::directSum, Value::linkedCellsReferences, Value::varVerletListsAsBuild, Value::octree};
   }
 
   /**


### PR DESCRIPTION
# Description

VVL has a bug which keeps on cropping up (see #721 ). As far as I am aware, there are no major problems from using this container except that the tuner might select it without it being optimal. Without a fix, this container should at the very least be discouraged.

Also, I do not see why Verlet Cluster Lists are discouraged.


