### PR TITLE
Last result as extrapolation method

### DIFF
--- a/.github/workflows/TestSuites.yaml
+++ b/.github/workflows/TestSuites.yaml
@@ -123,7 +123,7 @@ jobs:
             -DMD_FLEXIBLE_FUNCTOR_SVE=OFF \
             -DAUTOPAS_ENABLE_ALLLBL=${UseMPI} \
             ..
-          entrypoint.sh cmake --build . --parallel 8 
+          entrypoint.sh cmake --build . --parallel 1 
       - name: Run tests ${{ matrix.part }}/2
         run: |
           # If single-site & No MPI, run every other AutoPas and example test

--- a/.github/workflows/TestSuites.yaml
+++ b/.github/workflows/TestSuites.yaml
@@ -123,7 +123,7 @@ jobs:
             -DMD_FLEXIBLE_FUNCTOR_SVE=OFF \
             -DAUTOPAS_ENABLE_ALLLBL=${UseMPI} \
             ..
-          entrypoint.sh cmake --build . --parallel 1 
+          entrypoint.sh cmake --build . --parallel 8 
       - name: Run tests ${{ matrix.part }}/2
         run: |
           # If single-site & No MPI, run every other AutoPas and example test

--- a/src/autopas/options/ExtrapolationMethodOption.h
+++ b/src/autopas/options/ExtrapolationMethodOption.h
@@ -33,6 +33,8 @@ class ExtrapolationMethodOption : public Option<ExtrapolationMethodOption> {
      * Places a polynomial function through a certain number of data points using Newtons method.
      */
     newton,
+
+    lastResult,
   };
 
   /**
@@ -61,6 +63,7 @@ class ExtrapolationMethodOption : public Option<ExtrapolationMethodOption> {
         {ExtrapolationMethodOption::linePrediction, "line-prediction"},
         {ExtrapolationMethodOption::linearRegression, "linear-regression"},
         {ExtrapolationMethodOption::newton, "newton"},
+        {ExtrapolationMethodOption::lastResult, "last-result"},
     };
   };
 

--- a/src/autopas/options/ExtrapolationMethodOption.h
+++ b/src/autopas/options/ExtrapolationMethodOption.h
@@ -33,7 +33,9 @@ class ExtrapolationMethodOption : public Option<ExtrapolationMethodOption> {
      * Places a polynomial function through a certain number of data points using Newtons method.
      */
     newton,
-
+    /**
+     * Simply use the last traversal time as an estimate (not actually an extrapolation)
+     */
     lastResult,
   };
 

