### PR TITLE
More Small Fixes

### DIFF
--- a/cmake/modules/autopas_logging.cmake
+++ b/cmake/modules/autopas_logging.cmake
@@ -1,11 +1,3 @@
-# option for more verbose log messages.
-option(AUTOPAS_VERBOSE_LOGGING "Print Filename and line in every log line." OFF)
-
-if (AUTOPAS_VERBOSE_LOGGING)
-    target_compile_definitions(autopas PUBLIC AUTOPAS_VERBOSE_LOG)
-    message(STATUS "Verbose log messages enabled.")
-endif ()
-
 # option for colored log messages.
 option(AUTOPAS_COLORED_LOGGING "Print colored logging messages (only applies to cout and cerr)." OFF)
 if (AUTOPAS_COLORED_LOGGING)

--- a/src/autopas/AutoPasImpl.h
+++ b/src/autopas/AutoPasImpl.h
@@ -64,12 +64,6 @@ template <class Particle>
 void AutoPas<Particle>::init() {
   AutoPasLog(INFO, "AutoPas Version: {}", AutoPas_VERSION);
   AutoPasLog(INFO, "Compiled with  : {}", utils::CompileInfo::getCompilerInfo());
-  if (_autoTunerInfo.maxSamples % _verletRebuildFrequency != 0) {
-    AutoPasLog(WARN,
-               "Number of samples ({}) is not a multiple of the rebuild frequency ({}). This can lead to problems "
-               "when multiple AutoPas instances interact (e.g. via MPI).",
-               _autoTunerInfo.maxSamples, _verletRebuildFrequency);
-  }
 
   if (_tuningStrategyFactoryInfo.autopasMpiCommunicator == AUTOPAS_MPI_COMM_NULL) {
     AutoPas_MPI_Comm_dup(AUTOPAS_MPI_COMM_WORLD, &_tuningStrategyFactoryInfo.autopasMpiCommunicator);

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -1187,6 +1187,10 @@ bool LogicHandler<Particle>::iteratePairwisePipeline(Functor *functor) {
             return measurements.timeTotal;
           case TuningMetricOption::energy:
             return measurements.energyTotal;
+          default:
+            autopas::utils::ExceptionHandler::exception(
+                "LogicHandler::iteratePairwisePipeline(): Unknown tuning metric.");
+            return 0l;
         }
       }();
       _autoTuner.addMeasurement(measurement, not neighborListsAreValid());

--- a/src/autopas/containers/LoadEstimators.h
+++ b/src/autopas/containers/LoadEstimators.h
@@ -54,7 +54,7 @@ unsigned long squaredParticlesPerCell(const std::vector<ParticleCell> &cells,
  */
 template <class Particle>
 unsigned long neighborListLengthImpl(
-    const typename autopas::VerletListsCellsHelpers<Particle>::NeighborListsType &neighborLists,
+    const typename autopas::VerletListsCellsHelpers<Particle>::AllCellsNeighborListsType &neighborLists,
     unsigned long cellIndex) {
   unsigned long cellLoad = 0;
   for (auto &list : neighborLists[cellIndex]) {

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -377,8 +377,8 @@ class ParticleContainerInterface {
                                                      IteratorBehavior iteratorBehavior,
                                                      const std::array<double, 3> &boxMin,
                                                      const std::array<double, 3> &boxMax) {
-    const Particle *ptr;
-    size_t nextCellIndex, nextParticleIndex;
+    const Particle *ptr{};
+    size_t nextCellIndex{}, nextParticleIndex{};
     std::tie(ptr, nextCellIndex, nextParticleIndex) =
         const_cast<const ParticleContainerInterface<Particle> *>(this)->getParticle(cellIndex, particleIndex,
                                                                                     iteratorBehavior, boxMin, boxMax);
@@ -392,8 +392,8 @@ class ParticleContainerInterface {
    */
   std::tuple<Particle *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
                                                      IteratorBehavior iteratorBehavior) {
-    const Particle *ptr;
-    size_t nextCellIndex, nextParticleIndex;
+    const Particle *ptr{};
+    size_t nextCellIndex{}, nextParticleIndex{};
     std::tie(ptr, nextCellIndex, nextParticleIndex) =
         const_cast<const ParticleContainerInterface<Particle> *>(this)->getParticle(cellIndex, particleIndex,
                                                                                     iteratorBehavior);

--- a/src/autopas/containers/linkedCells/traversals/LCC04Traversal.h
+++ b/src/autopas/containers/linkedCells/traversals/LCC04Traversal.h
@@ -85,7 +85,7 @@ class LCC04Traversal : public C08BasedTraversal<ParticleCell, PairwiseFunctor>,
 
   LCC08CellHandler<ParticleCell, PairwiseFunctor> _cellHandler;
 
-  const std::array<long, 3> _end;
+  std::array<long, 3> _end;
 };
 
 /**
@@ -126,7 +126,6 @@ constexpr auto LCC04Traversal<ParticleCell, PairwiseFunctor>::computeOffsets32Pa
   cellOffsets32Pack[i++] = {2l, 1l, z};
   cellOffsets32Pack[i++] = {2l, 2l, z};
 
-  /// @todo C++20: mark as unlikely
   if (i != 32) {
     utils::ExceptionHandler::exception("Internal error: Wrong number of offsets (expected: 32, actual: {})", i);
   }
@@ -147,14 +146,14 @@ template <class ParticleCell, class PairwiseFunctor>
 void LCC04Traversal<ParticleCell, PairwiseFunctor>::processBasePack32(std::vector<ParticleCell> &cells,
                                                                       const std::array<long, 3> &base3DIndex) {
   using utils::ThreeDimensionalMapping::threeToOneD;
-  std::array<long, 3> index;
+  std::array<long, 3> index{};
   const std::array<long, 3> signedDims = utils::ArrayUtils::static_cast_copy_array<long>(this->_cellsPerDimension);
 
-  for (auto Offset32Pack : _cellOffsets32Pack) {
+  for (auto offset32Pack : _cellOffsets32Pack) {
     // compute 3D index
     bool isIn = true;
     for (int d = 0; d < 3; ++d) {
-      index[d] = base3DIndex[d] + Offset32Pack[d];
+      index[d] = base3DIndex[d] + offset32Pack[d];
       isIn &= (index[d] >= 0l) and (index[d] < _end[d]);
     }
 

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
@@ -34,7 +34,6 @@ namespace autopas {
 
 template <class Particle, class NeighborList>
 class VerletListsCells : public VerletListsLinkedBase<Particle> {
-  using verlet_internal = VerletListsCellsHelpers<FullParticleCell<Particle>>;
   using ParticleCell = FullParticleCell<Particle>;
 
  public:

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
@@ -54,7 +54,7 @@ class VerletListsCells : public VerletListsLinkedBase<Particle> {
                    const double skinPerTimestep = 0, const unsigned int rebuildFrequency = 2,
                    const double cellSizeFactor = 1.0,
                    const LoadEstimatorOption loadEstimator = LoadEstimatorOption::squaredParticlesPerCell,
-                   typename VerletListsCellsHelpers<Particle>::VLCBuildType::Value buildType =
+                   typename VerletListsCellsHelpers<Particle>::VLCBuildType buildType =
                        VerletListsCellsHelpers<Particle>::VLCBuildType::soaBuild)
       : VerletListsLinkedBase<Particle>(boxMin, boxMax, cutoff, skinPerTimestep, rebuildFrequency,
                                         compatibleTraversals::allVLCCompatibleTraversals(), cellSizeFactor),
@@ -153,6 +153,6 @@ class VerletListsCells : public VerletListsLinkedBase<Particle> {
   /**
    * Data layout of the particles which are used to generate the neighbor lists.
    */
-  typename VerletListsCellsHelpers<Particle>::VLCBuildType::Value _buildType;
+  typename VerletListsCellsHelpers<Particle>::VLCBuildType _buildType;
 };
 }  // namespace autopas

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsHelpers.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsHelpers.h
@@ -38,17 +38,9 @@ class VerletListsCellsHelpers {
    * Indicates which build functor should be used for the generation of the neighbor list.
    * To be passed to the generator functors in the neighbor lists.
    */
-  class VLCBuildType {
-   public:
-    /**
-     * Enum value indicating whether the AoS functor or the SoA functors will be used to generate
-     * the neighbor list.
-     */
-    enum Value {
-      aosBuild,
-      soaBuild,
-    };
+  enum class VLCBuildType {
+    aosBuild,
+    soaBuild,
   };
-
 };  // class VerletListsCellsHelpers
 }  // namespace autopas

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsHelpers.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsHelpers.h
@@ -21,9 +21,10 @@ template <class Particle>
 class VerletListsCellsHelpers {
  public:
   /**
-   * Cell wise verlet lists: For every cell, a vector of pairs. Each pair maps a particle to a vector of its neighbors.
+   * Cell wise verlet lists for neighbors from all adjacent cells: For every cell, a vector of pairs.
+   * Each pair maps a particle to a vector of its neighbors.
    */
-  using NeighborListsType = std::vector<std::vector<std::pair<Particle *, std::vector<Particle *>>>>;
+  using AllCellsNeighborListsType = std::vector<std::vector<std::pair<Particle *, std::vector<Particle *>>>>;
 
   /**
    * Pairwise verlet lists: For every cell a vector, for every neighboring cell a vector of particle-neighborlist pairs.

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCAllCellsGeneratorFunctor.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCAllCellsGeneratorFunctor.h
@@ -15,7 +15,7 @@ namespace autopas {
  */
 template <class Particle>
 class VLCAllCellsGeneratorFunctor : public Functor<Particle, VLCAllCellsGeneratorFunctor<Particle>> {
-  using NeighborListsType = typename VerletListsCellsHelpers<Particle>::NeighborListsType;
+  using NeighborListsType = typename VerletListsCellsHelpers<Particle>::AllCellsNeighborListsType;
   using SoAArraysType = typename Particle::SoAArraysType;
 
  public:

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCAllCellsNeighborList.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCAllCellsNeighborList.h
@@ -63,7 +63,7 @@ class VLCAllCellsNeighborList : public VLCNeighborListInterface<Particle> {
    */
   void buildAoSNeighborList(LinkedCells<Particle> &linkedCells, bool useNewton3, double cutoff, double skin,
                             double interactionLength, const TraversalOption buildTraversalOption,
-                            typename VerletListsCellsHelpers<Particle>::VLCBuildType::Value buildType) override {
+                            typename VerletListsCellsHelpers<Particle>::VLCBuildType buildType) override {
     // Initialize a neighbor list for each cell.
     _aosNeighborList.clear();
     this->_internalLinkedCells = &linkedCells;
@@ -167,7 +167,7 @@ class VLCAllCellsNeighborList : public VLCNeighborListInterface<Particle> {
    */
   void applyBuildFunctor(LinkedCells<Particle> &linkedCells, bool useNewton3, double cutoff, double skin,
                          double interactionLength, const TraversalOption buildTraversalOption,
-                         typename VerletListsCellsHelpers<Particle>::VLCBuildType::Value buildType) override {
+                         typename VerletListsCellsHelpers<Particle>::VLCBuildType buildType) override {
     VLCAllCellsGeneratorFunctor<Particle> f(_aosNeighborList, _particleToCellMap, cutoff + skin);
 
     // Generate the build traversal with the traversal selector and apply the build functor with it.
@@ -176,7 +176,7 @@ class VLCAllCellsNeighborList : public VLCNeighborListInterface<Particle> {
     TraversalSelectorInfo traversalSelectorInfo(linkedCells.getCellBlock().getCellsPerDimensionWithHalo(),
                                                 interactionLength, linkedCells.getCellBlock().getCellLength(), 0);
 
-    const auto dataLayout = buildType == VerletListsCellsHelpers<Particle>::VLCBuildType::Value::aosBuild
+    const auto dataLayout = buildType == VerletListsCellsHelpers<Particle>::VLCBuildType::aosBuild
                                 ? DataLayoutOption::aos
                                 : DataLayoutOption::soa;
 

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCAllCellsNeighborList.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCAllCellsNeighborList.h
@@ -99,7 +99,9 @@ class VLCAllCellsNeighborList : public VLCNeighborListInterface<Particle> {
    * Returns the neighbor list in AoS layout.
    * @return Neighbor list in AoS layout.
    */
-  typename VerletListsCellsHelpers<Particle>::AllCellsNeighborListsType &getAoSNeighborList() { return _aosNeighborList; }
+  typename VerletListsCellsHelpers<Particle>::AllCellsNeighborListsType &getAoSNeighborList() {
+    return _aosNeighborList;
+  }
 
   /**
    * Returns the neighbor list in SoA layout.

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCAllCellsNeighborList.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCAllCellsNeighborList.h
@@ -40,7 +40,7 @@ class VLCAllCellsNeighborList : public VLCNeighborListInterface<Particle> {
   /**
    * Type of the data structure used to save the neighbor lists.
    */
-  using listType = typename VerletListsCellsHelpers<Particle>::NeighborListsType;
+  using listType = typename VerletListsCellsHelpers<Particle>::AllCellsNeighborListsType;
 
   /**
    * Helper type definition. Pair of particle and neighbor list for SoA layout.
@@ -99,7 +99,7 @@ class VLCAllCellsNeighborList : public VLCNeighborListInterface<Particle> {
    * Returns the neighbor list in AoS layout.
    * @return Neighbor list in AoS layout.
    */
-  typename VerletListsCellsHelpers<Particle>::NeighborListsType &getAoSNeighborList() { return _aosNeighborList; }
+  typename VerletListsCellsHelpers<Particle>::AllCellsNeighborListsType &getAoSNeighborList() { return _aosNeighborList; }
 
   /**
    * Returns the neighbor list in SoA layout.
@@ -189,7 +189,7 @@ class VLCAllCellsNeighborList : public VLCNeighborListInterface<Particle> {
   /**
    * Internal neighbor list structure in AoS format - Verlet lists for each particle for each cell.
    */
-  typename VerletListsCellsHelpers<Particle>::NeighborListsType _aosNeighborList{};
+  typename VerletListsCellsHelpers<Particle>::AllCellsNeighborListsType _aosNeighborList{};
 
   /**
    * Mapping of each particle to its corresponding cell and id within this cell.

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCCellPairNeighborList.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCCellPairNeighborList.h
@@ -81,7 +81,7 @@ class VLCCellPairNeighborList : public VLCNeighborListInterface<Particle> {
 
   void buildAoSNeighborList(LinkedCells<Particle> &linkedCells, bool useNewton3, double cutoff, double skin,
                             double interactionLength, const TraversalOption buildTraversalOption,
-                            typename VerletListsCellsHelpers<Particle>::VLCBuildType::Value buildType) override {
+                            typename VerletListsCellsHelpers<Particle>::VLCBuildType buildType) override {
     this->_internalLinkedCells = &linkedCells;
     _aosNeighborList.clear();
     _globalToLocalIndex.clear();
@@ -213,7 +213,7 @@ class VLCCellPairNeighborList : public VLCNeighborListInterface<Particle> {
  private:
   void applyBuildFunctor(LinkedCells<Particle> &linkedCells, bool useNewton3, double cutoff, double skin,
                          double interactionLength, const TraversalOption buildTraversalOption,
-                         typename VerletListsCellsHelpers<Particle>::VLCBuildType::Value buildType) override {
+                         typename VerletListsCellsHelpers<Particle>::VLCBuildType buildType) override {
     VLCCellPairGeneratorFunctor<Particle> f(_aosNeighborList, _particleToCellMap, _globalToLocalIndex, cutoff + skin);
 
     // Generate the build traversal with the traversal selector and apply the build functor with it.
@@ -222,7 +222,7 @@ class VLCCellPairNeighborList : public VLCNeighborListInterface<Particle> {
     TraversalSelectorInfo traversalSelectorInfo(linkedCells.getCellBlock().getCellsPerDimensionWithHalo(),
                                                 interactionLength, linkedCells.getCellBlock().getCellLength(), 0);
 
-    const auto dataLayout = buildType == VerletListsCellsHelpers<Particle>::VLCBuildType::Value::aosBuild
+    const auto dataLayout = buildType == VerletListsCellsHelpers<Particle>::VLCBuildType::aosBuild
                                 ? DataLayoutOption::aos
                                 : DataLayoutOption::soa;
 

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCNeighborListInterface.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCNeighborListInterface.h
@@ -35,7 +35,7 @@ class VLCNeighborListInterface {
    */
   virtual void buildAoSNeighborList(LinkedCells<Particle> &linkedCells, bool useNewton3, double cutoff, double skin,
                                     double interactionLength, const TraversalOption buildTraversalOption,
-                                    typename VerletListsCellsHelpers<Particle>::VLCBuildType::Value buildType) = 0;
+                                    typename VerletListsCellsHelpers<Particle>::VLCBuildType buildType) = 0;
 
   /**
    * Gets the number of neighbors over all neighbor lists that belong to this particle.
@@ -131,7 +131,7 @@ class VLCNeighborListInterface {
    */
   virtual void applyBuildFunctor(LinkedCells<Particle> &linkedCells, bool useNewton3, double cutoff, double skin,
                                  double interactionLength, const TraversalOption buildTraversalOption,
-                                 typename VerletListsCellsHelpers<Particle>::VLCBuildType::Value buildType) = 0;
+                                 typename VerletListsCellsHelpers<Particle>::VLCBuildType buildType) = 0;
 };
 
 }  // namespace autopas

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCC01Traversal.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCC01Traversal.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "autopas/containers/cellPairTraversals/C01BasedTraversal.h"
-#include "autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCCellPairTraversalInterface.h"
 #include "autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCTraversalInterface.h"
 #include "autopas/utils/WrapOpenMP.h"
 

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCC18Traversal.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCC18Traversal.h
@@ -8,7 +8,6 @@
 
 #include "autopas/containers/cellPairTraversals/C18BasedTraversal.h"
 #include "autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsHelpers.h"
-#include "autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCCellPairTraversalInterface.h"
 #include "autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCTraversalInterface.h"
 #include "autopas/utils/WrapOpenMP.h"
 

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCCellPairC08Traversal.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCCellPairC08Traversal.h
@@ -8,7 +8,6 @@
 #include "autopas/containers/cellPairTraversals/C08BasedTraversal.h"
 #include "autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCCellPairNeighborList.h"
 #include "autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCCellPairC08CellHandler.h"
-#include "autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCTraversalInterface.h"
 #include "autopas/options/DataLayoutOption.h"
 
 namespace autopas {

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCSlicedBalancedTraversal.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCSlicedBalancedTraversal.h
@@ -11,7 +11,6 @@
 
 #include "autopas/containers/cellPairTraversals/SlicedBalancedBasedTraversal.h"
 #include "autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsHelpers.h"
-#include "autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCCellPairTraversalInterface.h"
 #include "autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCTraversalInterface.h"
 #include "autopas/utils/ThreeDimensionalMapping.h"
 #include "autopas/utils/WrapOpenMP.h"

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCSlicedC02Traversal.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCSlicedC02Traversal.h
@@ -11,7 +11,6 @@
 
 #include "autopas/containers/cellPairTraversals/SlicedC02BasedTraversal.h"
 #include "autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsHelpers.h"
-#include "autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCCellPairTraversalInterface.h"
 #include "autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCTraversalInterface.h"
 #include "autopas/utils/ThreeDimensionalMapping.h"
 #include "autopas/utils/WrapOpenMP.h"

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCSlicedTraversal.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCSlicedTraversal.h
@@ -11,7 +11,6 @@
 
 #include "autopas/containers/cellPairTraversals/SlicedLockBasedTraversal.h"
 #include "autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsHelpers.h"
-#include "autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCCellPairTraversalInterface.h"
 #include "autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCTraversalInterface.h"
 #include "autopas/utils/ThreeDimensionalMapping.h"
 #include "autopas/utils/WrapOpenMP.h"

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCTraversalInterface.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCTraversalInterface.h
@@ -110,8 +110,8 @@ class VLCTraversalInterface {
   void processCellListsImpl(VLCAllCellsNeighborList<Particle> &neighborList, unsigned long cellIndex,
                             PairwiseFunctor *pairwiseFunctor, DataLayoutOption dataLayout, bool useNewton3) {
     if (dataLayout == DataLayoutOption::aos) {
-      auto &internalList = neighborList.getAoSNeighborList();
-      for (auto &[particlePtr, neighbors] : internalList[cellIndex]) {
+      auto &aosList = neighborList.getAoSNeighborList();
+      for (auto &[particlePtr, neighbors] : aosList[cellIndex]) {
         Particle &particle = *particlePtr;
         for (auto neighborPtr : neighbors) {
           Particle &neighbor = *neighborPtr;
@@ -121,8 +121,8 @@ class VLCTraversalInterface {
     }
 
     else if (dataLayout == DataLayoutOption::soa) {
-      auto &_soaList = neighborList.getSoANeighborList();
-      for (auto &[particleIndex, neighbors] : _soaList[cellIndex]) {
+      auto &soaList = neighborList.getSoANeighborList();
+      for (auto &[particleIndex, neighbors] : soaList[cellIndex]) {
         if (not neighbors.empty()) {
           pairwiseFunctor->SoAFunctorVerlet(*_soa, particleIndex, neighbors, useNewton3);
         }
@@ -143,8 +143,8 @@ class VLCTraversalInterface {
   void processCellListsImpl(VLCCellPairNeighborList<Particle> &neighborList, unsigned long cellIndex,
                             PairwiseFunctor *pairwiseFunctor, DataLayoutOption dataLayout, bool useNewton3) {
     if (dataLayout == DataLayoutOption::aos) {
-      auto &internalList = neighborList.getAoSNeighborList();
-      for (auto &cellPair : internalList[cellIndex]) {
+      auto &aosList = neighborList.getAoSNeighborList();
+      for (auto &cellPair : aosList[cellIndex]) {
         for (auto &[particlePtr, neighbors] : cellPair) {
           Particle &particle = *particlePtr;
           for (auto neighborPtr : neighbors) {
@@ -156,9 +156,9 @@ class VLCTraversalInterface {
     }
 
     else if (dataLayout == DataLayoutOption::soa) {
-      auto &_soaList = neighborList.getSoANeighborList();
+      auto &soaList = neighborList.getSoANeighborList();
       // iterate over soa and call soaFunctorVerlet for each of the neighbor lists
-      for (auto &cellPair : _soaList[cellIndex]) {
+      for (auto &cellPair : soaList[cellIndex]) {
         for (auto &[particleIndex, neighbors] : cellPair) {
           if (not neighbors.empty()) {
             pairwiseFunctor->SoAFunctorVerlet(*_soa, particleIndex, neighbors, useNewton3);

--- a/src/autopas/iterators/ContainerIterator.h
+++ b/src/autopas/iterators/ContainerIterator.h
@@ -241,7 +241,6 @@ class ContainerIterator {
                     ParticleVecType *additionalVectorsToIterate, const std::array<double, 3> &regionMin,
                     const std::array<double, 3> &regionMax)
       : _container(&container),
-        _currentVectorIndex(0),
         _behavior(behavior),
         _vectorIndexOffset((behavior & IteratorBehavior::forceSequential) ? 1 : autopas_get_num_threads()) {
     if (additionalVectorsToIterate) {

--- a/src/autopas/options/TraversalOption.h
+++ b/src/autopas/options/TraversalOption.h
@@ -34,8 +34,8 @@ class TraversalOption : public Option<TraversalOption> {
      */
     lc_c01,
     /**
-     * LCC01Traversal : Same as LCC01Traversal but SoAs are combined into a circular buffer and the domain is traversed
-     * line-wise.
+     * LCC01CombinedSoATraversal : Same as LCC01Traversal but SoAs are combined into a circular buffer and the domain
+     * is traversed line-wise.
      */
     lc_c01_combined_SoA,
     /**
@@ -100,7 +100,8 @@ class TraversalOption : public Option<TraversalOption> {
      */
     vcl_c06,
     /**
-     * VCLClusterIterationTraversal : Schedule ClusterTower to threads.
+     * VCLClusterIterationTraversal : Dynamically schedule ClusterTower to threads.
+     * Does not support Newton3.
      */
     vcl_cluster_iteration,
     /**
@@ -152,31 +153,31 @@ class TraversalOption : public Option<TraversalOption> {
 
     // PairwiseVerletLists Traversals - same traversals as VLC but with a new name for the pairwise container
     /**
-     * VLCC01Traversal : Equivalent to LCC01Traversal. Schedules all neighbor lists of one cell at once.
+     * VLPC01Traversal : Equivalent to LCC01Traversal. Schedules all neighbor lists of one cell at once.
      * Does not support Newton3.
      */
     vlp_c01,
     /**
-     * VLCC18Traversal : Equivalent to LCC18Traversal. Neighbor lists contain only forward neighbors.
+     * VLPC18Traversal : Equivalent to LCC18Traversal. Neighbor lists contain only forward neighbors.
      */
     vlp_c18,
     /**
-     * VLCSlicedTraversal : Equivalent to LCSlicedTraversal.
+     * VLPSlicedTraversal : Equivalent to LCSlicedTraversal.
      */
     vlp_sliced,
     /**
-     * VLCSlicedBalancedTraversal : Equivalent to LCSlicedBalancedTraversal.
+     * VLPSlicedBalancedTraversal : Equivalent to LCSlicedBalancedTraversal.
      * Tries to balance slice thickness according to a given LoadEstimatorOption.
      */
     vlp_sliced_balanced,
     /**
-     * VLCSlicedC02Traversal : Equivalent to LCSlicedC02Traversal.
+     * VLPSlicedC02Traversal : Equivalent to LCSlicedC02Traversal.
      * 1D slicing with as many slices of minimal thickness as possible. No locks but two-way coloring of slices.
      */
     vlp_sliced_c02,
 
     /**
-     * VLCCellPairC08Traversal : based on LCC08Traversal.
+     * VLPCellPairC08Traversal : based on LCC08Traversal.
      * The pairwise neighbor list allows access to the relevant pairs of interacting particles for each pair of cells,
      * including the diagonal non-base pair of cells in the standard c08 step.
      */

--- a/src/autopas/tuning/AutoTuner.cpp
+++ b/src/autopas/tuning/AutoTuner.cpp
@@ -13,7 +13,6 @@
 
 #include "autopas/tuning/selectors/OptimumSelector.h"
 #include "autopas/tuning/tuningStrategy/MPIParallelizedStrategy.h"
-#include "autopas/tuning/tuningStrategy/TuningStrategyLogger.h"
 #include "autopas/tuning/utils/Smoothing.h"
 #include "autopas/utils/ArrayUtils.h"
 #include "autopas/utils/ExceptionHandler.h"

--- a/src/autopas/tuning/selectors/ContainerSelector.h
+++ b/src/autopas/tuning/selectors/ContainerSelector.h
@@ -128,7 +128,7 @@ std::unique_ptr<autopas::ParticleContainerInterface<Particle>> ContainerSelector
       container = std::make_unique<VerletListsCells<Particle, VLCAllCellsNeighborList<Particle>>>(
           _boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep, containerInfo.verletRebuildFrequency,
           containerInfo.cellSizeFactor, containerInfo.loadEstimator,
-          VerletListsCellsHelpers<Particle>::VLCBuildType::Value::soaBuild);
+          VerletListsCellsHelpers<Particle>::VLCBuildType::soaBuild);
       break;
     }
     case ContainerOption::verletClusterLists: {
@@ -148,7 +148,7 @@ std::unique_ptr<autopas::ParticleContainerInterface<Particle>> ContainerSelector
       container = std::make_unique<VerletListsCells<Particle, VLCCellPairNeighborList<Particle>>>(
           _boxMin, _boxMax, _cutoff, containerInfo.verletSkinPerTimestep, containerInfo.verletRebuildFrequency,
           containerInfo.cellSizeFactor, containerInfo.loadEstimator,
-          VerletListsCellsHelpers<Particle>::VLCBuildType::Value::soaBuild);
+          VerletListsCellsHelpers<Particle>::VLCBuildType::soaBuild);
       break;
     }
     case ContainerOption::octree: {

--- a/src/autopas/utils/logging/IterationLogger.cpp
+++ b/src/autopas/utils/logging/IterationLogger.cpp
@@ -15,7 +15,7 @@ autopas::IterationLogger::IterationLogger(const std::string &outputSuffix)
   const auto outputFileName("AutoPas_iterationPerformance_" + outputSuffix + fillerAfterSuffix +
                             utils::Timer::getDateStamp() + ".csv");
   // Start of workaround: Because we want to use an asynchronous logger we can't quickly switch patterns for the header.
-  // Create and register a non-asychronous logger to write the header.
+  // Create and register a non-asynchronous logger to write the header.
   const auto headerLoggerName = _loggerName + "header";
   auto headerLogger = spdlog::basic_logger_mt(headerLoggerName, outputFileName);
   // set the pattern to the message only

--- a/src/autopas/utils/logging/Logger.h
+++ b/src/autopas/utils/logging/Logger.h
@@ -14,30 +14,6 @@
 
 #include <iostream>
 
-#ifdef AUTOPAS_VERBOSE_LOG
-/**
- * Helper Macro to get only the basename
- */
-#define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
-
-/**
- * Macro for logging providing common meta information.
- * @param lvl Possible levels: trace, debug, info, warn, error, critical.
- * @param fmt Message with formatting tokens
- * @param ... Formatting arguments
- */
-#define AutoPasLog(lvl, fmt, ...)                                        \
-  {                                                                      \
-    size_t textwidth = 35; /* If filenames get cropped increase this! */ \
-    std::string s;                                                       \
-    s.reserve(textwidth);                                                \
-    s.append(__FILENAME__);                                              \
-    s.append(":");                                                       \
-    s.append(std::to_string(__LINE__));                                  \
-    s.resize(textwidth, ' ');                                            \
-    spdlog::get("AutoPasLog")->lvl("[{}] " fmt, s, ##__VA_ARGS__);       \
-  }
-#else
 /**
  * Macro for logging providing common meta information without filename.
  * @param lvl Possible levels: trace, debug, info, warn, error, critical.
@@ -46,7 +22,6 @@
  * @note A ';' is enforced at the end of the macro.
  */
 #define AutoPasLog(lvl, fmt, ...) SPDLOG_LOGGER_##lvl(spdlog::get("AutoPasLog"), fmt, ##__VA_ARGS__)
-#endif
 
 namespace autopas {
 /**

--- a/src/autopas/utils/logging/PredictionLogger.cpp
+++ b/src/autopas/utils/logging/PredictionLogger.cpp
@@ -15,7 +15,7 @@ autopas::PredictionLogger::PredictionLogger(const std::string &outputSuffix)
   auto outputFileName("AutoPas_predictions_" + outputSuffix + fillerAfterSuffix + utils::Timer::getDateStamp() +
                       ".csv");
   // Start of workaround: Because we want to use an asynchronous logger we can't quickly switch patterns for the header.
-  // create and register a non-asychronous logger to write the header
+  // create and register a non-asynchronous logger to write the header
   auto headerLoggerName = _loggerName + "header";
   auto headerLogger = spdlog::basic_logger_mt(headerLoggerName, outputFileName);
   // set the pattern to the message only

--- a/src/autopas/utils/logging/TuningDataLogger.cpp
+++ b/src/autopas/utils/logging/TuningDataLogger.cpp
@@ -14,7 +14,7 @@ autopas::TuningDataLogger::TuningDataLogger(size_t numSamples, const std::string
   const auto *fillerAfterSuffix = outputSuffix.empty() or outputSuffix.back() == '_' ? "" : "_";
   auto outputFileName("AutoPas_tuningData_" + outputSuffix + fillerAfterSuffix + utils::Timer::getDateStamp() + ".csv");
   // Start of workaround: Because we want to use an asynchronous logger we can't quickly switch patterns for the header.
-  // create and register a non-asychronous logger to write the header
+  // create and register a non-asynchronous logger to write the header
   auto headerLoggerName = _loggerName + "header";
   auto headerLogger = spdlog::basic_logger_mt(headerLoggerName, outputFileName);
   // set the pattern to the message only

--- a/src/autopas/utils/logging/TuningDataLogger.cpp
+++ b/src/autopas/utils/logging/TuningDataLogger.cpp
@@ -6,6 +6,8 @@
 
 #include "TuningDataLogger.h"
 
+#include <spdlog/async.h>
+
 #include "utils/Timer.h"
 
 autopas::TuningDataLogger::TuningDataLogger(size_t numSamples, const std::string &outputSuffix)

--- a/src/autopas/utils/logging/TuningDataLogger.h
+++ b/src/autopas/utils/logging/TuningDataLogger.h
@@ -6,8 +6,6 @@
 
 #pragma once
 
-#include <spdlog/async.h>
-
 #include "autopas/tuning/Configuration.h"
 
 namespace autopas {

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/PairwiseVerletListsTest.h
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/PairwiseVerletListsTest.h
@@ -20,7 +20,7 @@
 class PairwiseVerletListsTest
     : public AutoPasTestBase,
       public ::testing::WithParamInterface<
-          std::tuple<double, bool, autopas::VerletListsCellsHelpers<Particle>::VLCBuildType::Value>> {
+          std::tuple<double, bool, autopas::VerletListsCellsHelpers<Particle>::VLCBuildType>> {
  public:
   struct PrintToStringParamName {
     template <class ParamType>
@@ -38,7 +38,7 @@ class PairwiseVerletListsTest
       }
     }
 
-    std::string buildTypeToString(autopas::VerletListsCellsHelpers<Particle>::VLCBuildType::Value buildType) const {
+    std::string buildTypeToString(autopas::VerletListsCellsHelpers<Particle>::VLCBuildType buildType) const {
       if (buildType == autopas::VerletListsCellsHelpers<Particle>::VLCBuildType::soaBuild) {
         return "buildSoA";
       } else {

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/VerletListsCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/VerletListsCellsTest.cpp
@@ -62,8 +62,7 @@ void applyFunctor(MockFunctor<Particle> &functor, const double cellSizefactor,
  * Fills an AoS and an SoA list with particles, executes one iteration
  * and compares the positions of each pair of corresponding particles.
  * */
-void soaTest(const double cellSizeFactor,
-             autopas::VerletListsCellsHelpers<Particle>::VLCBuildType oldBuildType) {
+void soaTest(const double cellSizeFactor, autopas::VerletListsCellsHelpers<Particle>::VLCBuildType oldBuildType) {
   const double cutoff = 2.;
   const autopas::LoadEstimatorOption loadEstimator = autopas::LoadEstimatorOption::none;
   std::array<double, 3> min = {0, 0, 0};

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/VerletListsCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/VerletListsCellsTest.cpp
@@ -20,7 +20,7 @@ using ::testing::_;
 using ::testing::AtLeast;
 
 void applyFunctor(MockFunctor<Particle> &functor, const double cellSizefactor,
-                  autopas::VerletListsCellsHelpers<Particle>::VLCBuildType::Value buildType) {
+                  autopas::VerletListsCellsHelpers<Particle>::VLCBuildType buildType) {
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
@@ -63,7 +63,7 @@ void applyFunctor(MockFunctor<Particle> &functor, const double cellSizefactor,
  * and compares the positions of each pair of corresponding particles.
  * */
 void soaTest(const double cellSizeFactor,
-             autopas::VerletListsCellsHelpers<Particle>::VLCBuildType::Value oldBuildType) {
+             autopas::VerletListsCellsHelpers<Particle>::VLCBuildType oldBuildType) {
   const double cutoff = 2.;
   const autopas::LoadEstimatorOption loadEstimator = autopas::LoadEstimatorOption::none;
   std::array<double, 3> min = {0, 0, 0};


### PR DESCRIPTION
# Description

Collection of annoyances I stumbled upon while reading the code.

- [x] renamings
- [x] Change `class` `VLCBuildType` that only contains an `enum` to an `enum class`
- [x] Remove unused and now redundant option `AUTOPAS_VERBOSE_LOGGING`
- [x] Remove warning that is not valid anymore.
