### PR TITLE
Adding getter for tuningMetric in Autopas class to access from ls1-mardyn

### DIFF
--- a/src/autopas/AutoPasDecl.h
+++ b/src/autopas/AutoPasDecl.h
@@ -911,6 +911,14 @@ class AutoPas {
   }
 
   /**
+   * Getter for the tuning metric option.
+   * @return
+   */
+  [[nodiscard]] const TuningMetricOption &getTuningMetricOption() const {
+    return _autoTunerInfo.tuningMetric;
+  }
+
+  /**
    * Setter for the tuning metric option.
    * For possible tuning metric choices see options::TuningMetricOption::Value.
    * @param tuningMetricOption

--- a/src/autopas/AutoPasDecl.h
+++ b/src/autopas/AutoPasDecl.h
@@ -914,9 +914,7 @@ class AutoPas {
    * Getter for the tuning metric option.
    * @return
    */
-  [[nodiscard]] const TuningMetricOption &getTuningMetricOption() const {
-    return _autoTunerInfo.tuningMetric;
-  }
+  [[nodiscard]] const TuningMetricOption &getTuningMetricOption() const { return _autoTunerInfo.tuningMetric; }
 
   /**
    * Setter for the tuning metric option.


### PR DESCRIPTION
# Description

Added a getter function for `tuningMetric` in `AutoPasDecl.h` to access it from ls1-mardyn. A getter function is available in `AutoTuner.cpp` but cannot be directly accessed from there. 


# How Has This Been Tested?

Only a getter function added, no effect on any tests or simulation pipeline.
