### PR TITLE
Refactor calculation of globals

### DIFF
--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorSVE.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorSVE.h
@@ -157,13 +157,16 @@ class LJFunctorSVE : public autopas::Functor<Particle, LJFunctorSVE<Particle, ap
       j.subF(f);
     }
     if (calculateGlobals) {
+      // We always add the full contribution for each owned particle and divide the sums by 2 in endTraversal().
+      // Potential energy has an additional factor of 6, which is also handled in endTraversal().
+
       auto virial = dr * f;
       double potentialEnergy6 = epsilon24 * lj12m6 + shift6;
 
       const int threadnum = autopas::autopas_get_thread_num();
       if (i.isOwned()) {
-          _aosThreadData[threadnum].potentialEnergySum += potentialEnergy6;
-          _aosThreadData[threadnum].virialSum += virial;
+        _aosThreadData[threadnum].potentialEnergySum += potentialEnergy6;
+        _aosThreadData[threadnum].virialSum += virial;
       }
       // for non-newton3 the second particle will be considered in a separate calculation
       if (newton3 and j.isOwned()) {
@@ -275,12 +278,10 @@ class LJFunctorSVE : public autopas::Functor<Particle, LJFunctorSVE<Particle, ap
     if constexpr (calculateGlobals) {
       const int threadnum = autopas::autopas_get_thread_num();
 
-      // we assume newton3 to be enabled in this function call, thus we multiply by two if the value of newton3 is
-      // false, since for newton3 disabled we divide by two later on.
-        _aosThreadData[threadnum].potentialEnergySum += svaddv_f64(svptrue_b64(), potentialEnergySum);
-        _aosThreadData[threadnum].virialSum[0] += svaddv_f64(svptrue_b64(), virialSumX);
-        _aosThreadData[threadnum].virialSum[1] += svaddv_f64(svptrue_b64(), virialSumY);
-        _aosThreadData[threadnum].virialSum[2] += svaddv_f64(svptrue_b64(), virialSumZ);
+      _aosThreadData[threadnum].potentialEnergySum += svaddv_f64(svptrue_b64(), potentialEnergySum);
+      _aosThreadData[threadnum].virialSum[0] += svaddv_f64(svptrue_b64(), virialSumX);
+      _aosThreadData[threadnum].virialSum[1] += svaddv_f64(svptrue_b64(), virialSumY);
+      _aosThreadData[threadnum].virialSum[2] += svaddv_f64(svptrue_b64(), virialSumZ);
     }
 #endif
   }
@@ -361,10 +362,9 @@ class LJFunctorSVE : public autopas::Functor<Particle, LJFunctorSVE<Particle, ap
       const int threadnum = autopas::autopas_get_thread_num();
 
       _aosThreadData[threadnum].potentialEnergySum += svaddv_f64(svptrue_b64(), potentialEnergySum);
-        _aosThreadData[threadnum].virialSum[0] += svaddv_f64(svptrue_b64(), virialSumX);
-        _aosThreadData[threadnum].virialSum[1] += svaddv_f64(svptrue_b64(), virialSumY);
-        _aosThreadData[threadnum].virialSum[2] += svaddv_f64(svptrue_b64(), virialSumZ);
-
+      _aosThreadData[threadnum].virialSum[0] += svaddv_f64(svptrue_b64(), virialSumX);
+      _aosThreadData[threadnum].virialSum[1] += svaddv_f64(svptrue_b64(), virialSumY);
+      _aosThreadData[threadnum].virialSum[2] += svaddv_f64(svptrue_b64(), virialSumZ);
     }
 #endif
   }
