### PR TITLE
Extending array math

### DIFF
--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ArgonInclude/Legendre.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ArgonInclude/Legendre.h
@@ -22,10 +22,6 @@ namespace autopas::utils::ArrayMath::Argon {
  */
 template <class T>
 [[nodiscard]] constexpr T LegendrePol(const T &x, const size_t d) {
-  if (d > 6) {
-    throw ExceptionHandler::AutoPasException(
-        "Argon Simulation: asked to compute Legendre polynomial of order higher than 6.");
-  }
   switch (d) {
     case 0:
       return 1;
@@ -42,6 +38,8 @@ template <class T>
     case 6:
       return 0.0625 * (231 * Math::pow<6>(x) - 315 * Math::pow<4>(x) + 105 * Math::pow<2>(x) - 5);
   }
+  throw ExceptionHandler::AutoPasException(
+      "Argon Simulation: asked to compute Legendre polynomial of order higher than 6.");
 }
 
 /**

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ArgonInclude/RepulsiveTerm.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ArgonInclude/RepulsiveTerm.h
@@ -46,8 +46,7 @@ template <size_t a, size_t b, size_t c, size_t ID>
   const auto multiplyingFactor{-A_abc * std::exp(-alpha_abc * (IJ + JK + KI))};
 
   const auto firstTerm{-alpha_abc * (displacementIJ.derive_wrt<ID>() + displacementJK.derive_wrt<ID>() +
-                                     displacementKI.derive_wrt<ID>())};
-  firstTerm *= Permutation(a, b, c, cosineI, cosineJ, cosineK);
+                                     displacementKI.derive_wrt<ID>()) * Permutation(a, b, c, cosineI, cosineJ, cosineK)};
 
   const auto secondTerm{Permutation_deriv_wrt<ID>(a, b, c, cosineI, cosineJ, cosineK)};
 

--- a/src/autopas/utils/ArrayMath.h
+++ b/src/autopas/utils/ArrayMath.h
@@ -633,6 +633,19 @@ constexpr std::array<T, SIZE> operator*(const std::array<T, SIZE> &a, T s) {
 }
 
 /**
+ * Multiplies a scalar s to each element of array a and returns the result.
+ * @tparam T floating point type
+ * @tparam SIZE size of the array a
+ * @param s the scalar to be multiplied to each element of a
+ * @param a the array
+ * @return array who's elements are a[i]*s
+ */
+template <class T, std::size_t SIZE>
+constexpr std::array<T, SIZE> operator*(T s, const std::array<T, SIZE> &a) {
+  return mulScalar(a, s);
+}
+
+/**
  * Assignment operator to multiply a scalar s to each element of array
  * @tparam T floating point type
  * @tparam SIZE size of the array a

--- a/tests/testAutopas/tests/utils/ArrayMathTest.cpp
+++ b/tests/testAutopas/tests/utils/ArrayMathTest.cpp
@@ -163,6 +163,11 @@ TEST(ArrayMathTest, testMulScalarOp) {
     ASSERT_DOUBLE_EQ(result[d], a[d] * scalar);
   }
 
+  result = scalar * a;
+  for (int d = 0; d < 3; ++d) {
+    ASSERT_DOUBLE_EQ(result[d], a[d] * scalar);
+  }
+
   result *= scalar;
   for (int d = 0; d < 3; ++d) {
     ASSERT_DOUBLE_EQ(result[d], a[d] * scalar * scalar);


### PR DESCRIPTION
Added `operator*(T s, const std::array<T, SIZE> &a)` which returns same result as `operator*(Tconst std::array<T, SIZE> &a, T s)`.
