### PR TITLE
Argon refactoring

### DIFF
--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ArgonFunctor.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ArgonFunctor.h
@@ -56,25 +56,7 @@ class ArgonFunctor : public autopas::TriwiseFunctor<Particle, ArgonFunctor<Parti
    * @param newton3
    */
   void AoSFunctor(Particle &i, Particle &j, Particle &k, bool newton3) {
-    const auto A_000{A[index<param::A>(0, 0, 0)]};
 
-    if (i.isDummy() or j.isDummy() or k.isDummy()) {
-      return;
-    }
-
-    enum IJK { I, J, K };
-
-    const auto displacementIJ = DisplacementHandle(i.getR(), j.getR(), I, J);
-    const auto displacementJK = DisplacementHandle(j.getR(), k.getR(), J, K);
-    const auto displacementKI = DisplacementHandle(k.getR(), i.getR(), K, I);
-
-    const auto IJ = displacementIJ.getDisplacement();
-    const auto JK = displacementJK.getDisplacement();
-    const auto KI = displacementKI.getDisplacement();
-
-    const auto cosineI = CosineHandle(displacementIJ, displacementKI.getInv());
-    const auto cosineJ = CosineHandle(displacementIJ.getInv(), displacementJK);
-    const auto cosineK = Cosinehandle(displacementKI, displacementJK.getInv());
   }
 
   /**

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ArgonInclude/CosineHandle.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ArgonInclude/CosineHandle.h
@@ -37,24 +37,24 @@ class CosineHandle {
   [[nodiscard]] nabla derive_wrt() const;
 
  private:
-  DisplacementHandle displacementAB_;
-  DisplacementHandle displacementAC_;
   std::array<double, 3> AB_;
   std::array<double, 3> AC_;
   double cos_;
   size_t id_;
+  size_t B_;
+  size_t C_;
 };
 
 CosineHandle::CosineHandle(const DisplacementHandle &displacementAB, const DisplacementHandle &displacementAC) {
   if (displacementAB.getIdStartVertex() != displacementAC.getIdStartVertex()) {
     throw autopas::utils::ExceptionHandler::AutoPasException("cannot build cosine");
   }
-  displacementAB_ = displacementAB;
-  displacementAC_ = displacementAC;
-  AB_ = displacementAB_.getDisplacement();
-  AC_ = displacementAC_.getDisplacement();
+  AB_ = displacementAB.getDisplacement();
+  AC_ = displacementAC.getDisplacement();
   cos_ = ArrayMath::dot(AB_, AC_) / (ArrayMath::L2Norm(AB_) * ArrayMath::L2Norm(AC_));
   id_ = displacementAB.getIdStartVertex();
+  B_ = displacementAB.getIdEndVertex();
+  C_ = displacementAC.getIdEndVertex();
 }
 
 template <size_t ID>
@@ -65,11 +65,11 @@ template <size_t ID>
     auto secondTerm{cos_ / (ArrayMath::L2Norm(AC_) * ArrayMath::L2Norm(AC_)) -
                     1. / (ArrayMath::L2Norm(AB_) * ArrayMath::L2Norm(AC_))};
     return AB_ * firstTerm + AC_ * secondTerm;
-  } else if (ID == displacementAB_.getIdEndVertex()) {
+  } else if (ID == B_) {
     auto firstTerm{-cos_ / (ArrayMath::L2Norm(AB_) * ArrayMath::L2Norm(AB_))};
     auto secondTerm{1. / (ArrayMath::L2Norm(AB_) * ArrayMath::L2Norm(AC_))};
     return AB_ * firstTerm + AC_ * secondTerm;
-  } else if (ID == displacementAC_.getIdEndVertex()) {
+  } else if (ID == C_) {
     auto firstTerm{-cos_ / (ArrayMath::L2Norm(AC_) * ArrayMath::L2Norm(AC_))};
     auto secondTerm{1. / (ArrayMath::L2Norm(AB_) * ArrayMath::L2Norm(AC_))};
     return AC_ * firstTerm + AB_ * secondTerm;

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ArgonInclude/DisplacementHandle.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ArgonInclude/DisplacementHandle.h
@@ -17,15 +17,12 @@ class DisplacementHandle {
   DisplacementHandle() = default;
 
   /**
-   * Constructor for DisplacementHandle. It stores the ids and the positions of the start and end vertices, as well as
-   * the displacement vector between the two (i.e. positionEndVertex - positionStartVertex)
-   * @param positionStartVertex position of the start vertex
-   * @param positionEndVertex position of the end vertex
+   * Constructor for DisplacementHandle. It stores the ids of start and end vertices and the displacement vector between the two
+   * @param displacement displacement vector
    * @param idStartVertex id of the start vertex
    * @param idEndVertex id of the end vertex
    */
-  explicit DisplacementHandle(const std::array<double, 3> &positionStartVertex,
-                              const std::array<double, 3> &positionEndVertex, const size_t &idStartVertex,
+  explicit DisplacementHandle(const std::array<double, 3> &displacement, const size_t &idStartVertex,
                               const size_t &idEndVertex);
 
   /**
@@ -61,24 +58,19 @@ class DisplacementHandle {
   [[nodiscard]] nabla derive_wrt() const;
 
  private:
-  std::array<double, 3> positionStartVertex_;
-  std::array<double, 3> positionEndVertex_;
   std::array<double, 3> displacement_;
   size_t idStartVertex_;
   size_t idEndVertex_;
 };
 
-DisplacementHandle::DisplacementHandle(const std::array<double, 3> &positionStartVertex,
-                                       const std::array<double, 3> &positionEndVertex, const size_t &idStartVertex,
+DisplacementHandle::DisplacementHandle(const std::array<double, 3> &displacement, const size_t &idStartVertex,
                                        const size_t &idEndVertex)
-    : positionStartVertex_(positionStartVertex),
-      positionEndVertex_(positionEndVertex),
-      displacement_(positionEndVertex - positionStartVertex),
+    : displacement_(displacement),
       idStartVertex_(idStartVertex),
       idEndVertex_(idEndVertex) {}
 
 [[nodiscard]] DisplacementHandle DisplacementHandle::getInv() const {
-  return DisplacementHandle(positionEndVertex_, positionStartVertex_, idEndVertex_, idStartVertex_);
+  return DisplacementHandle(-1.*displacement_, idEndVertex_, idStartVertex_);
 }
 
 template <size_t ID>


### PR DESCRIPTION
- removed displacementAB_ and displacement AC_ from CosineHandle private members
- instead storing B_ and C_ as vertex IDs
- passing displacement vector instead of start and end vectors to DisplacementHandle constructor