@@ -765,19 +765,16 @@ class LJFunctorSVE : public autopas::Functor<Particle, LJFunctorSVE<Particle, ap
           "Already postprocessed, endTraversal(bool newton3) was called twice without calling initTraversal().");
     }
     if (calculateGlobals) {
-      // We distinguish between non-newton3 and newton3 functor calls. Newton3 calls are accumulated directly.
-      // Non-newton3 calls are accumulated temporarily and later divided by 2.
-
       for (size_t i = 0; i < _aosThreadData.size(); ++i) {
         _potentialEnergySum += _aosThreadData[i].potentialEnergySum;
         _virialSum += _aosThreadData[i].virialSum;
       }
-      // if the newton3 optimization is disabled we have added every energy contribution twice, so we divide by 2
-      // here.
+      // For each interaction, we added the full contribution for both particles. Divide by 2 here, so that each
+      // contribution is only counted once per pair.
       _potentialEnergySum *= 0.5;
       _virialSum *= 0.5;
 
-      // we have always calculated 6*potentialEnergy, so we divide by 6 here!
+      // We have always calculated 6*potentialEnergy, so we divide by 6 here!
       _potentialEnergySum /= 6.;
       _postProcessed = true;
 
@@ -855,10 +852,7 @@ class LJFunctorSVE : public autopas::Functor<Particle, LJFunctorSVE<Particle, ap
    */
   class AoSThreadData {
    public:
-    AoSThreadData()
-        : virialSum{0., 0., 0.},
-          potentialEnergySum{0.},
-          __remainingTo64{} {}
+    AoSThreadData() : virialSum{0., 0., 0.}, potentialEnergySum{0.}, __remainingTo64{} {}
     void setZero() {
       virialSum = {0., 0., 0.};
       potentialEnergySum = 0.;

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorSVE.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorSVE.h
@@ -162,19 +162,13 @@ class LJFunctorSVE : public autopas::Functor<Particle, LJFunctorSVE<Particle, ap
 
       const int threadnum = autopas::autopas_get_thread_num();
       if (i.isOwned()) {
-        if (newton3) {
-          _aosThreadData[threadnum].potentialEnergySumN3 += potentialEnergy6 * 0.5;
-          _aosThreadData[threadnum].virialSumN3 += virial * 0.5;
-        } else {
-          // for non-newton3 the division is in the post-processing step.
-          _aosThreadData[threadnum].potentialEnergySumNoN3 += potentialEnergy6;
-          _aosThreadData[threadnum].virialSumNoN3 += virial;
-        }
+          _aosThreadData[threadnum].potentialEnergySum += potentialEnergy6;
+          _aosThreadData[threadnum].virialSum += virial;
       }
       // for non-newton3 the second particle will be considered in a separate calculation
       if (newton3 and j.isOwned()) {
-        _aosThreadData[threadnum].potentialEnergySumN3 += potentialEnergy6 * 0.5;
-        _aosThreadData[threadnum].virialSumN3 += virial * 0.5;
+        _aosThreadData[threadnum].potentialEnergySum += potentialEnergy6;
+        _aosThreadData[threadnum].virialSum += virial;
       }
     }
   }
@@ -283,17 +277,10 @@ class LJFunctorSVE : public autopas::Functor<Particle, LJFunctorSVE<Particle, ap
 
       // we assume newton3 to be enabled in this function call, thus we multiply by two if the value of newton3 is
       // false, since for newton3 disabled we divide by two later on.
-      if (newton3) {
-        _aosThreadData[threadnum].potentialEnergySumN3 += svaddv_f64(svptrue_b64(), potentialEnergySum) * 0.5;
-        _aosThreadData[threadnum].virialSumN3[0] += svaddv_f64(svptrue_b64(), virialSumX) * 0.5;
-        _aosThreadData[threadnum].virialSumN3[1] += svaddv_f64(svptrue_b64(), virialSumY) * 0.5;
-        _aosThreadData[threadnum].virialSumN3[2] += svaddv_f64(svptrue_b64(), virialSumZ) * 0.5;
-      } else {
-        _aosThreadData[threadnum].potentialEnergySumNoN3 += svaddv_f64(svptrue_b64(), potentialEnergySum);
-        _aosThreadData[threadnum].virialSumNoN3[0] += svaddv_f64(svptrue_b64(), virialSumX);
-        _aosThreadData[threadnum].virialSumNoN3[1] += svaddv_f64(svptrue_b64(), virialSumY);
-        _aosThreadData[threadnum].virialSumNoN3[2] += svaddv_f64(svptrue_b64(), virialSumZ);
-      }
+        _aosThreadData[threadnum].potentialEnergySum += svaddv_f64(svptrue_b64(), potentialEnergySum);
+        _aosThreadData[threadnum].virialSum[0] += svaddv_f64(svptrue_b64(), virialSumX);
+        _aosThreadData[threadnum].virialSum[1] += svaddv_f64(svptrue_b64(), virialSumY);
+        _aosThreadData[threadnum].virialSum[2] += svaddv_f64(svptrue_b64(), virialSumZ);
     }
 #endif
   }
