### PR TITLE
Small Fixes

### DIFF
--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJ.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJ.h
@@ -31,7 +31,7 @@ class MoleculeLJ : public autopas::Particle {
   MoleculeLJ(const std::array<double, 3> &pos, const std::array<double, 3> &v, unsigned long moleculeId,
              unsigned long typeId = 0);
 
-  ~MoleculeLJ() = default;
+  ~MoleculeLJ() override = default;
 
   /**
    * Enums used as ids for accessing and creating a dynamically sized SoA.

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -470,7 +470,7 @@ long Simulation::accumulateTime(const long &time) {
 
 bool Simulation::calculatePairwiseForces() {
   const auto wasTuningIteration =
-      applyWithChosenFunctor<bool>([&](auto functor) { return _autoPasContainer->template iteratePairwise(&functor); });
+      applyWithChosenFunctor<bool>([&](auto functor) { return _autoPasContainer->iteratePairwise(&functor); });
   return wasTuningIteration;
 }
 

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -231,7 +231,8 @@ void Simulation::run() {
           return false;
         });
 
-        std::remove_if(emigrants.begin(), emigrants.end(), [&](const auto &p) { return p.isDummy(); });
+        emigrants.erase(std::remove_if(emigrants.begin(), emigrants.end(), [&](const auto &p) { return p.isDummy(); }),
+                        emigrants.end());
 
         emigrants.insert(emigrants.end(), additionalEmigrants.begin(), additionalEmigrants.end());
         _timers.loadBalancing.stop();

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -217,14 +217,15 @@ void Simulation::run() {
         _domainDecomposition->update(computationalLoad);
         auto additionalEmigrants = _autoPasContainer->resizeBox(_domainDecomposition->getLocalBoxMin(),
                                                                 _domainDecomposition->getLocalBoxMax());
-        // because boundaries shifted, particles that were thrown out by the updateContainer previously might now be in
-        // the container again
+        // If the boundaries shifted, particles that were thrown out by updateContainer() previously might now be in the
+        // container again.
+        // Reinsert emigrants if they are now inside the domain and mark local copies as dummy,
+        // so that remove_if can erase them after.
         const auto &boxMin = _autoPasContainer->getBoxMin();
         const auto &boxMax = _autoPasContainer->getBoxMax();
         _autoPasContainer->addParticlesIf(emigrants, [&](auto &p) {
           if (autopas::utils::inBox(p.getR(), boxMin, boxMax)) {
-            // mark p as dummy in the emigrants vector, so it will be kicked out via remove_if later.
-            // It's still added to autopas here and its ownership state set by addParticle().
+            // This only changes the ownership state in the emigrants vector, not in AutoPas
             p.setOwnershipState(autopas::OwnershipState::dummy);
             return true;
           }

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -223,6 +223,8 @@ void Simulation::run() {
         const auto &boxMax = _autoPasContainer->getBoxMax();
         _autoPasContainer->addParticlesIf(emigrants, [&](auto &p) {
           if (autopas::utils::inBox(p.getR(), boxMin, boxMax)) {
+            // mark p as dummy in the emigrants vector, so it will be kicked out via remove_if later.
+            // It's still added to autopas here and its ownership state set by addParticle().
             p.setOwnershipState(autopas::OwnershipState::dummy);
             return true;
           }

--- a/examples/md-flexible/src/configuration/MDFlexConfig.h
+++ b/examples/md-flexible/src/configuration/MDFlexConfig.h
@@ -170,9 +170,9 @@ class MDFlexConfig {
   /**
    * Loads the particles from the checkpoint file defined in the configuration file.
    * If the checkpoint has been recorded using multiple processes, the rank of the current process needs to be passed.
-   * The provided rank also needs to respect the domain decomposition. E. g. if the a regular grid decomposition is
-   * used,   * don't pass the MPI_COMM_WORLD rank, as it might differ from the grid rank derived in the decomposition
-   * scheme. The wrong rank might result in a very bad network topology and therefore increase communication cost.
+   * The provided rank also needs to respect the domain decomposition. E. g. if the regular grid decomposition is
+   * used, don't pass the MPI_COMM_WORLD rank, as it might differ from the grid rank derived in the decomposition
+   * scheme. The wrong rank might result in a very bad network topology and therefore increase communication costs.
    * @param rank: The MPI rank of the current process.
    * @param communicatorSize: The size of the MPI communicator used for the simulation.
    */

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -717,7 +717,7 @@ class LogicHandler {
   size_t _sortingThreshold;
 
   /**
-   * Reference to the AutoTuner that owns the container, ...
+   * Reference to the AutoTuner which is managed by the AutoPas main interface.
    */
   autopas::AutoTuner &_autoTuner;
 

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -1180,14 +1180,16 @@ bool LogicHandler<Particle>::iteratePairwisePipeline(Functor *functor) {
   // if this was a major iteration add measurements and bump counters
   if (functor->isRelevantForTuning()) {
     if (stillTuning) {
-      switch (_autoTuner.getTuningMetric()) {
-        case TuningMetricOption::time:
-          _autoTuner.addMeasurement(measurements.timeTotal, not neighborListsAreValid());
-          break;
-        case TuningMetricOption::energy:
-          _autoTuner.addMeasurement(measurements.energyTotal, not neighborListsAreValid());
-          break;
-      }
+      // choose the metric of interest
+      const auto measurement = [&]() {
+        switch (_autoTuner.getTuningMetric()) {
+          case TuningMetricOption::time:
+            return measurements.timeTotal;
+          case TuningMetricOption::energy:
+            return measurements.energyTotal;
+        }
+      };
+      _autoTuner.addMeasurement(measurement, not neighborListsAreValid());
     } else {
       AutoPasLog(TRACE, "Skipping adding of sample because functor is not marked relevant.");
     }

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -1188,7 +1188,7 @@ bool LogicHandler<Particle>::iteratePairwisePipeline(Functor *functor) {
           case TuningMetricOption::energy:
             return measurements.energyTotal;
         }
-      };
+      }();
       _autoTuner.addMeasurement(measurement, not neighborListsAreValid());
     } else {
       AutoPasLog(TRACE, "Skipping adding of sample because functor is not marked relevant.");

--- a/src/autopas/containers/linkedCells/LinkedCellsReferences.h
+++ b/src/autopas/containers/linkedCells/LinkedCellsReferences.h
@@ -354,7 +354,7 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
     }
 
     if (exceptionCaught) {
-      throw autopas::utils::ExceptionHandler::AutoPasException(exceptionMsg);
+      autopas::utils::ExceptionHandler::exception(exceptionMsg);
     }
 
     // we have to remove halo particles after the above for-loop since removing halo particles changes the underlying

--- a/src/autopas/tuning/AutoTuner.cpp
+++ b/src/autopas/tuning/AutoTuner.cpp
@@ -197,61 +197,65 @@ std::tuple<Configuration, bool> AutoTuner::rejectConfig(const Configuration &rej
 
 void AutoTuner::addMeasurement(long sample, bool neighborListRebuilt) {
   const auto &currentConfig = _configQueue.back();
-  if (getCurrentNumSamples() < _maxSamples) {
-    AutoPasLog(TRACE, "Adding sample {} to configuration {}.", sample, currentConfig.toShortString());
-    if (neighborListRebuilt) {
-      _samplesRebuildingNeighborLists.push_back(sample);
-    } else {
-      _samplesNotRebuildingNeighborLists.push_back(sample);
-    }
-    // if this was the last sample for this configuration:
-    //  - calculate the evidence from the collected samples
-    //  - log what was collected
-    //  - remove the configuration from the queue
-    if (getCurrentNumSamples() == _maxSamples) {
-      const long reducedValue = estimateRuntimeFromSamples();
-      _evidenceCollection.addEvidence(currentConfig, {_iteration, _tuningPhase, reducedValue});
+  // sanity check
+  if (getCurrentNumSamples() >= _maxSamples) {
+    autopas::utils::ExceptionHandler::exception(
+        "AutoTuner::addMeasurement(): Trying to add new measurements but there are already enough!"
+        "tuneConfiguration() should have been called before to process and flush samples.");
+  }
+  AutoPasLog(TRACE, "Adding sample {} to configuration {}.", sample, currentConfig.toShortString());
+  if (neighborListRebuilt) {
+    _samplesRebuildingNeighborLists.push_back(sample);
+  } else {
+    _samplesNotRebuildingNeighborLists.push_back(sample);
+  }
+  // if this was the last sample for this configuration:
+  //  - calculate the evidence from the collected samples
+  //  - log what was collected
+  //  - remove the configuration from the queue
+  if (getCurrentNumSamples() == _maxSamples) {
+    const long reducedValue = estimateRuntimeFromSamples();
+    _evidenceCollection.addEvidence(currentConfig, {_iteration, _tuningPhase, reducedValue});
 
-      // smooth evidence to remove high outliers. If smoothing results in a higher value use the original value.
-      const auto smoothedValue =
-          std::min(reducedValue, smoothing::smoothLastPoint(*_evidenceCollection.getEvidence(currentConfig), 5));
+    // smooth evidence to remove high outliers. If smoothing results in a higher value use the original value.
+    const auto smoothedValue =
+        std::min(reducedValue, smoothing::smoothLastPoint(*_evidenceCollection.getEvidence(currentConfig), 5));
 
-      // replace collected evidence with smoothed value to improve next smoothing
-      _evidenceCollection.modifyLastEvidence(currentConfig).value = smoothedValue;
+    // replace collected evidence with smoothed value to improve next smoothing
+    _evidenceCollection.modifyLastEvidence(currentConfig).value = smoothedValue;
 
-      std::for_each(_tuningStrategies.begin(), _tuningStrategies.end(), [&](auto &tuningStrategy) {
-        tuningStrategy->addEvidence(getCurrentConfig(), _evidenceCollection.modifyLastEvidence(currentConfig));
-      });
+    std::for_each(_tuningStrategies.begin(), _tuningStrategies.end(), [&](auto &tuningStrategy) {
+      tuningStrategy->addEvidence(getCurrentConfig(), _evidenceCollection.modifyLastEvidence(currentConfig));
+    });
 
-      // print config, times and reduced value
-      AutoPasLog(
-          DEBUG, "Collected {} for {}",
-          [&]() {
-            switch (this->_tuningMetric) {
-              case TuningMetricOption::time:
-                return "times";
-              case TuningMetricOption::energy:
-                return "energy consumption";
-            }
-            autopas::utils::ExceptionHandler::exception("AutoTuner::addMeasurement(): Unknown tuning metric.");
-            return "Unknown tuning metric";
-          }(),
-          [&]() {
-            std::ostringstream ss;
-            // print config
-            ss << currentConfig << " : ";
-            // print all timings
-            ss << utils::ArrayUtils::to_string(_samplesRebuildingNeighborLists, " ",
-                                               {"With rebuilding neighbor lists [ ", " ] "});
-            ss << utils::ArrayUtils::to_string(_samplesNotRebuildingNeighborLists, " ",
-                                               {"Without rebuilding neighbor lists [ ", " ] "});
-            ss << "Smoothed value: " << smoothedValue;
-            return ss.str();
-          }());
+    // print config, times and reduced value
+    AutoPasLog(
+        DEBUG, "Collected {} for {}",
+        [&]() {
+          switch (this->_tuningMetric) {
+            case TuningMetricOption::time:
+              return "times";
+            case TuningMetricOption::energy:
+              return "energy consumption";
+          }
+          autopas::utils::ExceptionHandler::exception("AutoTuner::addMeasurement(): Unknown tuning metric.");
+          return "Unknown tuning metric";
+        }(),
+        [&]() {
+          std::ostringstream ss;
+          // print config
+          ss << currentConfig << " : ";
+          // print all timings
+          ss << utils::ArrayUtils::to_string(_samplesRebuildingNeighborLists, " ",
+                                             {"With rebuilding neighbor lists [ ", " ] "});
+          ss << utils::ArrayUtils::to_string(_samplesNotRebuildingNeighborLists, " ",
+                                             {"Without rebuilding neighbor lists [ ", " ] "});
+          ss << "Smoothed value: " << smoothedValue;
+          return ss.str();
+        }());
 
-      _tuningDataLogger.logTuningData(currentConfig, _samplesRebuildingNeighborLists,
-                                      _samplesNotRebuildingNeighborLists, _iteration, reducedValue, smoothedValue);
-    }
+    _tuningDataLogger.logTuningData(currentConfig, _samplesRebuildingNeighborLists, _samplesNotRebuildingNeighborLists,
+                                    _iteration, reducedValue, smoothedValue);
   }
 }
 

--- a/src/autopas/tuning/AutoTuner.cpp
+++ b/src/autopas/tuning/AutoTuner.cpp
@@ -288,7 +288,7 @@ bool AutoTuner::initEnergy() {
       _raplMeter.sample();
     } catch (const utils::ExceptionHandler::AutoPasException &e) {
       if (_tuningMetric == TuningMetricOption::energy) {
-        throw e;
+        utils::ExceptionHandler::exception(e);
       } else {
         AutoPasLog(WARN, "Energy Measurement not possible:\n\t{}", e.what());
         return false;
@@ -296,7 +296,7 @@ bool AutoTuner::initEnergy() {
     }
   } else {
     if (_tuningMetric == TuningMetricOption::energy) {
-      throw utils::ExceptionHandler::AutoPasException(errMsg);
+      utils::ExceptionHandler::exception(errMsg);
     } else {
       AutoPasLog(WARN, "Energy Measurement not possible:\n\t{}", errMsg);
       return false;
@@ -317,7 +317,7 @@ bool AutoTuner::resetEnergy() {
       AutoPasLog(WARN, "Energy Measurement no longer possible:\n\t{}", e.what());
       _energyMeasurementPossible = false;
       if (_tuningMetric == TuningMetricOption::energy) {
-        throw e;
+        utils::ExceptionHandler::exception(e);
       }
     }
   }
@@ -332,7 +332,7 @@ std::tuple<double, double, double, long> AutoTuner::sampleEnergy() {
       AutoPasLog(WARN, "Energy Measurement no longer possible:\n\t{}", e.what());
       _energyMeasurementPossible = false;
       if (_tuningMetric == TuningMetricOption::energy) {
-        throw e;
+        utils::ExceptionHandler::exception(e);
       }
     }
   }

--- a/src/autopas/tuning/AutoTuner.cpp
+++ b/src/autopas/tuning/AutoTuner.cpp
@@ -354,13 +354,8 @@ long AutoTuner::estimateRuntimeFromSamples() const {
           ? reducedValueBuilding
           : autopas::OptimumSelector::optimumValue(_samplesNotRebuildingNeighborLists, _selectorStrategy);
 
-  const auto numIterationsNotBuilding =
-      std::max(0, static_cast<int>(_rebuildFrequency) - static_cast<int>(_samplesRebuildingNeighborLists.size()));
-  const auto numIterationsBuilding = _rebuildFrequency - numIterationsNotBuilding;
-
-  // calculate weighted estimate for one iteration
-  return (numIterationsBuilding * reducedValueBuilding + numIterationsNotBuilding * reducedValueNotBuilding) /
-         _rebuildFrequency;
+  // Calculate weighted average as if there was exactly one sample for each iteration in the rebuild interval.
+  return (1 * reducedValueBuilding + (_rebuildFrequency - 1) * reducedValueNotBuilding) / _rebuildFrequency;
 }
 
 bool AutoTuner::prepareIteration() {

--- a/src/autopas/tuning/AutoTuner.h
+++ b/src/autopas/tuning/AutoTuner.h
@@ -92,7 +92,7 @@ class AutoTuner {
   bool needsHomogeneityAndMaxDensityBeforePrepare() const;
 
   /**
-   * Determines what live infos are needed and resets the strategy upon the start of a new tuning phase.
+   * Determines what live infos are needed and passes collected live info to the tuning strategies.
    *
    * @note The live info is not gathered here because then we would need the container.
    *

--- a/src/autopas/utils/ArrayMath.h
+++ b/src/autopas/utils/ArrayMath.h
@@ -247,7 +247,11 @@ template <class T, std::size_t SIZE>
  */
 template <class T>
 [[nodiscard]] constexpr std::array<T, 3> cross(const std::array<T, 3> &a, const std::array<T, 3> &b) {
-  return {a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]};
+  return {
+      a[1] * b[2] - a[2] * b[1],
+      a[2] * b[0] - a[0] * b[2],
+      a[0] * b[1] - a[1] * b[0],
+  };
 }
 
 /**

--- a/src/autopas/utils/RaplMeter.cpp
+++ b/src/autopas/utils/RaplMeter.cpp
@@ -31,12 +31,12 @@ int RaplMeter::open_perf_event(int type, int config, int cpu) {
   int fd = syscall(__NR_perf_event_open, &attr, -1 /*PID*/, cpu, -1 /*GROUP FD*/, 0 /*FLAGS*/);
   if (fd < 0) {
     if (errno == EACCES) {
-      throw ExceptionHandler::AutoPasException("Failed to open perf event: Permission denied");
+      utils::ExceptionHandler::exception("Failed to open perf event: Permission denied");
     }
     std::stringstream err_msg;
     err_msg << "Failed to open perf event " << strerror(errno) << " (type=" << type << ", config=" << config
             << ", cpu=" << cpu << ")";
-    throw ExceptionHandler::AutoPasException(err_msg.str());
+    utils::ExceptionHandler::exception(err_msg.str());
   }
   return fd;
 }
@@ -190,7 +190,7 @@ long RaplMeter::read_perf_event(int fd) {
   long value;
   lseek(fd, 0, SEEK_SET);
   if (read(fd, &value, 8) == -1) {
-    throw ExceptionHandler::AutoPasException("Failed to read perf event:\n\t");
+    utils::ExceptionHandler::exception("Failed to read perf event:\n\t");
   }
   return value;
 }

--- a/src/autopas/utils/RaplMeter.h
+++ b/src/autopas/utils/RaplMeter.h
@@ -33,8 +33,8 @@ class RaplMeter {
   ~RaplMeter();
 
   /**
-   * Initialisation may fail, so moved out of constructor.
-   * Note: This functions returns an error message instead of throwing an exception if initialization is not possible.
+   * Initialization may fail, so moved out of constructor.
+   * Note: This function returns an error message instead of throwing an exception if initialization is not possible.
    * This way debuggers don't break on the start of every autopas initialization if we are not interested in energy
    * measurement.
    * @return Error message. The error is message is empty on success

--- a/src/autopas/utils/RaplMeter.h
+++ b/src/autopas/utils/RaplMeter.h
@@ -33,57 +33,58 @@ class RaplMeter {
   ~RaplMeter();
 
   /**
-   *initialisation may fail, so moved out of constructor
-   Note: This functios returns an error message instead of throwing an exception if initialization is not possible. This
-   way debuggers don't break on the start of every autopas initialization if we are not interested in energy
-   measurement.
-   @return Error message. The error is message is empty on success
+   * Initialisation may fail, so moved out of constructor.
+   * Note: This functions returns an error message instead of throwing an exception if initialization is not possible.
+   * This way debuggers don't break on the start of every autopas initialization if we are not interested in energy
+   * measurement.
+   * @return Error message. The error is message is empty on success
    */
   std::string init();
 
   /**
-   * reset perf file descriptors to start new measurement
+   * Reset perf file descriptors to start new measurement.
    */
   void reset();
 
   /**
-   * measure power consumption since last call to reset
+   * Measure power consumption since last call to reset
    * the results can be retrieved with the get_<domain>_energy() functions.
    */
   void sample();
 
   /**
-   * returns the energy consumed by the cpu package between the last call to sample() and the preceding
-   * call to reset()
+   * Returns the energy consumed by the cpu package between the last call to sample() and the preceding
+   * call to reset().
    * @return Energy in Joules
    */
   double get_pkg_energy();
 
   /**
-   * returns the energy consumed by the cpu cores between the last call to sample() and the preceding
-   * call to reset()
+   * Returns the energy consumed by the cpu cores between the last call to sample() and the preceding
+   * call to reset().
    * @return Energy in Joules
    */
   double get_cores_energy();
 
   /**
-   *returns the energy consumed by ram between the last call to sample() and the preceding call to
-   * reset()
+   * Returns the energy consumed by ram between the last call to sample() and the preceding call to
+   * reset().
    * @return Energy in Joules
    */
   double get_ram_energy();
 
   /**
-   * returns the energy consumed by the entire system between the last call to sample() and the preceding
-   * call to reset()
+   * Returns the energy consumed by the entire system between the last call to sample() and the preceding
+   * call to reset().
    * @return Energy in Joules
    */
   double get_psys_energy();
 
   /**
-   * return energy measurement for tuning purposes. Depending on which perf counters are available this
-   * may return psys, or a sum of pkg and ram. Note that the units used here are not consistent across different
-   * systems. The scaling is skipped for this purpose, as the AutoTuner expects long values as opposed to doubles
+   * Return energy measurement for tuning purposes.
+   * Depending on which perf counters are available this may return psys, or a sum of pkg and ram.
+   * Note that the units used here are not consistent across different systems.
+   * The scaling is skipped for this purpose, as the AutoTuner expects long values as opposed to doubles
    * and rounding the scaled value seems like the inferior option as well as unnecessary given that the values provided
    * by the powercap framework already have the correct type. The getters for pkg, cores, ram and psys provide scaled
    * values for comparisons between different systems.
@@ -92,5 +93,4 @@ class RaplMeter {
    */
   long get_total_energy();
 };
-
 }  // namespace autopas::utils


### PR DESCRIPTION
# Description

A bunch of small but not necessarily minor fixes:

- [x] doc fixes
- [x] reformatting for readability
- [x] use exception function for better exception behavior control
- [x] some missing `const`
- [x] ~**BUGFIX** fix weighted average of tuning samples~ -> moved to #838
- [x] ~Resolve redefinition of `MD_FLEXIBLE_MODE` in `mdLibSingleSiteTests` and `mdLibMultiSiteTests` by building only one set of tests.~ -> moved to #839 
- [x] Fix missing erase-remove in emigrants filtering.

## ~Related Pull Requests~

## ~Resolved Issues~

# ~How Has This Been Tested?~