### PR TITLE
Fix calculate homogeneity and max density

### DIFF
--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -186,10 +186,6 @@ void Simulation::finalize() {
 }
 
 void Simulation::run() {
-  _homogeneity =
-      autopas::utils::calculateHomogeneityAndMaxDensity(*_autoPasContainer, _domainDecomposition->getGlobalBoxMin(),
-                                                        _domainDecomposition->getGlobalBoxMax())
-          .first;
   _timers.simulate.start();
   while (needsMoreIterations()) {
     if (_createVtkFiles and _iteration % _configuration.vtkWriteFrequency.value == 0) {
@@ -498,18 +494,11 @@ void Simulation::logSimulationState() {
   autopas::AutoPas_MPI_Allreduce(&particleCount, &haloParticles, 1, AUTOPAS_MPI_UNSIGNED_LONG, AUTOPAS_MPI_SUM,
                                  AUTOPAS_MPI_COMM_WORLD);
 
-  double squaredHomogeneity = _homogeneity * _homogeneity;
-  double standardDeviationOfHomogeneity{};
-  autopas::AutoPas_MPI_Allreduce(&squaredHomogeneity, &standardDeviationOfHomogeneity, 1, AUTOPAS_MPI_DOUBLE,
-                                 AUTOPAS_MPI_SUM, AUTOPAS_MPI_COMM_WORLD);
-  standardDeviationOfHomogeneity = std::sqrt(standardDeviationOfHomogeneity);
-
   if (_domainDecomposition->getDomainIndex() == 0) {
     std::cout << "\n\n"
               << "Total number of particles at the end of Simulation: " << totalNumberOfParticles << "\n"
               << "Owned: " << ownedParticles << "\n"
-              << "Halo : " << haloParticles << "\n"
-              << "Standard Deviation of Homogeneity: " << standardDeviationOfHomogeneity << std::endl;
+              << "Halo : " << haloParticles << std::endl;
   }
 }
 

--- a/examples/md-flexible/src/Simulation.h
+++ b/examples/md-flexible/src/Simulation.h
@@ -102,11 +102,6 @@ class Simulation {
   constexpr static auto _floatStringPrecision = 3;
 
   /**
-   * Homogeneity of the scenario, calculated by the standard deviation of the density.
-   */
-  double _homogeneity = 0;
-
-  /**
    * Struct containing all timers used for the simulation.
    */
   struct Timers {

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -1105,7 +1105,7 @@ std::tuple<Configuration, std::unique_ptr<TraversalInterface>, bool> LogicHandle
       timerCalculateHomogeneity.start();
       const auto &container = _containerSelector.getCurrentContainer();
       const auto [homogeneity, maxDensity] =
-          autopas::utils::calculateHomogeneityAndMaxDensity(container, container.getBoxMin(), container.getBoxMax());
+          autopas::utils::calculateHomogeneityAndMaxDensity(container);
       timerCalculateHomogeneity.stop();
       _autoTuner.addHomogeneityAndMaxDensity(homogeneity, maxDensity, timerCalculateHomogeneity.getTotalTime());
     }

--- a/src/autopas/utils/SimilarityFunctions.h
+++ b/src/autopas/utils/SimilarityFunctions.h
@@ -49,6 +49,7 @@ std::pair<double, double> calculateHomogeneityAndMaxDensity(const ParticleContai
   const auto domainVolume = domainDimensions[0] * domainDimensions[1] * domainDimensions[2];
 
   // We scale the dimensions of the domain to bins with volumes which give approximately 10 particles per bin.
+  // Todo The choice of 10 is arbitrary and probably can be optimized
   const auto targetNumberOfBins = std::ceil(numberOfParticles / 10.);
   const auto targetNumberOfBinsPerDim = std::cbrt(static_cast<double>(targetNumberOfBins));
   // This is probably not an integer, so we floor to get more than 10 particles per bin than too small bins
@@ -100,7 +101,8 @@ std::pair<double, double> calculateHomogeneityAndMaxDensity(const ParticleContai
   const double homogeneity = std::sqrt(densityVariance);
   // normally between 0.0 and 1.5
   if (homogeneity < 0.0) {
-    throw std::runtime_error("homogeneity can never be smaller than 0.0, but is:" + std::to_string(homogeneity));
+    utils::ExceptionHandler::exception(
+        "calculateHomogeneityAndMaxDensity(): homogeneity can never be smaller than 0.0, but is: {}", homogeneity);
   }
   return {homogeneity, maxDensity};
 }

--- a/src/autopas/utils/SimilarityFunctions.h
+++ b/src/autopas/utils/SimilarityFunctions.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "ThreeDimensionalMapping.h"
-#include "autopas/AutoPasDecl.h"
 #include "autopas/containers/ParticleContainerInterface.h"
 #include "autopas/utils/ArrayMath.h"
 #include "autopas/utils/WrapMPI.h"
@@ -42,7 +41,7 @@ namespace autopas::utils {
  * @return {homogeneity, maxDensity}
  */
 template <typename Particle>
-std::pair<double, double> calculateHomogeneityAndMaxDensity(const AutoPas<Particle> &container) {
+std::pair<double, double> calculateHomogeneityAndMaxDensity(const ParticleContainerInterface<Particle> &container) {
   using namespace autopas::utils::ArrayMath::literals;
 
   const auto numberOfParticles = container.getNumberOfParticles();

--- a/src/autopas/utils/SimilarityFunctions.h
+++ b/src/autopas/utils/SimilarityFunctions.h
@@ -77,7 +77,7 @@ std::pair<double, double> calculateHomogeneityAndMaxDensity(const ParticleContai
   std::vector<double> densityPerBin{};
   densityPerBin.reserve(numberOfBins);
   for (size_t i = 0; i < numberOfBins; i++) {
-    densityPerBin[i] = static_cast<double>(particlesPerBin[i]) / binVolume;
+    densityPerBin.push_back(static_cast<double>(particlesPerBin[i]) / binVolume);
     maxDensity = std::max(maxDensity, densityPerBin[i]);
   }
 

--- a/src/autopas/utils/SimilarityFunctions.h
+++ b/src/autopas/utils/SimilarityFunctions.h
@@ -88,15 +88,11 @@ std::pair<double, double> calculateHomogeneityAndMaxDensity(const ParticleContai
   // get mean and reserve variable for densityVariance
   const double densityMean = numberOfParticles / domainVolume;
 
-
-  const double densityDifferenceSquaredSum = std::transform_reduce(
-        densityPerBin.begin(), densityPerBin.end(), 0.0,
-        std::plus<>(),
-        [densityMean](double density) {
-            double densityDifference = density - densityMean;
-            return densityDifference * densityDifference;
-        }
-    );
+  const double densityDifferenceSquaredSum = std::transform_reduce(densityPerBin.begin(), densityPerBin.end(), 0.0,
+                                                                   std::plus<>(), [densityMean](double density) {
+                                                                     double densityDifference = density - densityMean;
+                                                                     return densityDifference * densityDifference;
+                                                                   });
 
   const auto densityVariance = densityDifferenceSquaredSum / numberOfBins;
 

--- a/src/autopas/utils/SimilarityFunctions.h
+++ b/src/autopas/utils/SimilarityFunctions.h
@@ -27,7 +27,7 @@ namespace autopas::utils {
  * Not a rigorous proof, but should give an idea:
  * - Assume homogeneous distribution.
  * - For every particle assume it could move in any direction with equal probability (not a terrible assumption).
- * - So every particle near a bin face has a chance to more into the neighboring bin.
+ * - So every particle near a bin face has a chance to move into the neighboring bin.
  * - And this probability is independent of the bin (i.e. the bin shape)
  * - With a larger surface area, there are more particles with a probability of moving into the neighboring bin.
  * - On average, same density, but each individual bin has a greater probability of losing or gaining a lot of
@@ -54,12 +54,12 @@ std::pair<double, double> calculateHomogeneityAndMaxDensity(const Container &con
 
   // We scale the dimensions of the domain to bins with volumes which give approximately 10 particles per bin.
   const auto targetNumberOfBins = std::ceil(numberOfParticles / 10.);
-  const auto targetNumberOfBinsPerDim = std::cbrt((double)targetNumberOfBins);
+  const auto targetNumberOfBinsPerDim = std::cbrt(static_cast<double>(targetNumberOfBins));
   // This is probably not an integer, so we floor to get more than 10 particles per bin than too small bins
   const auto numberOfBinsPerDim = static_cast<int>(std::floor(targetNumberOfBinsPerDim));
   const auto numberOfBins = numberOfBinsPerDim * numberOfBinsPerDim * numberOfBinsPerDim;
-  const auto binVolume = domainVolume / (double)numberOfBins;
-  const auto binDimensions = domainDimensions / (double)numberOfBinsPerDim;
+  const auto binVolume = domainVolume / static_cast<double>(numberOfBins);
+  const auto binDimensions = domainDimensions / static_cast<double>(numberOfBinsPerDim);
 
   // Calculate the actual number of bins per dimension. The rounding is needed in case the division slightly
   // underestimates the division. The choice of dimension 0 is arbitrary.
@@ -80,10 +80,10 @@ std::pair<double, double> calculateHomogeneityAndMaxDensity(const Container &con
 
   // calculate density for each bin and track max density
   double maxDensity{0.};
-  std::vector<double> densityPerBin;
+  std::vector<double> densityPerBin{};
   densityPerBin.reserve(numberOfBins);
   for (size_t i = 0; i < numberOfBins; i++) {
-    densityPerBin[i] = (double)particlesPerBin[i] / binVolume;
+    densityPerBin[i] = static_cast<double>(particlesPerBin[i]) / binVolume;
     if (densityPerBin[i] > maxDensity) {
       maxDensity = densityPerBin[i];
     }

--- a/src/autopas/utils/SimilarityFunctions.h
+++ b/src/autopas/utils/SimilarityFunctions.h
@@ -8,8 +8,8 @@
 
 #include "ThreeDimensionalMapping.h"
 #include "autopas/containers/ParticleContainerInterface.h"
-#include "autopas/utils/WrapMPI.h"
 #include "autopas/utils/ArrayMath.h"
+#include "autopas/utils/WrapMPI.h"
 
 namespace autopas::utils {
 
@@ -21,8 +21,8 @@ namespace autopas::utils {
  *
  * These values are calculated by dividing the domain into bins of perfectly equal cuboid shapes.
  *
- * @note The bin shapes between different AutoPas container will not match if the dimensions of their domains don't match.
- * Bins with greater surface area are probably more likely to feature fluctuations in the density.
+ * @note The bin shapes between different AutoPas container will not match if the dimensions of their domains don't
+ * match. Bins with greater surface area are probably more likely to feature fluctuations in the density.
  *
  * Not a rigorous proof, but should give an idea:
  * - Assume homogeneous distribution.
@@ -30,9 +30,11 @@ namespace autopas::utils {
  * - So every particle near a bin face has a chance to more into the neighboring bin.
  * - And this probability is independent of the bin (i.e. the bin shape)
  * - With a larger surface area, there are more particles with a probability of moving into the neighboring bin.
- * - On average, same density, but each individual bin has a greater probability of losing or gaining a lot of particles.
+ * - On average, same density, but each individual bin has a greater probability of losing or gaining a lot of
+ * particles.
  *
- * This is probably still fine for MPI Parallelized Tuning purposes, but be careful with comparing homogeneities and densities.
+ * This is probably still fine for MPI Parallelized Tuning purposes, but be careful with comparing homogeneities and
+ * densities.
  *
  * @tparam Particle
  * @param container container of current simulation
@@ -59,7 +61,6 @@ std::pair<double, double> calculateHomogeneityAndMaxDensity(const Container &con
   const auto binVolume = domainVolume / (double)numberOfBins;
   const auto binDimensions = domainDimensions / (double)numberOfBinsPerDim;
 
-
   // Calculate the actual number of bins per dimension. The rounding is needed in case the division slightly
   // underestimates the division. The choice of dimension 0 is arbitrary.
   const int binsPerDimension = static_cast<int>(std::round(domainDimensions[0] / binDimensions[0]));
@@ -70,8 +71,9 @@ std::pair<double, double> calculateHomogeneityAndMaxDensity(const Container &con
   for (auto particleItr = container.begin(autopas::IteratorBehavior::owned); particleItr.isValid(); ++particleItr) {
     const auto &particleLocation = particleItr->getR();
 
-    const auto binIndex3d = autopas::utils::ArrayMath::floorToInt((particleLocation-startCorner)/binDimensions);
-    const auto binIndex1d = autopas::utils::ThreeDimensionalMapping::threeToOneD(binIndex3d, {binsPerDimension, binsPerDimension, binsPerDimension});
+    const auto binIndex3d = autopas::utils::ArrayMath::floorToInt((particleLocation - startCorner) / binDimensions);
+    const auto binIndex1d = autopas::utils::ThreeDimensionalMapping::threeToOneD(
+        binIndex3d, {binsPerDimension, binsPerDimension, binsPerDimension});
 
     particlesPerBin[binIndex1d] += 1;
   }

--- a/src/autopas/utils/SimilarityFunctions.h
+++ b/src/autopas/utils/SimilarityFunctions.h
@@ -88,24 +88,17 @@ std::pair<double, double> calculateHomogeneityAndMaxDensity(const ParticleContai
   // get mean and reserve variable for densityVariance
   const double densityMean = numberOfParticles / domainVolume;
 
-  double densityVariance{0.};
-  for (size_t i = 0; i < numberOfBins; ++i) {
-    const double densityDifference = densityPerBin[i] - densityMean;
-    densityVariance += (densityDifference * densityDifference);
-  }
 
-  /*
-    double densityVariance = std::transform_reduce(
-          densityPerBin.begin(), densityPerBin.end(), 0.0,
-          std::plus<>(),
-          [densityMean](double density) {
-              double densityDifference = density - densityMean;
-              return densityDifference * densityDifference;
-          }
-      );
-  */
-  densityVariance = densityVariance / numberOfBins;
-  std::cout << densityVariance << "\n";
+  const double densityDifferenceSquaredSum = std::transform_reduce(
+        densityPerBin.begin(), densityPerBin.end(), 0.0,
+        std::plus<>(),
+        [densityMean](double density) {
+            double densityDifference = density - densityMean;
+            return densityDifference * densityDifference;
+        }
+    );
+
+  const auto densityVariance = densityDifferenceSquaredSum / numberOfBins;
 
   // finally calculate standard deviation
   const double homogeneity = std::sqrt(densityVariance);

--- a/src/autopas/utils/SimilarityFunctions.h
+++ b/src/autopas/utils/SimilarityFunctions.h
@@ -50,10 +50,13 @@ std::pair<double, double> calculateHomogeneityAndMaxDensity(const Container &con
   const auto domainVolume = domainDimensions[0] * domainDimensions[1] * domainDimensions[2];
 
   // We scale the dimensions of the domain to bins with volumes which give approximately 10 particles per bin.
-  const auto numberOfBins = std::ceil(numberOfParticles / 10.);
+  const auto targetNumberOfBins = std::ceil(numberOfParticles / 10.);
+  const auto targetNumberOfBinsPerDim = std::cbrt((double)targetNumberOfBins);
+  // This is probably not an integer, so we floor to get more than 10 particles per bin than too small bins
+  const auto numberOfBinsPerDim = static_cast<int>(std::floor(targetNumberOfBinsPerDim));
+  const auto numberOfBins = numberOfBinsPerDim * numberOfBinsPerDim * numberOfBinsPerDim;
   const auto binVolume = domainVolume / (double)numberOfBins;
-  const auto scalingFactor = binVolume / domainVolume;
-  const auto binDimensions = domainDimensions * scalingFactor;
+  const auto binDimensions = domainDimensions / (double)numberOfBinsPerDim;
 
 
   // Calculate the actual number of bins per dimension. The rounding is needed in case the division slightly

--- a/src/autopas/utils/ThreeDimensionalMapping.h
+++ b/src/autopas/utils/ThreeDimensionalMapping.h
@@ -41,7 +41,7 @@ constexpr T threeToOneD(T x, T y, T z, const std::array<T, 3> &dims) {
 template <typename T>
 constexpr T threeToOneD(const std::array<T, 3> &index3d, const std::array<T, 3> &dims) {
   static_assert(std::is_integral<T>::value, "threeToOneD requires integral types");
-  return (index3d[2] * dims[1] + index3d[1]) * dims[0] + index3d[0];
+  return index3d[2] * dims[1] * dims[0] + index3d[1] * dims[0] + index3d[0];
 }
 
 /**
@@ -52,12 +52,12 @@ constexpr T threeToOneD(const std::array<T, 3> &index3d, const std::array<T, 3> 
  * @return The 3d index.
  */
 template <typename T>
-constexpr std::array<T, 3> oneToThreeD(T ind, const std::array<T, 3> &dims) {
+constexpr std::array<size_t, 3> oneToThreeD(T ind, const std::array<T, 3> &dims) {
   static_assert(std::is_integral<T>::value, "oneToThreeD requires integral types");
   std::array<T, 3> pos{};
-  pos[2] = ind / (dims[0] * dims[1]);
-  pos[1] = (ind - pos[2] * dims[0] * dims[1]) / dims[0];
-  pos[0] = ind - dims[0] * (pos[1] + dims[1] * pos[2]);
+  pos[2] = static_cast<size_t>(ind / (dims[0] * dims[1]));
+  pos[1] = static_cast<size_t>((ind % (dims[0] * dims[1])) / dims[0]);
+  pos[0] = static_cast<size_t>(ind % dims[0]);
   return pos;
 }
 

--- a/src/autopas/utils/ThreeDimensionalMapping.h
+++ b/src/autopas/utils/ThreeDimensionalMapping.h
@@ -41,7 +41,7 @@ constexpr T threeToOneD(T x, T y, T z, const std::array<T, 3> &dims) {
 template <typename T>
 constexpr T threeToOneD(const std::array<T, 3> &index3d, const std::array<T, 3> &dims) {
   static_assert(std::is_integral<T>::value, "threeToOneD requires integral types");
-  return index3d[2] * dims[1] * dims[0] + index3d[1] * dims[0] + index3d[0];
+  return (index3d[2] * dims[1] + index3d[1]) * dims[0] + index3d[0];
 }
 
 /**
@@ -52,12 +52,12 @@ constexpr T threeToOneD(const std::array<T, 3> &index3d, const std::array<T, 3> 
  * @return The 3d index.
  */
 template <typename T>
-constexpr std::array<size_t, 3> oneToThreeD(T ind, const std::array<T, 3> &dims) {
+constexpr std::array<T, 3> oneToThreeD(T ind, const std::array<T, 3> &dims) {
   static_assert(std::is_integral<T>::value, "oneToThreeD requires integral types");
   std::array<T, 3> pos{};
-  pos[2] = static_cast<size_t>(ind / (dims[0] * dims[1]));
-  pos[1] = static_cast<size_t>((ind % (dims[0] * dims[1])) / dims[0]);
-  pos[0] = static_cast<size_t>(ind % dims[0]);
+  pos[2] = ind / (dims[0] * dims[1]);
+  pos[1] = (ind - pos[2] * dims[0] * dims[1]) / dims[0];
+  pos[0] = ind - dims[0] * (pos[1] + dims[1] * pos[2]);
   return pos;
 }
 

--- a/tests/testAutopas/tests/utils/SimilarityFunctionsTest.cpp
+++ b/tests/testAutopas/tests/utils/SimilarityFunctionsTest.cpp
@@ -1,23 +1,25 @@
 /**
-* @file SimilarityFunctionsTest.cpp
-* @author S. Newcome
-* @date 06/06/2024
+ * @file SimilarityFunctionsTest.cpp
+ * @author S. Newcome
+ * @date 06/06/2024
  */
+
+#include <gtest/gtest.h>
 
 #include <algorithm>
 #include <iterator>
 #include <vector>
 
-#include <gtest/gtest.h>
 #include "autopas/AutoPasDecl.h"
-#include "testingHelpers/commonTypedefs.h"
-#include "autopas/utils/ThreeDimensionalMapping.h"
 #include "autopas/utils/SimilarityFunctions.h"
+#include "autopas/utils/ThreeDimensionalMapping.h"
+#include "testingHelpers/commonTypedefs.h"
 
 /**
  * Test calculateHomogeneityAndMaxDensity by
  * - creating a container with 88 particles, such that there are 8 bins
- * - using 88 particles, gives 11 particles per bin, testing handling of non-perfectly-divisible-by-10 numbers of particles.
+ * - using 88 particles, gives 11 particles per bin, testing handling of non-perfectly-divisible-by-10 numbers of
+ * particles.
  * - the container has a cuboid shape to test handling of non cube shapes and is offset from the origin to test this
  *   scenario which is important e.g. if MPI is used.
  * - particles are placed evenly between bins
@@ -28,8 +30,8 @@
 TEST(SimilarityFunctionsTest, testCalculateHomogeneityAndMaxDensity) {
   autopas::AutoPas<Molecule> autoPas;
 
-  const std::array<double, 3> domainMin{1,1,0};
-  const std::array<double, 3> domainMax{9,9,4};
+  const std::array<double, 3> domainMin{1, 1, 0};
+  const std::array<double, 3> domainMax{9, 9, 4};
   const auto domainVol = (domainMax[0] - domainMin[0]) * (domainMax[1] - domainMin[1]) * (domainMax[2] - domainMin[2]);
 
   autoPas.setBoxMin(domainMin);
@@ -39,10 +41,11 @@ TEST(SimilarityFunctionsTest, testCalculateHomogeneityAndMaxDensity) {
 
   for (int i = 0; i < 88; ++i) {
     const auto boxIndex1D = i / 11;
-    const auto boxIndex3D = autopas::utils::ThreeDimensionalMapping::oneToThreeD(boxIndex1D, {2,2,2});
-    const std::array<double, 3> position = {3. + (double)boxIndex3D[0] * 4., 3. + (double)boxIndex3D[1] * 4., 1. + (double)boxIndex3D[2] * 2.};
+    const auto boxIndex3D = autopas::utils::ThreeDimensionalMapping::oneToThreeD(boxIndex1D, {2, 2, 2});
+    const std::array<double, 3> position = {3. + (double)boxIndex3D[0] * 4., 3. + (double)boxIndex3D[1] * 4.,
+                                            1. + (double)boxIndex3D[2] * 2.};
 
-    Molecule m(position, {0,0,0}, i);
+    Molecule m(position, {0, 0, 0}, i);
     autoPas.addParticle(m);
   }
 
@@ -54,7 +57,8 @@ TEST(SimilarityFunctionsTest, testCalculateHomogeneityAndMaxDensity) {
     const double expectedHomogeneity = 0.;
     const double expectedMaxDensity = expectedMeanDensity;
 
-    const auto [actualHomogeneity, actualMaxDensity] = autopas::utils::calculateHomogeneityAndMaxDensity(autoPas, autoPas.getBoxMin(), autoPas.getBoxMax());
+    const auto [actualHomogeneity, actualMaxDensity] =
+        autopas::utils::calculateHomogeneityAndMaxDensity(autoPas, autoPas.getBoxMin(), autoPas.getBoxMax());
 
     EXPECT_NEAR(actualHomogeneity, expectedHomogeneity, 1e-12);
     EXPECT_NEAR(actualMaxDensity, expectedMaxDensity, 1e-12);
@@ -64,7 +68,7 @@ TEST(SimilarityFunctionsTest, testCalculateHomogeneityAndMaxDensity) {
 
   for (auto iter = autoPas.begin(); iter.isValid(); ++iter) {
     if (iter->getID() == 0) {
-      iter->setR({7,3,1}); // Shifted to neighboring bin
+      iter->setR({7, 3, 1});  // Shifted to neighboring bin
       break;
     }
   }
@@ -82,10 +86,10 @@ TEST(SimilarityFunctionsTest, testCalculateHomogeneityAndMaxDensity) {
     const double expectedHomogeneity = std::sqrt(densityVariance);
     const double expectedMaxDensity = 12. / binVol;
 
-    const auto [actualHomogeneity, actualMaxDensity] = autopas::utils::calculateHomogeneityAndMaxDensity(autoPas, autoPas.getBoxMin(), autoPas.getBoxMax());
+    const auto [actualHomogeneity, actualMaxDensity] =
+        autopas::utils::calculateHomogeneityAndMaxDensity(autoPas, autoPas.getBoxMin(), autoPas.getBoxMax());
 
     EXPECT_NEAR(actualHomogeneity, expectedHomogeneity, 1e-12);
     EXPECT_NEAR(actualMaxDensity, expectedMaxDensity, 1e-12);
   }
-
 }

--- a/tests/testAutopas/tests/utils/SimilarityFunctionsTest.cpp
+++ b/tests/testAutopas/tests/utils/SimilarityFunctionsTest.cpp
@@ -38,10 +38,14 @@ TEST(SimilarityFunctionsTest, testCalculateHomogeneityAndMaxDensity) {
   const auto domainVol = (domainMax[0] - domainMin[0]) * (domainMax[1] - domainMin[1]) * (domainMax[2] - domainMin[2]);
 
   for (int i = 0; i < 88; ++i) {
-    const auto boxIndex1D = i / 11;
+    const size_t boxIndex1D = i / 11;
     const auto boxIndex3D = autopas::utils::ThreeDimensionalMapping::oneToThreeD(boxIndex1D, {2, 2, 2});
     const std::array<double, 3> position = {3. + (double)boxIndex3D[0] * 4., 3. + (double)boxIndex3D[1] * 4.,
                                             1. + (double)boxIndex3D[2] * 2.};
+
+    ASSERT_LT(boxIndex3D[0], 2) << "Only two bins per direction expected\n";
+    ASSERT_LT(boxIndex3D[1], 2) << "Only two bins per direction expected\n";
+    ASSERT_LT(boxIndex3D[2], 2) << "Only two bins per direction expected\n";
 
     Molecule m(position, {0, 0, 0}, i);
     dsContainer.addParticle(m);

--- a/tests/testAutopas/tests/utils/SimilarityFunctionsTest.cpp
+++ b/tests/testAutopas/tests/utils/SimilarityFunctionsTest.cpp
@@ -57,8 +57,7 @@ TEST(SimilarityFunctionsTest, testCalculateHomogeneityAndMaxDensity) {
     const double expectedHomogeneity = 0.;
     const double expectedMaxDensity = expectedMeanDensity;
 
-    const auto [actualHomogeneity, actualMaxDensity] =
-        autopas::utils::calculateHomogeneityAndMaxDensity(autoPas, autoPas.getBoxMin(), autoPas.getBoxMax());
+    const auto [actualHomogeneity, actualMaxDensity] = autopas::utils::calculateHomogeneityAndMaxDensity(autoPas);
 
     EXPECT_NEAR(actualHomogeneity, expectedHomogeneity, 1e-12);
     EXPECT_NEAR(actualMaxDensity, expectedMaxDensity, 1e-12);
@@ -86,8 +85,7 @@ TEST(SimilarityFunctionsTest, testCalculateHomogeneityAndMaxDensity) {
     const double expectedHomogeneity = std::sqrt(densityVariance);
     const double expectedMaxDensity = 12. / binVol;
 
-    const auto [actualHomogeneity, actualMaxDensity] =
-        autopas::utils::calculateHomogeneityAndMaxDensity(autoPas, autoPas.getBoxMin(), autoPas.getBoxMax());
+    const auto [actualHomogeneity, actualMaxDensity] = autopas::utils::calculateHomogeneityAndMaxDensity(autoPas);
 
     EXPECT_NEAR(actualHomogeneity, expectedHomogeneity, 1e-12);
     EXPECT_NEAR(actualMaxDensity, expectedMaxDensity, 1e-12);

--- a/tests/testAutopas/tests/utils/SimilarityFunctionsTest.cpp
+++ b/tests/testAutopas/tests/utils/SimilarityFunctionsTest.cpp
@@ -1,0 +1,90 @@
+/**
+* @file SimilarityFunctionsTest.cpp
+* @author S. Newcome
+* @date 06/06/2024
+ */
+
+#include <algorithm>
+#include <iterator>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include "autopas/AutoPasDecl.h"
+#include "testingHelpers/commonTypedefs.h"
+#include "autopas/utils/ThreeDimensionalMapping.h"
+#include "autopas/utils/SimilarityFunctions.h"
+
+/**
+ * Test calculateHomogeneityAndMaxDensity by
+ * - creating a container with 80 particles, such that there are 8 bins
+ * - the container has a cuboid shape to test handling of non cube shapes and is offset from the origin to test this
+ *   scenario which is important e.g. if MPI is used.
+ * - particles are placed evenly between bins
+ * - tests density is correct and homogeneity is 0
+ * - moves a particle between bins and tests again
+ * - contiane
+ */
+TEST(SimilarityFunctionsTest, testCalculateHomogeneityAndMaxDensity) {
+  autopas::AutoPas<Molecule> autoPas;
+
+  const std::array<double, 3> domainMin{1,1,0};
+  const std::array<double, 3> domainMax{9,9,8};
+  const auto domainVol = (domainMax[0] - domainMin[0]) * (domainMax[1] - domainMin[1]) * (domainMax[2] - domainMin[2]);
+
+  autoPas.setBoxMin(domainMin);
+  autoPas.setBoxMax(domainMax);
+
+  autoPas.init();
+
+  for (int i = 0; i < 80; ++i) {
+    const auto boxIndex1D = i / 10;
+    const auto boxIndex3D = autopas::utils::ThreeDimensionalMapping::oneToThreeD(boxIndex1D, {2,2,2});
+    const std::array<double, 3> position = {3. + (double)boxIndex3D[0] * 4., 3. + (double)boxIndex3D[1] * 4., 2. + (double)boxIndex3D[2] * 4.};
+
+    Molecule m(position, {0,0,0}, i);
+    autoPas.addParticle(m);
+  }
+
+  const double binVol = 4. * 4. * 4.;
+  const double expectedMeanDensity = 80. / domainVol;
+  const int numBins = 8;
+
+  {
+    const double expectedHomogeneity = 0.;
+    const double expectedMaxDensity = expectedMeanDensity;
+
+    const auto [actualHomogeneity, actualMaxDensity] = autopas::utils::calculateHomogeneityAndMaxDensity(autoPas, autoPas.getBoxMin(), autoPas.getBoxMax());
+
+    EXPECT_NEAR(actualHomogeneity, expectedHomogeneity, 1e-12);
+    EXPECT_NEAR(actualMaxDensity, expectedMaxDensity, 1e-12);
+  }
+
+  // Move particle 0
+
+  for (auto iter = autoPas.begin(); iter.isValid(); ++iter) {
+    if (iter->getID() == 0) {
+      iter->setR({7,3,2}); // Shifted to neighboring bin
+      break;
+    }
+  }
+
+  {
+    // Most bins are still at the mean density but two have different densities
+    const double densityDiff = 1. / binVol;
+
+    // Both denser and less dense bins have the same varaince contribution
+    const auto varianceContributionOfDiffBins = densityDiff * densityDiff / (double)numBins;
+
+    // Add contributions from both bins.
+    const auto densityVariance = 2. * varianceContributionOfDiffBins;
+
+    const double expectedHomogeneity = std::sqrt(densityVariance);
+    const double expectedMaxDensity = 11. / binVol;
+
+    const auto [actualHomogeneity, actualMaxDensity] = autopas::utils::calculateHomogeneityAndMaxDensity(autoPas, autoPas.getBoxMin(), autoPas.getBoxMax());
+
+    EXPECT_NEAR(actualHomogeneity, expectedHomogeneity, 1e-12);
+    EXPECT_NEAR(actualMaxDensity, expectedMaxDensity, 1e-12);
+  }
+
+}

--- a/tests/testAutopas/tests/utils/SimilarityFunctionsTest.cpp
+++ b/tests/testAutopas/tests/utils/SimilarityFunctionsTest.cpp
@@ -23,7 +23,6 @@
  * - particles are placed evenly between bins
  * - tests density is correct and homogeneity is 0
  * - moves a particle between bins and tests again
- * - contiane
  */
 TEST(SimilarityFunctionsTest, testCalculateHomogeneityAndMaxDensity) {
   const std::array<double, 3> domainMin{1, 1, 0};

--- a/tests/testAutopas/tests/utils/SimilarityFunctionsTest.cpp
+++ b/tests/testAutopas/tests/utils/SimilarityFunctionsTest.cpp
@@ -6,8 +6,6 @@
 
 #include <gtest/gtest.h>
 
-#include <algorithm>
-#include <iterator>
 #include <vector>
 
 #include "autopas/containers/directSum/DirectSum.h"


### PR DESCRIPTION
# Description

Fixes `calculateHomogeneityAndMaxDensity` and adds a test for it.

Previously, `calculateHomogeneityAndMaxDensity` assumed that the domain started at (0,0,0) when indexing particles into bins. Furthermore, the algorithm was sub optimal and the code was messy.

This PR:

- [x] Fixes the non-(0,0,0) domain indexing.
- [x] Improves readability, including renaming from "cells" to "bins"
- [x] Switches from perfect cube bins, with the upper boundary handled by truncating bins (messy logic + truncated bins could cause greater statistical uncertainties), to dividing the domain into identical cuboids that perfectly fit into the domain.

## Related Pull Requests

- #PR #876 highlighted the issue

## Resolved Issues

- [x] fixes #881

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Existing tests
- [x] New test for this function