@@ -373,17 +360,11 @@ class LJFunctorSVE : public autopas::Functor<Particle, LJFunctorSVE<Particle, ap
     if constexpr (calculateGlobals) {
       const int threadnum = autopas::autopas_get_thread_num();
 
-      if (newton3) {
-        _aosThreadData[threadnum].potentialEnergySumN3 += svaddv_f64(svptrue_b64(), potentialEnergySum) * 0.5;
-        _aosThreadData[threadnum].virialSumN3[0] += svaddv_f64(svptrue_b64(), virialSumX) * 0.5;
-        _aosThreadData[threadnum].virialSumN3[1] += svaddv_f64(svptrue_b64(), virialSumY) * 0.5;
-        _aosThreadData[threadnum].virialSumN3[2] += svaddv_f64(svptrue_b64(), virialSumZ) * 0.5;
-      } else {
-        _aosThreadData[threadnum].potentialEnergySumNoN3 += svaddv_f64(svptrue_b64(), potentialEnergySum);
-        _aosThreadData[threadnum].virialSumNoN3[0] += svaddv_f64(svptrue_b64(), virialSumX);
-        _aosThreadData[threadnum].virialSumNoN3[1] += svaddv_f64(svptrue_b64(), virialSumY);
-        _aosThreadData[threadnum].virialSumNoN3[2] += svaddv_f64(svptrue_b64(), virialSumZ);
-      }
+      _aosThreadData[threadnum].potentialEnergySum += svaddv_f64(svptrue_b64(), potentialEnergySum);
+        _aosThreadData[threadnum].virialSum[0] += svaddv_f64(svptrue_b64(), virialSumX);
+        _aosThreadData[threadnum].virialSum[1] += svaddv_f64(svptrue_b64(), virialSumY);
+        _aosThreadData[threadnum].virialSum[2] += svaddv_f64(svptrue_b64(), virialSumZ);
+
     }
 #endif
   }
@@ -699,17 +680,10 @@ class LJFunctorSVE : public autopas::Functor<Particle, LJFunctorSVE<Particle, ap
     if constexpr (calculateGlobals) {
       const int threadnum = autopas::autopas_get_thread_num();
 
-      if (newton3) {
-        _aosThreadData[threadnum].potentialEnergySumN3 += svaddv_f64(svptrue_b64(), potentialEnergySum) * 0.5;
-        _aosThreadData[threadnum].virialSumN3[0] += svaddv_f64(svptrue_b64(), virialSumX) * 0.5;
-        _aosThreadData[threadnum].virialSumN3[1] += svaddv_f64(svptrue_b64(), virialSumY) * 0.5;
-        _aosThreadData[threadnum].virialSumN3[2] += svaddv_f64(svptrue_b64(), virialSumZ) * 0.5;
-      } else {
-        _aosThreadData[threadnum].potentialEnergySumNoN3 += svaddv_f64(svptrue_b64(), potentialEnergySum);
-        _aosThreadData[threadnum].virialSumNoN3[0] += svaddv_f64(svptrue_b64(), virialSumX);
-        _aosThreadData[threadnum].virialSumNoN3[1] += svaddv_f64(svptrue_b64(), virialSumY);
-        _aosThreadData[threadnum].virialSumNoN3[2] += svaddv_f64(svptrue_b64(), virialSumZ);
-      }
+      _aosThreadData[threadnum].potentialEnergySum += svaddv_f64(svptrue_b64(), potentialEnergySum);
+      _aosThreadData[threadnum].virialSum[0] += svaddv_f64(svptrue_b64(), virialSumX);
+      _aosThreadData[threadnum].virialSum[1] += svaddv_f64(svptrue_b64(), virialSumY);
+      _aosThreadData[threadnum].virialSum[2] += svaddv_f64(svptrue_b64(), virialSumZ);
     }
 #endif
   }
