### PR TITLE
Bug fixes to force calculation

### DIFF
--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ArgonInclude/AngularFunctions.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ArgonInclude/AngularFunctions.h
@@ -298,7 +298,7 @@ template <size_t ID>
   const auto nablaCosineTerm =
       9. * nablaCosK - 25. * nablaCos3K + 6. * nablaCosIminusJ * (3 + 5. * cos2K) + 30. * cosIminusJ * nablaCos2K;
 
-  return 3. / 16 / (Math::pow<3>(IJ) + Math::pow<4>(JK) + Math::pow<4>(KI)) *
+  return 3. / 16 / (Math::pow<3>(IJ) * Math::pow<4>(JK) * Math::pow<4>(KI)) *
          (nablaDisplacementTerm * cosineTerm + nablaCosineTerm);
 }
 
@@ -352,7 +352,7 @@ template <size_t ID>
                                60. * cosJminusK * nablaCos2I + 70. * nablaCos2JminusK * cosI +
                                70. * cos2JminusK * nablaCosI;
 
-  return 15. / 64 / (Math::pow<4>(IJ) + Math::pow<5>(JK) + Math::pow<4>(KI)) *
+  return 15. / 64 / (Math::pow<4>(IJ) * Math::pow<5>(JK) * Math::pow<4>(KI)) *
          (nablaDisplacementTerm * cosineTerm + nablaCosineTerm);
 }
 
@@ -414,7 +414,7 @@ template <size_t ID>
       490. * (nablaCos2I * cos2J * cos2K + cos2I * nablaCos2J * cos2K + cos2I * cos2J * nablaCos2K);
   const auto nablaCosineTerm3 = 175. * (nablaCos2IminusJ + nablaCos2JminusK + nablaCos2KminusI);
 
-  return 15. / 128 / (Math::pow<5>(IJ) + Math::pow<5>(JK) + Math::pow<5>(KI)) *
+  return 15. / 128 / (Math::pow<5>(IJ) * Math::pow<5>(JK) * Math::pow<5>(KI)) *
          (nablaDisplacementTerm * cosineTerm + nablaCosineTerm1 + nablaCosineTerm2 + nablaCosineTerm3);
 }
 
@@ -449,7 +449,7 @@ template <size_t ID>
   const auto nablaCosineTerm = 8. * nablaCos2K - 49. * nablaCos4K + 6. * nablaCosIminusJ * (9. * cosK + 7. * cos3K) +
                                6. * cosIminusJ * (9. * nablaCosK + 7. * nablaCos3K);
 
-  return 5. / 32 / (Math::pow<3>(IJ) + Math::pow<5>(JK) + Math::pow<5>(KI)) *
+  return 5. / 32 / (Math::pow<3>(IJ) * Math::pow<5>(JK) * Math::pow<5>(KI)) *
          (nablaDisplacementTerm * cosineTerm + nablaCosineTerm);
 }
 

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ArgonInclude/AngularFunctions.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ArgonInclude/AngularFunctions.h
@@ -61,6 +61,9 @@ template <size_t ID>
   if (cos_deriv == std::array<double, 3>{{0, 0, 0}}) {
     return cos_deriv;
   }
