### PR TITLE
Make getNearbyHaloCells reserve

### DIFF
--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -177,9 +177,9 @@ class CellBlock3D : public CellBorderAndFlagManager {
 
   /**
    * Get the halo cells around a given point.
-   * A list of halo cells is returned whose distance to position is at most allowedDistance.
+   * Returns a list of halo cells that are at least partially within allowedDistance of the given position.
    * If position is inside a halo cell that cell is also returned.
-   * @note 1 norm is used, i.e. the distance is computed for each dimension separately, aka. Manhattan distance)
+   * @note The 1 norm is used, i.e. the distance is computed for each dimension separately, aka. Manhattan distance)
    *
    * @param position cells close to this position are to be returned.
    * @param allowedDistance the maximal distance to the position.
@@ -201,7 +201,7 @@ class CellBlock3D : public CellBorderAndFlagManager {
     // If the size of the overallocation ever becomes a problem we can use vector::shrink_to_fit() before return.
     closeHaloCells.reserve(interestingCellsBlockSize);
 
-    // always add the cell the particle is currently in first, for that we test if it is a halo cell.
+    // always add the cell the particle is currently in first if it is a halo cell.
     if ((*_cells)[index1D].getPossibleParticleOwnerships() == OwnershipState::halo) {
       closeHaloCells.push_back(&getCell(index3D));
     }
@@ -307,7 +307,7 @@ class CellBlock3D : public CellBorderAndFlagManager {
 
   /**
    * 1/_cellLength
-   * Since this value is needed for sorting particles in cells, it is computed quite often.
+   * Since this value is often needed for sorting particles in cells, we precompute it.
    */
   std::array<double, 3> _cellLengthReciprocal{};
 };

--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -310,8 +310,10 @@ class CellBlock3D : public CellBorderAndFlagManager {
 
   std::array<double, 3> _cellLength{};
 
-  // 1 over above. Since this value is needed for sorting particles in cells, it
-  // is computed quite often
+  /**
+   * 1/_cellLength
+   * Since this value is needed for sorting particles in cells, it is computed quite often.
+   */
   std::array<double, 3> _cellLengthReciprocal{};
 };
 

