### PR TITLE
Fix Loading MPI Checkpoints

### DIFF
--- a/examples/md-flexible/input/SpinodalDecomposition_equilibration.yaml
+++ b/examples/md-flexible/input/SpinodalDecomposition_equilibration.yaml
@@ -6,7 +6,7 @@ verlet-skin-radius-per-timestep  :  0.05
 verlet-rebuild-frequency         :  10
 deltaT                           :  0.00182367
 iterations                       :  100000
-boundary-type                    : [periodic, periodic, periodic]
+boundary-type                    :  [periodic, periodic, periodic]
 Sites:
   0:
     epsilon                      :  1.

--- a/examples/md-flexible/input/explodingLiquid.yaml
+++ b/examples/md-flexible/input/explodingLiquid.yaml
@@ -18,7 +18,7 @@ box-max                          :  [15, 60, 15]
 cell-size                        :  [1]
 deltaT                           :  0.00182367
 iterations                       :  12000
-boundary-type                    : [periodic, periodic, periodic]
+boundary-type                    :  [periodic, periodic, periodic]
 Sites:
   0:
     epsilon                      :  1.

--- a/examples/md-flexible/input/explodingLiquid.yaml
+++ b/examples/md-flexible/input/explodingLiquid.yaml
@@ -34,8 +34,9 @@ Objects:
   CubeClosestPacked:
     0:
       particle-type-id           :  0
-      box-length                 :  [15, 6, 15]
-      bottomLeftCorner           :  [0, 27, 0]
+      box-length                 :  [14, 6, 14]
+      # Move particles half spacing away from domain border to prevent automatic border extension
+      bottomLeftCorner           :  [0.5, 27, 0.5]
       particle-spacing           :  1.
       velocity                   :  [0, 0, 0]
 no-end-config                    :  true

