### PR TITLE
Ignore Wiping Tuning Strategies

### DIFF
--- a/src/autopas/tuning/AutoTuner.cpp
+++ b/src/autopas/tuning/AutoTuner.cpp
@@ -24,7 +24,6 @@ AutoTuner::AutoTuner(TuningStrategiesListType &tuningStrategies, const SearchSpa
                      const AutoTunerInfo &autoTunerInfo, unsigned int rebuildFrequency, const std::string &outputSuffix)
     : _selectorStrategy(autoTunerInfo.selectorStrategy),
       _tuningStrategies(std::move(tuningStrategies)),
-      _iteration(0),
       _tuningInterval(autoTunerInfo.tuningInterval),
       _iterationsSinceTuning(autoTunerInfo.tuningInterval),  // init to max so that tuning happens in first iteration
       _tuningMetric(autoTunerInfo.tuningMetric),

--- a/tests/testAutopas/tests/tuning/AutoTunerTest.cpp
+++ b/tests/testAutopas/tests/tuning/AutoTunerTest.cpp
@@ -16,6 +16,8 @@
 #include "autopas/options/ContainerOption.h"
 #include "autopas/tuning/AutoTuner.h"
 #include "autopas/tuning/Configuration.h"
+#include "autopas/tuning/tuningStrategy/SlowConfigFilter.h"
+#include "autopas/tuning/tuningStrategy/SortByName.h"
 #include "autopas/tuning/utils/AutoTunerInfo.h"
 #include "autopas/tuning/utils/SearchSpaceGenerators.h"
 #include "autopas/utils/WrapOpenMP.h"
@@ -648,4 +650,38 @@ TEST_F(AutoTunerTest, testSampleWeightingTwoRebuild) {
   constexpr long expectedEvidence =
       (sampleWithRebuild + (rebuildFrequency - 1) * sampleWithoutRebuild) / rebuildFrequency;
   EXPECT_EQ(expectedEvidence, autoTuner.getEvidenceCollection().getEvidence(config)->front().value);
+}
+
+/**
+ * Test that if a tuning strategy wipes the whole config queue it is not applied.
+ */
+TEST_F(AutoTunerTest, testRestoreAfterWipe) {
+  // Create a tuning strategy that will always reject everything
+  autopas::AutoTuner::TuningStrategiesListType tuningStrategies{};
+  // This strategy will throw out all configurations that are slower than 50% of the fastest
+  // (incl. fastest, yes this is bug abuse)
+  tuningStrategies.emplace_back(std::make_unique<autopas::SlowConfigFilter>(0.5));
+  tuningStrategies.emplace_back(std::make_unique<autopas::SortByName>());
+
+  // Set up the tuner
+  const autopas::AutoTuner::SearchSpaceType searchSpace{_confLc_c08_noN3, _confLc_c01_noN3};
+  const autopas::AutoTunerInfo autoTunerInfo{
+      .maxSamples = 1,
+  };
+  constexpr size_t rebuildFrequency = 3;
+  autopas::AutoTuner autoTuner{tuningStrategies, searchSpace, autoTunerInfo, rebuildFrequency, ""};
+
+  // Fill the search space with random data so the slow config filter can work
+  for (const auto conf : searchSpace) {
+    const auto iDontCare = autoTuner.getNextConfig();
+    autoTuner.addMeasurement(42, true);
+  }
+
+  // Trigger the tuning process with evidence. Here the slow config filter would wipe out everything
+  const auto iDontCare = autoTuner.getNextConfig();
+
+  // The slow config filter should have been ignored
+  // But the second strategy should still have been applied reversing the order of configs
+  EXPECT_EQ(autoTuner.getConfigQueue()[0], _confLc_c01_noN3);
+  EXPECT_EQ(autoTuner.getConfigQueue()[1], _confLc_c08_noN3);
 }


### PR DESCRIPTION
# Description

Sometimes, tuning strategies might wipe all available tuning strategies from the queue, resulting in an error. This PR introduces a mechanism in which the queue is reset to the state before the wipe, effectively ignoring this tuning strategy for this one tuning phase.

## ~Related Pull Requests~

## ~Resolved Issues~

# How Has This Been Tested?

- [x] New Test