--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -193,7 +193,7 @@ class CellBlock3D : public CellBorderAndFlagManager {
 
     std::vector<ParticleCell *> closeHaloCells;
     // x2 for left and right of the cell; +1 for the cell itself
-    const auto interestingCellsPerDim = (2. * allowedDistance / _cellLength) + 1.;
+    const auto interestingCellsPerDim = utils::ArrayMath::ceilToInt((2. * allowedDistance / _cellLength)) + 1;
     const auto interestingCellsBlockSize =
         interestingCellsPerDim[0] * interestingCellsPerDim[1] * interestingCellsPerDim[2];
     // This is an overestimation with the upper bound of possible number of cells in the vicinity.

--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -22,24 +22,23 @@
 namespace autopas::internal {
 /**
  * Class that manages a block of ParticleCells.
- * It is used to resize the cellblock and to handle the conversion of 3d to 1d
- * indices
- * @tparam ParticleCell type of the handled ParticleCells
+ * It is used to resize the cell block and to handle the conversion of 3d to 1d indices.
+ * @tparam ParticleCell Type of the handled ParticleCells.
  */
 template <class ParticleCell>
 class CellBlock3D : public CellBorderAndFlagManager {
  public:
   /**
-   * the index type to access the particle cells
+   * The index type to access the particle cells
    */
   using index_t = std::size_t;
   /**
    * Constructor of CellBlock3D
-   * @param vec vector of ParticleCells that this class manages
-   * @param bMin lower corner of the cellblock
-   * @param bMax higher corner of the cellblock
-   * @param interactionLength max. radius of interaction between particles
-   * @param cellSizeFactor cell size factor relative to interactionLength
+   * @param vec Vector of ParticleCells that this class manages.
+   * @param bMin Lower corner of the cell block.
+   * @param bMax Higher corner of the cell block.
+   * @param interactionLength Max. radius of interaction between particles.
+   * @param cellSizeFactor Cell size factor relative to interactionLength.
    */
   CellBlock3D(std::vector<ParticleCell> &vec, const std::array<double, 3> &bMin, const std::array<double, 3> &bMax,
               double interactionLength, double cellSizeFactor = 1.0)
@@ -55,13 +54,13 @@ class CellBlock3D : public CellBorderAndFlagManager {
   }
 
   /**
-   * deleted copy constructor
+   * Deleted copy constructor.
    */
   CellBlock3D(const CellBlock3D &) = delete;
 
   /**
-   * delete assignment operator
-   * @return deleted
+   * Deleted assignment operator.
+   * @return
    */
   CellBlock3D &operator=(const CellBlock3D) = delete;
 
@@ -86,16 +85,16 @@ class CellBlock3D : public CellBorderAndFlagManager {
   }
 
   /**
-   * get the ParticleCell of a specified 1d index
-   * @param index1d the index of the cell
-   * @return the specified cell
+   * get the ParticleCell of a specified 1d index.
+   * @param index1d The 1D index of the cell.
+   * @return Non-const cell reference.
    */
   ParticleCell &getCell(index_t index1d) const;
 
   /**
-   * get the ParticleCell of a specified 3d index
-   * @param index3d the index of the cell
-   * @return the specified cell
+   * Get the ParticleCell of a specified 3d index.
+   * @param index3d The 3D index of the cell.
+   * @return Non-const cell reference.
    */
   ParticleCell &getCell(const std::array<index_t, 3> &index3d) const;
 
@@ -106,88 +105,85 @@ class CellBlock3D : public CellBorderAndFlagManager {
   void reserve(size_t numParticles);
 
   /**
-   * rebuild the cellblock. This resizes the cellblock and sets the appropriate
-   * internal variables
-   * @param vec new vector of ParticleCells to which the internal pointer is set
-   * @param bMin new lower corner of the cellblock
-   * @param bMax new higher corner of the cellblock
-   * @param interactionLength max. radius of interaction between particles
-   * @param cellSizeFactor cell size factor relative to interactionLength
+   * Rebuild the cell block. This resizes the cell block and sets the appropriate internal variables.
+   * @param vec new vector of ParticleCells to which the internal pointer is set.
+   * @param bMin new lower corner of the cell block.
+   * @param bMax new higher corner of the cell block.
+   * @param interactionLength max. radius of interaction between particles.
+   * @param cellSizeFactor cell size factor relative to interactionLength.
    */
   void rebuild(std::vector<ParticleCell> &vec, const std::array<double, 3> &bMin, const std::array<double, 3> &bMax,
                double interactionLength, double cellSizeFactor);
 
-  // this class doesn't actually know about particles
   /**
-   * Get the containing cell of a specified position
+   * Get the containing cell of a specified position.
    * @note If pos is outside the domain vector->operator[]() will trigger undefined behavior.
    *
-   * @param pos the position for which the cell is needed
-   * @return cell at the given position
+   * @param pos The position for which the cell is needed.
+   * @return Cell at the given position.
    */
   ParticleCell &getContainingCell(const std::array<double, 3> &pos) const;
 
   /**
    * Get the lower and upper corner of the cell at the 1d index index1d
-   * @param index1d the 1d index
-   * @return std::pair of boxmin (lower corner) and boxmax (upper corner) of the box.
+   * @param index1d The 1d cell index.
+   * @return std::pair of boxMin (lower corner) and boxMax (upper corner) of the box.
    */
   std::pair<std::array<double, 3>, std::array<double, 3>> getCellBoundingBox(index_t index1d) const;
 
   /**
-   * Get the lower and upper corner of the cell at the 3d index index3d
-   * @param index3d the 3d index
-   * @return std::pair of boxmin (lower corner) and boxmax (upper corner) of the box.
+   * Get the lower and upper corner of the cell at the 3d index index3d.
+   * @param index3d The 3d cell index.
+   * @return std::pair of boxMin (lower corner) and boxMax (upper corner) of the box.
    */
   std::pair<std::array<double, 3>, std::array<double, 3>> getCellBoundingBox(
       const std::array<index_t, 3> &index3d) const;
 
   /**
-   * Get the 3d index of the cellblock for a given position
+   * Get the 3d index of the cell block for a given position.
    * @note If pos is outside the domain the returned 3d index is also outside the domain.
    *
-   * @param pos the position
-   * @return the 3d index
+   * @param pos The position of interest.
+   * @return The 3d cell index,
    */
   [[nodiscard]] std::array<index_t, 3> get3DIndexOfPosition(const std::array<double, 3> &pos) const;
 
   /**
-   * get the 1d index of the cellblock for a given position
-   * @param pos the position
-   * @return the 1d index
+   * Get the 1d index of the cell block for a given position.
+   * @param pos the position of interest.
+   * @return The 1d cell index.
    */
   [[nodiscard]] index_t get1DIndexOfPosition(const std::array<double, 3> &pos) const;
 
   /**
-   * get the dimension of the cellblock including the haloboxes
-   * @return the dimensions of the cellblock
+   * Get the dimension of the cell block including the halo boxes.
+   * @return The dimensions of the cell block.
    */
   [[nodiscard]] const std::array<index_t, 3> &getCellsPerDimensionWithHalo() const {
     return _cellsPerDimensionWithHalo;
   }
 
   /**
-   * checks whether a given position is inside the halo region of the managed
-   * cell block
-   * @param position the given position
-   * @return true if the position is inside the halo region
+   * Checks whether a given position is inside the halo region of the managed cell block.
+   * @param position the given position.
+   * @return true if the position is inside the halo region.
    */
   [[nodiscard]] bool checkInHalo(const std::array<double, 3> &position) const;
 
   /**
-   * deletes all particles in the halo cells of the managed cell block
+   * Deletes all particles in the halo cells of the managed cell block.
    */
   void clearHaloCells();
 
   /**
-   * Get the nearby halo cells.
-   * A list of halo cells is returned whose distance to position is at most
-   * allowedDistance. If position is inside a halo cell that cell is also
-   * returned. (1 norm is used, i.e. the distance is computed for each dimension
-   * separately, Manhattan distance)
-   * @param position cells close to this position are to be returned
-   * @param allowedDistance the maximal distance to the position
-   * @return a container of references to nearby halo cells
+   * Get the halo cells around a given point.
+   * A list of halo cells is returned whose distance to position is at most allowedDistance.
+   * If position is inside a halo cell that cell is also returned.
+   * @note 1 norm is used, i.e. the distance is computed for each dimension separately, aka. Manhattan distance)
+   *
+   * @param position cells close to this position are to be returned.
+   * @param allowedDistance the maximal distance to the position.
+   * @return A vector of references to nearby halo cells.
    */
   std::vector<ParticleCell *> getNearbyHaloCells(const std::array<double, 3> &position, double allowedDistance) const {
     using namespace autopas::utils::ArrayMath::literals;
@@ -248,13 +244,13 @@ class CellBlock3D : public CellBorderAndFlagManager {
 
   /**
    * Get the number of cells per interaction length.
-   * @return cells per interaction length.
+   * @return Cells per interaction length.
    */
   [[nodiscard]] unsigned long getCellsPerInteractionLength() const { return _cellsPerInteractionLength; }
 
   /**
    * Get the cell lengths.
-   * @return array of cell lengths.
+   * @return Array of cell lengths.
    */
   [[nodiscard]] const std::array<double, 3> &getCellLength() const { return _cellLength; }
 
@@ -280,14 +276,14 @@ class CellBlock3D : public CellBorderAndFlagManager {
   /**
    * Transform a 1D index to a 3D index in the context of this cell block.
    * @param index1D
-   * @return 3D cell index
+   * @return 3D cell index.
    */
   [[nodiscard]] std::array<index_t, 3> oneToThreeD(index_t index1D) const;
 
   /**
    * Transform a 3D index to a 1D index in the context of this cell block.
    * @param index3D
-   * @return 1D cell index
+   * @return 1D cell index.
    */
   [[nodiscard]] index_t threeToOneD(const std::array<index_t, 3> &index3D) const;
 

--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -196,6 +196,14 @@ class CellBlock3D : public CellBorderAndFlagManager {
     const auto index1D = threeToOneD(index3D);
 
     std::vector<ParticleCell *> closeHaloCells;
+    // x2 for left and right of the cell; +1 for the cell itself
+    const auto interestingCellsPerDim = (2. * allowedDistance / _cellLength) + 1.;
+    const auto interestingCellsBlockSize =
+        interestingCellsPerDim[0] * interestingCellsPerDim[1] * interestingCellsPerDim[2];
+    // This is an overestimation with the upper bound of possible number of cells in the vicinity.
+    // An overestimate is cheaper than many reallocations.
+    // If the size of the overallocation ever becomes a problem we can use vector::shrink_to_fit() before return.
+    closeHaloCells.reserve(interestingCellsBlockSize);
 
     // always add the cell the particle is currently in first, for that we test if it is a halo cell.
     if (_cells[index1D].getPossibleParticleOwnerships() == OwnershipState::halo) {

--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -107,11 +107,11 @@ class CellBlock3D : public CellBorderAndFlagManager {
 
   /**
    * Rebuild the cell block. This resizes the cell block and sets the appropriate internal variables.
-   * @param vec new vector of ParticleCells to which the internal pointer is set.
-   * @param bMin new lower corner of the cell block.
-   * @param bMax new higher corner of the cell block.
-   * @param interactionLength max. radius of interaction between particles.
-   * @param cellSizeFactor cell size factor relative to interactionLength.
+   * @param vec New vector of ParticleCells to which the internal pointer is set.
+   * @param bMin New lower corner of the cell block.
+   * @param bMax New higher corner of the cell block.
+   * @param interactionLength Max. radius of interaction between particles.
+   * @param cellSizeFactor Cell size factor relative to interactionLength.
    */
   void rebuild(std::vector<ParticleCell> &vec, const std::array<double, 3> &bMin, const std::array<double, 3> &bMax,
                double interactionLength, double cellSizeFactor);
@@ -166,7 +166,7 @@ class CellBlock3D : public CellBorderAndFlagManager {
 
   /**
    * Checks whether a given position is inside the halo region of the managed cell block.
-   * @param position the given position.
+   * @param position The given position.
    * @return true if the position is inside the halo region.
    */
   [[nodiscard]] bool checkInHalo(const std::array<double, 3> &position) const;
@@ -182,8 +182,8 @@ class CellBlock3D : public CellBorderAndFlagManager {
    * If position is inside a halo cell that cell is also returned.
    * @note The 1 norm is used, i.e. the distance is computed for each dimension separately, aka. Manhattan distance)
    *
-   * @param position cells close to this position are to be returned.
-   * @param allowedDistance the maximal distance to the position.
+   * @param position Cells close to this position are to be returned.
+   * @param allowedDistance The maximal distance to the position.
    * @return A vector of references to nearby halo cells.
    */
   std::vector<ParticleCell *> getNearbyHaloCells(const std::array<double, 3> &position, double allowedDistance) const {
@@ -305,7 +305,7 @@ class CellBlock3D : public CellBorderAndFlagManager {
   std::array<double, 3> _cellLength{};
 
   /**
-   * 1/_cellLength
+   * 1.0 / _cellLength
    * Since this value is often needed for sorting particles in cells, we precompute it.
    */
   std::array<double, 3> _cellLengthReciprocal{};

--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -201,7 +201,7 @@ class CellBlock3D : public CellBorderAndFlagManager {
     // If the size of the overallocation ever becomes a problem we can use vector::shrink_to_fit() before return.
     const auto blockLength = highIndex3D - lowIndex3D;
     const auto numInterestingCells = std::max(1, blockLength[0] * blockLength[1] * blockLength[2]);
-    closeHaloCells.reserve(interestingCellsBlockSize);
+    closeHaloCells.reserve(numInterestingCells);
 
     // always add the cell the particle is currently in first if it is a halo cell.
     if ((*_cells)[index1D].getPossibleParticleOwnerships() == OwnershipState::halo) {

--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <numeric>
@@ -200,7 +201,7 @@ class CellBlock3D : public CellBorderAndFlagManager {
     // An overestimate is cheaper than many reallocations.
     // If the size of the overallocation ever becomes a problem we can use vector::shrink_to_fit() before return.
     const auto blockLength = highIndex3D - lowIndex3D;
-    const auto numInterestingCells = std::max(1, blockLength[0] * blockLength[1] * blockLength[2]);
+    const auto numInterestingCells = std::max(1ul, blockLength[0] * blockLength[1] * blockLength[2]);
     closeHaloCells.reserve(numInterestingCells);
 
     // always add the cell the particle is currently in first if it is a halo cell.

--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -191,24 +191,22 @@ class CellBlock3D : public CellBorderAndFlagManager {
     const auto index3D = get3DIndexOfPosition(position);
     const auto index1D = threeToOneD(index3D);
 
+    // these indices are (already) at least 0 and at most _cellsPerDimensionWithHalo[i]-1
+    const auto lowIndex3D = get3DIndexOfPosition(position - allowedDistance);
+    const auto highIndex3D = get3DIndexOfPosition(position + allowedDistance);
+
     std::vector<ParticleCell *> closeHaloCells;
-    // x2 for left and right of the cell; +1 for the cell itself
-    const auto interestingCellsPerDim = utils::ArrayMath::ceilToInt((2. * allowedDistance / _cellLength)) + 1;
-    const auto interestingCellsBlockSize =
-        interestingCellsPerDim[0] * interestingCellsPerDim[1] * interestingCellsPerDim[2];
     // This is an overestimation with the upper bound of possible number of cells in the vicinity.
     // An overestimate is cheaper than many reallocations.
     // If the size of the overallocation ever becomes a problem we can use vector::shrink_to_fit() before return.
+    const auto blockLength = highIndex3D - lowIndex3D;
+    const auto numInterestingCells = std::max(1, blockLength[0] * blockLength[1] * blockLength[2]);
     closeHaloCells.reserve(interestingCellsBlockSize);
 
     // always add the cell the particle is currently in first if it is a halo cell.
     if ((*_cells)[index1D].getPossibleParticleOwnerships() == OwnershipState::halo) {
       closeHaloCells.push_back(&getCell(index3D));
     }
-
-    // these indices are (already) at least 0 and at most _cellsPerDimensionWithHalo[i]-1
-    const auto lowIndex3D = get3DIndexOfPosition(position - allowedDistance);
-    const auto highIndex3D = get3DIndexOfPosition(position + allowedDistance);
 
     auto currentIndex3D = lowIndex3D;
     for (currentIndex3D[0] = lowIndex3D[0]; currentIndex3D[0] <= highIndex3D[0]; ++currentIndex3D[0]) {

--- a/src/autopas/containers/CellBlock3D.h
+++ b/src/autopas/containers/CellBlock3D.h
@@ -202,7 +202,7 @@ class CellBlock3D : public CellBorderAndFlagManager {
     closeHaloCells.reserve(interestingCellsBlockSize);
 
     // always add the cell the particle is currently in first, for that we test if it is a halo cell.
-    if (_cells[index1D].getPossibleParticleOwnerships() == OwnershipState::halo) {
+    if ((*_cells)[index1D].getPossibleParticleOwnerships() == OwnershipState::halo) {
       closeHaloCells.push_back(&getCell(index3D));
     }
 
@@ -220,7 +220,7 @@ class CellBlock3D : public CellBorderAndFlagManager {
           }
           // we need to return the cell is it is a halo cell.
           const auto currentIndex1D = threeToOneD(currentIndex3D);
-          if (_cells[currentIndex1D].getPossibleParticleOwnerships() == OwnershipState::halo) {
+          if ((*_cells)[currentIndex1D].getPossibleParticleOwnerships() == OwnershipState::halo) {
             closeHaloCells.push_back(&getCell(currentIndex3D));
           }
         }


### PR DESCRIPTION
# Description

- [x] use cell information to identify halo cells
- [x] `reserve` before `push_back`
- [x] Doc and renaming.

All actual code changes are inside of `getNearbyHaloCells()`.

## ~Related Pull Requests~

## Resolved Issues

- [x] fixes #890 

# How Has This Been Tested?

- [x] CI
