### PR TITLE
Fix Clang Format

### DIFF
--- a/.github/workflows/TestSuites.yaml
+++ b/.github/workflows/TestSuites.yaml
@@ -19,6 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      
+      # make sure requirements is installed
+      - name: Install Requirements
+        run: sudo apt-get update && sudo apt-get install -y python3-distutils
+
+      # Run the style check
       - uses: DoozyX/clang-format-lint-action@v0.18.1
         with:
           source: 'src tests examples applicationLibrary tools'

--- a/.github/workflows/TestSuites.yaml
+++ b/.github/workflows/TestSuites.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       # Run the style check
-      - uses: DoozyX/clang-format-lint-action@v0.18.1
+      - uses: DoozyX/clang-format-lint-action@v0.18.2
         with:
           source: 'src tests examples applicationLibrary tools'
           # exclude: 'none'

--- a/.github/workflows/TestSuites.yaml
+++ b/.github/workflows/TestSuites.yaml
@@ -19,15 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      # Update clang-format to the specified version
-      - name: Install clang-format
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang-format-14
-          sudo ln -sf /usr/bin/clang-format-14 /usr/bin/clang-format
-
-      - uses: DoozyX/clang-format-lint-action@v0.16.2
+      - uses: DoozyX/clang-format-lint-action@v0.18.1
         with:
           source: 'src tests examples applicationLibrary tools'
           # exclude: 'none'

--- a/.github/workflows/TestSuites.yaml
+++ b/.github/workflows/TestSuites.yaml
@@ -19,11 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
-      # make sure requirements is installed
-      - name: Install Requirements
-        run: sudo apt-get update && sudo apt-get install -y python3-distutils
-
       # Run the style check
       - uses: DoozyX/clang-format-lint-action@v0.18.1
         with:

--- a/.github/workflows/TestSuites.yaml
+++ b/.github/workflows/TestSuites.yaml
@@ -19,6 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      # Update clang-format to the specified version
+      - name: Install clang-format
+        run: |
+          apt-get update
+          apt-get install -y clang-format-14
+          ln -sf /usr/bin/clang-format-14 /usr/bin/clang-format
+
       - uses: DoozyX/clang-format-lint-action@v0.16.2
         with:
           source: 'src tests examples applicationLibrary tools'

--- a/.github/workflows/TestSuites.yaml
+++ b/.github/workflows/TestSuites.yaml
@@ -23,9 +23,9 @@ jobs:
       # Update clang-format to the specified version
       - name: Install clang-format
         run: |
-          apt-get update
-          apt-get install -y clang-format-14
-          ln -sf /usr/bin/clang-format-14 /usr/bin/clang-format
+          sudo apt-get update
+          sudo apt-get install -y clang-format-14
+          sudo ln -sf /usr/bin/clang-format-14 /usr/bin/clang-format
 
       - uses: DoozyX/clang-format-lint-action@v0.16.2
         with:


### PR DESCRIPTION
# Description

Switch to a new version (v0.18.2) of clang-format-lint-action to fix the style checker.

# How Has This Been Tested?

- [ ] Existing Tests
