### PR TITLE
Update Regex Pattern

### DIFF
--- a/src/autopas/tuning/Configuration.cpp
+++ b/src/autopas/tuning/Configuration.cpp
@@ -24,12 +24,13 @@ bool autopas::Configuration::hasValidValues() const {
 }
 
 std::string autopas::Configuration::getCSVRepresentation(bool returnHeaderOnly) const {
+  // Escape for '{' and '}' required when using Apple Clang 15.0.0
   auto rgx = returnHeaderOnly ?
                               // match any sequence before a colon and drop any spaces, comma or brackets before it
-                 std::regex("[{, ]+([^:]+):[^,]*")
+                 std::regex("[\\{, ]+([^:]+):[^,]*")
                               :
                               // match any sequence after a colon and drop any spaces, comma or brackets around it
-                 std::regex(": ([^,]+)(?: ,|})");
+                 std::regex(": ([^,]+)(?: ,|\\})");
   auto searchString = toString();
   std::sregex_iterator matchIter(searchString.begin(), searchString.end(), rgx);
   std::sregex_iterator end;


### PR DESCRIPTION
# Description

Revised regex patterns in IterationLogger to use escape characters for `{` and '}'. This is required by Apple Clang 15.0.0

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Tested on macOS using Apple Clang 15.0.0 and GCC 14.0
- [x] Tested only Linux by Fabio and Markus
