### PR TITLE
MPI Bugfix Halo Box

### DIFF
--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -510,9 +510,9 @@ void RegularGridDecomposition::collectHaloParticlesForLeftNeighbor(
   using namespace autopas::utils::ArrayMath::literals;
 
   const auto skinWidth = _skinWidthPerTimestep * _rebuildFrequency;
-  const std::array<double, _dimensionCount> boxMin = _localBoxMin - skinWidth;
+  const std::array<double, _dimensionCount> boxMin = _localBoxMin;
   const std::array<double, _dimensionCount> boxMax = [&]() {
-    auto boxMax = _localBoxMax + skinWidth;
+    auto boxMax = _localBoxMax;
     boxMax[direction] = _localBoxMin[direction] + _cutoffWidth + skinWidth;
     return boxMax;
   }();
@@ -528,9 +528,9 @@ void RegularGridDecomposition::collectHaloParticlesForRightNeighbor(
   using namespace autopas::utils::ArrayMath::literals;
 
   const auto skinWidth = _skinWidthPerTimestep * _rebuildFrequency;
-  const std::array<double, _dimensionCount> boxMax = _localBoxMax + skinWidth;
+  const std::array<double, _dimensionCount> boxMax = _localBoxMax;
   const std::array<double, _dimensionCount> boxMin = [&]() {
-    auto boxMin = _localBoxMin - skinWidth;
+    auto boxMin = _localBoxMin;
     boxMin[direction] = _localBoxMax[direction] - _cutoffWidth - skinWidth;
     return boxMin;
   }();


### PR DESCRIPTION
# Description

This PR aims to fix an issue with adding halo particles in MPI runs.
The problem was solved by removing the double addition of the `skinWidth*rebuildFrequency` from `boxMin` and `boxMax` in the `RegularGridDecomposition::collectHaloParticlesForLeftNeighbor` abd `RegularGridDecomposition::collectHaloParticlesForRightNeighbor`. This is now done in the `getParticleImpl` functions of the containers.

## Resolved Issues

- [x] fixes #891 

# How Has This Been Tested?

All existing tests.
