### PR TITLE
Fix MacOS Compliance

### DIFF
--- a/src/autopas/CMakeLists.txt
+++ b/src/autopas/CMakeLists.txt
@@ -30,7 +30,7 @@ add_library(autopas STATIC ${MY_SRC})
 target_link_libraries(
     autopas
     PUBLIC
-        rt # required for Time.h
+        $<$<NOT:$<PLATFORM_ID:Darwin>>:rt> # required for Time.h, on macOS not needed
         ${CMAKE_THREAD_LIBS_INIT} # required for Logger and ExceptionHandler
         $<$<BOOL:${AUTOPAS_OPENMP}>:OpenMP::OpenMP_CXX>
         spdlog::spdlog

--- a/src/autopas/pairwiseFunctors/CellFunctor.h
+++ b/src/autopas/pairwiseFunctors/CellFunctor.h
@@ -151,6 +151,7 @@ void CellFunctor<ParticleCell, ParticleFunctor, bidirectional>::processCell(Part
     return;
   }
 
+  // (Explicit) static cast required for Apple Clang (last tested version: 15.0.0)
   switch (static_cast<DataLayoutOption::Value>(_dataLayout)) {
     case DataLayoutOption::aos:
       processCellAoS(cell);
@@ -185,6 +186,7 @@ void CellFunctor<ParticleCell, ParticleFunctor, bidirectional>::processCellPair(
     return;
   }
 
+  // (Explicit) static cast required for Apple Clang (last tested version: 15.0.0)
   switch (static_cast<DataLayoutOption::Value>(_dataLayout)) {
     case DataLayoutOption::aos:
       if (_useNewton3) {

--- a/src/autopas/pairwiseFunctors/CellFunctor.h
+++ b/src/autopas/pairwiseFunctors/CellFunctor.h
@@ -151,7 +151,7 @@ void CellFunctor<ParticleCell, ParticleFunctor, bidirectional>::processCell(Part
     return;
   }
 
-  switch (_dataLayout) {
+  switch (static_cast<DataLayoutOption::Value>(_dataLayout)) {
     case DataLayoutOption::aos:
       processCellAoS(cell);
       break;
@@ -185,7 +185,7 @@ void CellFunctor<ParticleCell, ParticleFunctor, bidirectional>::processCellPair(
     return;
   }
 
-  switch (_dataLayout) {
+  switch (static_cast<DataLayoutOption::Value>(_dataLayout)) {
     case DataLayoutOption::aos:
       if (_useNewton3) {
         processCellPairAoSN3(cell1, cell2, sortingDirection);

--- a/src/autopas/utils/DataLayoutConverter.h
+++ b/src/autopas/utils/DataLayoutConverter.h
@@ -34,6 +34,7 @@ class DataLayoutConverter {
    */
   template <class ParticleCell>
   void loadDataLayout(ParticleCell &cell) {
+    // (Explicit) static cast required for Apple Clang (last tested version: 15.0.0)
     switch (static_cast<DataLayoutOption::Value>(_dataLayout)) {
       case DataLayoutOption::aos: {
         return;
@@ -52,6 +53,7 @@ class DataLayoutConverter {
    */
   template <class ParticleCell>
   void storeDataLayout(ParticleCell &cell) {
+    // (Explicit) static cast required for Apple Clang (last tested version: 15.0.0)
     switch (static_cast<DataLayoutOption::Value>(_dataLayout)) {
       case DataLayoutOption::aos: {
         return;

--- a/src/autopas/utils/DataLayoutConverter.h
+++ b/src/autopas/utils/DataLayoutConverter.h
@@ -34,7 +34,7 @@ class DataLayoutConverter {
    */
   template <class ParticleCell>
   void loadDataLayout(ParticleCell &cell) {
-    switch (_dataLayout) {
+    switch (static_cast<DataLayoutOption::Value>(_dataLayout)) {
       case DataLayoutOption::aos: {
         return;
       }
@@ -52,7 +52,7 @@ class DataLayoutConverter {
    */
   template <class ParticleCell>
   void storeDataLayout(ParticleCell &cell) {
-    switch (_dataLayout) {
+    switch (static_cast<DataLayoutOption::Value>(_dataLayout)) {
       case DataLayoutOption::aos: {
         return;
       }

--- a/src/autopas/utils/MemoryProfiler.cpp
+++ b/src/autopas/utils/MemoryProfiler.cpp
@@ -35,7 +35,7 @@ size_t autopas::memoryProfiler::currentMemoryUsage() {
     AutoPasLog(ERROR, "Error querying the resident memory size", statusFileName);
     return 0;
   }
-  // info.resident_size is the resident memory size in bytes, hence we divide by 1024 to return kilobytes
-  return static_cast<size_t>(info.resident_size / 1024);
+  // info.resident_size is the resident memory size in bytes, hence we divide by 1000 to return kilobytes
+  return static_cast<size_t>(info.resident_size / 1000);
 #endif
 }

--- a/src/autopas/utils/MemoryProfiler.cpp
+++ b/src/autopas/utils/MemoryProfiler.cpp
@@ -6,13 +6,8 @@
 
 #include "MemoryProfiler.h"
 
-#include <sys/stat.h>
-
-#include <fstream>
-
-#include "autopas/utils/logging/Logger.h"
-
 size_t autopas::memoryProfiler::currentMemoryUsage() {
+#ifdef __linux__
   std::ifstream statusFile(statusFileName);
   if (statusFile.rdstate() != std::ifstream::goodbit) {
     // this seems non-critical so we don't throw an exception
@@ -32,4 +27,15 @@ size_t autopas::memoryProfiler::currentMemoryUsage() {
 
   AutoPasLog(ERROR, "Could not read memory usage!");
   return 0;
+#elif defined __APPLE__
+  mach_task_basic_info info{};
+  mach_msg_type_number_t infoCount = MACH_TASK_BASIC_INFO_COUNT;
+  if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO, reinterpret_cast<task_info_t>(&info), &infoCount) !=
+      KERN_SUCCESS) {
+    AutoPasLog(ERROR, "Error querying the resident memory size", statusFileName);
+    return 0;
+  }
+  // info.resident_size is the resident memory size in bytes, hence we divide by 1024 to return kilobytes
+  return static_cast<size_t>(info.resident_size / 1024);
+#endif
 }

--- a/src/autopas/utils/MemoryProfiler.h
+++ b/src/autopas/utils/MemoryProfiler.h
@@ -6,7 +6,16 @@
 
 #pragma once
 
+#include <sys/stat.h>
+
 #include <cstdlib>
+#include <fstream>
+
+#ifdef __APPLE__
+#include <mach/mach.h>
+#endif
+
+#include "autopas/utils/logging/Logger.h"
 
 namespace autopas::memoryProfiler {
 

--- a/tests/testAutopas/tests/utils/LoggerTest.h
+++ b/tests/testAutopas/tests/utils/LoggerTest.h
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 #include <spdlog/common.h>
 
+#include <algorithm>
 #include <ostream>
 
 #include "AutoPasTestBase.h"


### PR DESCRIPTION
# Description 🍎

_Finally, the update nobody asked for 🙃_

## Benefits

- Compilation/ MD-Flexible/ Testing works now on macOS using Apple Clang and GCC Compilers

## Code Changes

- Update `CMakeList.txt` with a generator expression that enables  the `rt` library depending on whether you use macOS or Linux. The library is not available on macOS, but it is also not needed to access the `Time.h` header!
-  Add `<algorithm>` in `LoggerTest.h` due to the usage of `std::clamp` - some compilation problem which probably has not yet appeared before due to nondeterministic compilation, but happened on my machine
- Fixes implicit conversion for `Apple Clang` in `CellFunctor.h` and `DataLayoutConverter.h` by introducing a `static_cast` 
  - I am not certainly sure why `Apple Clang` complains about the current usage of the `DataLayoutOption` with its internal `enum` given that a *non*-explicit `constexpr` conversion operator exists. 
  - However, I assume (I could not nail it down to a concrete [C++ Standard Paper](https://en.cppreference.com/w/cpp/compiler_support))  that the integration of `constexpr` into `Apple Clang` is a bit behind, causing the issue.
- Fix the `MemoryProfiler`. A mechanism like `/proc/self/status` does not exist on macOS and led to a `segfault`. Instead, we use the available `mach.h` header to request the memory information.


## For the reviewer/ Discussable

- [X] ~Definition thing: Conversion from bytes --> kilobytes (Divide by 1024 or 1000?) - Currently 1024 is used in the `MemoryProfiler`.~  --> Since 1998, a kilobyte is officially unambiguously an increment of 1000 bytes as defined by the International Electrotechnical Commission (compare [here](http://userpage.fu-berlin.de/~ram/pub/pub_jf47ht81Ht/code_kbyte_en))
- [X] ~Shall we now support the `Apple Clang` compiler and remove the warning during the CMake Setup (or keep it for now as "unofficially" supported)~ --> We do not introduce macOS support, and keep it "unofficial" (due to additional testing requirements, i.e. a macOS CI/CD, and support for all features not yet available)


# How Has This Been Tested?

The `runTests`  && `md-flex` targets without arguments (and without MPI) have been run with the following combinations:

- macOS, GNU 14.1.0
- macOS, Apple Clang 15.0.0
- Linux ARM64 (through docker image on macOS), GNU 13.2.0
- Linux AMD64, GNU 9.4.0
