### PR TITLE
Only build matching mdLib tests

### DIFF
--- a/.github/workflows/TestSuites.yaml
+++ b/.github/workflows/TestSuites.yaml
@@ -153,7 +153,9 @@ jobs:
           # If multi-site run every md-flexible test and multi site tests
           if [[ "${{ matrix.md-flex-mode }}" = 'multisite' ]]
           then
-            cd build/examples/md-flexible
+            cd build/applicationLibrary
+            ctest --output-on-failure --tests-regex '[mM]ulti[sS]ite'
+            cd ../examples/md-flexible
             ctest --output-on-failure --build-config mdFlexTests 
           fi
               

--- a/.github/workflows/TestSuites.yaml
+++ b/.github/workflows/TestSuites.yaml
@@ -135,7 +135,7 @@ jobs:
             cd applicationLibrary
             ctest --output-on-failure -I ${{ matrix.part }},,2 -j 2
             cd ../examples
-            ctest -C checkExamples --output-on-failure -I ${{ matrix.part }},,2 -j 2
+            ctest --output-on-failure --build-config checkExamples -I ${{ matrix.part }},,2 -j 2
           fi
           
           # If single-site & MPI, run MPI tests for AutoPas and example tests
@@ -144,16 +144,16 @@ jobs:
             cd build
             # Only run MPI tests.
             # No `--oversubscribe`, as MPI in container doesn't need it.
-            ctest --output-on-failure -R MPIParallelAutoPasTests
+            ctest --output-on-failure --tests-regex MPIParallelAutoPasTests
             cd examples
             # exclude examples that do not support MPI 
-            ctest --output-on-failure -C checkExamples -E 'sph-((main.test)|(diagram.*))'
+            ctest --output-on-failure --build-config checkExamples --exclude-regex 'sph-((main.test)|(diagram.*))'
           fi
           
-          # If multi-site run every md-flexible test
+          # If multi-site run every md-flexible test and multi site tests
           if [[ "${{ matrix.md-flex-mode }}" = 'multisite' ]]
           then
             cd build/examples/md-flexible
-            ctest -C mdFlexTests --output-on-failure
+            ctest --output-on-failure --build-config mdFlexTests 
           fi
               

--- a/.github/workflows/TestSuites.yaml
+++ b/.github/workflows/TestSuites.yaml
@@ -154,7 +154,10 @@ jobs:
           if [[ "${{ matrix.md-flex-mode }}" = 'multisite' ]]
           then
             cd build/applicationLibrary
-            ctest --output-on-failure --tests-regex '[mM]ulti[sS]ite'
+            # Only run multi-site tests for non-mpi case
+            if [[ "${{ matrix.config[1] }}" != 'mpicc' ]]
+              ctest --output-on-failure --tests-regex '[mM]ulti[sS]ite'
+            fi
             cd ../examples/md-flexible
             ctest --output-on-failure --build-config mdFlexTests 
           fi

--- a/.github/workflows/TestSuites.yaml
+++ b/.github/workflows/TestSuites.yaml
@@ -156,6 +156,7 @@ jobs:
             cd build/applicationLibrary
             # Only run multi-site tests for non-mpi case
             if [[ "${{ matrix.config[1] }}" != 'mpicc' ]]
+            then
               ctest --output-on-failure --tests-regex '[mM]ulti[sS]ite'
             fi
             cd ../examples/md-flexible

--- a/applicationLibrary/CMakeLists.txt
+++ b/applicationLibrary/CMakeLists.txt
@@ -55,64 +55,37 @@ target_include_directories(SPHLibrary PUBLIC ./sph)
 # --- molecular dynamics ---
 
 if (AUTOPAS_BUILD_TESTS)
-    message(STATUS "applicationLibrary - adding all tests")
+    message(STATUS "applicationLibrary - adding all ${MD_FLEXIBLE_MODE_lower} tests")
+
+    if (MD_FLEXIBLE_MODE_lower MATCHES "singlesite")
+        set(TEST_EXE_NAME "mdLibSingleSiteTests")
+        set(TEST_EXE_UNIQUE_PATH "molecularDynamics/tests/multiSiteTests")
+    elseif (MD_FLEXIBLE_MODE_lower MATCHES "multisite")
+        set(TEST_EXE_NAME "mdLibMultiSiteTests")
+        set(TEST_EXE_UNIQUE_PATH "molecularDynamics/tests/multiSiteTests")
+    endif()
+
     file(
             GLOB_RECURSE
-            SS_TEST_SRC
-            "molecularDynamics/tests/singleSiteTests/*.cpp"
-            "molecularDynamics/tests/singleSiteTests/*.h"
+            TEST_SRC
+            "${TEST_EXE_UNIQUE_PATH}/*.cpp"
+            "${TEST_EXE_UNIQUE_PATH}/*.h"
             "molecularDynamics/tests/particlePropertiesLibraryTests/*.cpp"
             "molecularDynamics/tests/particlePropertiesLibraryTests/*.h"
             "molecularDynamics/tests/templateInstatiations/AutoPasInstantiations.cpp"
     )
