### PR TITLE
Verlet Cluster Lists Bugfix

### DIFF
--- a/src/autopas/containers/verletClusterLists/VerletClusterListsRebuilder.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterListsRebuilder.h
@@ -86,8 +86,8 @@ class VerletClusterListsRebuilder {
     const auto numTowersNew = numTowersPerDim[0] * numTowersPerDim[1];
 
     // collect all particles that are now not in the right tower anymore
-    auto invalidParticles = collectOutOfBoundsParticlesFromTowers();
-    // collect all remaining particles that are not yet assigned to towers
+    std::vector<std::vector<Particle>> invalidParticles;
+    //  collect all particles that are not yet assigned to towers
     invalidParticles.push_back(std::move(_particlesToAdd));
     _particlesToAdd.clear();
     // if we have less towers than before, collect all particles from the unused towers.
@@ -98,6 +98,11 @@ class VerletClusterListsRebuilder {
     // resize to number of towers.
     // Attention! This uses the dummy constructor so we still need to set the desired cluster size.
     _towerBlock.resize(towerSideLength, numTowersPerDim);
+
+    // after resizing the towers we collect all the particles that are out of bounds
+    const auto collectedParticlesFromTowers = collectOutOfBoundsParticlesFromTowers();
+    invalidParticles.insert(invalidParticles.end(), collectedParticlesFromTowers.begin(),
+                            collectedParticlesFromTowers.end());
 
     // create more towers if needed and make an estimate for how many particles memory needs to be allocated
     // Factor is more or less a random guess.

--- a/src/autopas/containers/verletClusterLists/VerletClusterListsRebuilder.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterListsRebuilder.h
@@ -86,8 +86,14 @@ class VerletClusterListsRebuilder {
     const auto numTowersNew = numTowersPerDim[0] * numTowersPerDim[1];
 
     // collect all particles that are now not in the right tower anymore
-    std::vector<std::vector<Particle>> invalidParticles;
-    //  collect all particles that are not yet assigned to towers
+    std::vector<std::vector<Particle>> invalidParticles{};
+    // Reserve for:
+    //   - _particlesToAdd (+1)
+    //   - surplus towers (+max(0, numTowersNew - numTowersOld))
+    //   - particles out of bounds of new towers (+numTowersNew)
+    invalidParticles.reserve(1 + std::max(0, static_cast<int>(numTowersNew) - static_cast<int>(numTowersOld)) +
+                             numTowersNew);
+    // collect all particles that are not yet assigned to towers
     invalidParticles.push_back(std::move(_particlesToAdd));
     _particlesToAdd.clear();
     // if we have less towers than before, collect all particles from the unused towers.


### PR DESCRIPTION
# Description

This PR is intended to fix a bug with the Verlet Cluster Lists. 
Particles were not sorted into the correct towers when recreating the neighborlists. The problem was that the order in which out-of-bound particles of the tower were collected and the resizing of the towerblock was wrong. The out-of-bound particles were collected first, then the tower block (and thus also the bounding boxes of the tower) were recalculated. However, the out-of-bounds particles should be collected only after the new tower bounding boxes have been calculated.

## Resolved Issues

- [x] fixes #917 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

The scenario from #917 with a single thread was used. The results for VCL and linked cells were compared (particle interactions and resulting forces). A python script was used that calculates possible differences in the particle interactions from the log output of the calculation with both containers. After the bugfix, there are no more differences between the two containers. The same particle interactions and the same forces are calculated.