--- a/examples/md-flexible/src/ParallelVtkWriter.cpp
+++ b/examples/md-flexible/src/ParallelVtkWriter.cpp
@@ -150,14 +150,15 @@ void ParallelVtkWriter::recordParticleStates(size_t currentIteration,
     // considered to be not part of the domain, hence such a particle would not be loaded and thus be lost.
     // This function identifies these problematic values and raises the write precision just for this value high enough
     // to be distinguishable from the boundary.
-    const auto writeWithDynamicPrecision = [&](double d, double border) {
+    const auto writeWithDynamicPrecision = [&](double position, double border) {
       const auto initialPrecision = timestepFile.precision();
       // Simple and cheap check if we even need to do anything.
-      if (border - d < 0.1) {
+      if (border - position < 0.1) {
         using autopas::utils::Math::roundFloating;
         using autopas::utils::Math::isNearAbs;
         // As long as the used precision results in the two values being indistinguishable increase the precision
-        while (isNearAbs(roundFloating(d, timestepFile.precision()), border, std::pow(10, -timestepFile.precision()))) {
+        while (isNearAbs(roundFloating(position, timestepFile.precision()), border,
+                         std::pow(10, -timestepFile.precision()))) {
           timestepFile << std::setprecision(timestepFile.precision() + 1);
           // Abort if the numbers are indistinguishable beyond machine precision
           if (timestepFile.precision() > 20) {
@@ -165,12 +166,12 @@ void ParallelVtkWriter::recordParticleStates(size_t currentIteration,
                 "ParallelVtkWriter::writeWithDynamicPrecision(): "
                 "The two given numbers are identical up to 20 digits of precision!\n"
                 "Number: " +
-                std::to_string(d) + "\n" + particle->toString());
+                std::to_string(position) + "\n" + particle->toString());
           }
         }
       }
       // Write with the new precision and then reset it
-      timestepFile << d << std::setprecision(initialPrecision);
+      timestepFile << position << std::setprecision(initialPrecision);
     };
 
     const auto pos = particle->getR();

--- a/examples/md-flexible/src/ParallelVtkWriter.cpp
+++ b/examples/md-flexible/src/ParallelVtkWriter.cpp
@@ -162,10 +162,13 @@ void ParallelVtkWriter::recordParticleStates(size_t currentIteration,
                          std::pow(10, -timestepFile.precision()))) {
           timestepFile << std::setprecision(timestepFile.precision() + 1);
           // Abort if the numbers are indistinguishable beyond machine precision
-          if (timestepFile.precision() > std::numeric_limits<double>::digits10) {
+          constexpr auto machinePrecision = std::numeric_limits<double>::digits10;
+          if (timestepFile.precision() > machinePrecision) {
             throw std::runtime_error(
                 "ParallelVtkWriter::writeWithDynamicPrecision(): "
-                "The two given numbers are identical up to 20 digits of precision!\n"
+                "The two given numbers are identical up to " +
+                std::to_string(machinePrecision) +
+                " digits of precision!\n"
                 "Number: " +
                 std::to_string(position) + "\n" + particle->toString());
           }

--- a/examples/md-flexible/src/ParallelVtkWriter.cpp
+++ b/examples/md-flexible/src/ParallelVtkWriter.cpp
@@ -78,7 +78,7 @@ void ParallelVtkWriter::recordParticleStates(size_t currentIteration,
   timestepFile
       << "        <DataArray Name=\"velocities\" NumberOfComponents=\"3\" format=\"ascii\" type=\"Float32\">\n";
   for (auto particle = autoPasContainer.begin(autopas::IteratorBehavior::owned); particle.isValid(); ++particle) {
-    auto v = particle->getV();
+    const auto v = particle->getV();
     timestepFile << "        " << v[0] << " " << v[1] << " " << v[2] << "\n";
   }
   timestepFile << "        </DataArray>\n";
@@ -86,7 +86,7 @@ void ParallelVtkWriter::recordParticleStates(size_t currentIteration,
   // print forces
   timestepFile << "        <DataArray Name=\"forces\" NumberOfComponents=\"3\" format=\"ascii\" type=\"Float32\">\n";
   for (auto particle = autoPasContainer.begin(autopas::IteratorBehavior::owned); particle.isValid(); ++particle) {
-    auto f = particle->getF();
+    const auto f = particle->getF();
     timestepFile << "        " << f[0] << " " << f[1] << " " << f[2] << "\n";
   }
   timestepFile << "        </DataArray>\n";
@@ -96,7 +96,7 @@ void ParallelVtkWriter::recordParticleStates(size_t currentIteration,
   timestepFile
       << "        <DataArray Name=\"quaternions\" NumberOfComponents=\"4\" format=\"ascii\" type=\"Float32\">\n";
   for (auto particle = autoPasContainer.begin(autopas::IteratorBehavior::owned); particle.isValid(); ++particle) {
-    auto q = particle->getQuaternion();
+    const auto q = particle->getQuaternion();
     timestepFile << "        " << q[0] << " " << q[1] << " " << q[2] << " " << q[3] << "\n";
   }
   timestepFile << "        </DataArray>\n";
@@ -105,7 +105,7 @@ void ParallelVtkWriter::recordParticleStates(size_t currentIteration,
   timestepFile
       << "        <DataArray Name=\"angularVelocities\" NumberOfComponents=\"3\" format=\"ascii\" type=\"Float32\">\n";
   for (auto particle = autoPasContainer.begin(autopas::IteratorBehavior::owned); particle.isValid(); ++particle) {
-    auto angVel = particle->getAngularVel();
+    const auto angVel = particle->getAngularVel();
     timestepFile << "        " << angVel[0] << " " << angVel[1] << " " << angVel[2] << "\n";
   }
   timestepFile << "        </DataArray>\n";
@@ -113,7 +113,7 @@ void ParallelVtkWriter::recordParticleStates(size_t currentIteration,
   // print torques
   timestepFile << "        <DataArray Name=\"torques\" NumberOfComponents=\"3\" format=\"ascii\" type=\"Float32\">\n";
   for (auto particle = autoPasContainer.begin(autopas::IteratorBehavior::owned); particle.isValid(); ++particle) {
-    auto torque = particle->getTorque();
+    const auto torque = particle->getTorque();
     timestepFile << "        " << torque[0] << " " << torque[1] << " " << torque[2] << "\n";
   }
   timestepFile << "        </DataArray>\n";
@@ -354,7 +354,7 @@ void ParallelVtkWriter::tryCreateFolder(const std::string &name, const std::stri
     const auto newDirectoryPath{location + "/" + name};
     mkdir(newDirectoryPath.c_str(), 0777);
   } catch (const std::exception &ex) {
-    throw std::runtime_error("The output location " + location +
+    throw std::runtime_error("ParallelVtkWriter::tryCreateFolder(): The output location " + location +
                              " passed to ParallelVtkWriter is invalid: " + ex.what());
   }
 }

--- a/examples/md-flexible/src/ParallelVtkWriter.cpp
+++ b/examples/md-flexible/src/ParallelVtkWriter.cpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <ios>
 #include <iostream>
+#include <limits>
 #include <string>
 #include <utility>
 
@@ -161,7 +162,7 @@ void ParallelVtkWriter::recordParticleStates(size_t currentIteration,
                          std::pow(10, -timestepFile.precision()))) {
           timestepFile << std::setprecision(timestepFile.precision() + 1);
           // Abort if the numbers are indistinguishable beyond machine precision
-          if (timestepFile.precision() > 20) {
+          if (timestepFile.precision() > std::numeric_limits<double>::digits10) {
             throw std::runtime_error(
                 "ParallelVtkWriter::writeWithDynamicPrecision(): "
                 "The two given numbers are identical up to 20 digits of precision!\n"

--- a/examples/md-flexible/src/ParallelVtkWriter.cpp
+++ b/examples/md-flexible/src/ParallelVtkWriter.cpp
@@ -155,10 +155,11 @@ void ParallelVtkWriter::recordParticleStates(size_t currentIteration,
       // Simple and cheap check if we even need to do anything.
       if (border - d < 0.1) {
         using autopas::utils::Math::roundFloating;
-        // As long as the used precision results in the two values being the same increase it
-        while (roundFloating(d, timestepFile.precision()) == border) {
+        using autopas::utils::Math::isNearAbs;
+        // As long as the used precision results in the two values being indistinguishable increase the precision
+        while (isNearAbs(roundFloating(d, timestepFile.precision()), border, std::pow(10, -timestepFile.precision()))) {
           timestepFile << std::setprecision(timestepFile.precision() + 1);
-          // Abort if the numbers are indistinguishable
+          // Abort if the numbers are indistinguishable beyond machine precision
           if (timestepFile.precision() > 20) {
             throw std::runtime_error(
                 "ParallelVtkWriter::writeWithDynamicPrecision(): "

--- a/examples/md-flexible/src/ParticleSerializationTools.cpp
+++ b/examples/md-flexible/src/ParticleSerializationTools.cpp
@@ -136,6 +136,9 @@ void deserializeParticle(char *particleData, ParticleType &particle) {
 
 void deserializeParticles(std::vector<char> &particlesData, std::vector<ParticleType> &particles) {
   ParticleType particle;
+  // Reserve space for particles before deserializing them
+  const auto numParticles = particlesData.size() / AttributesSize;
+  particles.reserve(particles.size() + numParticles);
   for (size_t i = 0; i < particlesData.size(); i += AttributesSize) {
     deserializeParticle(&particlesData[i], particle);
     particles.push_back(particle);

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -665,7 +665,7 @@ void Simulation::loadParticles() {
   //       Nevertheless it could be improved by determining which particle has to go to which rank.
   const auto rank = _domainDecomposition->getDomainIndex();
   ParticleCommunicator particleCommunicator(_domainDecomposition->getCommunicator());
-  for (int receiverRank = 0; receiverRank < _domainDecomposition->getSubdomainCount(); ++receiverRank) {
+  for (int receiverRank = 0; receiverRank < _domainDecomposition->getNumberOfSubdomains(); ++receiverRank) {
     // don't send to ourselves
     if (receiverRank == rank) {
       continue;
@@ -676,7 +676,7 @@ void Simulation::loadParticles() {
   _configuration.flushParticles();
 
   // Receive particles from all other ranks.
-  for (int senderRank = 0; senderRank < _domainDecomposition->getSubdomainCount(); ++senderRank) {
+  for (int senderRank = 0; senderRank < _domainDecomposition->getNumberOfSubdomains(); ++senderRank) {
     // don't send to ourselves
     if (senderRank == rank) {
       continue;

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -671,12 +671,6 @@ void Simulation::loadParticles() {
   }
   particleCommunicator.waitForSendRequests();
 
-  // Remove duplicates. This is a safety mechanism for the odd case that two ranks loaded the same particle.
-  std::sort(_configuration.particles.begin(), _configuration.particles.end(),
-            [](const auto &p1, const auto &p2) { return p1.getID() < p2.getID(); });
-  _configuration.particles.erase(std::unique(_configuration.particles.begin(), _configuration.particles.end()),
-                                 _configuration.particles.end());
-
   // Add all new particles that belong in this rank
   _autoPasContainer->addParticlesIf(_configuration.particles,
                                     [&](auto &p) { return _domainDecomposition->isInsideLocalDomain(p.getR()); });

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -164,8 +164,7 @@ Simulation::Simulation(const MDFlexConfig &configuration,
   if (rank == 0) {
     autopas::AutoPas_MPI_Reduce(AUTOPAS_MPI_IN_PLACE, &numParticles, 1, AUTOPAS_MPI_UNSIGNED_LONG, AUTOPAS_MPI_SUM, 0,
                                 _domainDecomposition->getCommunicator());
-    std::cout << "Number of particles at initialization globally: "
-              << "\n";
+    std::cout << "Number of particles at initialization globally: " << numParticles << "\n";
   } else {
     // In-place reduce needs different calls on root vs rest...
     autopas::AutoPas_MPI_Reduce(&numParticles, nullptr, 1, AUTOPAS_MPI_UNSIGNED_LONG, AUTOPAS_MPI_SUM, 0,

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -681,7 +681,9 @@ void Simulation::loadParticles() {
   // Output and sanity checks
   const size_t numParticlesLocally = _autoPasContainer->getNumberOfParticles(autopas::IteratorBehavior::owned);
   std::cout << "Number of particles at initialization "
-            << "on rank " << rank << ": " << numParticlesLocally << "\n";
+            // align outputs based on the max number of ranks
+            << "on rank " << std::setw(std::to_string(_domainDecomposition->getNumberOfSubdomains()).length())
+            << std::right << rank << ": " << numParticlesLocally << "\n";
 
   // Local unnamed struct to pack data for MPI
   struct {
@@ -692,7 +694,10 @@ void Simulation::loadParticles() {
   if (rank == 0) {
     autopas::AutoPas_MPI_Reduce(AUTOPAS_MPI_IN_PLACE, &dataPackage, 2, AUTOPAS_MPI_UNSIGNED_LONG, AUTOPAS_MPI_SUM, 0,
                                 _domainDecomposition->getCommunicator());
-    std::cout << "Number of particles at initialization globally: " << dataPackage.numParticlesAdded << "\n";
+    std::cout << "Number of particles at initialization globally"
+              // align ":" with the messages above
+              << std::setw(std::to_string(_domainDecomposition->getNumberOfSubdomains()).length()) << ""
+              << ": " << dataPackage.numParticlesAdded << "\n";
     // Sanity check that on a global scope all particles have been loaded
     if (dataPackage.numParticlesAdded != dataPackage.numParticlesInConfig) {
       throw std::runtime_error(

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -539,7 +539,10 @@ void Simulation::logMeasurements() {
   const long loadBalancing = accumulateTime(_timers.loadBalancing.getTotalTime());
 
   if (_domainDecomposition->getDomainIndex() == 0) {
-    const auto maximumNumberOfDigits = static_cast<int>(std::to_string(total).length());
+    const long wallClockTime = _timers.total.getTotalTime();
+    // use the two potentially largest timers to determine the number of chars needed
+    const auto maximumNumberOfDigits =
+        static_cast<int>(std::max(std::to_string(total).length(), std::to_string(wallClockTime).length()));
     std::cout << "Measurements:\n";
     std::cout << timerToString("Total accumulated                 ", total, maximumNumberOfDigits);
     std::cout << timerToString("  Initialization                  ", initialization, maximumNumberOfDigits, total);
@@ -576,9 +579,7 @@ void Simulation::logMeasurements() {
     std::cout << timerToString("One iteration                     ", simulate / static_cast<long>(_iteration),
                                maximumNumberOfDigits, total);
 
-    const long wallClockTime = _timers.total.getTotalTime();
-    std::cout << timerToString("Total wall-clock time             ", wallClockTime,
-                               static_cast<int>(std::to_string(wallClockTime).length()), total);
+    std::cout << timerToString("Total wall-clock time             ", wallClockTime, maximumNumberOfDigits, total);
     std::cout << "\n";
 
     std::cout << "Tuning iterations                  : " << _numTuningIterations << " / " << _iteration << " = "

--- a/examples/md-flexible/src/Simulation.h
+++ b/examples/md-flexible/src/Simulation.h
@@ -229,6 +229,13 @@ class Simulation {
 
  private:
   /**
+   * Load particles from this object's config into this object's AutoPas container.
+   *
+   * @note This also clears all particles from the config file!
+   */
+  void loadParticles();
+
+  /**
    * Estimates the number of tuning iterations which ocurred during the simulation so far.
    * @return an estimation of the number of tuning iterations which occured so far.
    */

--- a/examples/md-flexible/src/configuration/MDFlexConfig.cpp
+++ b/examples/md-flexible/src/configuration/MDFlexConfig.cpp
@@ -565,7 +565,7 @@ void MDFlexConfig::loadParticlesFromCheckpoint(const size_t &rank, const size_t 
   if (numRanks == numCheckpointPieces) {
     loadParticlesFromRankRecord(filename, rank, particles);
   } else if (rank == 0) {
-    // Otherwise, each rank 0 loads everything and distributes it later.
+    // Otherwise, rank 0 loads everything and distributes it later.
     for (size_t i = 0; i < numCheckpointPieces; ++i) {
       loadParticlesFromRankRecord(filename, i, particles);
     }

--- a/examples/md-flexible/src/configuration/MDFlexConfig.cpp
+++ b/examples/md-flexible/src/configuration/MDFlexConfig.cpp
@@ -451,9 +451,9 @@ void MDFlexConfig::addSiteType(unsigned long siteId, double epsilon, double sigm
   // check if siteId is already existing and if there is no error in input
   if (epsilonMap.value.count(siteId) == 1) {
     // check if type is already added
-    if (autopas::utils::Math::isNear(epsilonMap.value.at(siteId), epsilon) and
-        autopas::utils::Math::isNear(sigmaMap.value.at(siteId), sigma) and
-        autopas::utils::Math::isNear(massMap.value.at(siteId), mass)) {
+    if (autopas::utils::Math::isNearRel(epsilonMap.value.at(siteId), epsilon) and
+        autopas::utils::Math::isNearRel(sigmaMap.value.at(siteId), sigma) and
+        autopas::utils::Math::isNearRel(massMap.value.at(siteId), mass)) {
       return;
     } else {  // wrong initialization:
       throw std::runtime_error("Wrong Particle initialization: using same siteId for different properties");
@@ -473,8 +473,8 @@ void MDFlexConfig::addMolType(unsigned long molId, const std::vector<unsigned lo
   if (molToSiteIdMap.count(molId) == 1) {
     // check if type is already added
     if (autopas::utils::ArrayMath::isEqual(molToSiteIdMap.at(molId), siteIds) and
-        autopas::utils::ArrayMath::isNear(molToSitePosMap.at(molId), relSitePos) and
-        autopas::utils::ArrayMath::isNear(momentOfInertiaMap.at(molId), momentOfInertia)) {
+        autopas::utils::ArrayMath::isNearRel(molToSitePosMap.at(molId), relSitePos) and
+        autopas::utils::ArrayMath::isNearRel(momentOfInertiaMap.at(molId), momentOfInertia)) {
       return;
     } else {  // wrong initialization:
       throw std::runtime_error("Wrong Particle initialization: using same molId for different properties");

--- a/examples/md-flexible/src/configuration/MDFlexConfig.h
+++ b/examples/md-flexible/src/configuration/MDFlexConfig.h
@@ -126,12 +126,6 @@ class MDFlexConfig {
   void calcSimulationBox();
 
   /**
-   * Returns the particles generated based on the provided configuration file.
-   * @return a vector containing the generated particles.
-   */
-  std::vector<ParticleType> getParticles() { return _particles; }
-
-  /**
    * Returns the ParticlePropertiesLibrary containing the properties of the particle types used in this simulation.
    * @return the ParticlePropertiesLibrary
    */
@@ -760,13 +754,14 @@ class MDFlexConfig {
    */
   static constexpr int valueOffset{33};
 
- private:
   /**
    * Stores the particles generated based on the provided configuration file
    * These particles can be added to the respective autopas container,
    * but have to be converted to the respective particle type, first.
    */
-  std::vector<ParticleType> _particles;
+  std::vector<ParticleType> particles{};
+
+ private:
 
   /**
    * Stores the physical properties of the particles used in the an MDFlexSimulation

--- a/examples/md-flexible/src/configuration/MDFlexConfig.h
+++ b/examples/md-flexible/src/configuration/MDFlexConfig.h
@@ -174,9 +174,9 @@ class MDFlexConfig {
    * used, don't pass the MPI_COMM_WORLD rank, as it might differ from the grid rank derived in the decomposition
    * scheme. The wrong rank might result in a very bad network topology and therefore increase communication costs.
    * @param rank: The MPI rank of the current process.
-   * @param communicatorSize: The size of the MPI communicator used for the simulation.
+   * @param numRanks: The size of the MPI communicator used for the simulation.
    */
-  void loadParticlesFromCheckpoint(const size_t &rank, const size_t &communicatorSize);
+  void loadParticlesFromCheckpoint(const size_t &rank, const size_t &numRanks);
 
   /**
    * Choice of the functor

--- a/examples/md-flexible/src/configuration/MDFlexConfig.h
+++ b/examples/md-flexible/src/configuration/MDFlexConfig.h
@@ -762,7 +762,6 @@ class MDFlexConfig {
   std::vector<ParticleType> particles{};
 
  private:
-
   /**
    * Stores the physical properties of the particles used in the an MDFlexSimulation
    */

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -158,7 +158,7 @@ std::array<int, 6> RegularGridDecomposition::getExtentOfSubdomain(const int subd
 }
 
 void RegularGridDecomposition::exchangeHaloParticles(AutoPasType &autoPasContainer) {
-  using autopas::utils::Math::isNear;
+  using autopas::utils::Math::isNearRel;
   using namespace autopas::utils::ArrayMath::literals;
 
   _haloParticles.clear();
@@ -178,8 +178,8 @@ void RegularGridDecomposition::exchangeHaloParticles(AutoPasType &autoPasContain
     // completely bypass Halo particle exchange in this dimension if boundaries in this direction are not periodic
     // *and* if both local boundaries are the global boundaries in this dimension
     if (_boundaryType[dimensionIndex] != options::BoundaryTypeOption::periodic and
-        isNear(_localBoxMin[dimensionIndex], _globalBoxMin[dimensionIndex]) and
-        isNear(_localBoxMax[dimensionIndex], _globalBoxMax[dimensionIndex])) {
+        isNearRel(_localBoxMin[dimensionIndex], _globalBoxMin[dimensionIndex]) and
+        isNearRel(_localBoxMax[dimensionIndex], _globalBoxMax[dimensionIndex])) {
       continue;
     }
 
@@ -199,7 +199,7 @@ void RegularGridDecomposition::exchangeHaloParticles(AutoPasType &autoPasContain
         _particlesForLeftNeighbor.push_back(particle);
 
         // Apply boundary condition
-        if (isNear(_localBoxMin[dimensionIndex], _globalBoxMin[dimensionIndex])) {
+        if (isNearRel(_localBoxMin[dimensionIndex], _globalBoxMin[dimensionIndex])) {
           position[dimensionIndex] =
               position[dimensionIndex] + (_globalBoxMax[dimensionIndex] - _globalBoxMin[dimensionIndex]);
           _particlesForLeftNeighbor.back().setR(position);
@@ -208,7 +208,7 @@ void RegularGridDecomposition::exchangeHaloParticles(AutoPasType &autoPasContain
         _particlesForRightNeighbor.push_back(particle);
 
         // Apply boundary condition
-        if (isNear(_localBoxMax[dimensionIndex], _globalBoxMax[dimensionIndex])) {
+        if (isNearRel(_localBoxMax[dimensionIndex], _globalBoxMax[dimensionIndex])) {
           position[dimensionIndex] =
               position[dimensionIndex] - (_globalBoxMax[dimensionIndex] - _globalBoxMin[dimensionIndex]);
           _particlesForRightNeighbor.back().setR(position);
@@ -229,14 +229,14 @@ void RegularGridDecomposition::exchangeHaloParticles(AutoPasType &autoPasContain
 
 void RegularGridDecomposition::exchangeMigratingParticles(AutoPasType &autoPasContainer,
                                                           std::vector<ParticleType> &emigrants) {
-  using autopas::utils::Math::isNear;
+  using autopas::utils::Math::isNearRel;
   // buffer for particles that are neither for the left nor right neighbor. This buffer exists to avoid reallocations.
   std::vector<ParticleType> remainingEmigrants;
   for (int dimensionIndex = 0; dimensionIndex < _dimensionCount; ++dimensionIndex) {
     // if this rank spans the whole dimension but is not periodic -> skip.
     if (_boundaryType[dimensionIndex] != options::BoundaryTypeOption::periodic and
-        isNear(_localBoxMin[dimensionIndex], _globalBoxMin[dimensionIndex]) and
-        isNear(_localBoxMax[dimensionIndex], _globalBoxMax[dimensionIndex]))
+        isNearRel(_localBoxMin[dimensionIndex], _globalBoxMin[dimensionIndex]) and
+        isNearRel(_localBoxMax[dimensionIndex], _globalBoxMax[dimensionIndex]))
       continue;
 
     // If the ALL load balancer is used, it may happen that particles migrate to a non-adjacent domain.
@@ -294,7 +294,7 @@ void RegularGridDecomposition::exchangeMigratingParticles(AutoPasType &autoPasCo
 
 void RegularGridDecomposition::reflectParticlesAtBoundaries(AutoPasType &autoPasContainer,
                                                             ParticlePropertiesLibraryType &particlePropertiesLib) {
-  using autopas::utils::Math::isNear;
+  using autopas::utils::Math::isNearRel;
   std::array<double, _dimensionCount> reflSkinMin{}, reflSkinMax{};
 
   for (int dimensionIndex = 0; dimensionIndex < _dimensionCount; ++dimensionIndex) {
@@ -429,7 +429,7 @@ void RegularGridDecomposition::reflectParticlesAtBoundaries(AutoPasType &autoPas
     };
 
     // apply if we are at a global boundary on lower end of the dimension
-    if (isNear(_localBoxMin[dimensionIndex], _globalBoxMin[dimensionIndex])) {
+    if (isNearRel(_localBoxMin[dimensionIndex], _globalBoxMin[dimensionIndex])) {
       reflSkinMin = _globalBoxMin;
       reflSkinMax = _globalBoxMax;
       reflSkinMax[dimensionIndex] = _globalBoxMin[dimensionIndex] + _maxReflectiveSkin;
@@ -437,7 +437,7 @@ void RegularGridDecomposition::reflectParticlesAtBoundaries(AutoPasType &autoPas
       reflect(false);
     }
     // apply if we are at a global boundary on upper end of the dimension
-    if (isNear(_localBoxMax[dimensionIndex], _globalBoxMax[dimensionIndex])) {
+    if (isNearRel(_localBoxMax[dimensionIndex], _globalBoxMax[dimensionIndex])) {
       reflSkinMin = _globalBoxMin;
       reflSkinMax = _globalBoxMax;
       reflSkinMin[dimensionIndex] = _globalBoxMax[dimensionIndex] - _maxReflectiveSkin;
@@ -473,7 +473,7 @@ void RegularGridDecomposition::collectHaloParticlesAux(AutoPasType &autoPasConta
                                                        const std::array<double, _dimensionCount> &boxMax,
                                                        bool atGlobalBoundary, double wrapAroundDistance,
                                                        std::vector<ParticleType> &haloParticlesBuffer) {
-  using autopas::utils::Math::isNear;
+  using autopas::utils::Math::isNearRel;
   using namespace autopas::utils::ArrayMath::literals;
 
   const auto getBoxDimensions = [](const auto &bMin, const auto &bMax) {
@@ -502,7 +502,7 @@ void RegularGridDecomposition::collectHaloParticlesAux(AutoPasType &autoPasConta
 
 void RegularGridDecomposition::collectHaloParticlesForLeftNeighbor(
     AutoPasType &autoPasContainer, size_t direction, std::vector<ParticleType> &particlesForLeftNeighborBuffer) {
-  using autopas::utils::Math::isNear;
+  using autopas::utils::Math::isNearRel;
   using namespace autopas::utils::ArrayMath::literals;
 
   const auto skinWidth = _skinWidthPerTimestep * _rebuildFrequency;
@@ -512,7 +512,7 @@ void RegularGridDecomposition::collectHaloParticlesForLeftNeighbor(
     boxMax[direction] = _localBoxMin[direction] + _cutoffWidth + skinWidth;
     return boxMax;
   }();
-  const auto atGlobalBoundary = isNear(_localBoxMin[direction], _globalBoxMin[direction]);
+  const auto atGlobalBoundary = isNearRel(_localBoxMin[direction], _globalBoxMin[direction]);
   const auto wrapAroundDistance = +(_globalBoxMax[direction] - _globalBoxMin[direction]);
   collectHaloParticlesAux(autoPasContainer, direction, boxMin, boxMax, atGlobalBoundary, wrapAroundDistance,
                           particlesForLeftNeighborBuffer);
@@ -520,7 +520,7 @@ void RegularGridDecomposition::collectHaloParticlesForLeftNeighbor(
 
 void RegularGridDecomposition::collectHaloParticlesForRightNeighbor(
     AutoPasType &autoPasContainer, size_t direction, std::vector<ParticleType> &particlesForRightNeighborBuffer) {
-  using autopas::utils::Math::isNear;
+  using autopas::utils::Math::isNearRel;
   using namespace autopas::utils::ArrayMath::literals;
 
   const auto skinWidth = _skinWidthPerTimestep * _rebuildFrequency;
@@ -530,7 +530,7 @@ void RegularGridDecomposition::collectHaloParticlesForRightNeighbor(
     boxMin[direction] = _localBoxMax[direction] - _cutoffWidth - skinWidth;
     return boxMin;
   }();
-  const auto atGlobalBoundary = isNear(_localBoxMax[direction], _globalBoxMax[direction]);
+  const auto atGlobalBoundary = isNearRel(_localBoxMax[direction], _globalBoxMax[direction]);
   const auto wrapAroundDistance = -(_globalBoxMax[direction] - _globalBoxMin[direction]);
   collectHaloParticlesAux(autoPasContainer, direction, boxMin, boxMax, atGlobalBoundary, wrapAroundDistance,
                           particlesForRightNeighborBuffer);
@@ -539,7 +539,7 @@ void RegularGridDecomposition::collectHaloParticlesForRightNeighbor(
 std::tuple<std::vector<ParticleType>, std::vector<ParticleType>, std::vector<ParticleType>>
 RegularGridDecomposition::categorizeParticlesIntoLeftAndRightNeighbor(const std::vector<ParticleType> &particles,
                                                                       size_t direction) {
-  using autopas::utils::Math::isNear;
+  using autopas::utils::Math::isNearRel;
   using namespace autopas::utils::ArrayMath::literals;
   const std::array<double, _dimensionCount> globalBoxDimensions = _globalBoxMax - _globalBoxMin;
 
@@ -559,7 +559,7 @@ RegularGridDecomposition::categorizeParticlesIntoLeftAndRightNeighbor(const std:
       leftNeighborParticles.push_back(particle);
 
       // if the particle is outside the global box move it to the other side (periodic boundary)
-      if (isNear(_localBoxMin[direction], _globalBoxMin[direction])) {
+      if (isNearRel(_localBoxMin[direction], _globalBoxMin[direction])) {
         // TODO: check if this failsafe is really reasonable.
         //  It should only trigger if a particle's position was already inside the box?
         const auto periodicPosition = position[direction] + globalBoxDimensions[direction];
@@ -572,7 +572,7 @@ RegularGridDecomposition::categorizeParticlesIntoLeftAndRightNeighbor(const std:
       rightNeighborParticles.push_back(particle);
 
       // if the particle is outside the global box move it to the other side (periodic boundary)
-      if (isNear(_localBoxMax[direction], _globalBoxMax[direction])) {
+      if (isNearRel(_localBoxMax[direction], _globalBoxMax[direction])) {
         // TODO: check if this failsafe is really reasonable.
         //  It should only trigger if a particle's position was already inside the box?
         const auto periodicPosition = position[direction] - globalBoxDimensions[direction];
@@ -587,7 +587,7 @@ RegularGridDecomposition::categorizeParticlesIntoLeftAndRightNeighbor(const std:
 }
 
 void RegularGridDecomposition::balanceWithInvertedPressureLoadBalancer(double work) {
-  using autopas::utils::Math::isNear;
+  using autopas::utils::Math::isNearRel;
   // This is a dummy variable which is not being used. It is required by the non-blocking MPI_Send calls.
   autopas::AutoPas_MPI_Request dummyRequest{};
 
@@ -613,14 +613,14 @@ void RegularGridDecomposition::balanceWithInvertedPressureLoadBalancer(double wo
     const int rightNeighbor = _neighborDomainIndices[i * 2 + 1];
 
     // Send average work in plane to neighbours
-    if (not isNear(_localBoxMin[i], _globalBoxMin[i])) {
+    if (not isNearRel(_localBoxMin[i], _globalBoxMin[i])) {
       autopas::AutoPas_MPI_Isend(&averageWorkInPlane[i], 1, AUTOPAS_MPI_DOUBLE, leftNeighbor, 0, _communicator,
                                  &dummyRequest);
       autopas::AutoPas_MPI_Isend(&oldLocalBoxMax[i], 1, AUTOPAS_MPI_DOUBLE, leftNeighbor, 0, _communicator,
                                  &dummyRequest);
     }
 
-    if (not isNear(_localBoxMax[i], _globalBoxMax[i])) {
+    if (not isNearRel(_localBoxMax[i], _globalBoxMax[i])) {
       autopas::AutoPas_MPI_Isend(&averageWorkInPlane[i], 1, AUTOPAS_MPI_DOUBLE, rightNeighbor, 0, _communicator,
                                  &dummyRequest);
       autopas::AutoPas_MPI_Isend(&oldLocalBoxMin[i], 1, AUTOPAS_MPI_DOUBLE, rightNeighbor, 0, _communicator,
@@ -634,7 +634,7 @@ void RegularGridDecomposition::balanceWithInvertedPressureLoadBalancer(double wo
     const int rightNeighbor = _neighborDomainIndices[i * 2 + 1];
 
     double neighborPlaneWork{}, neighborBoundary{}, balancedPosition{};
-    if (not isNear(_localBoxMin[i], _globalBoxMin[i])) {
+    if (not isNearRel(_localBoxMin[i], _globalBoxMin[i])) {
       // Receive average work from neighbour planes.
       autopas::AutoPas_MPI_Recv(&neighborPlaneWork, 1, AUTOPAS_MPI_DOUBLE, leftNeighbor, 0, _communicator,
                                 AUTOPAS_MPI_STATUS_IGNORE);
@@ -649,7 +649,7 @@ void RegularGridDecomposition::balanceWithInvertedPressureLoadBalancer(double wo
       _localBoxMin[i] += (balancedPosition - _localBoxMin[i]) / 2;
     }
 
-    if (not isNear(_localBoxMax[i], _globalBoxMax[i])) {
+    if (not isNearRel(_localBoxMax[i], _globalBoxMax[i])) {
       // Receive average work from neighbour planes.
       autopas::AutoPas_MPI_Recv(&neighborPlaneWork, 1, AUTOPAS_MPI_DOUBLE, rightNeighbor, 0, _communicator,
                                 AUTOPAS_MPI_STATUS_IGNORE);

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -102,10 +102,6 @@ void RegularGridDecomposition::update(const double &work) {
   }
 }
 
-int RegularGridDecomposition::getNumberOfSubdomains() const {
-  return std::accumulate(_decomposition.begin(), _decomposition.end(), 1, std::multiplies<>());
-}
-
 void RegularGridDecomposition::initializeMPICommunicator() {
   // have to cast away const because MPI requires it
   autopas::AutoPas_MPI_Cart_create(AUTOPAS_MPI_COMM_WORLD, _dimensionCount, _decomposition.data(),

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -670,6 +670,8 @@ void RegularGridDecomposition::balanceWithInvertedPressureLoadBalancer(double wo
   }
 }
 
+autopas::AutoPas_MPI_Comm RegularGridDecomposition::getCommunicator() const { return _communicator; }
+
 #if defined(MD_FLEXIBLE_ENABLE_ALLLBL)
 void RegularGridDecomposition::balanceWithAllLoadBalancer(const double &work) {
   std::vector<ALL::Point<double>> domain(2, ALL::Point<double>(3));

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
@@ -143,6 +143,12 @@ class RegularGridDecomposition final : public DomainDecomposition {
    */
   void reflectParticlesAtBoundaries(AutoPasType &autoPasContainer, ParticlePropertiesLibraryType &PPL);
 
+  /**
+   * Getter for the communicator that encompasses the whole decomposition.
+   * @return
+   */
+  autopas::AutoPas_MPI_Comm getCommunicator() const;
+
  private:
   /**
    * The number of neighbors of a rectangular domain.

--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.h
@@ -87,22 +87,16 @@ class RegularGridDecomposition final : public DomainDecomposition {
   [[nodiscard]] const std::array<int, 3> &getDecomposition() const { return _decomposition; }
 
   /**
-   * Returns the numnber of subdomains in the decomposition.
+   * Returns the numnber of subdomains (=ranks) in the decomposition.
    * @return numner of subdomains in the decomposition.
    */
-  [[nodiscard]] int getSubdomainCount() const { return _subdomainCount; }
+  [[nodiscard]] int getNumberOfSubdomains() const { return _subdomainCount; }
 
   /**
    * Returns the current processes domain id.
    * @return domain id of the current processor
    */
   [[nodiscard]] const std::array<int, 3> &getDomainId() const { return _domainId; }
-
-  /**
-   * Returns the number of subdomains in the simulation.
-   * @return number of subdomains
-   */
-  [[nodiscard]] int getNumberOfSubdomains() const;
 
   /**
    * Checks if the provided coordinates are located in the local domain.
@@ -205,7 +199,7 @@ class RegularGridDecomposition final : public DomainDecomposition {
   bool _mpiCommunicationNeeded;
 
   /**
-   * The number of subdomains in this decomposition.
+   * The number of subdomains (=ranks) in this decomposition.
    */
   int _subdomainCount{};
 

--- a/examples/md-flexible/src/main.cpp
+++ b/examples/md-flexible/src/main.cpp
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
     if (not configuration.checkpointfile.value.empty()) {
       configuration.flushParticles();
       configuration.loadParticlesFromCheckpoint(domainDecomposition->getDomainIndex(),
-                                                domainDecomposition->getSubdomainCount());
+                                                domainDecomposition->getNumberOfSubdomains());
     }
 
     // print start configuration and parallelization info

--- a/examples/md-flexible/tests/configuration/GeneratorsTest.cpp
+++ b/examples/md-flexible/tests/configuration/GeneratorsTest.cpp
@@ -32,6 +32,14 @@ TEST_F(GeneratorsTest, GridFillwithBoxMin) {
  * This test expects multipleObjectsWithMultipleTypesTest.yaml to be placed in md-flexible/tests/yamlTestFiles
  */
 TEST_F(GeneratorsTest, MultipleObjectGeneration) {
+  int myRank{};
+  autopas::AutoPas_MPI_Comm_rank(AUTOPAS_MPI_COMM_WORLD, &myRank);
+  if (myRank != 0) {
+    GTEST_SKIP() << "[Rank " << myRank
+                 << "] MultipleObjectGeneration test works only on rank 0 because MDFlexConfig only generates "
+                    "particles on rank 0.";
+  }
+
   std::vector<std::string> arguments = {"md-flexible", "--yaml-filename",
                                         std::string(YAMLDIRECTORY) + "multipleObjectsWithMultipleTypesTest.yaml"};
 

--- a/examples/md-flexible/tests/configuration/GeneratorsTest.cpp
+++ b/examples/md-flexible/tests/configuration/GeneratorsTest.cpp
@@ -53,7 +53,7 @@ TEST_F(GeneratorsTest, MultipleObjectGeneration) {
   int closestCounter = 0;
 
   const std::array<double, 3> velocity = {0., 0., 0.};
-  for (auto &particle : configuration.getParticles()) {
+  for (auto &particle : configuration.particles) {
     EXPECT_EQ(velocity, particle.getV());  // velocity set to {0.,0.,0.} in parsingFile
     switch (particle.getTypeId()) {
       case 0: {
@@ -89,10 +89,10 @@ TEST_F(GeneratorsTest, MultipleObjectGeneration) {
   EXPECT_EQ(closestCounter, configuration.cubeClosestPackedObjects.at(0).getParticlesTotal());
   // check if during initialization, not 2 Particles were initialized with same id
   std::set<size_t> ids;
-  for (auto &particle : configuration.getParticles()) {
+  for (auto &particle : configuration.particles) {
     const auto particleId = particle.getID();
     ASSERT_EQ(ids.count(particleId), 0) << "Two particles have the same ID " << particleId;
     ids.insert(particleId);
   }
-  EXPECT_EQ(ids.size(), configuration.getParticles().size());
+  EXPECT_EQ(ids.size(), configuration.particles.size());
 }

--- a/src/autopas/AutoPasImpl.h
+++ b/src/autopas/AutoPasImpl.h
@@ -62,8 +62,12 @@ AutoPas<Particle> &AutoPas<Particle>::operator=(AutoPas &&other) noexcept {
 
 template <class Particle>
 void AutoPas<Particle>::init() {
-  AutoPasLog(INFO, "AutoPas Version: {}", AutoPas_VERSION);
-  AutoPasLog(INFO, "Compiled with  : {}", utils::CompileInfo::getCompilerInfo());
+  int myRank{};
+  AutoPas_MPI_Comm_rank(AUTOPAS_MPI_COMM_WORLD, &myRank);
+  if (myRank == 0) {
+    AutoPasLog(INFO, "AutoPas Version: {}", AutoPas_VERSION);
+    AutoPasLog(INFO, "Compiled with  : {}", utils::CompileInfo::getCompilerInfo());
+  }
 
   if (_tuningStrategyFactoryInfo.autopasMpiCommunicator == AUTOPAS_MPI_COMM_NULL) {
     AutoPas_MPI_Comm_dup(AUTOPAS_MPI_COMM_WORLD, &_tuningStrategyFactoryInfo.autopasMpiCommunicator);

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -106,11 +106,13 @@ class LogicHandler {
     for (auto &cell : _particleBuffer) {
       auto &buffer = cell._particles;
       if (insertOwnedParticlesToContainer) {
-        for (const auto &p : buffer) {
+        // Can't be const because we potentially modify ownership before re-adding
+        for (auto &p : buffer) {
           if (p.isDummy()) {
             continue;
           }
           if (utils::inBox(p.getR(), boxMin, boxMax)) {
+            p.setOwnershipState(OwnershipState::owned);
             _containerSelector.getCurrentContainer().addParticle(p);
           } else {
             leavingBufferParticles.push_back(p);
@@ -292,12 +294,14 @@ class LogicHandler {
           "{}",
           boxMin, boxMax, p.toString());
     }
+    Particle particleCopy = p;
+    particleCopy.setOwnershipState(OwnershipState::owned);
     if (not neighborListsAreValid()) {
       // Container has to (about to) be invalid to be able to add Particles!
-      _containerSelector.getCurrentContainer().template addParticle<false>(p);
+      _containerSelector.getCurrentContainer().template addParticle<false>(particleCopy);
     } else {
       // If the container is valid, we add it to the particle buffer.
-      _particleBuffer[autopas_get_thread_num()].addParticle(p);
+      _particleBuffer[autopas_get_thread_num()].addParticle(particleCopy);
     }
     _numParticlesOwned.fetch_add(1, std::memory_order_relaxed);
   }
@@ -317,15 +321,17 @@ class LogicHandler {
           "{}",
           utils::ArrayUtils::to_string(boxMin), utils::ArrayUtils::to_string(boxMax), haloParticle.toString());
     }
+    Particle haloParticleCopy = haloParticle;
+    haloParticleCopy.setOwnershipState(OwnershipState::halo);
     if (not neighborListsAreValid()) {
       // If the neighbor lists are not valid, we can add the particle.
-      container.template addHaloParticle</* checkInBox */ false>(haloParticle);
+      container.template addHaloParticle</* checkInBox */ false>(haloParticleCopy);
     } else {
       // Check if we can update an existing halo(dummy) particle.
-      bool updated = container.updateHaloParticle(haloParticle);
+      bool updated = container.updateHaloParticle(haloParticleCopy);
       if (not updated) {
         // If we couldn't find an existing particle, add it to the halo particle buffer.
-        _haloParticleBuffer[autopas_get_thread_num()].addParticle(haloParticle);
+        _haloParticleBuffer[autopas_get_thread_num()].addParticle(haloParticleCopy);
         _haloParticleBuffer[autopas_get_thread_num()]._particles.back().setOwnershipState(OwnershipState::halo);
       }
     }

--- a/src/autopas/tuning/tuningStrategy/ruleBasedTuning/RuleBasedTuning.cpp
+++ b/src/autopas/tuning/tuningStrategy/ruleBasedTuning/RuleBasedTuning.cpp
@@ -24,7 +24,11 @@ RuleBasedTuning::RuleBasedTuning(const std::set<Configuration> &searchSpace, boo
     utils::ExceptionHandler::exception("Rule file {} does not exist!", _ruleFileName);
   }
   // By default, dump the rules for reproducibility reasons.
-  AutoPasLog(INFO, "Rule File {}:\n{}", _ruleFileName, rulesToString(_ruleFileName));
+  int myRank{};
+  AutoPas_MPI_Comm_rank(AUTOPAS_MPI_COMM_WORLD, &myRank);
+  if (myRank == 0) {
+    AutoPasLog(INFO, "Rule File {}:\n{}", _ruleFileName, rulesToString(_ruleFileName));
+  }
 #else
 {
   autopas::utils::ExceptionHandler::exception(

--- a/src/autopas/utils/ArrayMath.h
+++ b/src/autopas/utils/ArrayMath.h
@@ -359,15 +359,15 @@ template <class T, std::size_t SIZE>
  * @tparam SIZE size of the array
  * @param a input array
  * @param b input array
- * @param relativeDifference
+ * @param maxRelativeDifference
  * @return
  */
 template <class T, std::size_t SIZE>
-[[nodiscard]] bool isNear(const std::array<T, SIZE> &a, const std::array<T, SIZE> &b,
-                          double relativeDifference = 1e-9) {
+[[nodiscard]] bool isNearRel(const std::array<T, SIZE> &a, const std::array<T, SIZE> &b,
+                             double maxRelativeDifference = 1e-9) {
   bool arraysAreNear = true;
   for (std::size_t i = 0; i < SIZE; ++i) {
-    arraysAreNear = arraysAreNear and utils::Math::isNear(a[i], b[i], relativeDifference);
+    arraysAreNear = arraysAreNear and utils::Math::isNearRel(a[i], b[i], maxRelativeDifference);
   }
   return arraysAreNear;
 }
@@ -379,19 +379,19 @@ template <class T, std::size_t SIZE>
  * @tparam SIZE size of the array
  * @param a input vector of arrays
  * @param b input vector of arrays
- * @param relativeDifference
+ * @param maxRelativeDifference
  * @return
  */
 template <class T, std::size_t SIZE>
-[[nodiscard]] bool isNear(const std::vector<std::array<T, SIZE>> &a, const std::vector<std::array<T, SIZE>> &b,
-                          double relativeDifference = 1e-9) {
+[[nodiscard]] bool isNearRel(const std::vector<std::array<T, SIZE>> &a, const std::vector<std::array<T, SIZE>> &b,
+                             double maxRelativeDifference = 1e-9) {
   const auto size = a.size();
   if (size != b.size()) {
     return false;
   }
   bool arraysAreNear = true;
   for (std::size_t i = 0; i < size; ++i) {
-    arraysAreNear = arraysAreNear and utils::ArrayMath::isNear(a[i], b[i], relativeDifference);
+    arraysAreNear = arraysAreNear and utils::ArrayMath::isNearRel(a[i], b[i], maxRelativeDifference);
   }
   return arraysAreNear;
 }

--- a/src/autopas/utils/Math.cpp
+++ b/src/autopas/utils/Math.cpp
@@ -36,6 +36,8 @@ bool isNearRel(double a, double b, double maxRelativeDifference) {
   return diff <= maxAbsoluteDifference;
 }
 
+bool isNearAbs(double a, double b, double maxAbsoluteDifference) { return std::abs(a - b) <= maxAbsoluteDifference; }
+
 double roundFixed(double d, int fixedPrecision) {
   const auto factor = std::pow(10, fixedPrecision);
   return std::round(d * factor) / factor;

--- a/src/autopas/utils/Math.cpp
+++ b/src/autopas/utils/Math.cpp
@@ -30,10 +30,10 @@ double sigmoid(double x) {
 }
 
 bool isNearRel(double a, double b, double maxRelativeDifference) {
-  const auto [smallerNumber, biggerNumber] = std::minmax(a, b);
-  const auto maxAbsoluteDifference = maxRelativeDifference * biggerNumber;
-  const auto diff = biggerNumber - smallerNumber;
-  return diff <= maxAbsoluteDifference;
+  const auto greaterNumber = std::max(std::abs(a), std::abs(b));
+  const auto absoluteDifference = maxRelativeDifference * greaterNumber;
+  const auto diff = std::abs(a - b);
+  return diff <= absoluteDifference;
 }
 
 bool isNearAbs(double a, double b, double maxAbsoluteDifference) { return std::abs(a - b) <= maxAbsoluteDifference; }

--- a/src/autopas/utils/Math.cpp
+++ b/src/autopas/utils/Math.cpp
@@ -36,6 +36,21 @@ bool isNear(double a, double b, double relativeDifference) {
   return diff <= absoluteDifference;
 }
 
+double roundFixed(double d, int fixedPrecision) {
+  const auto factor = std::pow(10, fixedPrecision);
+  return std::round(d * factor) / factor;
+}
+
+double roundFloating(double d, int floatingPrecision) {
+  // Special case for 0 to avoid log10(0)
+  if (d == 0.0) {
+    return d;
+  }
+  // The shift factor is the precision minus the number of digits d has before the decimal point
+  const auto factor = std::pow(10, floatingPrecision - std::ceil(std::log10(std::abs(d))));
+  return std::round(d * factor) / factor;
+}
+
 Eigen::VectorXd makeVectorXd(const std::vector<double> &elements) {
   return Eigen::Map<const Eigen::VectorXd>(elements.data(), elements.size());
 }

--- a/src/autopas/utils/Math.cpp
+++ b/src/autopas/utils/Math.cpp
@@ -29,11 +29,11 @@ double sigmoid(double x) {
   }
 }
 
-bool isNear(double a, double b, double relativeDifference) {
-  const auto greaterNumber = std::max(std::abs(a), std::abs(b));
-  const auto absoluteDifference = relativeDifference * greaterNumber;
-  const auto diff = std::abs(a - b);
-  return diff <= absoluteDifference;
+bool isNearRel(double a, double b, double maxRelativeDifference) {
+  const auto [smallerNumber, biggerNumber] = std::minmax(a, b);
+  const auto maxAbsoluteDifference = maxRelativeDifference * biggerNumber;
+  const auto diff = biggerNumber - smallerNumber;
+  return diff <= maxAbsoluteDifference;
 }
 
 double roundFixed(double d, int fixedPrecision) {

--- a/src/autopas/utils/Math.h
+++ b/src/autopas/utils/Math.h
@@ -222,7 +222,7 @@ double sigmoid(double x);
  * Determines if two doubles are near each other. This function should be preferred to comparing with ==.
  * @param a
  * @param b
- * @param maxRelativeDifference inclusive
+ * @param maxRelativeDifference inclusive, relative to max(|a|, |b|).
  * @return
  */
 bool isNearRel(double a, double b, double maxRelativeDifference = 1e-9);

--- a/src/autopas/utils/Math.h
+++ b/src/autopas/utils/Math.h
@@ -222,10 +222,10 @@ double sigmoid(double x);
  * Determines if two doubles are near each other. This function should be preferred to comparing with ==.
  * @param a
  * @param b
- * @param relativeDifference
+ * @param maxRelativeDifference inclusive
  * @return
  */
-bool isNear(double a, double b, double relativeDifference = 1e-9);
+bool isNearRel(double a, double b, double maxRelativeDifference = 1e-9);
 
 /**
  * Round a floating point number to a given number of decimal digits.

--- a/src/autopas/utils/Math.h
+++ b/src/autopas/utils/Math.h
@@ -228,6 +228,15 @@ double sigmoid(double x);
 bool isNearRel(double a, double b, double maxRelativeDifference = 1e-9);
 
 /**
+ * Determines if two doubles are near each other. This function should be preferred to comparing with ==.
+ * @param a
+ * @param b
+ * @param maxAbsoluteDifference inclusive
+ * @return
+ */
+bool isNearAbs(double a, double b, double maxAbsoluteDifference);
+
+/**
  * Round a floating point number to a given number of decimal digits.
  * @param d Number to round.
  * @param fixedPrecision Number of decimal digits. Negative values lead to rounding of digits left of the decimal.

--- a/src/autopas/utils/Math.h
+++ b/src/autopas/utils/Math.h
@@ -228,6 +228,22 @@ double sigmoid(double x);
 bool isNear(double a, double b, double relativeDifference = 1e-9);
 
 /**
+ * Round a floating point number to a given number of decimal digits.
+ * @param d Number to round.
+ * @param fixedPrecision Number of decimal digits. Negative values lead to rounding of digits left of the decimal.
+ * @return d rounded to the given number of digits.
+ */
+double roundFixed(double d, int fixedPrecision);
+
+/**
+ * Round a floating point number to a given floating precision.
+ * @param d Number to round.
+ * @param floatingPrecision Number of significant digits. Values <0 will return in 0.
+ * @return d rounded to the given number of digits.
+ */
+double roundFloating(double d, int floatingPrecision);
+
+/**
  * Create a vector of doubles from given elements
  * @param elements
  * @return

--- a/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
+++ b/tests/testAutopas/tests/iterators/RegionParticleIteratorTest.cpp
@@ -236,7 +236,7 @@ TEST_P(RegionParticleIteratorTestTwo, testParticleMisplacement) {
   // This function creates particle positions within the simulation box that are the offset-value distant from the
   // boundary and the positions mirrored at the boundary. In addition, a search box is calculated for each position.
   auto generateParticlePositions = [&autoPas, &shortDistance]() {
-    using autopas::utils::Math::isNear;
+    using autopas::utils::Math::isNearRel;
     constexpr size_t numParticles1DTotal = 3;
     constexpr double margin = 1e-10;
 
@@ -260,8 +260,8 @@ TEST_P(RegionParticleIteratorTestTwo, testParticleMisplacement) {
     for (auto [x, xMirrored] : generateInteresting1DPositions(boxMin[0], boxMax[0])) {
       for (auto [y, yMirrored] : generateInteresting1DPositions(boxMin[1], boxMax[1])) {
         for (auto [z, zMirrored] : generateInteresting1DPositions(boxMin[2], boxMax[2])) {
-          if (not(isNear(x, (boxMax[0] - boxMin[0]) / 2.0) and isNear(y, (boxMax[1] - boxMin[1]) / 2.0) and
-                  isNear(z, (boxMax[2] - boxMin[2]) / 2.0))) {
+          if (not(isNearRel(x, (boxMax[0] - boxMin[0]) / 2.0) and isNearRel(y, (boxMax[1] - boxMin[1]) / 2.0) and
+                  isNearRel(z, (boxMax[2] - boxMin[2]) / 2.0))) {
             positionsInsideBox.push_back({x, y, z});
             positionsMirroredAtBoundary.push_back({xMirrored, yMirrored, zMirrored});
 

--- a/tests/testAutopas/tests/utils/MathTest.cpp
+++ b/tests/testAutopas/tests/utils/MathTest.cpp
@@ -8,25 +8,29 @@
 
 #include "autopas/utils/Math.h"
 
-TEST(MathTest, isNearRelTest) {
+TEST(MathTest, isNearTest) {
   {
     const double a = 0;
     EXPECT_TRUE(autopas::utils::Math::isNearRel(a, a));
+    EXPECT_TRUE(autopas::utils::Math::isNearAbs(a, a, 0.));
   }
   {
     const double a = 0;
     const double b = -0;
     EXPECT_TRUE(autopas::utils::Math::isNearRel(a, b));
+    EXPECT_TRUE(autopas::utils::Math::isNearAbs(a, b, 0.));
   }
   {
     const double a = 1. / 3.;
     const double b = std::nextafter(a, a + 1);
     EXPECT_TRUE(autopas::utils::Math::isNearRel(a, b));
+    EXPECT_TRUE(autopas::utils::Math::isNearAbs(a, b, 1e-10));
   }
   {
     const double a = 1. / 3.;
     const double b = a + 1e-8;
     EXPECT_FALSE(autopas::utils::Math::isNearRel(a, b));
+    EXPECT_FALSE(autopas::utils::Math::isNearAbs(a, b, 1e-10));
   }
 }
 

--- a/tests/testAutopas/tests/utils/MathTest.cpp
+++ b/tests/testAutopas/tests/utils/MathTest.cpp
@@ -31,13 +31,13 @@ TEST(MathTest, isNearTest) {
 }
 
 TEST(MathTest, roundFixed) {
-    const double n = 123.123456789;
-    EXPECT_EQ(autopas::utils::Math::roundFixed(n, -3), 0.);
-    EXPECT_EQ(autopas::utils::Math::roundFixed(n, -2), 100.);
-    EXPECT_EQ(autopas::utils::Math::roundFixed(n, -1), 120.);
-    EXPECT_EQ(autopas::utils::Math::roundFixed(n, 0), 123.);
-    EXPECT_EQ(autopas::utils::Math::roundFixed(n, 2), 123.12);
-    EXPECT_EQ(autopas::utils::Math::roundFixed(n, 5), 123.12346);
+  const double n = 123.123456789;
+  EXPECT_EQ(autopas::utils::Math::roundFixed(n, -3), 0.);
+  EXPECT_EQ(autopas::utils::Math::roundFixed(n, -2), 100.);
+  EXPECT_EQ(autopas::utils::Math::roundFixed(n, -1), 120.);
+  EXPECT_EQ(autopas::utils::Math::roundFixed(n, 0), 123.);
+  EXPECT_EQ(autopas::utils::Math::roundFixed(n, 2), 123.12);
+  EXPECT_EQ(autopas::utils::Math::roundFixed(n, 5), 123.12346);
 }
 
 TEST(MathTest, roundFloating) {

--- a/tests/testAutopas/tests/utils/MathTest.cpp
+++ b/tests/testAutopas/tests/utils/MathTest.cpp
@@ -30,6 +30,28 @@ TEST(MathTest, isNearTest) {
   }
 }
 
+TEST(MathTest, roundFixed) {
+    const double n = 123.123456789;
+    EXPECT_EQ(autopas::utils::Math::roundFixed(n, -3), 0.);
+    EXPECT_EQ(autopas::utils::Math::roundFixed(n, -2), 100.);
+    EXPECT_EQ(autopas::utils::Math::roundFixed(n, -1), 120.);
+    EXPECT_EQ(autopas::utils::Math::roundFixed(n, 0), 123.);
+    EXPECT_EQ(autopas::utils::Math::roundFixed(n, 2), 123.12);
+    EXPECT_EQ(autopas::utils::Math::roundFixed(n, 5), 123.12346);
+}
+
+TEST(MathTest, roundFloating) {
+  const double n = 123.456789;
+  EXPECT_EQ(autopas::utils::Math::roundFloating(n, -2), 0.);
+  EXPECT_EQ(autopas::utils::Math::roundFloating(n, -1), 0.);
+  EXPECT_EQ(autopas::utils::Math::roundFloating(n, 0), 0.);
+  EXPECT_EQ(autopas::utils::Math::roundFloating(n, 1), 100.);
+  EXPECT_EQ(autopas::utils::Math::roundFloating(n, 2), 120.);
+  EXPECT_EQ(autopas::utils::Math::roundFloating(n, 3), 123.);
+  EXPECT_EQ(autopas::utils::Math::roundFloating(n, 4), 123.5);
+  EXPECT_EQ(autopas::utils::Math::roundFloating(n, 5), 123.46);
+}
+
 TYPED_TEST_SUITE_P(MathTest);
 
 TYPED_TEST_P(MathTest, safeAddTest) {

--- a/tests/testAutopas/tests/utils/MathTest.cpp
+++ b/tests/testAutopas/tests/utils/MathTest.cpp
@@ -8,25 +8,25 @@
 
 #include "autopas/utils/Math.h"
 
-TEST(MathTest, isNearTest) {
+TEST(MathTest, isNearRelTest) {
   {
     const double a = 0;
-    EXPECT_TRUE(autopas::utils::Math::isNear(a, a));
+    EXPECT_TRUE(autopas::utils::Math::isNearRel(a, a));
   }
   {
     const double a = 0;
     const double b = -0;
-    EXPECT_TRUE(autopas::utils::Math::isNear(a, b));
+    EXPECT_TRUE(autopas::utils::Math::isNearRel(a, b));
   }
   {
     const double a = 1. / 3.;
     const double b = std::nextafter(a, a + 1);
-    EXPECT_TRUE(autopas::utils::Math::isNear(a, b));
+    EXPECT_TRUE(autopas::utils::Math::isNearRel(a, b));
   }
   {
     const double a = 1. / 3.;
     const double b = a + 1e-8;
-    EXPECT_FALSE(autopas::utils::Math::isNear(a, b));
+    EXPECT_FALSE(autopas::utils::Math::isNearRel(a, b));
   }
 }
 


### PR DESCRIPTION
# Description

- [x] Refactor loading of particles from checkpoints and generators
  - [x] When in doubt or using generators, load all particles into conf of rank 0
  - [x] Each rank sends all particles it can't insert locally to all other ranks
- [x] Multiple minor fixes
  - [x] Reserve before `push_back()` in deserialization
  - [x] `const`
  - [x] Remove redundant function `getSubdomainCount()`
  - [x] rename `isNear()` to `isNearRel()` to distinguish it from new `isNearAbs()`
- [x] Behavior changes:
  - [x] Force correct `OwnershipState` upon `addParticle` via `LogicHandler` (this will be cleaned up in #821)
  - [x] When writing checkpoints, prevent positions to be rounded to backside boundaries 73ab90b
  - [x] Print number of particles upon init per rank + total
  - [x] Restrict info logs to rank 0

## ~Related Pull Requests~

## Resolved Issues

- [x] Loading parallel checkpoints (`pvtu`) with different domain boundaries would result in particle loss. This is almost always the case when using mpi load balancing.

# How Has This Been Tested?

- [x] Store and load MPI parallel checkpoints
- [x] Store and load serial checkpoints
- [x] Start MPI parallel simulation with objects
