### PR TITLE
Tuning Strategy Config Wipe Fix

### DIFF
--- a/src/autopas/tuning/AutoTuner.cpp
+++ b/src/autopas/tuning/AutoTuner.cpp
@@ -117,8 +117,7 @@ bool AutoTuner::tuneConfiguration() {
     // then let the strategies filter and sort it
     std::for_each(_tuningStrategies.begin(), _tuningStrategies.end(), [&](auto &tuningStrategy) {
       const auto configQueueBackup = _configQueue;
-      bool intentionalWipe{false};
-      tuningStrategy->reset(_iteration, _tuningPhase, _configQueue, _evidenceCollection, intentionalWipe);
+      const auto intentionalWipe = tuningStrategy->reset(_iteration, _tuningPhase, _configQueue, _evidenceCollection);
       AutoPasLog(DEBUG, "ConfigQueue after applying {}::reset(): (Size={}) {}",
                  tuningStrategy->getOptionType().to_string(), _configQueue.size(),
                  utils::ArrayUtils::to_string(_configQueue, ", ", {"[", "]"},
@@ -134,8 +133,7 @@ bool AutoTuner::tuneConfiguration() {
                                             [](const auto &conf) { return conf.toShortString(false); }));
     std::for_each(_tuningStrategies.begin(), _tuningStrategies.end(), [&](auto &tuningStrategy) {
       const auto configQueueBackup = _configQueue;
-      bool intentionalWipe{false};
-      tuningStrategy->optimizeSuggestions(_configQueue, _evidenceCollection, intentionalWipe);
+      const auto intentionalWipe = tuningStrategy->optimizeSuggestions(_configQueue, _evidenceCollection);
       AutoPasLog(DEBUG, "ConfigQueue after applying {}::optimizeSuggestions(): (Size={}) {}",
                  tuningStrategy->getOptionType().to_string(), _configQueue.size(),
                  utils::ArrayUtils::to_string(_configQueue, ", ", {"[", "]"},

--- a/src/autopas/tuning/tuningStrategy/ActiveHarmony.cpp
+++ b/src/autopas/tuning/tuningStrategy/ActiveHarmony.cpp
@@ -135,7 +135,7 @@ void ActiveHarmony::optimizeSuggestions(std::vector<Configuration> &configQueue,
     }
     const auto potentialConf = fetchConfiguration();
     // If we already know the performance for this config in this tuning phase skip it.
-    if (const auto *potentialConfEvidence = evidence.getEvidence(potentialConf);
+    if (const auto *potentialConfEvidence = evidenceCollection.getEvidence(potentialConf);
         potentialConfEvidence and not potentialConfEvidence->empty() and
         potentialConfEvidence->back().tuningPhase == _tuningPhase) {
       addEvidence(potentialConf, potentialConfEvidence->back());

--- a/src/autopas/tuning/tuningStrategy/ActiveHarmony.cpp
+++ b/src/autopas/tuning/tuningStrategy/ActiveHarmony.cpp
@@ -122,7 +122,9 @@ void ActiveHarmony::rejectConfiguration(const Configuration &configuration, bool
 #endif
 }
 
-void ActiveHarmony::optimizeSuggestions(std::vector<Configuration> &configQueue, const EvidenceCollection &evidence) {
+void ActiveHarmony::optimizeSuggestions(std::vector<Configuration> &configQueue,
+                                        const EvidenceCollection &evidenceCollection,
+                                        std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
 #ifdef AUTOPAS_ENABLE_HARMONY
   // get configurations from server until new configuration with valid newton3 option is found
   bool skipConfig;
@@ -185,7 +187,8 @@ void ActiveHarmony::configureTuningParameter(hdef_t *hdef, const char *name, con
 }
 
 void ActiveHarmony::reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-                          const EvidenceCollection &evidenceCollection) {
+                          const EvidenceCollection &evidenceCollection,
+                          std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
   resetHarmony();
 }
 

--- a/src/autopas/tuning/tuningStrategy/ActiveHarmony.cpp
+++ b/src/autopas/tuning/tuningStrategy/ActiveHarmony.cpp
@@ -122,9 +122,8 @@ void ActiveHarmony::rejectConfiguration(const Configuration &configuration, bool
 #endif
 }
 
-void ActiveHarmony::optimizeSuggestions(std::vector<Configuration> &configQueue,
-                                        const EvidenceCollection &evidenceCollection,
-                                        std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
+bool ActiveHarmony::optimizeSuggestions(std::vector<Configuration> &configQueue,
+                                        const EvidenceCollection &evidenceCollection) {
 #ifdef AUTOPAS_ENABLE_HARMONY
   // get configurations from server until new configuration with valid newton3 option is found
   bool skipConfig;
@@ -165,6 +164,8 @@ void ActiveHarmony::optimizeSuggestions(std::vector<Configuration> &configQueue,
     }
   } while (skipConfig);
 #endif
+  // ActiveHarmony does no intentional config wipes to stop the tuning phase
+  return false;
 }
 
 template <class OptionClass>
@@ -186,10 +187,11 @@ void ActiveHarmony::configureTuningParameter(hdef_t *hdef, const char *name, con
 #endif
 }
 
-void ActiveHarmony::reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-                          const EvidenceCollection &evidenceCollection,
-                          std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
+bool ActiveHarmony::reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
+                          const EvidenceCollection &evidenceCollection) {
   resetHarmony();
+  // ActiveHarmony does no intentional config wipes to stop the tuning phase
+  return false;
 }
 
 void ActiveHarmony::resetHarmony() {

--- a/src/autopas/tuning/tuningStrategy/ActiveHarmony.cpp
+++ b/src/autopas/tuning/tuningStrategy/ActiveHarmony.cpp
@@ -152,7 +152,7 @@ bool ActiveHarmony::optimizeSuggestions(std::vector<Configuration> &configQueue,
       if (std::find(configQueue.begin(), configQueue.end(), potentialConf) == configQueue.end()) {
         skipConfig = true;
       } else {
-        return;
+        return false;
       }
     }
 
@@ -160,7 +160,7 @@ bool ActiveHarmony::optimizeSuggestions(std::vector<Configuration> &configQueue,
       // When using a non-local server, it is possible that only tested configurations are fetched before the search
       // converges.
       // Because this is difficult to test for, the loop is simply ignored for non-local servers.
-      return;
+      return false;
     }
   } while (skipConfig);
 #endif

--- a/src/autopas/tuning/tuningStrategy/ActiveHarmony.h
+++ b/src/autopas/tuning/tuningStrategy/ActiveHarmony.h
@@ -60,8 +60,8 @@ class ActiveHarmony : public TuningStrategyInterface {
 
   void addEvidence(const Configuration &configuration, const Evidence &evidence) override;
 
-  void optimizeSuggestions(std::vector<Configuration> &configQueue, const EvidenceCollection &evidenceCollection,
-                           std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
+  bool optimizeSuggestions(std::vector<Configuration> &configQueue,
+                           const EvidenceCollection &evidenceCollection) override;
 
   /**
    * Indicate if the search space contains only one configuration.
@@ -77,9 +77,8 @@ class ActiveHarmony : public TuningStrategyInterface {
 
   bool needsSmoothedHomogeneityAndMaxDensity() const override;
 
-  void reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-             const autopas::EvidenceCollection &evidenceCollection,
-             std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
+  bool reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
+             const autopas::EvidenceCollection &evidenceCollection) override;
 
  private:
 #ifdef AUTOPAS_ENABLE_HARMONY

--- a/src/autopas/tuning/tuningStrategy/ActiveHarmony.h
+++ b/src/autopas/tuning/tuningStrategy/ActiveHarmony.h
@@ -60,7 +60,8 @@ class ActiveHarmony : public TuningStrategyInterface {
 
   void addEvidence(const Configuration &configuration, const Evidence &evidence) override;
 
-  void optimizeSuggestions(std::vector<Configuration> &configQueue, const EvidenceCollection &evidence) override;
+  void optimizeSuggestions(std::vector<Configuration> &configQueue, const EvidenceCollection &evidenceCollection,
+                           std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
 
   /**
    * Indicate if the search space contains only one configuration.
@@ -77,7 +78,8 @@ class ActiveHarmony : public TuningStrategyInterface {
   bool needsSmoothedHomogeneityAndMaxDensity() const override;
 
   void reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-             const autopas::EvidenceCollection &evidenceCollection) override;
+             const autopas::EvidenceCollection &evidenceCollection,
+             std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
 
  private:
 #ifdef AUTOPAS_ENABLE_HARMONY

--- a/src/autopas/tuning/tuningStrategy/BayesianClusterSearch.cpp
+++ b/src/autopas/tuning/tuningStrategy/BayesianClusterSearch.cpp
@@ -96,7 +96,8 @@ void autopas::BayesianClusterSearch::addEvidence(const Configuration &configurat
 
 void autopas::BayesianClusterSearch::reset(size_t iteration, size_t tuningPhase,
                                            std::vector<Configuration> &configQueue,
-                                           const autopas::EvidenceCollection &evidenceCollection) {
+                                           const autopas::EvidenceCollection &evidenceCollection,
+                                           std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
   const auto iterationSinceLastEvidence = iteration - _currentIteration;
   if (static_cast<double>(iterationSinceLastEvidence) * _iterationScale > suggestedMaxDistance) {
     AutoPasLog(WARN,
@@ -133,8 +134,9 @@ void autopas::BayesianClusterSearch::updateOptions() {
   _gaussianCluster.setDimensions(std::vector<int>(newRestrictions.begin(), newRestrictions.end()));
 }
 
-void autopas::BayesianClusterSearch::optimizeSuggestions(std::vector<Configuration> &configQueue,
-                                                         const EvidenceCollection &evidence) {
+void autopas::BayesianClusterSearch::optimizeSuggestions(
+    std::vector<Configuration> &configQueue, const EvidenceCollection &evidenceCollection,
+    std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
   // In the first tuning phase do nothing since we first need some data.
   if (_firstTuningPhase) {
     return;
@@ -144,6 +146,9 @@ void autopas::BayesianClusterSearch::optimizeSuggestions(std::vector<Configurati
   if (_currentNumEvidence >= _maxEvidence) {
     // select best config of current tuning phase
     configQueue.clear();
+    if (intentionalConfigWipe) {
+      intentionalConfigWipe->get() = true;
+    }
     return;
   }
 

--- a/src/autopas/tuning/tuningStrategy/BayesianClusterSearch.h
+++ b/src/autopas/tuning/tuningStrategy/BayesianClusterSearch.h
@@ -87,12 +87,11 @@ class BayesianClusterSearch : public TuningStrategyInterface {
 
   void addEvidence(const Configuration &configuration, const Evidence &evidence) override;
 
-  void reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-             const autopas::EvidenceCollection &evidenceCollection,
-             std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
+  bool reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
+             const autopas::EvidenceCollection &evidenceCollection) override;
 
-  void optimizeSuggestions(std::vector<Configuration> &configQueue, const EvidenceCollection &evidenceCollection,
-                           std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
+  bool optimizeSuggestions(std::vector<Configuration> &configQueue,
+                           const EvidenceCollection &evidenceCollection) override;
 
   void rejectConfiguration(const Configuration &configuration, bool indefinitely) override;
 

--- a/src/autopas/tuning/tuningStrategy/BayesianClusterSearch.h
+++ b/src/autopas/tuning/tuningStrategy/BayesianClusterSearch.h
@@ -88,9 +88,11 @@ class BayesianClusterSearch : public TuningStrategyInterface {
   void addEvidence(const Configuration &configuration, const Evidence &evidence) override;
 
   void reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-             const autopas::EvidenceCollection &evidenceCollection) override;
+             const autopas::EvidenceCollection &evidenceCollection,
+             std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
 
-  void optimizeSuggestions(std::vector<Configuration> &configQueue, const EvidenceCollection &evidence) override;
+  void optimizeSuggestions(std::vector<Configuration> &configQueue, const EvidenceCollection &evidenceCollection,
+                           std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
 
   void rejectConfiguration(const Configuration &configuration, bool indefinitely) override;
 

--- a/src/autopas/tuning/tuningStrategy/BayesianSearch.cpp
+++ b/src/autopas/tuning/tuningStrategy/BayesianSearch.cpp
@@ -65,10 +65,14 @@ autopas::BayesianSearch::BayesianSearch(const std::set<ContainerOption> &allowed
 }
 
 void autopas::BayesianSearch::optimizeSuggestions(std::vector<Configuration> &configQueue,
-                                                  const EvidenceCollection &evidence) {
+                                                  const EvidenceCollection &evidenceCollection,
+                                                  std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
   // if enough evidence was collected abort the tuning process.
   if (_gaussianProcess.numEvidence() >= _maxEvidence) {
     configQueue.clear();
+    if (intentionalConfigWipe) {
+      intentionalConfigWipe->get() = true;
+    }
     return;
   }
 
@@ -155,7 +159,8 @@ void autopas::BayesianSearch::addEvidence(const Configuration &configuration, co
 }
 
 void autopas::BayesianSearch::reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-                                    const autopas::EvidenceCollection &evidenceCollection) {
+                                    const autopas::EvidenceCollection &evidenceCollection,
+                                    std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
   _gaussianProcess.clear();
   optimizeSuggestions(configQueue, evidenceCollection);
 }

--- a/src/autopas/tuning/tuningStrategy/BayesianSearch.cpp
+++ b/src/autopas/tuning/tuningStrategy/BayesianSearch.cpp
@@ -64,16 +64,12 @@ autopas::BayesianSearch::BayesianSearch(const std::set<ContainerOption> &allowed
   _gaussianProcess.setDimension(_encoder.getOneHotDims());
 }
 
-void autopas::BayesianSearch::optimizeSuggestions(std::vector<Configuration> &configQueue,
-                                                  const EvidenceCollection &evidenceCollection,
-                                                  std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
+bool autopas::BayesianSearch::optimizeSuggestions(std::vector<Configuration> &configQueue,
+                                                  const EvidenceCollection &evidenceCollection) {
   // if enough evidence was collected abort the tuning process.
   if (_gaussianProcess.numEvidence() >= _maxEvidence) {
     configQueue.clear();
-    if (intentionalConfigWipe) {
-      intentionalConfigWipe->get() = true;
-    }
-    return;
+    return true;
   }
 
   // Sample the search space, check that the samples are in the available configurations, and
@@ -111,6 +107,7 @@ void autopas::BayesianSearch::optimizeSuggestions(std::vector<Configuration> &co
       break;
     }
   }
+  return false;
 }
 
 std::vector<autopas::FeatureVector> autopas::BayesianSearch::sampleAcquisitions(size_t n,
@@ -158,11 +155,10 @@ void autopas::BayesianSearch::addEvidence(const Configuration &configuration, co
   _gaussianProcess.addEvidence(_encoder.oneHotEncode(configuration), -evidence.value * secondsPerMicroseconds, true);
 }
 
-void autopas::BayesianSearch::reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-                                    const autopas::EvidenceCollection &evidenceCollection,
-                                    std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
+bool autopas::BayesianSearch::reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
+                                    const autopas::EvidenceCollection &evidenceCollection) {
   _gaussianProcess.clear();
-  optimizeSuggestions(configQueue, evidenceCollection);
+  return optimizeSuggestions(configQueue, evidenceCollection);
 }
 
 bool autopas::BayesianSearch::needsSmoothedHomogeneityAndMaxDensity() const { return false; }

--- a/src/autopas/tuning/tuningStrategy/BayesianSearch.h
+++ b/src/autopas/tuning/tuningStrategy/BayesianSearch.h
@@ -65,12 +65,11 @@ class BayesianSearch final : public TuningStrategyInterface {
 
   void addEvidence(const Configuration &configuration, const Evidence &evidence) override;
 
-  void reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-             const autopas::EvidenceCollection &evidenceCollection,
-             std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
+  bool reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
+             const autopas::EvidenceCollection &evidenceCollection) override;
 
-  void optimizeSuggestions(std::vector<Configuration> &configQueue, const EvidenceCollection &evidenceCollection,
-                           std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
+  bool optimizeSuggestions(std::vector<Configuration> &configQueue,
+                           const EvidenceCollection &evidenceCollection) override;
 
   bool needsSmoothedHomogeneityAndMaxDensity() const override;
 

--- a/src/autopas/tuning/tuningStrategy/BayesianSearch.h
+++ b/src/autopas/tuning/tuningStrategy/BayesianSearch.h
@@ -66,9 +66,11 @@ class BayesianSearch final : public TuningStrategyInterface {
   void addEvidence(const Configuration &configuration, const Evidence &evidence) override;
 
   void reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-             const autopas::EvidenceCollection &evidenceCollection) override;
+             const autopas::EvidenceCollection &evidenceCollection,
+             std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
 
-  void optimizeSuggestions(std::vector<Configuration> &configQueue, const EvidenceCollection &evidence) override;
+  void optimizeSuggestions(std::vector<Configuration> &configQueue, const EvidenceCollection &evidenceCollection,
+                           std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
 
   bool needsSmoothedHomogeneityAndMaxDensity() const override;
 

--- a/src/autopas/tuning/tuningStrategy/MPIParallelizedStrategy.cpp
+++ b/src/autopas/tuning/tuningStrategy/MPIParallelizedStrategy.cpp
@@ -25,7 +25,8 @@ MPIParallelizedStrategy::MPIParallelizedStrategy(const Configuration &fallbackCo
       _mpiTuningWeightForMaxDensity(mpiTuningWeightForMaxDensity) {}
 
 void MPIParallelizedStrategy::optimizeSuggestions(std::vector<Configuration> &configQueue,
-                                                  const EvidenceCollection &evidence) {
+                                                  const EvidenceCollection &evidenceCollection,
+                                                  std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
   // sanity check
   if (_bucket == AUTOPAS_MPI_COMM_NULL) {
     AutoPasLog(WARN, "_bucket was AUTOPAS_MPI_COMM_NULL");
@@ -34,7 +35,7 @@ void MPIParallelizedStrategy::optimizeSuggestions(std::vector<Configuration> &co
 
   // All ranks should stay in tuning mode equally long so that none settles on an optimum
   // before the other's data is there.
-  const auto [myBestConf, myBestEvidence] = evidence.getLatestOptimalConfiguration();
+  const auto [myBestConf, myBestEvidence] = evidenceCollection.getLatestOptimalConfiguration();
   const auto globallyBestConfig =
       utils::AutoPasConfigurationCommunicator::findGloballyBestConfiguration(_bucket, myBestConf, myBestEvidence.value);
 
@@ -93,7 +94,8 @@ void MPIParallelizedStrategy::rejectConfiguration(const Configuration &configura
 }
 
 void MPIParallelizedStrategy::reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-                                    const EvidenceCollection &evidenceCollection) {
+                                    const EvidenceCollection &evidenceCollection,
+                                    std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
   // clear rejects since they now might be valid.
   _rejectedConfigurations.clear();
 

--- a/src/autopas/tuning/tuningStrategy/MPIParallelizedStrategy.cpp
+++ b/src/autopas/tuning/tuningStrategy/MPIParallelizedStrategy.cpp
@@ -24,9 +24,8 @@ MPIParallelizedStrategy::MPIParallelizedStrategy(const Configuration &fallbackCo
       _mpiTuningMaxDifferenceForBucket(mpiTuningMaxDifferenceForBucket),
       _mpiTuningWeightForMaxDensity(mpiTuningWeightForMaxDensity) {}
 
-void MPIParallelizedStrategy::optimizeSuggestions(std::vector<Configuration> &configQueue,
-                                                  const EvidenceCollection &evidenceCollection,
-                                                  std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
+bool MPIParallelizedStrategy::optimizeSuggestions(std::vector<Configuration> &configQueue,
+                                                  const EvidenceCollection &evidenceCollection) {
   // sanity check
   if (_bucket == AUTOPAS_MPI_COMM_NULL) {
     AutoPasLog(WARN, "_bucket was AUTOPAS_MPI_COMM_NULL");
@@ -63,6 +62,8 @@ void MPIParallelizedStrategy::optimizeSuggestions(std::vector<Configuration> &co
         "MPIParallelizedStrategy::optimizeSuggestions: All ranks defaulted to their fallback configuration. This means "
         "no rank could find an applicable configuration in their respective configuration sub queue");
   }
+  // MPIParallelizedStrategy does no intentional config wipes to stop the tuning phase
+  return false;
 }
 
 Configuration MPIParallelizedStrategy::createFallBackConfiguration(const std::set<Configuration> &searchSpace) {
@@ -93,9 +94,8 @@ void MPIParallelizedStrategy::rejectConfiguration(const Configuration &configura
   _rejectedConfigurations.insert(configuration);
 }
 
-void MPIParallelizedStrategy::reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-                                    const EvidenceCollection &evidenceCollection,
-                                    std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
+bool MPIParallelizedStrategy::reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
+                                    const EvidenceCollection &evidenceCollection) {
   // clear rejects since they now might be valid.
   _rejectedConfigurations.clear();
 
@@ -128,6 +128,9 @@ void MPIParallelizedStrategy::reset(size_t iteration, size_t tuningPhase, std::v
     myConfigQueue.push_back(configQueue[randomConfigId]);
   }
   configQueue = myConfigQueue;
+
+  // MPIParallelizedStrategy does no intentional config wipes to stop the tuning phase
+  return false;
 }
 
 bool MPIParallelizedStrategy::needsSmoothedHomogeneityAndMaxDensity() const { return true; }

--- a/src/autopas/tuning/tuningStrategy/MPIParallelizedStrategy.h
+++ b/src/autopas/tuning/tuningStrategy/MPIParallelizedStrategy.h
@@ -50,14 +50,13 @@ class MPIParallelizedStrategy : public TuningStrategyInterface {
 
   TuningStrategyOption getOptionType() const override;
 
-  void optimizeSuggestions(std::vector<Configuration> &configQueue, const EvidenceCollection &evidenceCollection,
-                           std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
+  bool optimizeSuggestions(std::vector<Configuration> &configQueue,
+                           const EvidenceCollection &evidenceCollection) override;
 
   void receiveSmoothedHomogeneityAndMaxDensity(double homogeneity, double maxDensity) override;
 
-  void reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-             const autopas::EvidenceCollection &evidenceCollection,
-             std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
+  bool reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
+             const autopas::EvidenceCollection &evidenceCollection) override;
 
   [[nodiscard]] inline bool needsSmoothedHomogeneityAndMaxDensity() const override;
 

--- a/src/autopas/tuning/tuningStrategy/MPIParallelizedStrategy.h
+++ b/src/autopas/tuning/tuningStrategy/MPIParallelizedStrategy.h
@@ -50,13 +50,14 @@ class MPIParallelizedStrategy : public TuningStrategyInterface {
 
   TuningStrategyOption getOptionType() const override;
 
-  void optimizeSuggestions(std::vector<Configuration> &configQueue,
-                           const EvidenceCollection &evidenceCollection) override;
+  void optimizeSuggestions(std::vector<Configuration> &configQueue, const EvidenceCollection &evidenceCollection,
+                           std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
 
   void receiveSmoothedHomogeneityAndMaxDensity(double homogeneity, double maxDensity) override;
 
   void reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-             const autopas::EvidenceCollection &evidenceCollection) override;
+             const autopas::EvidenceCollection &evidenceCollection,
+             std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
 
   [[nodiscard]] inline bool needsSmoothedHomogeneityAndMaxDensity() const override;
 

--- a/src/autopas/tuning/tuningStrategy/PredictiveTuning.cpp
+++ b/src/autopas/tuning/tuningStrategy/PredictiveTuning.cpp
@@ -348,13 +348,14 @@ long PredictiveTuning::lastResult(size_t tuningPhase, const Configuration &confi
   }
 }
 
-void PredictiveTuning::optimizeSuggestions(std::vector<Configuration> &configQueue,
-                                           const EvidenceCollection &evidenceCollection,
-                                           std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {}
+bool PredictiveTuning::optimizeSuggestions(std::vector<Configuration> &configQueue,
+                                           const EvidenceCollection &evidenceCollection) {
+  // PredictiveTuning does no intentional config wipes to stop the tuning phase
+  return false;
+}
 
-void PredictiveTuning::reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-                             const EvidenceCollection &evidenceCollection,
-                             std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
+bool PredictiveTuning::reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
+                             const EvidenceCollection &evidenceCollection) {
   // collect all configurations that were not tested for too long
   for (const auto &conf : configQueue) {
     const auto *evidenceVec = evidenceCollection.getEvidence(conf);
@@ -370,7 +371,7 @@ void PredictiveTuning::reset(size_t iteration, size_t tuningPhase, std::vector<C
   const auto predictions = calculatePredictions(iteration, tuningPhase, configQueue, evidenceCollection);
   // if there is not enough data to make any predictions yet do nothing.
   if (predictions.empty()) {
-    return;
+    return false;
   }
   // find the best prediction
   const auto &[bestConf, bestPrediction] =
@@ -411,6 +412,9 @@ void PredictiveTuning::reset(size_t iteration, size_t tuningPhase, std::vector<C
 
   // Then, insert all worthy configurations so that the most promising is now at the back of the fifo queue.
   configQueue.insert(configQueue.end(), worthyConfigurations.begin(), worthyConfigurations.end());
+
+  // PredictiveTuning does no intentional config wipes to stop the tuning phase
+  return false;
 }
 
 void PredictiveTuning::addEvidence(const Configuration &configuration, const Evidence & /*evidence*/) {

--- a/src/autopas/tuning/tuningStrategy/PredictiveTuning.cpp
+++ b/src/autopas/tuning/tuningStrategy/PredictiveTuning.cpp
@@ -349,10 +349,12 @@ long PredictiveTuning::lastResult(size_t tuningPhase, const Configuration &confi
 }
 
 void PredictiveTuning::optimizeSuggestions(std::vector<Configuration> &configQueue,
-                                           const EvidenceCollection &evidence) {}
+                                           const EvidenceCollection &evidenceCollection,
+                                           std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {}
 
 void PredictiveTuning::reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-                             const EvidenceCollection &evidenceCollection) {
+                             const EvidenceCollection &evidenceCollection,
+                             std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
   // collect all configurations that were not tested for too long
   for (const auto &conf : configQueue) {
     const auto *evidenceVec = evidenceCollection.getEvidence(conf);

--- a/src/autopas/tuning/tuningStrategy/PredictiveTuning.h
+++ b/src/autopas/tuning/tuningStrategy/PredictiveTuning.h
@@ -64,12 +64,11 @@ class PredictiveTuning final : public TuningStrategyInterface {
 
   void addEvidence(const Configuration &configuration, const Evidence &evidence) override;
 
-  void reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-             const autopas::EvidenceCollection &evidenceCollection,
-             std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
+  bool reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
+             const autopas::EvidenceCollection &evidenceCollection) override;
 
-  void optimizeSuggestions(std::vector<Configuration> &configQueue, const EvidenceCollection &evidenceCollection,
-                           std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
+  bool optimizeSuggestions(std::vector<Configuration> &configQueue,
+                           const EvidenceCollection &evidenceCollection) override;
 
   void rejectConfiguration(const Configuration &configuration, bool indefinitely) override;
 

--- a/src/autopas/tuning/tuningStrategy/PredictiveTuning.h
+++ b/src/autopas/tuning/tuningStrategy/PredictiveTuning.h
@@ -65,9 +65,11 @@ class PredictiveTuning final : public TuningStrategyInterface {
   void addEvidence(const Configuration &configuration, const Evidence &evidence) override;
 
   void reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-             const autopas::EvidenceCollection &evidenceCollection) override;
+             const autopas::EvidenceCollection &evidenceCollection,
+             std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
 
-  void optimizeSuggestions(std::vector<Configuration> &configQueue, const EvidenceCollection &evidence) override;
+  void optimizeSuggestions(std::vector<Configuration> &configQueue, const EvidenceCollection &evidenceCollection,
+                           std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
 
   void rejectConfiguration(const Configuration &configuration, bool indefinitely) override;
 

--- a/src/autopas/tuning/tuningStrategy/RandomSearch.cpp
+++ b/src/autopas/tuning/tuningStrategy/RandomSearch.cpp
@@ -14,28 +14,28 @@
 autopas::RandomSearch::RandomSearch(size_t maxEvidence, unsigned long seed)
     : _rng(seed), _maxEvidence(maxEvidence), _numEvidenceCollected(0) {}
 
-void autopas::RandomSearch::optimizeSuggestions(std::vector<Configuration> &configQueue,
-                                                const EvidenceCollection &evidenceCollection,
-                                                std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
+bool autopas::RandomSearch::optimizeSuggestions(std::vector<Configuration> &configQueue,
+                                                const EvidenceCollection &evidenceCollection) {
   // Check if enough evidence was collected.
   if (_numEvidenceCollected == _maxEvidence) {
     // Remove everything from the queue and only insert the optimum.
     configQueue.clear();
-    if (intentionalConfigWipe) {
-      intentionalConfigWipe->get() = true;
-    }
+    return true;
   } else {
     // Swap a randomly selected configuration to the end.
     std::uniform_int_distribution<std::mt19937::result_type> distribution(0, configQueue.size() - 1);
     const auto selectedIndex = distribution(_rng);
     std::swap(configQueue.back(), configQueue[selectedIndex]);
   }
+  return false;
 }
 
-void autopas::RandomSearch::reset(size_t, size_t tuningPhase, std::vector<Configuration> &configQueue,
-                                  const autopas::EvidenceCollection &evidenceCollection,
-                                  std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
+bool autopas::RandomSearch::reset(size_t, size_t tuningPhase, std::vector<Configuration> &configQueue,
+                                  const autopas::EvidenceCollection &evidenceCollection) {
   _numEvidenceCollected = 0;
+
+  // config queue is not wiped here
+  return false;
 }
 
 void autopas::RandomSearch::addEvidence(const Configuration &configuration, const Evidence &evidence) {

--- a/src/autopas/tuning/tuningStrategy/RandomSearch.cpp
+++ b/src/autopas/tuning/tuningStrategy/RandomSearch.cpp
@@ -15,21 +15,27 @@ autopas::RandomSearch::RandomSearch(size_t maxEvidence, unsigned long seed)
     : _rng(seed), _maxEvidence(maxEvidence), _numEvidenceCollected(0) {}
 
 void autopas::RandomSearch::optimizeSuggestions(std::vector<Configuration> &configQueue,
-                                                const EvidenceCollection &evidenceCollection) {
+                                                const EvidenceCollection &evidenceCollection,
+                                                std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
   // Check if enough evidence was collected.
   if (_numEvidenceCollected == _maxEvidence) {
     // Remove everything from the queue and only insert the optimum.
     configQueue.clear();
+    if (intentionalConfigWipe) {
+      intentionalConfigWipe->get() = true;
+    }
   } else {
     // Swap a randomly selected configuration to the end.
     std::uniform_int_distribution<std::mt19937::result_type> distribution(0, configQueue.size() - 1);
     const auto selectedIndex = distribution(_rng);
     std::swap(configQueue.back(), configQueue[selectedIndex]);
+    ++_numEvidenceCollected;
   }
 }
 
 void autopas::RandomSearch::reset(size_t, size_t tuningPhase, std::vector<Configuration> &configQueue,
-                                  const autopas::EvidenceCollection &evidenceCollection) {
+                                  const autopas::EvidenceCollection &evidenceCollection,
+                                  std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
   _numEvidenceCollected = 0;
 }
 

--- a/src/autopas/tuning/tuningStrategy/RandomSearch.cpp
+++ b/src/autopas/tuning/tuningStrategy/RandomSearch.cpp
@@ -29,7 +29,6 @@ void autopas::RandomSearch::optimizeSuggestions(std::vector<Configuration> &conf
     std::uniform_int_distribution<std::mt19937::result_type> distribution(0, configQueue.size() - 1);
     const auto selectedIndex = distribution(_rng);
     std::swap(configQueue.back(), configQueue[selectedIndex]);
-    ++_numEvidenceCollected;
   }
 }
 
@@ -38,6 +37,10 @@ void autopas::RandomSearch::reset(size_t, size_t tuningPhase, std::vector<Config
                                   std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
   _numEvidenceCollected = 0;
 }
+
+void autopas::RandomSearch::addEvidence(const Configuration &configuration, const Evidence &evidence) {
+  ++_numEvidenceCollected;
+};
 
 autopas::TuningStrategyOption autopas::RandomSearch::getOptionType() const {
   return TuningStrategyOption::randomSearch;

--- a/src/autopas/tuning/tuningStrategy/RandomSearch.h
+++ b/src/autopas/tuning/tuningStrategy/RandomSearch.h
@@ -31,10 +31,11 @@ class RandomSearch final : public TuningStrategyInterface {
   TuningStrategyOption getOptionType() const override;
 
   void reset(size_t, size_t tuningPhase, std::vector<Configuration> &configQueue,
-             const autopas::EvidenceCollection &evidenceCollection) override;
+             const autopas::EvidenceCollection &evidenceCollection,
+             std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
 
-  void optimizeSuggestions(std::vector<Configuration> &configQueue,
-                           const EvidenceCollection &evidenceCollection) override;
+  void optimizeSuggestions(std::vector<Configuration> &configQueue, const EvidenceCollection &evidenceCollection,
+                           std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
 
  private:
   /**

--- a/src/autopas/tuning/tuningStrategy/RandomSearch.h
+++ b/src/autopas/tuning/tuningStrategy/RandomSearch.h
@@ -37,6 +37,8 @@ class RandomSearch final : public TuningStrategyInterface {
   void optimizeSuggestions(std::vector<Configuration> &configQueue, const EvidenceCollection &evidenceCollection,
                            std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
 
+  void addEvidence(const Configuration &configuration, const Evidence &evidence) override;
+
  private:
   /**
    * Random engine for selecting configurations.

--- a/src/autopas/tuning/tuningStrategy/RandomSearch.h
+++ b/src/autopas/tuning/tuningStrategy/RandomSearch.h
@@ -30,12 +30,11 @@ class RandomSearch final : public TuningStrategyInterface {
 
   TuningStrategyOption getOptionType() const override;
 
-  void reset(size_t, size_t tuningPhase, std::vector<Configuration> &configQueue,
-             const autopas::EvidenceCollection &evidenceCollection,
-             std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
+  bool reset(size_t, size_t tuningPhase, std::vector<Configuration> &configQueue,
+             const autopas::EvidenceCollection &evidenceCollection) override;
 
-  void optimizeSuggestions(std::vector<Configuration> &configQueue, const EvidenceCollection &evidenceCollection,
-                           std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
+  bool optimizeSuggestions(std::vector<Configuration> &configQueue,
+                           const EvidenceCollection &evidenceCollection) override;
 
   void addEvidence(const Configuration &configuration, const Evidence &evidence) override;
 

--- a/src/autopas/tuning/tuningStrategy/SlowConfigFilter.cpp
+++ b/src/autopas/tuning/tuningStrategy/SlowConfigFilter.cpp
@@ -39,7 +39,7 @@ bool autopas::SlowConfigFilter::optimizeSuggestions(std::vector<Configuration> &
 bool autopas::SlowConfigFilter::reset(size_t /*iteration*/, size_t /*tuningPhase*/,
                                       std::vector<Configuration> &configQueue,
                                       const autopas::EvidenceCollection &evidenceCollection) {
-  optimizeSuggestions(configQueue, evidenceCollection);
+  return optimizeSuggestions(configQueue, evidenceCollection);
 }
 
 autopas::TuningStrategyOption autopas::SlowConfigFilter::getOptionType() const {

--- a/src/autopas/tuning/tuningStrategy/SlowConfigFilter.cpp
+++ b/src/autopas/tuning/tuningStrategy/SlowConfigFilter.cpp
@@ -8,12 +8,11 @@
 
 #include <algorithm>
 
-void autopas::SlowConfigFilter::optimizeSuggestions(std::vector<Configuration> &configQueue,
-                                                    const EvidenceCollection &evidenceCollection,
-                                                    std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
+bool autopas::SlowConfigFilter::optimizeSuggestions(std::vector<Configuration> &configQueue,
+                                                    const EvidenceCollection &evidenceCollection) {
   // if there is not yet any evidence we can't do anything.
   if (evidenceCollection.empty()) {
-    return;
+    return false;
   }
 
   const auto [bestConfig, bestEvidence] = evidenceCollection.getLatestOptimalConfiguration();
@@ -34,11 +33,12 @@ void autopas::SlowConfigFilter::optimizeSuggestions(std::vector<Configuration> &
   configQueue.erase(std::remove_if(configQueue.begin(), configQueue.end(),
                                    [&](const auto &conf) { return _blacklist.count(conf) > 0; }),
                     configQueue.end());
+  // SlowConfigFilter does no intentional config wipes
+  return false;
 }
-void autopas::SlowConfigFilter::reset(size_t /*iteration*/, size_t /*tuningPhase*/,
+bool autopas::SlowConfigFilter::reset(size_t /*iteration*/, size_t /*tuningPhase*/,
                                       std::vector<Configuration> &configQueue,
-                                      const autopas::EvidenceCollection &evidenceCollection,
-                                      std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
+                                      const autopas::EvidenceCollection &evidenceCollection) {
   optimizeSuggestions(configQueue, evidenceCollection);
 }
 

--- a/src/autopas/tuning/tuningStrategy/SlowConfigFilter.cpp
+++ b/src/autopas/tuning/tuningStrategy/SlowConfigFilter.cpp
@@ -9,7 +9,8 @@
 #include <algorithm>
 
 void autopas::SlowConfigFilter::optimizeSuggestions(std::vector<Configuration> &configQueue,
-                                                    const EvidenceCollection &evidenceCollection) {
+                                                    const EvidenceCollection &evidenceCollection,
+                                                    std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
   // if there is not yet any evidence we can't do anything.
   if (evidenceCollection.empty()) {
     return;
@@ -36,7 +37,8 @@ void autopas::SlowConfigFilter::optimizeSuggestions(std::vector<Configuration> &
 }
 void autopas::SlowConfigFilter::reset(size_t /*iteration*/, size_t /*tuningPhase*/,
                                       std::vector<Configuration> &configQueue,
-                                      const autopas::EvidenceCollection &evidenceCollection) {
+                                      const autopas::EvidenceCollection &evidenceCollection,
+                                      std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
   optimizeSuggestions(configQueue, evidenceCollection);
 }
 

--- a/src/autopas/tuning/tuningStrategy/SlowConfigFilter.h
+++ b/src/autopas/tuning/tuningStrategy/SlowConfigFilter.h
@@ -22,11 +22,10 @@ class SlowConfigFilter : public TuningStrategyInterface {
 
   TuningStrategyOption getOptionType() const override;
 
-  void optimizeSuggestions(std::vector<Configuration> &configQueue, const EvidenceCollection &evidenceCollection,
-                           std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
-  void reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-             const EvidenceCollection &evidenceCollection,
-             std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
+  bool optimizeSuggestions(std::vector<Configuration> &configQueue,
+                           const EvidenceCollection &evidenceCollection) override;
+  bool reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
+             const EvidenceCollection &evidenceCollection) override;
 
  private:
   /**

--- a/src/autopas/tuning/tuningStrategy/SlowConfigFilter.h
+++ b/src/autopas/tuning/tuningStrategy/SlowConfigFilter.h
@@ -22,10 +22,11 @@ class SlowConfigFilter : public TuningStrategyInterface {
 
   TuningStrategyOption getOptionType() const override;
 
-  void optimizeSuggestions(std::vector<Configuration> &configQueue,
-                           const EvidenceCollection &evidenceCollection) override;
+  void optimizeSuggestions(std::vector<Configuration> &configQueue, const EvidenceCollection &evidenceCollection,
+                           std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
   void reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-             const EvidenceCollection &evidenceCollection) override;
+             const EvidenceCollection &evidenceCollection,
+             std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
 
  private:
   /**

--- a/src/autopas/tuning/tuningStrategy/SortByName.cpp
+++ b/src/autopas/tuning/tuningStrategy/SortByName.cpp
@@ -6,12 +6,14 @@
 
 #include "SortByName.h"
 void autopas::SortByName::optimizeSuggestions(std::vector<Configuration> &configQueue,
-                                              const autopas::EvidenceCollection &evidenceCollection) {
+                                              const EvidenceCollection &evidenceCollection,
+                                              std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
   // sort configurations to minimize container conversion overhead.
   std::sort(configQueue.begin(), configQueue.end());
 }
 void autopas::SortByName::reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-                                const autopas::EvidenceCollection &evidenceCollection) {
+                                const autopas::EvidenceCollection &evidenceCollection,
+                                std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
   optimizeSuggestions(configQueue, evidenceCollection);
 }
 

--- a/src/autopas/tuning/tuningStrategy/SortByName.cpp
+++ b/src/autopas/tuning/tuningStrategy/SortByName.cpp
@@ -5,16 +5,17 @@
  */
 
 #include "SortByName.h"
-void autopas::SortByName::optimizeSuggestions(std::vector<Configuration> &configQueue,
-                                              const EvidenceCollection &evidenceCollection,
-                                              std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
+bool autopas::SortByName::optimizeSuggestions(std::vector<Configuration> &configQueue,
+                                              const EvidenceCollection &evidenceCollection) {
   // sort configurations to minimize container conversion overhead.
   std::sort(configQueue.begin(), configQueue.end());
+
+  // SortByName does no intentional config wipes to stop the tuning phase
+  return false;
 }
-void autopas::SortByName::reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-                                const autopas::EvidenceCollection &evidenceCollection,
-                                std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
-  optimizeSuggestions(configQueue, evidenceCollection);
+bool autopas::SortByName::reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
+                                const autopas::EvidenceCollection &evidenceCollection) {
+  return optimizeSuggestions(configQueue, evidenceCollection);
 }
 
 autopas::TuningStrategyOption autopas::SortByName::getOptionType() const { return TuningStrategyOption::sortByName; }

--- a/src/autopas/tuning/tuningStrategy/SortByName.h
+++ b/src/autopas/tuning/tuningStrategy/SortByName.h
@@ -20,11 +20,10 @@ class SortByName : public TuningStrategyInterface {
  public:
   TuningStrategyOption getOptionType() const override;
 
-  void optimizeSuggestions(std::vector<Configuration> &configQueue, const EvidenceCollection &evidenceCollection,
-                           std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
-  void reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-             const EvidenceCollection &evidenceCollection,
-             std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
+  bool optimizeSuggestions(std::vector<Configuration> &configQueue,
+                           const EvidenceCollection &evidenceCollection) override;
+  bool reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
+             const EvidenceCollection &evidenceCollection) override;
 };
 
 }  // namespace autopas

--- a/src/autopas/tuning/tuningStrategy/SortByName.h
+++ b/src/autopas/tuning/tuningStrategy/SortByName.h
@@ -20,10 +20,11 @@ class SortByName : public TuningStrategyInterface {
  public:
   TuningStrategyOption getOptionType() const override;
 
-  void optimizeSuggestions(std::vector<Configuration> &configQueue,
-                           const EvidenceCollection &evidenceCollection) override;
+  void optimizeSuggestions(std::vector<Configuration> &configQueue, const EvidenceCollection &evidenceCollection,
+                           std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
   void reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-             const EvidenceCollection &evidenceCollection) override;
+             const EvidenceCollection &evidenceCollection,
+             std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
 };
 
 }  // namespace autopas

--- a/src/autopas/tuning/tuningStrategy/TuningStrategyInterface.h
+++ b/src/autopas/tuning/tuningStrategy/TuningStrategyInterface.h
@@ -53,6 +53,8 @@ class TuningStrategyInterface {
    *
    * @param configQueue Queue of configurations to be tested. The tuning strategy should edit this queue.
    * @param evidenceCollection All collected evidence until now.
+   * @param intentionalConfigWipe Optional flag that is used by tuning strategies to signal they have intentionally
+   * wiped the config queue
    */
   virtual void optimizeSuggestions(
       std::vector<Configuration> &configQueue, const EvidenceCollection &evidenceCollection,
@@ -67,6 +69,8 @@ class TuningStrategyInterface {
    * @param tuningPhase Gives the current tuning phase to the tuning strategy.
    * @param configQueue Queue of configurations to be tested. The tuning strategy should edit this queue.
    * @param evidenceCollection All collected evidence until now.
+   * @param intentionalConfigWipe Optional flag that is used by tuning strategies to signal they have intentionally
+   * wiped the config queue
    */
   virtual void reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
                      const autopas::EvidenceCollection &evidenceCollection,

--- a/src/autopas/tuning/tuningStrategy/TuningStrategyInterface.h
+++ b/src/autopas/tuning/tuningStrategy/TuningStrategyInterface.h
@@ -53,6 +53,7 @@ class TuningStrategyInterface {
    *
    * @param configQueue Queue of configurations to be tested. The tuning strategy should edit this queue.
    * @param evidenceCollection All collected evidence until now.
+   * @return boolean value to signal if the tuning strategy has intentionally wiped the config queue
    */
   virtual bool optimizeSuggestions(std::vector<Configuration> &configQueue,
                                    const EvidenceCollection &evidenceCollection) = 0;
@@ -66,6 +67,7 @@ class TuningStrategyInterface {
    * @param tuningPhase Gives the current tuning phase to the tuning strategy.
    * @param configQueue Queue of configurations to be tested. The tuning strategy should edit this queue.
    * @param evidenceCollection All collected evidence until now.
+   * @return boolean value to signal if the tuning strategy has intentionally wiped the config queue
    */
   virtual bool reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
                      const autopas::EvidenceCollection &evidenceCollection) = 0;

--- a/src/autopas/tuning/tuningStrategy/TuningStrategyInterface.h
+++ b/src/autopas/tuning/tuningStrategy/TuningStrategyInterface.h
@@ -6,6 +6,9 @@
 
 #pragma once
 
+#include <functional>
+#include <optional>
+
 #include "autopas/options/TuningStrategyOption.h"
 #include "autopas/tuning/Configuration.h"
 #include "autopas/tuning/searchSpace/Evidence.h"
@@ -51,8 +54,9 @@ class TuningStrategyInterface {
    * @param configQueue Queue of configurations to be tested. The tuning strategy should edit this queue.
    * @param evidenceCollection All collected evidence until now.
    */
-  virtual void optimizeSuggestions(std::vector<Configuration> &configQueue,
-                                   const EvidenceCollection &evidenceCollection) = 0;
+  virtual void optimizeSuggestions(
+      std::vector<Configuration> &configQueue, const EvidenceCollection &evidenceCollection,
+      std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) = 0;
 
   /**
    * Reset all internal parameters to the beginning of a new tuning phase.
@@ -65,7 +69,8 @@ class TuningStrategyInterface {
    * @param evidenceCollection All collected evidence until now.
    */
   virtual void reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-                     const autopas::EvidenceCollection &evidenceCollection) = 0;
+                     const autopas::EvidenceCollection &evidenceCollection,
+                     std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) = 0;
 
   /**
    * Returns whether this tuning strategy wants to get a LiveInfo object passed before a new tuning phase.

--- a/src/autopas/tuning/tuningStrategy/TuningStrategyInterface.h
+++ b/src/autopas/tuning/tuningStrategy/TuningStrategyInterface.h
@@ -53,12 +53,9 @@ class TuningStrategyInterface {
    *
    * @param configQueue Queue of configurations to be tested. The tuning strategy should edit this queue.
    * @param evidenceCollection All collected evidence until now.
-   * @param intentionalConfigWipe Optional flag that is used by tuning strategies to signal they have intentionally
-   * wiped the config queue
    */
-  virtual void optimizeSuggestions(
-      std::vector<Configuration> &configQueue, const EvidenceCollection &evidenceCollection,
-      std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) = 0;
+  virtual bool optimizeSuggestions(std::vector<Configuration> &configQueue,
+                                   const EvidenceCollection &evidenceCollection) = 0;
 
   /**
    * Reset all internal parameters to the beginning of a new tuning phase.
@@ -69,12 +66,9 @@ class TuningStrategyInterface {
    * @param tuningPhase Gives the current tuning phase to the tuning strategy.
    * @param configQueue Queue of configurations to be tested. The tuning strategy should edit this queue.
    * @param evidenceCollection All collected evidence until now.
-   * @param intentionalConfigWipe Optional flag that is used by tuning strategies to signal they have intentionally
-   * wiped the config queue
    */
-  virtual void reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-                     const autopas::EvidenceCollection &evidenceCollection,
-                     std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) = 0;
+  virtual bool reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
+                     const autopas::EvidenceCollection &evidenceCollection) = 0;
 
   /**
    * Returns whether this tuning strategy wants to get a LiveInfo object passed before a new tuning phase.

--- a/src/autopas/tuning/tuningStrategy/TuningStrategyLogger.cpp
+++ b/src/autopas/tuning/tuningStrategy/TuningStrategyLogger.cpp
@@ -27,16 +27,20 @@ void TuningStrategyLogger::addEvidence(const Configuration &configuration, const
   _logOut << tuningLogEntry::writeEvidence(evidence.value, evidence.iteration, configuration) << std::endl;
 }
 
-void TuningStrategyLogger::optimizeSuggestions(std::vector<Configuration> &configQueue,
-                                               const EvidenceCollection &evidenceCollection,
-                                               std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
+bool TuningStrategyLogger::optimizeSuggestions(std::vector<Configuration> &configQueue,
+                                               const EvidenceCollection &evidenceCollection) {
   _logOut << tuningLogEntry::writeTune() << std::endl;
+
+  // TuningStrategyLogger does no intentional config wipes
+  return false;
 }
 
-void TuningStrategyLogger::reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-                                 const autopas::EvidenceCollection &evidenceCollection,
-                                 std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
+bool TuningStrategyLogger::reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
+                                 const autopas::EvidenceCollection &evidenceCollection) {
   _logOut << tuningLogEntry::writeReset(iteration) << std::endl;
+
+  // TuningStrategyLogger does no intentional config wipes
+  return false;
 }
 
 bool TuningStrategyLogger::needsLiveInfo() const {

--- a/src/autopas/tuning/tuningStrategy/TuningStrategyLogger.cpp
+++ b/src/autopas/tuning/tuningStrategy/TuningStrategyLogger.cpp
@@ -28,12 +28,14 @@ void TuningStrategyLogger::addEvidence(const Configuration &configuration, const
 }
 
 void TuningStrategyLogger::optimizeSuggestions(std::vector<Configuration> &configQueue,
-                                               const EvidenceCollection &evidenceCollection) {
+                                               const EvidenceCollection &evidenceCollection,
+                                               std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
   _logOut << tuningLogEntry::writeTune() << std::endl;
 }
 
 void TuningStrategyLogger::reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-                                 const autopas::EvidenceCollection &evidenceCollection) {
+                                 const autopas::EvidenceCollection &evidenceCollection,
+                                 std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
   _logOut << tuningLogEntry::writeReset(iteration) << std::endl;
 }
 

--- a/src/autopas/tuning/tuningStrategy/TuningStrategyLogger.h
+++ b/src/autopas/tuning/tuningStrategy/TuningStrategyLogger.h
@@ -34,11 +34,12 @@ class TuningStrategyLogger final : public TuningStrategyInterface {
 
   void addEvidence(const Configuration &configuration, const Evidence &evidence) override;
 
-  void optimizeSuggestions(std::vector<Configuration> &configQueue,
-                           const EvidenceCollection &evidenceCollection) override;
+  void optimizeSuggestions(std::vector<Configuration> &configQueue, const EvidenceCollection &evidenceCollection,
+                           std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
 
   void reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-             const autopas::EvidenceCollection &evidenceCollection) override;
+             const autopas::EvidenceCollection &evidenceCollection,
+             std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
 
   [[nodiscard]] bool needsLiveInfo() const override;
 

--- a/src/autopas/tuning/tuningStrategy/TuningStrategyLogger.h
+++ b/src/autopas/tuning/tuningStrategy/TuningStrategyLogger.h
@@ -34,12 +34,11 @@ class TuningStrategyLogger final : public TuningStrategyInterface {
 
   void addEvidence(const Configuration &configuration, const Evidence &evidence) override;
 
-  void optimizeSuggestions(std::vector<Configuration> &configQueue, const EvidenceCollection &evidenceCollection,
-                           std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
+  bool optimizeSuggestions(std::vector<Configuration> &configQueue,
+                           const EvidenceCollection &evidenceCollection) override;
 
-  void reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-             const autopas::EvidenceCollection &evidenceCollection,
-             std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
+  bool reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
+             const autopas::EvidenceCollection &evidenceCollection) override;
 
   [[nodiscard]] bool needsLiveInfo() const override;
 

--- a/src/autopas/tuning/tuningStrategy/ruleBasedTuning/RuleBasedTuning.cpp
+++ b/src/autopas/tuning/tuningStrategy/ruleBasedTuning/RuleBasedTuning.cpp
@@ -51,9 +51,8 @@ void RuleBasedTuning::addEvidence(const Configuration &configuration, const Evid
 #endif
 }
 
-void RuleBasedTuning::reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-                            const EvidenceCollection &evidenceCollection,
-                            std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
+bool RuleBasedTuning::reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
+                            const EvidenceCollection &evidenceCollection) {
 #ifdef AUTOPAS_ENABLE_RULES_BASED_TUNING
   if (_verifyModeEnabled and _tuningTime > 0) {
     // It is fine to leave this log statement on Info level because it is behind if (_verificationModeEnabled).
@@ -74,15 +73,17 @@ void RuleBasedTuning::reset(size_t iteration, size_t tuningPhase, std::vector<Co
   _rulesTooHarsh = false;
   optimizeSuggestions(configQueue, evidenceCollection);
 #endif
+
+  // RuleBasedTuning does no intentional config wipes to stop the tuning phase
+  return false;
 }
 
 long RuleBasedTuning::getLifetimeWouldHaveSkippedTuningTime() const { return _wouldHaveSkippedTuningTimeLifetime; }
 
 long RuleBasedTuning::getLifetimeTuningTime() const { return _tuningTimeLifetime; }
 
-void RuleBasedTuning::optimizeSuggestions(std::vector<Configuration> &configQueue,
-                                          const EvidenceCollection &evidenceCollection,
-                                          std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
+bool RuleBasedTuning::optimizeSuggestions(std::vector<Configuration> &configQueue,
+                                          const EvidenceCollection &evidenceCollection) {
 #ifdef AUTOPAS_ENABLE_RULES_BASED_TUNING
   _lastApplicableConfigurationOrders = applyRules(configQueue);
 
@@ -98,6 +99,8 @@ void RuleBasedTuning::optimizeSuggestions(std::vector<Configuration> &configQueu
     std::copy(_searchSpace.rbegin(), _searchSpace.rend(), std::back_inserter(configQueue));
   }
 #endif
+  // RuleBasedTuning does no intentional config wipes to stop the tuning phase
+  return false;
 }
 
 TuningStrategyOption RuleBasedTuning::getOptionType() const { return TuningStrategyOption::ruleBasedTuning; }

--- a/src/autopas/tuning/tuningStrategy/ruleBasedTuning/RuleBasedTuning.cpp
+++ b/src/autopas/tuning/tuningStrategy/ruleBasedTuning/RuleBasedTuning.cpp
@@ -52,7 +52,8 @@ void RuleBasedTuning::addEvidence(const Configuration &configuration, const Evid
 }
 
 void RuleBasedTuning::reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-                            const EvidenceCollection &evidenceCollection) {
+                            const EvidenceCollection &evidenceCollection,
+                            std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
 #ifdef AUTOPAS_ENABLE_RULES_BASED_TUNING
   if (_verifyModeEnabled and _tuningTime > 0) {
     // It is fine to leave this log statement on Info level because it is behind if (_verificationModeEnabled).
@@ -80,7 +81,8 @@ long RuleBasedTuning::getLifetimeWouldHaveSkippedTuningTime() const { return _wo
 long RuleBasedTuning::getLifetimeTuningTime() const { return _tuningTimeLifetime; }
 
 void RuleBasedTuning::optimizeSuggestions(std::vector<Configuration> &configQueue,
-                                          const EvidenceCollection &evidenceCollection) {
+                                          const EvidenceCollection &evidenceCollection,
+                                          std::optional<std::reference_wrapper<bool>> intentionalConfigWipe) {
 #ifdef AUTOPAS_ENABLE_RULES_BASED_TUNING
   _lastApplicableConfigurationOrders = applyRules(configQueue);
 

--- a/src/autopas/tuning/tuningStrategy/ruleBasedTuning/RuleBasedTuning.h
+++ b/src/autopas/tuning/tuningStrategy/ruleBasedTuning/RuleBasedTuning.h
@@ -114,9 +114,8 @@ class RuleBasedTuning : public TuningStrategyInterface {
 
   void addEvidence(const Configuration &configuration, const Evidence &evidence) override;
 
-  void reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-             const autopas::EvidenceCollection &evidenceCollection,
-             std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
+  bool reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
+             const autopas::EvidenceCollection &evidenceCollection) override;
 
   /**
    * @returns the total time that would have been skipped if verify mode was disabled and thus
@@ -129,8 +128,8 @@ class RuleBasedTuning : public TuningStrategyInterface {
    */
   [[nodiscard]] long getLifetimeTuningTime() const;
 
-  void optimizeSuggestions(std::vector<Configuration> &configQueue, const EvidenceCollection &evidenceCollection,
-                           std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
+  bool optimizeSuggestions(std::vector<Configuration> &configQueue,
+                           const EvidenceCollection &evidenceCollection) override;
 
  private:
 #ifdef AUTOPAS_ENABLE_RULES_BASED_TUNING

--- a/src/autopas/tuning/tuningStrategy/ruleBasedTuning/RuleBasedTuning.h
+++ b/src/autopas/tuning/tuningStrategy/ruleBasedTuning/RuleBasedTuning.h
@@ -115,7 +115,8 @@ class RuleBasedTuning : public TuningStrategyInterface {
   void addEvidence(const Configuration &configuration, const Evidence &evidence) override;
 
   void reset(size_t iteration, size_t tuningPhase, std::vector<Configuration> &configQueue,
-             const autopas::EvidenceCollection &evidenceCollection) override;
+             const autopas::EvidenceCollection &evidenceCollection,
+             std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
 
   /**
    * @returns the total time that would have been skipped if verify mode was disabled and thus
@@ -128,8 +129,8 @@ class RuleBasedTuning : public TuningStrategyInterface {
    */
   [[nodiscard]] long getLifetimeTuningTime() const;
 
-  void optimizeSuggestions(std::vector<Configuration> &configQueue,
-                           const EvidenceCollection &evidenceCollection) override;
+  void optimizeSuggestions(std::vector<Configuration> &configQueue, const EvidenceCollection &evidenceCollection,
+                           std::optional<std::reference_wrapper<bool>> intentionalConfigWipe = std::nullopt) override;
 
  private:
 #ifdef AUTOPAS_ENABLE_RULES_BASED_TUNING


### PR DESCRIPTION
# Description
As described in #894, some tuning strategies, like Random or Bayesian strategies, want to terminate tuning after a given number of samples has been collected. They do this by flushing the config queue.

Until now, however, this flushing was reset by the config wipe checker.

An optional flag (`intentionalConfigWipe`) has been introduced to indicate that the config wipe was intentional and the config wipe checker does not reset the queue. 

## Resolved Issues

- [x] fixes #894 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
The scenario in #894 was used to test the behavior. Instead of the 20/20 tuning iterations it does now 4/20 tuning iterations.
```
md-flexible \
  --tuning-strategies random-Search \
  --tuning-max-evidence 2 \
  --tuning-samples 2 \
  --iterations 20 \
  --no-flops \
  --no-end-config
```