### PR TITLE
Remove global force reset from updateForces

### DIFF
--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -196,7 +196,7 @@ void Simulation::run() {
 
     _timers.computationalLoad.start();
     if (_configuration.deltaT.value != 0) {
-      updatePositions();
+      updatePositionsAndResetForces();
 #if MD_FLEXIBLE_MODE == MULTISITE
       updateQuaternions();
 #endif
@@ -251,7 +251,7 @@ void Simulation::run() {
       _timers.computationalLoad.start();
     }
 
-    updateForces();
+    updateInteractionForces();
 
     if (_configuration.deltaT.value != 0) {
       updateVelocities();
@@ -383,7 +383,7 @@ std::string Simulation::timerToString(const std::string &name, long timeNS, int 
   return ss.str();
 }
 
-void Simulation::updatePositions() {
+void Simulation::updatePositionsAndResetForces() {
   _timers.positionUpdate.start();
   TimeDiscretization::calculatePositionsAndResetForces(
       *_autoPasContainer, *(_configuration.getParticlePropertiesLibrary()), _configuration.deltaT.value,
@@ -399,7 +399,7 @@ void Simulation::updateQuaternions() {
   _timers.quaternionUpdate.stop();
 }
 
-void Simulation::updateForces() {
+void Simulation::updateInteractionForces() {
   _timers.forceUpdateTotal.start();
 
   _timers.forceUpdatePairwise.start();
@@ -420,12 +420,6 @@ void Simulation::updateForces() {
     }
   }
   _previousIterationWasTuningIteration = isTuningIteration;
-
-  _timers.forceUpdateGlobal.start();
-  if (not _configuration.globalForceIsZero()) {
-    calculateGlobalForces(_configuration.globalForce.value);
-  }
-  _timers.forceUpdateGlobal.stop();
 
   _timers.forceUpdateTotal.stop();
 }
@@ -508,7 +502,6 @@ void Simulation::logMeasurements() {
   const long updateContainer = accumulateTime(_timers.updateContainer.getTotalTime());
   const long forceUpdateTotal = accumulateTime(_timers.forceUpdateTotal.getTotalTime());
   const long forceUpdatePairwise = accumulateTime(_timers.forceUpdatePairwise.getTotalTime());
-  const long forceUpdateGlobalForces = accumulateTime(_timers.forceUpdateGlobal.getTotalTime());
   const long forceUpdateTuning = accumulateTime(_timers.forceUpdateTuning.getTotalTime());
   const long forceUpdateNonTuning = accumulateTime(_timers.forceUpdateNonTuning.getTotalTime());
   const long velocityUpdate = accumulateTime(_timers.velocityUpdate.getTotalTime());
@@ -545,8 +538,6 @@ void Simulation::logMeasurements() {
                                haloParticleExchange + reflectParticlesAtBoundaries + migratingParticleExchange);
     std::cout << timerToString("    ForceUpdateTotal              ", forceUpdateTotal, maximumNumberOfDigits, simulate);
     std::cout << timerToString("      Tuning                      ", forceUpdateTuning, maximumNumberOfDigits,
-                               forceUpdateTotal);
-    std::cout << timerToString("      ForceUpdateGlobalForces     ", forceUpdateGlobalForces, maximumNumberOfDigits,
                                forceUpdateTotal);
     std::cout << timerToString("      ForceUpdateTuning           ", forceUpdateTuning, maximumNumberOfDigits,
                                forceUpdateTotal);

--- a/examples/md-flexible/src/Simulation.h
+++ b/examples/md-flexible/src/Simulation.h
@@ -244,7 +244,8 @@ class Simulation {
                                                  long maxTime = 0ul);
 
   /**
-   * Updates the position of particles in the local AutoPas container.
+   * Updates the position of particles in the local AutoPas container. In addition, the oldForce is set to the value of
+   * the current forces and the force buffers of the particles are reset to the global force.
    */
   void updatePositionsAndResetForces();
 

--- a/examples/md-flexible/src/Simulation.h
+++ b/examples/md-flexible/src/Simulation.h
@@ -126,11 +126,6 @@ class Simulation {
     autopas::utils::Timer forceUpdatePairwise;
 
     /**
-     * Records the time used for the update of the global forces of all particles.
-     */
-    autopas::utils::Timer forceUpdateGlobal;
-
-    /**
      * Records the time used for the force update of all particles during the tuning iterations.
      */
     autopas::utils::Timer forceUpdateTuning;
@@ -251,7 +246,7 @@ class Simulation {
   /**
    * Updates the position of particles in the local AutoPas container.
    */
-  void updatePositions();
+  void updatePositionsAndResetForces();
 
   /**
    * Update the quaternion orientation of the particles in the local AutoPas container.
@@ -262,7 +257,7 @@ class Simulation {
    * Updates the forces of particles in the local AutoPas container. Includes torque updates (if an appropriate functor
    * is used).
    */
-  void updateForces();
+  void updateInteractionForces();
 
   /**
    * Updates the velocities of particles in the local AutoPas container.


### PR DESCRIPTION
# Description

MD-flexible added the global forces to the particles twice. Once in `TimeDiscretization::calculatePositionsAndResetForces` and once in `updateForces`.
The addition of the global forces in `updateForces` has been removed, as `TimeDiscretization::calculatePositionsAndResetForces` iterates over the particles in a loop anyway. This saves further iteration over the particles in `updateForces`.
To make the names of the functions a little more intuitive, `Simulation::updatePositions` has been renamed `Simulation::updatePositionsAndResetForces`. `Simulation::updateForces` has been renamed `Simulation::updateInteractionForces`.

Since we do not have access to the timers in `TimeDiscretization::calculatePositionsAndResetForces`, the timer for setting the global forces has been removed.

## Resolved Issues

- [x] fixes #885 

# How Has This Been Tested?

- [x] Existing tests
