### PR TITLE
Change Markdown Language Tags from cpp to c++

### DIFF
--- a/docs/userdoc/CustomApplications.md
+++ b/docs/userdoc/CustomApplications.md
@@ -51,7 +51,7 @@ A demonstration of that is the [sph example](https://github.com/AutoPas/AutoPas/
 There exist some caveats that have to be considered when using multiple functors:
 * All functors need to support the same Newton3 options.
   If there is one functor not supporting Newton3, you have to disable Newton3 support for AutoPas by calling
-  ```cpp
+  ```c++
   autopas.setAllowedNewton3Options({false});
   ```
   Otherwise, the algorithm selection might choose a configuration with Newton3 and fail to apply the functor that does not support it.

--- a/docs/userdoc/Iterators.md
+++ b/docs/userdoc/Iterators.md
@@ -20,7 +20,7 @@ For the third, refer to [`SimulationLoop.md`](https://github.com/AutoPas/AutoPas
 
 The easiest way to iterate over all (= owned and halo) particles of an AutoPas instance is with a [range-based for loop](https://en.cppreference.com/w/cpp/language/range-for):
 
-```cpp
+```c++
 for(auto& particle : autoPas) {
   // user code:
   auto position = particle.getR();
@@ -31,7 +31,7 @@ for(auto& particle : autoPas) {
 
 If more fine-grained control is needed over the iteration sequence, the iterator can be accessed and advanced manually:
 
-```cpp
+```c++
 for(auto iter = autoPas.begin(); iter != autoPas.end(); ++iter) {
   // user code:
   auto position = iter->getR();
@@ -55,7 +55,7 @@ AutoPas supports the deletion of particles while iterating without invalidating 
 However, this needs to be done through the member function `AutoPas::deleteParticle()`.
 This function also leaves the iterator in a state so that `ContainerIterator::operator++()` needs to be called.
 
-```cpp
+```c++
 for(auto iter = autoPas.begin(); iter != autoPas.end(); ++iter) {
   autoPas.deleteParticle(iterator);
 }
@@ -67,7 +67,7 @@ Iterators can be restricted to only return particles of a given ownership type.
 The default is to cover owned and halo particles.
 See [ParticleOwnershipModel.md](https://github.com/AutoPas/AutoPas/blob/master/docs/userdoc/ParticleOwnershipModel.md) for particle ownership types.
 
-```cpp
+```c++
 // only iterate owned particles
 for(auto iter = autoPas.begin(autopas::IteratorBehavior::owned);
     iter != autoPas.end();
@@ -83,7 +83,7 @@ Depending on the container, this might be more efficient than iterating everythi
 Iterators can be restricted to only return particles inside of a given region.
 Regions are always cuboids defined by their left-lower-frontal and right-upper-back corner.
 
-```cpp
+```c++
 // only iterate particles in a given box
 const std::array<double, 3> lowCorner = ...;
 const std::array<double, 3> highCorner = ...;
@@ -101,7 +101,7 @@ Region Iterators also take an `IteratorBehavior` as an optional third argument.
 Iteration of the AutoPas object can also be done in parallel via OpenMP.
 For this, place any of the examples above in a parallel region.
 
-```cpp
+```c++
 AUTOPAS_OPENMP(parallel)
 for(auto& particle : autoPas) {
   // user code
@@ -116,7 +116,7 @@ All features described above also work in parallel, including particle deletion.
 
 If iterators are nested, inner loops should not spawn multiple iterators to avoid spreading the work too thin.
 This can be achieved by adapting the `IteratorBehavior`, which works similar to a bit vector:
-```cpp
+```c++
 AUTOPAS_OPENMP(parallel)
 for(auto& particle : autoPas) {   // spawns N iterators
   for(auto iter = autoPas.begin(autopas::IteratorBehavior::ownedOrHalo | autopas::IteratorBehavior::forceSequential);
@@ -145,7 +145,7 @@ For this, multiple member functions are available:
 Here, `Lambda` stands for a function of the signature `(Particle &) -> void`.
 All of those functions also exist in a `const` version with the otherwise same signature.
 
-```cpp
+```c++
 autoPas.forEachInRegionParallel([](auto &particle) {
   // user code (here e.g. calculating newR)
   particle.setR(newR);
@@ -156,7 +156,7 @@ autoPas.forEachInRegionParallel([](auto &particle) {
 
 On top of that, for every `forEach`-style function, there is also a corresponding `reduce[inRegion][Parallel]()` function.
 Here, the lambda function has the form `(Particle &, ResultT &) -> void`
-```cpp
+```c++
 size_t result = 0;
 autoPas.reduceInRegionParallel([](auto &particle, auto &accumulator) {
   // user code

--- a/docs/userdoc/Logging.md
+++ b/docs/userdoc/Logging.md
@@ -10,12 +10,12 @@ It supports all spdlog-levels, which are also accessible via the type alias `aut
 These levels can be (de)activated at compile time via the `CMake` variable `AUTOPAS_MIN_LOG_LVL`.
 At run time, this logger's compiled levels can be set, e.g., via:
 
-```cpp
+```c++
 autopas::Logger::get()->set_level(autopas::Logger::LogLevel::debug);
 ```
 
 To conveniently use this logger, a macro is provided that takes the log level in all caps, a message string which will be formatted by [fmt](https://github.com/fmtlib/fmt) followed by any number of arguments:
-```cpp
+```c++
 AutoPasLog(INFO, "Message with two arguments: {} {}", arg0, arg1);
 ```
 

--- a/docs/userdoc/SimulationLoop.md
+++ b/docs/userdoc/SimulationLoop.md
@@ -9,7 +9,7 @@ AutoPas assumes that any (short-range) particle simulation boils down to three h
 
 ## Code Example
 A conceptual example of a primary simulation loop:
-```cpp
+```c++
 // main simulation loop
 while (needsMoreIterations()) {
    // 1. Particles movement as a result of interactions or simulation forces.
@@ -40,7 +40,7 @@ This step is highly user-dependent.
 Based on the simulation at hand, particles move due to the result of interaction forces or forces coming from the simulation model.
 Nevertheless, positions are usually updated through regular AutoPas iterators
 (see [`Iterators.md`](https://github.com/AutoPas/AutoPas/blob/master/docs/userdoc/Iterators.md) for details):
-```cpp
+```c++
 void updatePositions() {
    for (auto &p : autopas) {
       p.setR(calculateNewPosition(p);
@@ -49,7 +49,7 @@ void updatePositions() {
 ```
 
 #### 1.1 Data Structure Update
-```cpp
+```c++
 auto emigrants = autopas->updateContainer();
 ```
 This method has to be called in every iteration after particles are moved.
@@ -59,7 +59,7 @@ It achieves three things (see [`ContainerInterfaceModel.md`](https://github.com/
   - Particles leaving the bounding box of the container are (marked as) deleted and returned as emigrants.
 
 #### 1.2 Particle Exchange
-```cpp
+```c++
 autopas->addParticles(immigrants);
 autopas->addHaloParticles(haloParticles);
 ```
@@ -71,7 +71,7 @@ Examples of this could be:
   - Deletion of particles due to outflow condition.
 
 ### 2. Particle Interaction
-```cpp
+```c++
 YourFunctor functor();
 autopas->iteratePairwise(&functor);
 ```

--- a/src/autopas/AutoPasDecl.h
+++ b/src/autopas/AutoPasDecl.h
@@ -386,7 +386,7 @@ class AutoPas {
 
   /**
    * Iterate over all particles in a specified region
-   * ```cpp
+   * ```c++
    * for (auto iter = container.getRegionIterator(lowCorner, highCorner); iter.isValid(); ++iter) { }
    * ```
    * @param lowerCorner lower corner of the region


### PR DESCRIPTION
# Description

Change Markdown Code language tags from `cpp` to `c++`:

  - Github supports both styles, there it doesn't matter
  - CLion only supports c++

## ~Related Pull Requests~

## ~Resolved Issues~

# How Has This Been Tested?

Looked at rendered markdown files with C++ code in them on:

- [x] GitHub
- [x] CLion