-
-    add_executable(mdLibSingleSiteTests ${SS_TEST_SRC} mdLibTests.cpp)
-
-    target_compile_definitions(
-            mdLibSingleSiteTests PRIVATE
-            MD_FLEXIBLE_MODE=0 # set MD_FLEXIBLE_MODE to single-site
-            # Tests need definitions of SINGLESITE and MULTISITE so it can correctly compile single-site tests
-            SINGLESITE=0
-            MULTISITE=1
-    )
+    add_executable(${TEST_EXE_NAME} ${TEST_SRC} mdLibTests.cpp)
 
     target_include_directories(
-            mdLibSingleSiteTests PUBLIC
-            ${PROJECT_SOURCE_DIR}/tests/testAutopas molecularDynamics
+            ${TEST_EXE_NAME}
+            PUBLIC
+            "${PROJECT_SOURCE_DIR}/tests/testAutopas"
+            "molecularDynamics"
     )
 
     target_link_libraries(
-            mdLibSingleSiteTests PUBLIC
-            autopas autopasTools molecularDynamicsLibrary gmock
-    )
-
-    file(
-            GLOB_RECURSE
-            MS_TEST_SRC
-            "molecularDynamics/tests/multiSiteTests/*.cpp"
-            "molecularDynamics/tests/multiSiteTests/*.h"
-            "molecularDynamics/tests/particlePropertiesLibraryTests/*.cpp"
-            "molecularDynamics/tests/particlePropertiesLibraryTests/*.h"
-            "molecularDynamics/tests/templateInstatiations/AutoPasInstantiations.cpp"
-    )
-
-    add_executable(mdLibMultiSiteTests ${MS_TEST_SRC} mdLibTests.cpp)
-
-    target_compile_definitions(
-            mdLibMultiSiteTests PRIVATE
-            MD_FLEXIBLE_MODE=1  # set MD_FLEXIBLE_MODE to multi-site
-            # Tests need definitions of SINGLESITE and MULTISITE so it can correctly compile multi-site tests
-            SINGLESITE=0
-            MULTISITE=1
-    )
-
-    target_include_directories(
-            mdLibMultiSiteTests PUBLIC
-            ${PROJECT_SOURCE_DIR}/tests/testAutopas molecularDynamics
-    )
-
-    target_link_libraries(
-            mdLibMultiSiteTests PUBLIC
+            ${TEST_EXE_NAME}
+            PUBLIC
             autopas autopasTools molecularDynamicsLibrary gmock
     )
 
@@ -120,12 +93,8 @@ if (AUTOPAS_BUILD_TESTS)
     include(GoogleTest)
     # more robust, queries the compiled executable
     gtest_discover_tests(
-            mdLibSingleSiteTests TEST_PREFIX "mdLibSingleSiteTests/"
-            PROPERTIES
-            ENVIRONMENT "${LSAN_OPTIONS_STR}"
-    )
-    gtest_discover_tests(
-            mdLibMultiSiteTests TEST_PREFIX "mdLibMultiSiteTests/"
+            ${TEST_EXE_NAME}
+            TEST_PREFIX "${TEST_EXE_NAME}/"
             PROPERTIES
             ENVIRONMENT "${LSAN_OPTIONS_STR}"
     )

--- a/applicationLibrary/CMakeLists.txt
+++ b/applicationLibrary/CMakeLists.txt
@@ -65,6 +65,14 @@ if (AUTOPAS_BUILD_TESTS)
         set(TEST_EXE_UNIQUE_PATH "molecularDynamics/tests/multiSiteTests")
     endif()
 
+    # sanity check to prevent against globbing the whole file system
+    if(NOT DEFINED TEST_EXE_NAME OR TEST_EXE_NAME STREQUAL "" OR
+       NOT DEFINED TEST_EXE_UNIQUE_PATH OR TEST_EXE_UNIQUE_PATH STREQUAL "")
+        message(FATAL_ERROR "Both TEST_EXE_NAME and TEST_EXE_UNIQUE_PATH must be defined and not empty.\
+        This probably resulted from MD_FLEXIBLE_MODE being set wrong.\
+        MD_FLEXIBLE_MODE=${MD_FLEXIBLE_MODE}")
+    endif()
+
     file(
             GLOB_RECURSE
             TEST_SRC

--- a/applicationLibrary/CMakeLists.txt
+++ b/applicationLibrary/CMakeLists.txt
@@ -59,7 +59,7 @@ if (AUTOPAS_BUILD_TESTS)
 
     if (MD_FLEXIBLE_MODE_lower MATCHES "singlesite")
         set(TEST_EXE_NAME "mdLibSingleSiteTests")
-        set(TEST_EXE_UNIQUE_PATH "molecularDynamics/tests/multiSiteTests")
+        set(TEST_EXE_UNIQUE_PATH "molecularDynamics/tests/singleSiteTests")
     elseif (MD_FLEXIBLE_MODE_lower MATCHES "multisite")
         set(TEST_EXE_NAME "mdLibMultiSiteTests")
         set(TEST_EXE_UNIQUE_PATH "molecularDynamics/tests/multiSiteTests")


### PR DESCRIPTION
# Description

Refactor creation of mdLib test targets
- [x] Only build the test target that matches the site mode
- [x] Remove cmake code duplication
- [x] Fixes duplicate definition of macros from `molecularDynamicsLibrary` and `mdLibMultiSiteTests`
- [x] Add single and multi site tests to the CI


## ~Related Pull Requests~

## ~Resolved Issues~

# How Has This Been Tested?

Check CI build and run output to confirm:
- [x] no compiler warnings
- [x] single and multisite tests are executed
