### PR TITLE
Refactor RuleBasedTuning class to avoid unused variable warnings.

### DIFF
--- a/src/autopas/tuning/tuningStrategy/ruleBasedTuning/RuleBasedTuning.cpp
+++ b/src/autopas/tuning/tuningStrategy/ruleBasedTuning/RuleBasedTuning.cpp
@@ -12,20 +12,21 @@ namespace autopas {
 
 RuleBasedTuning::RuleBasedTuning(const std::set<Configuration> &searchSpace, bool verifyModeEnabled,
                                  std::string ruleFileName, RuleBasedTuning::PrintTuningErrorFunType tuningErrorPrinter)
-    : _searchSpace(searchSpace),
-      _originalSearchSpace(searchSpace.begin(), searchSpace.end()),
-      _verifyModeEnabled(verifyModeEnabled),
-      _ruleFileName(std::move(ruleFileName)),
-      _tuningErrorPrinter(std::move(tuningErrorPrinter)) {
 #ifdef AUTOPAS_ENABLE_RULES_BASED_TUNING
+    : _verifyModeEnabled(verifyModeEnabled),
+      _tuningErrorPrinter(std::move(tuningErrorPrinter)),
+      _searchSpace(searchSpace),
+      _originalSearchSpace(searchSpace.begin(), searchSpace.end()),
+      _ruleFileName(std::move(ruleFileName)) {
   // Check if the given rule file exists and throw if not
-  struct stat buffer;
+  struct stat buffer {};
   if (stat(_ruleFileName.c_str(), &buffer) != 0) {
     utils::ExceptionHandler::exception("Rule file {} does not exist!", _ruleFileName);
   }
   // By default, dump the rules for reproducibility reasons.
   AutoPasLog(INFO, "Rule File {}:\n{}", _ruleFileName, rulesToString(_ruleFileName));
 #else
+{
   autopas::utils::ExceptionHandler::exception(
       "RuleBasedTuning constructed but AUTOPAS_ENABLE_RULES_BASED_TUNING=OFF! ");
 #endif

--- a/src/autopas/tuning/tuningStrategy/ruleBasedTuning/RuleBasedTuning.h
+++ b/src/autopas/tuning/tuningStrategy/ruleBasedTuning/RuleBasedTuning.h
@@ -160,31 +160,33 @@ class RuleBasedTuning : public TuningStrategyInterface {
 
   std::vector<rule_syntax::ConfigurationOrder> _lastApplicableConfigurationOrders{};
 
-#endif
+  // The following member variables are only conditionally compiled to avoid warnings about unused variables.
 
-  std::set<Configuration> _searchSpace;
-  const std::list<Configuration> _originalSearchSpace;
-  std::set<Configuration> _removedConfigurations;
-
-  bool _verifyModeEnabled;
-  std::string _ruleFileName;
-
-  std::unordered_map<Configuration, long, ConfigHash> _traversalTimes{};
+  bool _verifyModeEnabled{};
   /**
    * Sum of all evidence since the last reset. This, times the number of samples, is approximately the time spent
    * trying out configurations.
    */
   long _tuningTime{0};
   long _wouldHaveSkippedTuningTime{0};
-  long _tuningTimeLifetime{0};
-  long _wouldHaveSkippedTuningTimeLifetime{0};
   /**
    * If the rules would immediately remove all options deactivate the whole strategy until the next reset.
    */
   bool _rulesTooHarsh{false};
+  PrintTuningErrorFunType _tuningErrorPrinter{};
+#endif
 
-  PrintTuningErrorFunType _tuningErrorPrinter;
+  std::set<Configuration> _searchSpace{};
+  std::list<Configuration> _originalSearchSpace{};
+  std::set<Configuration> _removedConfigurations{};
 
-  LiveInfo _currentLiveInfo;
+  std::string _ruleFileName{};
+
+  std::unordered_map<Configuration, long, ConfigHash> _traversalTimes{};
+
+  long _tuningTimeLifetime{0};
+  long _wouldHaveSkippedTuningTimeLifetime{0};
+
+  LiveInfo _currentLiveInfo{};
 };
 }  // namespace autopas


### PR DESCRIPTION
# Description

When AutoPas is compiled with Clang and without RuleBasedTuining, the compiler complains about some unused variables.

- [x] Move unused variables inside `ifdef` to avoid compilation
- [x] Accordingly, adapt initialization order in the constructor
- [x] Make initialization in the constructor also conditional
- [x] Add default initializations.

Please include a summary of the changes.

## Related Pull Requests

- #866 

## ~Resolved Issues~

# How Has This Been Tested?

- [x] Compiled with clang without rule based tuning -> no warnings
