### PR TITLE
HOTFIX: Add missing return value

### DIFF
--- a/src/autopas/tuning/tuningStrategy/ruleBasedTuning/RuleBasedTuning.cpp
+++ b/src/autopas/tuning/tuningStrategy/ruleBasedTuning/RuleBasedTuning.cpp
@@ -91,7 +91,7 @@ bool RuleBasedTuning::optimizeSuggestions(std::vector<Configuration> &configQueu
   if (_rulesTooHarsh or (_searchSpace.empty() and _tuningTime == 0)) {
     _rulesTooHarsh = true;
     AutoPasLog(WARN, "Rules would remove all available options! Not applying them until next reset.");
-    return;
+    return false;
   }
 
   if (not _verifyModeEnabled) {


### PR DESCRIPTION
# Description

#936 changed `TuningStrategyInterface` functions to return a `bool`. For one return call it was missed to add a return value. This PR fixes this.

## Related Pull Requests

- #936 

## ~Resolved Issues~

# How Has This Been Tested?

- compiled without warning.
