### PR TITLE
Fix FLOP counting in Tests

### DIFF
--- a/applicationLibrary/molecularDynamics/tests/singleSiteTests/ForceCalculationTest.cpp
+++ b/applicationLibrary/molecularDynamics/tests/singleSiteTests/ForceCalculationTest.cpp
@@ -11,12 +11,8 @@
 #include "molecularDynamicsLibrary/LJFunctor.h"
 #include "testingHelpers/commonTypedefs.h"
 
-using ForceCalculationTestLJFunctor =
-    LJFunctorType</* shifting */ false, /*mixing*/ false, autopas::FunctorN3Modes::Both, /*globals*/ false,
-                  /*relevantForTuning*/ true>;
-
 extern template class autopas::AutoPas<Molecule>;
-extern template bool autopas::AutoPas<Molecule>::iteratePairwise(ForceCalculationTestLJFunctor *);
+extern template bool autopas::AutoPas<Molecule>::iteratePairwise(LJFunctorType<> *);
 
 void ForceCalculationTest::testLJ(double particleSpacing, double cutoff, autopas::DataLayoutOption dataLayoutOption,
                                   std::array<std::array<double, 3>, 4> expectedForces, double tolerance) {
@@ -38,10 +34,10 @@ void ForceCalculationTest::testLJ(double particleSpacing, double cutoff, autopas
   autopasTools::generators::GridGenerator::fillWithParticles(autoPas, {2, 2, 1}, defaultParticle,
                                                              {particleSpacing, particleSpacing, particleSpacing});
 
-  ForceCalculationTestLJFunctor functor(cutoff);
+  LJFunctorType<> functor(cutoff);
   functor.setParticleProperties(24, 1);
 
-  autoPas.iteratePairwise<ForceCalculationTestLJFunctor>(&functor);
+  autoPas.iteratePairwise(&functor);
 
   for (auto p = autoPas.begin(); p.isValid(); ++p) {
     auto id = p->getID();

--- a/tests/testAutopas/testingHelpers/commonTypedefs.h
+++ b/tests/testAutopas/testingHelpers/commonTypedefs.h
@@ -38,28 +38,15 @@ using FMCell = autopas::FullParticleCell<Molecule>;
  */
 using MFunctor = MockFunctor<autopas::Particle>;
 
-namespace autopasTestingTypeDefs {
 /**
- * If AutoPas is compiled with FLOP logging enabled, use functors with FLOP counting enabled.
- */
-constexpr bool countFLOPs =
-#ifdef AUTOPAS_LOG_FLOPS
-    true;
-#else
-    false;
-#endif
-}  // namespace autopasTestingTypeDefs
-
-/**
- * Helper alias for LJFunctor, which specifies Particle as Molecule (as defined above) and countFLOPs as defined above.
- * Primarily, this is useful to avoid specifying out default template when we just want to change countFLOPs, which we
- * need to do to avoid warnings/exceptions when the tests are compiled with AUTOPAS_LOG_FLOPS=ON.
+ * Helper alias for LJFunctor, with more defaults geared towards testing.
+ * This facilitates writing tests and tries to reduce the number of template instantiations.
  */
 template <bool applyShift = false, bool useMixing = false,
           autopas::FunctorN3Modes useNewton3 = autopas::FunctorN3Modes::Both, bool calculateGlobals = false,
-          bool relevantForTuning = true>
-using LJFunctorType = mdLib::LJFunctor<Molecule, applyShift, useMixing, useNewton3, calculateGlobals,
-                                       autopasTestingTypeDefs::countFLOPs, relevantForTuning>;
+          bool countFLOPs = false, bool relevantForTuning = true>
+using LJFunctorType =
+    mdLib::LJFunctor<Molecule, applyShift, useMixing, useNewton3, calculateGlobals, countFLOPs, relevantForTuning>;
 
 /**
  * Helper alias for specialization of LJFunctorType with globals and shift enabled but mixing disabled.

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/SlicedTraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/SlicedTraversalTest.cpp
@@ -16,7 +16,8 @@ using ::testing::_;
 
 void testSlicedTraversal(const std::array<size_t, 3> &edgeLength) {
   // Get LJ Functor with FLOP Counting enabled
-  LJFunctorType<false, false, autopas::FunctorN3Modes::Both, false, true> ljFunctor(1.);
+  LJFunctorType</*shift*/ false, /*mixing*/ false, autopas::FunctorN3Modes::Both, /*globals*/ false, /*flops*/ true>
+      ljFunctor(1.);
   std::vector<FMCell> cells;
   cells.resize(edgeLength[0] * edgeLength[1] * edgeLength[2]);
 
@@ -26,8 +27,8 @@ void testSlicedTraversal(const std::array<size_t, 3> &edgeLength) {
 
   NumThreadGuard numThreadGuard(4);
 
-  autopas::LCSlicedTraversal<FMCell, LJFunctorType<false, false, autopas::FunctorN3Modes::Both, false, true>>
-      slicedTraversal(edgeLength, &ljFunctor, 1., {1., 1., 1.}, autopas::DataLayoutOption::aos, true);
+  autopas::LCSlicedTraversal<FMCell, decltype(ljFunctor)> slicedTraversal(edgeLength, &ljFunctor, 1., {1., 1., 1.},
+                                                                          autopas::DataLayoutOption::aos, true);
 
   EXPECT_TRUE(slicedTraversal.isApplicable());
   slicedTraversal.setCellsToTraverse(cells);


### PR DESCRIPTION
# Description

When `AUTOPAS_LOG_FLOPS=OFF` the test `SlicedTraversalTest.testTraversalCubeShrink` fails. This went unnoticed because our CI only tests with the logging enabled.

- [x] Make flop counting in tests independent of CMake parameter
- [x] Clean up template parameter usage

## Related Pull Requests

The CMake Parameter and new FLOP counting mechanic was introduced in #850

## ~Resolved Issues~

# How Has This Been Tested?

- [x] `ctest -R 'SlicedTraversalTest.testTraversalCubeShrink'` passes when `AUTOPAS_LOG_FLOPS=OFF`