@@ -793,22 +767,15 @@ class LJFunctorSVE : public autopas::Functor<Particle, LJFunctorSVE<Particle, ap
     if (calculateGlobals) {
       // We distinguish between non-newton3 and newton3 functor calls. Newton3 calls are accumulated directly.
       // Non-newton3 calls are accumulated temporarily and later divided by 2.
-      double potentialEnergySumNoN3Acc = 0;
-      std::array<double, 3> virialSumNoN3Acc = {0, 0, 0};
-      for (size_t i = 0; i < _aosThreadData.size(); ++i) {
-        potentialEnergySumNoN3Acc += _aosThreadData[i].potentialEnergySumNoN3;
-        _potentialEnergySum += _aosThreadData[i].potentialEnergySumN3;
 
-        virialSumNoN3Acc += _aosThreadData[i].virialSumNoN3;
-        _virialSum += _aosThreadData[i].virialSumN3;
+      for (size_t i = 0; i < _aosThreadData.size(); ++i) {
+        _potentialEnergySum += _aosThreadData[i].potentialEnergySum;
+        _virialSum += _aosThreadData[i].virialSum;
       }
       // if the newton3 optimization is disabled we have added every energy contribution twice, so we divide by 2
       // here.
-      potentialEnergySumNoN3Acc *= 0.5;
-      virialSumNoN3Acc *= 0.5;
-
-      _potentialEnergySum += potentialEnergySumNoN3Acc;
-      _virialSum += virialSumNoN3Acc;
+      _potentialEnergySum *= 0.5;
+      _virialSum *= 0.5;
 
       // we have always calculated 6*potentialEnergy, so we divide by 6 here!
       _potentialEnergySum /= 6.;
@@ -889,27 +856,21 @@ class LJFunctorSVE : public autopas::Functor<Particle, LJFunctorSVE<Particle, ap
   class AoSThreadData {
    public:
     AoSThreadData()
-        : virialSumNoN3{0., 0., 0.},
-          virialSumN3{0., 0., 0.},
-          potentialEnergySumNoN3{0.},
-          potentialEnergySumN3{0.},
+        : virialSum{0., 0., 0.},
+          potentialEnergySum{0.},
           __remainingTo64{} {}
     void setZero() {
-      virialSumNoN3 = {0., 0., 0.};
-      virialSumN3 = {0., 0., 0.};
-      potentialEnergySumNoN3 = 0.;
-      potentialEnergySumN3 = 0.;
+      virialSum = {0., 0., 0.};
+      potentialEnergySum = 0.;
     }
 
     // variables
-    std::array<double, 3> virialSumNoN3;
-    std::array<double, 3> virialSumN3;
-    double potentialEnergySumNoN3;
-    double potentialEnergySumN3;
+    std::array<double, 3> virialSum;
+    double potentialEnergySum;
 
    private:
     // dummy parameter to get the right size (64 bytes)
-    double __remainingTo64[(64 - 8 * sizeof(double)) / sizeof(double)];
+    double __remainingTo64[(64 - 4 * sizeof(double)) / sizeof(double)];
   };
   // make sure of the size of AoSThreadData
   static_assert(sizeof(AoSThreadData) % 64 == 0, "AoSThreadData has wrong size");

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJMultisiteFunctor.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJMultisiteFunctor.h
@@ -247,19 +247,16 @@ class LJMultisiteFunctor
         }
 
         if (calculateGlobals) {
-          // Here we calculate the potential energy * 6.
-          // For newton3, this potential energy contribution is distributed evenly to the two molecules.
-          // For non-newton3, the full potential energy is added to the one molecule.
-          // The division by 6 is handled in endTraversal, as well as the division by two needed if newton3 is not used.
-          // There is a similar handling of the virial, but without the mutliplication/division by 6.
+          // We always add the full contribution for each owned particle and divide the sums by 2 in endTraversal().
+          // Potential energy has an additional factor of 6, which is also handled in endTraversal().
           const auto potentialEnergy6 = epsilon24 * lj12m6 + shift6;
           const auto virial = displacement * force;
 
           const auto threadNum = autopas::autopas_get_thread_num();
 
           if (particleA.isOwned()) {
-              _aosThreadData[threadNum].potentialEnergySum += potentialEnergy6;
-              _aosThreadData[threadNum].virialSum += virial;
+            _aosThreadData[threadNum].potentialEnergySum += potentialEnergy6;
+            _aosThreadData[threadNum].virialSum += virial;
           }
           // for non-newton3 the second particle will be considered in a separate calculation
           if (newton3 and particleB.isOwned()) {
@@ -522,8 +519,8 @@ class LJMultisiteFunctor
             const auto virialZ = displacementZ * forceZ;
             const auto potentialEnergy6 = siteMask[siteB] ? (epsilon24 * lj12m6 + shift6) : 0.;
 
-            // Add to the potential energy sum for each particle which is owned.
-            // This results in obtaining 12 * the potential energy for the SoA.
+            // We add 6 times the potential energy for each owned particle. The total sum is corrected in
+            // endTraversal().
             const auto ownershipMask =
                 (ownedStateA == autopas::OwnershipState::owned ? 1. : 0.) + (isSiteBOwned ? 1. : 0.);
             potentialEnergySum += potentialEnergy6 * ownershipMask;
@@ -581,8 +578,7 @@ class LJMultisiteFunctor
 
     if constexpr (calculateGlobals) {
       const auto threadNum = autopas::autopas_get_thread_num();
-      // SoAFunctorSingle obtains the potential energy * 12. For non-newton3, this sum is divided by 12 in
-      // post-processing. For newton3, this sum is only divided by 6 in post-processing, so must be divided by 2 here.
+
       _aosThreadData[threadNum].potentialEnergySum += potentialEnergySum;
       _aosThreadData[threadNum].virialSum[0] += virialSumX;
       _aosThreadData[threadNum].virialSum[1] += virialSumY;
@@ -729,18 +725,17 @@ class LJMultisiteFunctor
           "Already postprocessed, endTraversal(bool newton3) was called twice without calling initTraversal().");
     }
     if (calculateGlobals) {
-      // We distinguish between non-newton3 and newton3 functor calls. Newton3 calls are accumulated directly.
-      // Non-newton3 calls are accumulated temporarily and later divided by 2.
       for (size_t i = 0; i < _aosThreadData.size(); ++i) {
         _potentialEnergySum += _aosThreadData[i].potentialEnergySum;
         _virialSum += _aosThreadData[i].virialSum;
       }
-      // if the newton3 optimization is disabled we have added every energy contribution twice, so we divide by 2
-      // here.
+
+      // For each interaction, we added the full contribution for both particles. Divide by 2 here, so that each
+      // contribution is only counted once per pair.
       _potentialEnergySum *= 0.5;
       _virialSum *= 0.5;
 
-      // we have always calculated 6*potentialEnergy, so we divide by 6 here!
+      // We have always calculated 6*potentialEnergy, so we divide by 6 here!
       _potentialEnergySum /= 6.;
       _postProcessed = true;
 
@@ -1070,8 +1065,8 @@ class LJMultisiteFunctor
             const auto virialY = displacementY * forceY;
             const auto virialZ = displacementZ * forceZ;
 
-            // Add to the potential energy sum for each particle which is owned.
-            // This results in obtaining 12 * the potential energy for the SoA.
+            // We add 6 times the potential energy for each owned particle. The total sum is corrected in
+            // endTraversal().
             const auto ownershipFactor =
                 newton3 ? (ownedStateA == autopas::OwnershipState::owned ? 1. : 0.) + (isSiteOwnedB ? 1. : 0.)
                         : (ownedStateA == autopas::OwnershipState::owned ? 1. : 0.);
@@ -1425,8 +1420,7 @@ class LJMultisiteFunctor
           const auto virialY = displacementY * forceY;
           const auto virialZ = displacementZ * forceZ;
 
-          // Add to the potential energy sum for each particle which is owned.
-          // This results in obtaining 12 * the potential energy for the SoA.
+          // We add 6 times the potential energy for each owned particle. The total sum is corrected in endTraversal().
           const auto ownershipFactor =
               newton3 ? (ownedStatePrime == autopas::OwnershipState::owned ? 1. : 0.) + (isNeighborSiteOwned ? 1. : 0.)
                       : (ownedStatePrime == autopas::OwnershipState::owned ? 1. : 0.);
@@ -1492,8 +1486,7 @@ class LJMultisiteFunctor
 
     if constexpr (calculateGlobals) {
       const auto threadNum = autopas::autopas_get_thread_num();
-      // SoAFunctorSingle obtains the potential energy * 12. For non-newton3, this sum is divided by 12 in
-      // post-processing. For newton3, this sum is only divided by 6 in post-processing, so must be divided by 2 here.
+
       _aosThreadData[threadNum].potentialEnergySum += potentialEnergySum;
       _aosThreadData[threadNum].virialSum[0] += virialSumX;
       _aosThreadData[threadNum].virialSum[1] += virialSumY;
@@ -1506,10 +1499,7 @@ class LJMultisiteFunctor
    */
   class AoSThreadData {
    public:
-    AoSThreadData()
-        : virialSum{0., 0., 0.},
-          potentialEnergySum{0.},
-          __remainingTo64{} {}
+    AoSThreadData() : virialSum{0., 0., 0.}, potentialEnergySum{0.}, __remainingTo64{} {}
     void setZero() {
       virialSum = {0., 0., 0.};
       potentialEnergySum = 0.;

--- a/applicationLibrary/molecularDynamics/tests/singleSiteTests/LJFunctorFlopCounterTest.cpp
+++ b/applicationLibrary/molecularDynamics/tests/singleSiteTests/LJFunctorFlopCounterTest.cpp
@@ -139,7 +139,8 @@ void LJFunctorFlopCounterTest::testFLOPCounter(autopas::DataLayoutOption dataLay
   constexpr int numFLOPsPerN3GlobalsCall = applyShift ? 13 : 12;
   const auto expectedFlops =
       expectedDistanceCalculations * numFLOPsPerDistanceCalc + expectedN3KernelCalls * numFLOPsPerN3KernelCall +
-      expectedNoN3KernelCalls * numFLOPsPerNoN3KernelCall + expectedN3GlobalsCalcs * numFLOPsPerN3GlobalsCall + expectedNoN3GlobalsCalcs * numFLOPsPerNoN3GlobalsCall;
+      expectedNoN3KernelCalls * numFLOPsPerNoN3KernelCall + expectedN3GlobalsCalcs * numFLOPsPerN3GlobalsCall +
+      expectedNoN3GlobalsCalcs * numFLOPsPerNoN3GlobalsCall;
   ASSERT_EQ(expectedFlops, ljFunctor.getNumFLOPs());
 
   const auto expectedHitRate =

--- a/applicationLibrary/molecularDynamics/tests/singleSiteTests/LJFunctorFlopCounterTest.cpp
+++ b/applicationLibrary/molecularDynamics/tests/singleSiteTests/LJFunctorFlopCounterTest.cpp
@@ -126,17 +126,20 @@ void LJFunctorFlopCounterTest::testFLOPCounter(autopas::DataLayoutOption dataLay
   const auto expectedNoN3KernelCalls = newton3 ? 0 : (not isVerlet and isSoA ? 2 : 4);
   const auto expectedN3KernelCalls = newton3 ? 2 : (not isVerlet and isSoA ? 1 : 0);
 
-  const auto expectedGlobalsCalcs = calculateGlobals ? expectedN3KernelCalls + expectedNoN3KernelCalls : 0;
+  const auto expectedN3GlobalsCalcs = calculateGlobals ? expectedN3KernelCalls : 0;
+  const auto expectedNoN3GlobalsCalcs = calculateGlobals ? expectedNoN3KernelCalls : 0;
 
   // distance calculations cost 8 FLOPs, LJ kernel calls without Newton3 cost 15 FLOPs, with Newton 3 cost 18 FLOPs
-  // globals calculations cost 8 FLOPs, 9 with shift
+  // globals calculations without Newton3 cost 8 FLOPs, 9 with shift
+  // globals calculations with Newton3 cost 12 FLOPs, 13 with shift (+4 for adding energy and virial to Particle 2)
   constexpr int numFLOPsPerDistanceCalc = 8;
   constexpr int numFLOPsPerNoN3KernelCall = 15;
   constexpr int numFLOPsPerN3KernelCall = 18;
-  constexpr int numFLOPsPerGlobalsCall = applyShift ? 9 : 8;
+  constexpr int numFLOPsPerNoN3GlobalsCall = applyShift ? 9 : 8;
+  constexpr int numFLOPsPerN3GlobalsCall = applyShift ? 13 : 12;
   const auto expectedFlops =
       expectedDistanceCalculations * numFLOPsPerDistanceCalc + expectedN3KernelCalls * numFLOPsPerN3KernelCall +
-      expectedNoN3KernelCalls * numFLOPsPerNoN3KernelCall + expectedGlobalsCalcs * numFLOPsPerGlobalsCall;
+      expectedNoN3KernelCalls * numFLOPsPerNoN3KernelCall + expectedN3GlobalsCalcs * numFLOPsPerN3GlobalsCall + expectedNoN3GlobalsCalcs * numFLOPsPerNoN3GlobalsCall;
   ASSERT_EQ(expectedFlops, ljFunctor.getNumFLOPs());
 
   const auto expectedHitRate =

--- a/applicationLibrary/molecularDynamics/tests/singleSiteTests/LJFunctorTestGlobals.cpp
+++ b/applicationLibrary/molecularDynamics/tests/singleSiteTests/LJFunctorTestGlobals.cpp
@@ -531,5 +531,9 @@ using MyTypes = ::testing::Types<LJFunShiftNoMixGlob
                                  ,
                                  LJFunAVXShiftNoMixGlob
 #endif
+#ifdef __ARM_FEATURE_SVE
+                                 ,
+                                 LJFunSVEShiftNoMixGlob
+#endif
                                  >;
 INSTANTIATE_TYPED_TEST_SUITE_P(GeneratedTyped, LJFunctorTestGlobals, MyTypes);


### PR DESCRIPTION
# Description

Previously, when calculating globals, we had a differentiation of newton3 and non-newton3 cases. This seemed unnecessarily complicated and made it difficult to correctly count flops in case of enabled globals. (see #850)

The new implementation adds a full contribution of the virial and the energy for each owned particle. The sums are divided by 2 in the post processing step in `endTraversal()`.

This also reduces the number of flops in the `newton3` case as division by 2 is done only once in the post processing.

# How Has This Been Tested?

- [x] `LJFunctorTestGlobals` passes for LJ
- [x] Output for flop counting is more reasonable
- [x] ls1 Argon example with MPI still produces the same u_pot and pressure (see log for Argon Simulation, first 100 timesteps, 4 mpi ranks)
[ls1_only.log](https://github.com/user-attachments/files/16414991/ls1_only.log)
[old_autopas.log](https://github.com/user-attachments/files/16414992/old_autopas.log)
[refactored_autopas.log](https://github.com/user-attachments/files/16414993/refactored_autopas.log)