--- a/src/autopas/tuning/tuningStrategy/PredictiveTuning.cpp
+++ b/src/autopas/tuning/tuningStrategy/PredictiveTuning.cpp
@@ -21,10 +21,16 @@ PredictiveTuning::PredictiveTuning(double relativeOptimum, unsigned int maxTunin
     : _relativeOptimumRange(relativeOptimum),
       _maxTuningPhasesWithoutTest(maxTuningIterationsWithoutTest),
       _extrapolationMethod(extrapolationMethodOption),
-      _minNumberOfEvidence(
-          extrapolationMethodOption == ExtrapolationMethodOption::linePrediction
-              ? 2
-              : (extrapolationMethodOption == ExtrapolationMethodOption::lastResult ? 1 : testsUntilFirstPrediction)),
+      _minNumberOfEvidence([&]() {
+        // The minimal number of evidence needed depends on the extrapolation method
+        if (extrapolationMethodOption == ExtrapolationMethodOption::linePrediction) {
+          return 2u;
+        } else if (extrapolationMethodOption == ExtrapolationMethodOption::lastResult) {
+          return 1u;
+        } else {
+          return testsUntilFirstPrediction;
+        }
+      }()),
       _predictionLogger(outputSuffix) {
   if (_relativeOptimumRange < 1.) {
     utils::ExceptionHandler::exception(

--- a/src/autopas/tuning/tuningStrategy/PredictiveTuning.cpp
+++ b/src/autopas/tuning/tuningStrategy/PredictiveTuning.cpp
@@ -57,7 +57,7 @@ PredictiveTuning::PredictionsType PredictiveTuning::calculatePredictions(
           return newtonPolynomial(iteration, tuningPhase, configuration, *evidenceVec);
         }
         case ExtrapolationMethodOption::lastResult: {
-          return lastResult(iteration, tuningPhase, configuration, *evidenceVec);
+          return lastResult(tuningPhase, configuration, *evidenceVec);
         }
       }
       // should never be reached.
@@ -74,35 +74,6 @@ PredictiveTuning::PredictionsType PredictiveTuning::calculatePredictions(
   _predictionLogger.logAllPredictions(predictions, _predictionErrorValue, tuningPhase);
 
   return predictions;
-}
-
-long PredictiveTuning::lastResult(size_t iteration, size_t tuningPhase, const Configuration &configuration,
-                                  const std::vector<Evidence> &evidenceVec) {
-  auto &functionParams = _predictionFunctionParameters[configuration];
-  // if configuration was not tested in last tuning phase reuse prediction function.
-  // also make sure prediction function is of the right type (=correct amount of params)
-  if (evidenceVec.back().tuningPhase != (tuningPhase - 1) and functionParams.size() == 1) {
-    // last "calculated" value is used as prediction value
-    // no need to check for overflow or underflow here
-    return functionParams[0];
-  } else {
-    if (evidenceVec.size() >= _minNumberOfEvidence) {
-      const auto &[traversalIteration, traversalTuningPhase, traversalTime] = evidenceVec[evidenceVec.size() - 1];
-
-      // the prediction is the last traversal time
-      const long prediction = traversalTime;
-
-      functionParams.clear();
-      functionParams.emplace_back(prediction);
-
-      return prediction;
-
-    } else {
-      // When a configuration was not yet measured enough to make a prediction insert a placeholder.
-      _tooLongNotTestedSearchSpace.emplace(configuration);
-      return _predictionErrorValue;
-    }
-  }
 }
 
 long PredictiveTuning::linePrediction(size_t iteration, size_t tuningPhase, const Configuration &configuration,
@@ -339,6 +310,35 @@ long PredictiveTuning::newtonPolynomial(size_t iteration, size_t tuningPhase, co
     // When a configuration was not yet tested twice.
     _tooLongNotTestedSearchSpace.emplace(configuration);
     return _predictionErrorValue;
+  }
+}
+
+long PredictiveTuning::lastResult(size_t tuningPhase, const Configuration &configuration,
+                                  const std::vector<Evidence> &evidenceVec) {
+  auto &functionParams = _predictionFunctionParameters[configuration];
+  // if configuration was not tested in last tuning phase reuse prediction function.
+  // also make sure prediction function is of the right type (=correct amount of params)
+  if (evidenceVec.back().tuningPhase != (tuningPhase - 1) and functionParams.size() == 1) {
+    // last "calculated" value is used as prediction value
+    // no need to check for overflow or underflow here
+    return functionParams[0];
+  } else {
+    if (evidenceVec.size() >= _minNumberOfEvidence) {
+      const auto &[traversalIteration, traversalTuningPhase, traversalTime] = evidenceVec[evidenceVec.size() - 1];
+
+      // the prediction is the last traversal time
+      const long prediction = traversalTime;
+
+      functionParams.clear();
+      functionParams.emplace_back(prediction);
+
+      return prediction;
+
+    } else {
+      // When a configuration was not yet measured enough to make a prediction insert a placeholder.
+      _tooLongNotTestedSearchSpace.emplace(configuration);
+      return _predictionErrorValue;
+    }
   }
 }
 

--- a/src/autopas/tuning/tuningStrategy/PredictiveTuning.h
+++ b/src/autopas/tuning/tuningStrategy/PredictiveTuning.h
@@ -86,9 +86,6 @@ class PredictiveTuning final : public TuningStrategyInterface {
                                                          const autopas::EvidenceCollection &evidenceCollection);
 
  private:
-  long lastResult(size_t iteration, size_t tuningPhase, const Configuration &configuration,
-                  const std::vector<Evidence> &evidenceVec);
-
   /**
    * Predicts the traversal time by placing a line through the last two traversal points and calculating the prediction
    * for the current time.
@@ -109,6 +106,11 @@ class PredictiveTuning final : public TuningStrategyInterface {
                         const std::vector<Evidence> &evidenceVec);
 
   /**
+   * Uses the last traversal time as a prediction for the current iteration
+   */
+  long lastResult(size_t tuningPhase, const Configuration &configuration, const std::vector<Evidence> &evidenceVec);
+
+  /**
    * Error value used as a placeholder for the predictions of configurations that are not predicted.
    */
   constexpr static long _predictionErrorValue{std::numeric_limits<long>::max()};
@@ -127,10 +129,10 @@ class PredictiveTuning final : public TuningStrategyInterface {
    * A Map that for each configuration stores the function for the prediction to reuse it if no new traversal time was
    * added in the last tuning  phase. The way that function is stored depends on the prediction method, hence it is a
    * vector:
-   * Last Result: last evidence?
    * Line Prediction: Gradient and last evidence
    * Linear Regression: Gradient and iteration
    * Newton: Vector of coefficients
+   * Last Result: Last traversal time
    */
   std::unordered_map<Configuration, std::vector<double>, ConfigHash> _predictionFunctionParameters{};
   /**

--- a/src/autopas/tuning/tuningStrategy/PredictiveTuning.h
+++ b/src/autopas/tuning/tuningStrategy/PredictiveTuning.h
@@ -86,6 +86,9 @@ class PredictiveTuning final : public TuningStrategyInterface {
                                                          const autopas::EvidenceCollection &evidenceCollection);
 
  private:
+  long lastResult(size_t iteration, size_t tuningPhase, const Configuration &configuration,
+                  const std::vector<Evidence> &evidenceVec);
+
   /**
    * Predicts the traversal time by placing a line through the last two traversal points and calculating the prediction
    * for the current time.
@@ -116,7 +119,7 @@ class PredictiveTuning final : public TuningStrategyInterface {
   constexpr static long _predictionOverflowValue{std::numeric_limits<long>::max() - 1};
 
   /**
-   * Placeholder value used when a prediction overflows.
+   * Placeholder value used when a prediction underflows.
    */
   constexpr static long _predictionUnderflowValue{1l};
 
@@ -124,6 +127,7 @@ class PredictiveTuning final : public TuningStrategyInterface {
    * A Map that for each configuration stores the function for the prediction to reuse it if no new traversal time was
    * added in the last tuning  phase. The way that function is stored depends on the prediction method, hence it is a
    * vector:
+   * Last Result: last evidence?
    * Line Prediction: Gradient and last evidence
    * Linear Regression: Gradient and iteration
    * Newton: Vector of coefficients

--- a/tests/testAutopas/tests/tuning/tuningStrategy/PredictiveTuningTest.cpp
+++ b/tests/testAutopas/tests/tuning/tuningStrategy/PredictiveTuningTest.cpp
@@ -136,6 +136,7 @@ TEST_P(PredictiveTuningTest, testUnderAndOverflow) {
   constexpr auto maxLong = std::numeric_limits<long>::max();
   std::map<autopas::Configuration, long> expected = {
       {_configurationLC_C01, 1}, {_configurationLC_C08, maxLong - 1}, {_configurationLC_Sliced, 101}};
+  // since lastResult is not actually an exprapolation, we expect the last values as prediction
   if (extrapolationOption == autopas::ExtrapolationMethodOption::lastResult) {
     expected = {{_configurationLC_C01, 10}, {_configurationLC_C08, maxLong - 100}, {_configurationLC_Sliced, 101}};
   }

--- a/tests/testAutopas/tests/tuning/tuningStrategy/PredictiveTuningTest.cpp
+++ b/tests/testAutopas/tests/tuning/tuningStrategy/PredictiveTuningTest.cpp
@@ -134,12 +134,16 @@ TEST_P(PredictiveTuningTest, testPredictions) {
 TEST_P(PredictiveTuningTest, testUnderAndOverflow) {
   auto extrapolationOption = GetParam();
   constexpr auto maxLong = std::numeric_limits<long>::max();
-  std::map<autopas::Configuration, long> expected = {
-      {_configurationLC_C01, 1}, {_configurationLC_C08, maxLong - 1}, {_configurationLC_Sliced, 101}};
-  // since lastResult is not actually an exprapolation, we expect the last values as prediction
-  if (extrapolationOption == autopas::ExtrapolationMethodOption::lastResult) {
-    expected = {{_configurationLC_C01, 10}, {_configurationLC_C08, maxLong - 100}, {_configurationLC_Sliced, 101}};
-  }
+  const std::map<autopas::Configuration, long> expected = [&]() {
+    // since lastResult is not actually an exprapolation, we expect the last values as prediction
+    if (extrapolationOption == autopas::ExtrapolationMethodOption::lastResult) {
+      return std::map<autopas::Configuration, long>{
+          {_configurationLC_C01, 10}, {_configurationLC_C08, maxLong - 100}, {_configurationLC_Sliced, 101}};
+    } else {
+      return std::map<autopas::Configuration, long>{
+          {_configurationLC_C01, 1}, {_configurationLC_C08, maxLong - 1}, {_configurationLC_Sliced, 101}};
+    }
+  }();
   checkPredictions(
       extrapolationOption,
       {

--- a/tests/testAutopas/tests/tuning/tuningStrategy/PredictiveTuningTest.cpp
+++ b/tests/testAutopas/tests/tuning/tuningStrategy/PredictiveTuningTest.cpp
@@ -108,6 +108,16 @@ TEST_P(PredictiveTuningTest, testPredictions) {
           0, {{_configurationLC_C01, 100}, {_configurationLC_C08, 99}, {_configurationLC_Sliced, 101}});
       break;
     }
+    case autopas::ExtrapolationMethodOption::lastResult: {
+      checkPredictions(extrapolationOption,
+                       {
+                           {{_configurationLC_C01, 94}, {_configurationLC_C08, 109}, {_configurationLC_Sliced, 101}},
+                           {{_configurationLC_C01, 97}, {_configurationLC_C08, 103}, {_configurationLC_Sliced, 101}},
+                       },
+                       // all predictions are evaluated for the seventh iteration (iteration==6)
+                       0, {{_configurationLC_C01, 97}, {_configurationLC_C08, 103}, {_configurationLC_Sliced, 101}});
+      break;
+    }
     default:
       GTEST_FAIL() << "No test implemented for extrapolation method " << extrapolationOption.to_string();
   }
@@ -124,6 +134,11 @@ TEST_P(PredictiveTuningTest, testPredictions) {
 TEST_P(PredictiveTuningTest, testUnderAndOverflow) {
   auto extrapolationOption = GetParam();
   constexpr auto maxLong = std::numeric_limits<long>::max();
+  std::map<autopas::Configuration, long> expected = {
+      {_configurationLC_C01, 1}, {_configurationLC_C08, maxLong - 1}, {_configurationLC_Sliced, 101}};
+  if (extrapolationOption == autopas::ExtrapolationMethodOption::lastResult) {
+    expected = {{_configurationLC_C01, 10}, {_configurationLC_C08, maxLong - 100}, {_configurationLC_Sliced, 101}};
+  }
   checkPredictions(
       extrapolationOption,
       {
@@ -131,7 +146,7 @@ TEST_P(PredictiveTuningTest, testUnderAndOverflow) {
           {{_configurationLC_C01, 10}, {_configurationLC_C08, maxLong - 100}, {_configurationLC_Sliced, 101}},
       },
       // all predictions are evaluated for the seventh iteration (iteration==6)
-      100, {{_configurationLC_C01, 1}, {_configurationLC_C08, maxLong - 1}, {_configurationLC_Sliced, 101}});
+      100, expected);
 }
 
 INSTANTIATE_TEST_SUITE_P(Generated, PredictiveTuningTest,


### PR DESCRIPTION
# Description

This PR adds an option to use the last traversal time as an estimate for the upcoming iterations to predictive tuning.

## Resolved Issues

- [x] fixes #831 

# How Has This Been Tested?

Added the new extrapolation method to the existing tests for predictive tuning.