+  if (sin_theta(cos_theta) == 0) {
+    return std::array<double, 3>{{0, 0, 0}};
+  }
   return -cos_theta / sin_theta(cos_theta) * cos_deriv;
 }
 

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ArgonInclude/AngularFunctions.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ArgonInclude/AngularFunctions.h
@@ -58,6 +58,9 @@ template <size_t ID>
 [[nodiscard]] nabla sin_theta_derive_wrt(const CosineHandle &cosine) {
   const auto cos_theta = cosine.getCos();
   const auto cos_deriv = cosine.derive_wrt<ID>();
+  if (cos_deriv == std::array<double, 3>{{0, 0, 0}}) {
+    return cos_deriv;
+  }
   return -cos_theta / sin_theta(cos_theta) * cos_deriv;
 }
 

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ArgonInclude/CosineHandle.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ArgonInclude/CosineHandle.h
@@ -60,16 +60,16 @@ CosineHandle::CosineHandle(const DisplacementHandle &displacementAB, const Displ
 template <size_t ID>
 [[nodiscard]] nabla CosineHandle::derive_wrt() const {
   if (ID == id_) {
-    auto firstTerm{cos_ / ArrayMath::dot(AB_, AB_) - 1. / ArrayMath::dot(AB_, AC_)};
-    auto secondTerm{cos_ / ArrayMath::dot(AC_, AC_) - 1. / ArrayMath::dot(AB_, AC_)};
+    auto firstTerm{cos_ / (ArrayMath::L2Norm(AB_)* ArrayMath::L2Norm(AB_)) - 1. / (ArrayMath::L2Norm(AB_)* ArrayMath::L2Norm(AC_))};
+    auto secondTerm{cos_ / (ArrayMath::L2Norm(AC_)* ArrayMath::L2Norm(AC_)) - 1. / (ArrayMath::L2Norm(AB_)* ArrayMath::L2Norm(AC_))};
     return AB_ * firstTerm + AC_ * secondTerm;
   } else if (ID == displacementAB_.getIdEndVertex()) {
-    auto firstTerm{-cos_ / ArrayMath::dot(AB_, AB_)};
-    auto secondTerm{1. / ArrayMath::dot(AB_, AC_)};
+    auto firstTerm{-cos_ / (ArrayMath::L2Norm(AB_)* ArrayMath::L2Norm(AB_))};
+    auto secondTerm{1. / (ArrayMath::L2Norm(AB_)* ArrayMath::L2Norm(AC_))};
     return AB_ * firstTerm + AC_ * secondTerm;
   } else if (ID == displacementAC_.getIdEndVertex()) {
-    auto firstTerm{-cos_ / ArrayMath::dot(AC_, AC_)};
-    auto secondTerm{1. / ArrayMath::dot(AB_, AC_)};
+    auto firstTerm{-cos_ / (ArrayMath::L2Norm(AC_)* ArrayMath::L2Norm(AC_))};
+    auto secondTerm{1. / (ArrayMath::L2Norm(AB_)* ArrayMath::L2Norm(AC_))};
     return AC_ * firstTerm + AB_ * secondTerm;
   }
   return std::array<double, 3>{{0, 0, 0}};

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ArgonInclude/CosineHandle.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ArgonInclude/CosineHandle.h
@@ -60,16 +60,18 @@ CosineHandle::CosineHandle(const DisplacementHandle &displacementAB, const Displ
 template <size_t ID>
 [[nodiscard]] nabla CosineHandle::derive_wrt() const {
   if (ID == id_) {
-    auto firstTerm{cos_ / (ArrayMath::L2Norm(AB_)* ArrayMath::L2Norm(AB_)) - 1. / (ArrayMath::L2Norm(AB_)* ArrayMath::L2Norm(AC_))};
-    auto secondTerm{cos_ / (ArrayMath::L2Norm(AC_)* ArrayMath::L2Norm(AC_)) - 1. / (ArrayMath::L2Norm(AB_)* ArrayMath::L2Norm(AC_))};
+    auto firstTerm{cos_ / (ArrayMath::L2Norm(AB_) * ArrayMath::L2Norm(AB_)) -
+                   1. / (ArrayMath::L2Norm(AB_) * ArrayMath::L2Norm(AC_))};
+    auto secondTerm{cos_ / (ArrayMath::L2Norm(AC_) * ArrayMath::L2Norm(AC_)) -
+                    1. / (ArrayMath::L2Norm(AB_) * ArrayMath::L2Norm(AC_))};
     return AB_ * firstTerm + AC_ * secondTerm;
   } else if (ID == displacementAB_.getIdEndVertex()) {
-    auto firstTerm{-cos_ / (ArrayMath::L2Norm(AB_)* ArrayMath::L2Norm(AB_))};
-    auto secondTerm{1. / (ArrayMath::L2Norm(AB_)* ArrayMath::L2Norm(AC_))};
+    auto firstTerm{-cos_ / (ArrayMath::L2Norm(AB_) * ArrayMath::L2Norm(AB_))};
+    auto secondTerm{1. / (ArrayMath::L2Norm(AB_) * ArrayMath::L2Norm(AC_))};
     return AB_ * firstTerm + AC_ * secondTerm;
   } else if (ID == displacementAC_.getIdEndVertex()) {
-    auto firstTerm{-cos_ / (ArrayMath::L2Norm(AC_)* ArrayMath::L2Norm(AC_))};
-    auto secondTerm{1. / (ArrayMath::L2Norm(AB_)* ArrayMath::L2Norm(AC_))};
+    auto firstTerm{-cos_ / (ArrayMath::L2Norm(AC_) * ArrayMath::L2Norm(AC_))};
+    auto secondTerm{1. / (ArrayMath::L2Norm(AB_) * ArrayMath::L2Norm(AC_))};
     return AC_ * firstTerm + AB_ * secondTerm;
   }
   return std::array<double, 3>{{0, 0, 0}};

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ArgonInclude/DampingTerm.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ArgonInclude/DampingTerm.h
@@ -31,8 +31,7 @@ template <typename T>
   T result{0};
   auto x = beta * r;
   for (size_t n = from; n <= to; n++) {
-    result += std::pow(x, n) / factorial(n);
-    result *= (beta - n / r);
+    result += std::pow(x, n) / factorial(n) * (beta - n / r);
   }
   return result;
 }

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ArgonInclude/DispersionTerm.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ArgonInclude/DispersionTerm.h
@@ -55,7 +55,7 @@ template <size_t a, size_t b, size_t c, size_t ID>
   const auto nabla_W =
       AngularTerm_derive_wrt<a, b, c, ID>(displacementIJ, displacementJK, displacementKI, cosineI, cosineJ, cosineK);
 
-  return Z_abc * (W * (nabla_D1 * D2 * D3 + D1 * nabla_D2 * D3 + D1 * D2 * nabla_D3) + D1 * D2 * D3 * nabla_W);
+  return -Z_abc * (W * (nabla_D1 * D2 * D3 + D1 * nabla_D2 * D3 + D1 * D2 * nabla_D3) + D1 * D2 * D3 * nabla_W);
 }
 
 template <size_t a, size_t b, size_t c>

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ArgonInclude/Legendre.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ArgonInclude/Legendre.h
@@ -51,9 +51,24 @@ template <class T>
  */
 template <class T>
 [[nodiscard]] constexpr T derivativeLegendre(const T &x, size_t d) {
-  auto Legendre_order_minus_1 = (d == 0) ? 0 : LegendrePol(x, d - 1);
-  auto num{Legendre_order_minus_1 - x * LegendrePol(x, d)};
-  return d * num / (1 - Math::pow<2>(x));
+  switch (d) {
+    case 0:
+      return 0;
+    case 1:
+      return 1;
+    case 2:
+      return 3 * x;
+    case 3:
+      return 0.5 * (15 * Math::pow<2>(x) - 3);
+    case 4:
+      return 0.125 * (140 * Math::pow<3>(x) - 60 * x);
+    case 5:
+      return 0.125 * (315 * Math::pow<4>(x) - 210 * Math::pow<2>(x) + 15);
+    case 6:
+      return 0.0625 * (1386 * Math::pow<5>(x) - 1260 * Math::pow<3>(x) + 210 * x);
+  }
+  throw ExceptionHandler::AutoPasException(
+      "Argon Simulation: asked to compute derivative of Legendre polynomial of order higher than 6.");
 }
 
 /**


### PR DESCRIPTION
Fixed:
- `sin_theta_derive_wrt(CosineHandle cosine)` when derivative of cosine = (0, 0, 0)
- `CosineHandle::derive_wrt()` -> using L2Norm for denominators instead of cdot (order of vectors does not matter)
- damping term derivative -> summation term
- missing - sign in force from dispersion term
- derivative of Legendre Polynomial
- derivative of W calculations (* instead of + in denominator)
- derivative of sin_theta (divide by 0)