### PR TITLE
removing ownership setting in containers

### DIFF
--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -95,18 +95,16 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
    * @copydoc ParticleContainerInterface::addHaloParticleImpl()
    */
   void addHaloParticleImpl(const ParticleType &haloParticle) override {
-    ParticleType pCopy = haloParticle;
-    pCopy.setOwnershipState(OwnershipState::halo);
     const auto boxMax = this->getBoxMax();
     const auto boxMin = this->getBoxMin();
-    const auto pos = pCopy.getR();
+    const auto pos = haloParticle.getR();
 
     for (size_t dim = 0; dim < 3; ++dim) {
       if (pos[dim] < boxMin[dim]) {
-        this->_cells[2 * dim + 1].addParticle(pCopy);
+        this->_cells[2 * dim + 1].addParticle(haloParticle);
         return;
       } else if (pos[dim] >= boxMax[dim]) {
-        this->_cells[2 * dim + 2].addParticle(pCopy);
+        this->_cells[2 * dim + 2].addParticle(haloParticle);
         return;
       }
     }
@@ -116,21 +114,19 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
    * @copydoc ParticleContainerInterface::updateHaloParticle()
    */
   bool updateHaloParticle(const ParticleType &haloParticle) override {
-    ParticleType pCopy = haloParticle;
-    pCopy.setOwnershipState(OwnershipState::halo);
     const auto boxMax = this->getBoxMax();
     const auto boxMin = this->getBoxMin();
-    const auto pos = pCopy.getR();
+    const auto pos = haloParticle.getR();
     const auto skinHalf = 0.5 * this->getVerletSkin();
 
     // Look for the particle in halo cells that are within half the skin distance of its position
     for (size_t dim = 0; dim < 3; ++dim) {
       if (pos[dim] < boxMin[dim] + skinHalf) {
-        if (internal::checkParticleInCellAndUpdateByIDAndPosition(this->_cells[2 * dim + 1], pCopy, skinHalf)) {
+        if (internal::checkParticleInCellAndUpdateByIDAndPosition(this->_cells[2 * dim + 1], haloParticle, skinHalf)) {
           return true;
         }
       } else if (pos[dim] >= boxMax[dim] - skinHalf) {
-        if (internal::checkParticleInCellAndUpdateByIDAndPosition(this->_cells[2 * dim + 2], pCopy, skinHalf)) {
+        if (internal::checkParticleInCellAndUpdateByIDAndPosition(this->_cells[2 * dim + 2], haloParticle, skinHalf)) {
           return true;
         }
       }

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -80,18 +80,14 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
   }
 
   void addHaloParticleImpl(const ParticleType &haloParticle) override {
-    ParticleType pCopy = haloParticle;
-    pCopy.setOwnershipState(OwnershipState::halo);
-    ParticleCell &cell = _cellBlock.getContainingCell(pCopy.getR());
-    cell.addParticle(pCopy);
+    ParticleCell &cell = _cellBlock.getContainingCell(haloParticle.getR());
+    cell.addParticle(haloParticle);
   }
 
   bool updateHaloParticle(const ParticleType &haloParticle) override {
-    ParticleType pCopy = haloParticle;
-    pCopy.setOwnershipState(OwnershipState::halo);
-    auto cells = _cellBlock.getNearbyHaloCells(pCopy.getR(), this->getVerletSkin());
+    auto cells = _cellBlock.getNearbyHaloCells(haloParticle.getR(), this->getVerletSkin());
     for (auto cellptr : cells) {
-      bool updated = internal::checkParticleInCellAndUpdateByID(*cellptr, pCopy);
+      bool updated = internal::checkParticleInCellAndUpdateByID(*cellptr, haloParticle);
       if (updated) {
         return true;
       }

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -92,7 +92,7 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
         return true;
       }
     }
-    AutoPasLog(TRACE, "UpdateHaloParticle was not able to update particle: {}", pCopy.toString());
+    AutoPasLog(TRACE, "UpdateHaloParticle was not able to update particle: {}", haloParticle.toString());
     return false;
   }
 

--- a/src/autopas/containers/linkedCells/LinkedCellsReferences.h
+++ b/src/autopas/containers/linkedCells/LinkedCellsReferences.h
@@ -83,9 +83,8 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
    * @copydoc ParticleContainerInterface::addParticleImpl()
    */
   void addParticleImpl(const ParticleType &p) override {
-    ParticleType pCopy = p;
     addParticleLock.lock();
-    _particleList.push_back(pCopy);
+    _particleList.push_back(p);
     updateDirtyParticleReferences();
     addParticleLock.unlock();
   }
@@ -94,10 +93,8 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
    * @copydoc ParticleContainerInterface::addHaloParticleImpl()
    */
   void addHaloParticleImpl(const ParticleType &haloParticle) override {
-    ParticleType pCopy = haloParticle;
-    pCopy.setOwnershipState(OwnershipState::halo);
     addParticleLock.lock();
-    _particleList.push_back(pCopy);
+    _particleList.push_back(haloParticle);
     updateDirtyParticleReferences();
     addParticleLock.unlock();
   }
@@ -106,16 +103,14 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
    * @copydoc ParticleContainerInterface::updateHaloParticle()
    */
   bool updateHaloParticle(const ParticleType &haloParticle) override {
-    ParticleType pCopy = haloParticle;
-    pCopy.setOwnershipState(OwnershipState::halo);
-    auto cells = _cellBlock.getNearbyHaloCells(pCopy.getR(), this->getVerletSkin());
+    auto cells = _cellBlock.getNearbyHaloCells(haloParticle.getR(), this->getVerletSkin());
     for (auto cellptr : cells) {
-      bool updated = internal::checkParticleInCellAndUpdateByID(*cellptr, pCopy);
+      bool updated = internal::checkParticleInCellAndUpdateByID(*cellptr, haloParticle);
       if (updated) {
         return true;
       }
     }
-    AutoPasLog(TRACE, "UpdateHaloParticle was not able to update particle: {}", pCopy.toString());
+    AutoPasLog(TRACE, "UpdateHaloParticle was not able to update particle: {}", haloParticle.toString());
     return false;
   }
 

--- a/src/autopas/containers/linkedCells/ParticleVector.h
+++ b/src/autopas/containers/linkedCells/ParticleVector.h
@@ -63,7 +63,7 @@ class ParticleVector {
    * Add a Particle to the data structure.
    * @param value A reference to the value to be stored
    */
-  void push_back(Type &value) {
+  void push_back(const Type &value) {
     _particleListLock.lock();
     _dirty = true;
     if (_particleListImp.capacity() == _particleListImp.size()) {

--- a/src/autopas/containers/linkedCells/ParticleVector.h
+++ b/src/autopas/containers/linkedCells/ParticleVector.h
@@ -61,15 +61,15 @@ class ParticleVector {
 
   /**
    * Add a Particle to the data structure.
-   * @param value A reference to the value to be stored
+   * @param particle A reference to the particle to be stored
    */
-  void push_back(const Type &value) {
+  void push_back(const Type &particle) {
     _particleListLock.lock();
     _dirty = true;
     if (_particleListImp.capacity() == _particleListImp.size()) {
       _dirtyIndex = 0;
     }
-    _particleListImp.push_back(value);
+    _particleListImp.push_back(particle);
     _particleListLock.unlock();
   }
 

--- a/src/autopas/containers/octree/Octree.h
+++ b/src/autopas/containers/octree/Octree.h
@@ -175,18 +175,14 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
    * @copydoc ParticleContainerInterface::addHaloParticleImpl()
    */
   void addHaloParticleImpl(const ParticleType &haloParticle) override {
-    ParticleType p_copy = haloParticle;
-    p_copy.setOwnershipState(OwnershipState::halo);
-    this->_cells[CellTypes::HALO].addParticle(p_copy);
+    this->_cells[CellTypes::HALO].addParticle(haloParticle);
   }
 
   /**
    * @copydoc ParticleContainerInterface::updateHaloParticle()
    */
   bool updateHaloParticle(const ParticleType &haloParticle) override {
-    ParticleType pCopy = haloParticle;
-    pCopy.setOwnershipState(OwnershipState::halo);
-    return internal::checkParticleInCellAndUpdateByIDAndPosition(this->_cells[CellTypes::HALO], pCopy,
+    return internal::checkParticleInCellAndUpdateByIDAndPosition(this->_cells[CellTypes::HALO], haloParticle,
                                                                  this->getVerletSkin());
   }
 

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -183,9 +183,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
 
   void addHaloParticleImpl(const Particle &haloParticle) override {
     _isValid.store(ValidityState::invalid, std::memory_order::memory_order_relaxed);
-    Particle copy = haloParticle;
-    copy.setOwnershipState(OwnershipState::halo);
-    _particlesToAdd[autopas_get_thread_num()].push_back(copy);
+    _particlesToAdd[autopas_get_thread_num()].push_back(haloParticle);
   }
 
   bool updateHaloParticle(const Particle &haloParticle) override {

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -184,10 +184,10 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    * @param particle
    * @return true if a particle was found and updated, false if it was not found.
    */
-  bool updateHaloParticle(const Particle &particle) override {
-    auto cells = _linkedCells.getCellBlock().getNearbyHaloCells(particle.getR(), this->getVerletSkin());
+  bool updateHaloParticle(const Particle &haloParticle) override {
+    auto cells = _linkedCells.getCellBlock().getNearbyHaloCells(haloParticle.getR(), this->getVerletSkin());
     for (auto cellptr : cells) {
-      bool updated = internal::checkParticleInCellAndUpdateByID(*cellptr, particle);
+      bool updated = internal::checkParticleInCellAndUpdateByID(*cellptr, haloParticle);
       if (updated) {
         return true;
       }
@@ -195,7 +195,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
     AutoPasLog(TRACE,
                "updateHaloParticle was not able to update particle at "
                "[{}, {}, {}]",
-               particle.getR()[0], particle.getR()[1], particle.getR()[2]);
+               haloParticle.getR()[0], haloParticle.getR()[1], haloParticle.getR()[2]);
     return false;
   }
 

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -185,11 +185,9 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    * @return true if a particle was found and updated, false if it was not found.
    */
   bool updateHaloParticle(const Particle &particle) override {
-    Particle pCopy = particle;
-    pCopy.setOwnershipState(OwnershipState::halo);
-    auto cells = _linkedCells.getCellBlock().getNearbyHaloCells(pCopy.getR(), this->getVerletSkin());
+    auto cells = _linkedCells.getCellBlock().getNearbyHaloCells(particle.getR(), this->getVerletSkin());
     for (auto cellptr : cells) {
-      bool updated = internal::checkParticleInCellAndUpdateByID(*cellptr, pCopy);
+      bool updated = internal::checkParticleInCellAndUpdateByID(*cellptr, particle);
       if (updated) {
         return true;
       }
@@ -197,7 +195,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
     AutoPasLog(TRACE,
                "updateHaloParticle was not able to update particle at "
                "[{}, {}, {}]",
-               pCopy.getR()[0], pCopy.getR()[1], pCopy.getR()[2]);
+               particle.getR()[0], particle.getR()[1], particle.getR()[2]);
     return false;
   }
 

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -181,7 +181,7 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    * Searches the provided halo particle and updates the found particle.
    * Searches for the provided particle within the halo cells of the container
    * and overwrites the found particle with the provided particle.
-   * @param particle
+   * @param haloParticle
    * @return true if a particle was found and updated, false if it was not found.
    */
   bool updateHaloParticle(const Particle &haloParticle) override {

--- a/src/autopas/particles/ParticleBase.h
+++ b/src/autopas/particles/ParticleBase.h
@@ -32,7 +32,8 @@ namespace autopas {
 template <typename floatType, typename idType>
 class ParticleBase {
  public:
-  ParticleBase() : _r({0.0, 0.0, 0.0}), _v({0., 0., 0.}), _f({0.0, 0.0, 0.0}), _id(0) {}
+  ParticleBase()
+      : _r({0.0, 0.0, 0.0}), _v({0., 0., 0.}), _f({0.0, 0.0, 0.0}), _id(0), _ownershipState(OwnershipState::owned) {}
 
   /**
    * Constructor of the Particle class.
@@ -40,8 +41,9 @@ class ParticleBase {
    * @param v Velocity of the particle.
    * @param id Id of the particle.
    */
-  ParticleBase(const std::array<double, 3> &r, const std::array<double, 3> &v, idType id)
-      : _r(r), _v(v), _f({0.0, 0.0, 0.0}), _id(id) {}
+  ParticleBase(const std::array<double, 3> &r, const std::array<double, 3> &v, idType id,
+               OwnershipState ownershipState = OwnershipState::owned)
+      : _r(r), _v(v), _f({0.0, 0.0, 0.0}), _id(id), _ownershipState(ownershipState) {}
 
   /**
    * Destructor of ParticleBase class
@@ -72,7 +74,7 @@ class ParticleBase {
   /**
    * Defines the state of the ownership of the particle.
    */
-  OwnershipState _ownershipState{OwnershipState::owned};
+  OwnershipState _ownershipState;
 
  public:
   /**

--- a/src/autopas/particles/ParticleBase.h
+++ b/src/autopas/particles/ParticleBase.h
@@ -40,6 +40,7 @@ class ParticleBase {
    * @param r Position of the particle.
    * @param v Velocity of the particle.
    * @param id Id of the particle.
+   * @param ownershipState OwnershipState of the particle (can be either owned, halo, or dummy)
    */
   ParticleBase(const std::array<double, 3> &r, const std::array<double, 3> &v, idType id,
                OwnershipState ownershipState = OwnershipState::owned)

--- a/tests/testAutopas/tests/containers/AllContainersTests.cpp
+++ b/tests/testAutopas/tests/containers/AllContainersTests.cpp
@@ -122,8 +122,7 @@ TEST_P(AllContainersTests, testDeleteHaloParticles) {
         }
         auto pos = domainCenter + std::array<double, 3>{distCenterToMidHalo[0] * x, distCenterToMidHalo[1] * y,
                                                         distCenterToMidHalo[2] * z};
-        Particle p{pos, zeros, numParticles++};
-        p.setOwnershipState(autopas::OwnershipState::halo);
+        const Particle p{pos, zeros, numParticles++, autopas::OwnershipState::halo};
         container.addHaloParticle(p);
       }
     }
@@ -142,8 +141,8 @@ TEST_P(AllContainersTests, testDeleteHaloParticles) {
  */
 TEST_P(AllContainersTestsBothUpdates, testUpdateContainerHalo) {
   auto &container = getInitializedContainer(std::get<0>(GetParam()));
-  autopas::Particle p({boxMin[0] - 0.5, boxMin[1] - 0.5, boxMin[2] - 0.5}, {0, 0, 0}, 42);
-  p.setOwnershipState(autopas::OwnershipState::halo);
+  const autopas::Particle p({boxMin[0] - 0.5, boxMin[1] - 0.5, boxMin[2] - 0.5}, {0, 0, 0}, 42,
+                            autopas::OwnershipState::halo);
   container.addHaloParticle(p);
 
   EXPECT_EQ(container.size(), 1);
@@ -238,20 +237,17 @@ TEST_P(AllContainersTests, testUpdateContainerKeepsNeighborListsValidIfSpecified
   auto &container = getInitializedContainer(std::get<0>(GetParam()));
 
   {
-    Particle p({-.1, -.1, -.1}, {0., 0., 0.}, 0);
-    p.setOwnershipState(autopas::OwnershipState::halo);
+    const Particle p({-.1, -.1, -.1}, {0., 0., 0.}, 0, autopas::OwnershipState::halo);
     container.addHaloParticle(p);
   }
 
   {
-    Particle p({.02, .1, .1}, {0., 0., 0.}, 1);
-    p.setOwnershipState(autopas::OwnershipState::owned);
+    const Particle p({.02, .1, .1}, {0., 0., 0.}, 1);
     container.addParticle(p);
   }
 
   {
-    Particle p({1.23, .1, .1}, {0., 0., 0.}, 2);
-    p.setOwnershipState(autopas::OwnershipState::owned);
+    const Particle p({1.23, .1, .1}, {0., 0., 0.}, 2);
     container.addParticle(p);
   }
   struct Values {

--- a/tests/testAutopas/tests/containers/AllContainersTests.cpp
+++ b/tests/testAutopas/tests/containers/AllContainersTests.cpp
@@ -68,16 +68,20 @@ TEST_P(AllContainersTests, testParticleAdding) {
                      boxMax[1] + .5, boxMax[1] + 1.5}) {
       for (double z : {boxMin[2] - 1.5, boxMin[2] - .5, boxMin[2], boxMin[2] + 5., boxMax[2] - 0.001, boxMax[2],
                        boxMax[2] + .5, boxMax[2] + 1.5}) {
-        const autopas::Particle p({x, y, z}, {0., 0., 0.}, id++);
+        autopas::Particle p({x, y, z}, {0., 0., 0.},
+                            id++);  // not const as updating ownership (as containers no longer handle this)
         if (x == -1.5 or y == -1.5 or z == -1.5 or x == 11.5 or y == 11.5 or z == 11.5) {
-          EXPECT_ANY_THROW(container.addParticle(p));     // outside, therefore not ok!
+          EXPECT_ANY_THROW(container.addParticle(p));  // outside, therefore not ok!
+          p.setOwnershipState(autopas::OwnershipState::halo);
           EXPECT_NO_THROW(container.addHaloParticle(p));  // much outside, still ok because it is ignored!
         } else if (x == 10. or y == 10. or z == 10. or x == -.5 or y == -.5 or z == -.5 or x == 10.5 or y == 10.5 or
                    z == 10.5) {
-          EXPECT_ANY_THROW(container.addParticle(p));     // outside, therefore not ok!
+          EXPECT_ANY_THROW(container.addParticle(p));  // outside, therefore not ok!
+          p.setOwnershipState(autopas::OwnershipState::halo);
           EXPECT_NO_THROW(container.addHaloParticle(p));  // outside, therefore ok!
         } else {
           EXPECT_NO_THROW(container.addParticle(p));  // inside, therefore ok!
+          p.setOwnershipState(autopas::OwnershipState::halo);
           EXPECT_ANY_THROW(
               // inside, and not ok, as halo particles cannot be added inside of the domain!
               container.addHaloParticle(p));
@@ -118,7 +122,8 @@ TEST_P(AllContainersTests, testDeleteHaloParticles) {
         }
         auto pos = domainCenter + std::array<double, 3>{distCenterToMidHalo[0] * x, distCenterToMidHalo[1] * y,
                                                         distCenterToMidHalo[2] * z};
-        const Particle p{pos, zeros, numParticles++};
+        Particle p{pos, zeros, numParticles++};
+        p.setOwnershipState(autopas::OwnershipState::halo);
         container.addHaloParticle(p);
       }
     }
@@ -137,7 +142,8 @@ TEST_P(AllContainersTests, testDeleteHaloParticles) {
  */
 TEST_P(AllContainersTestsBothUpdates, testUpdateContainerHalo) {
   auto &container = getInitializedContainer(std::get<0>(GetParam()));
-  const autopas::Particle p({boxMin[0] - 0.5, boxMin[1] - 0.5, boxMin[2] - 0.5}, {0, 0, 0}, 42);
+  autopas::Particle p({boxMin[0] - 0.5, boxMin[1] - 0.5, boxMin[2] - 0.5}, {0, 0, 0}, 42);
+  p.setOwnershipState(autopas::OwnershipState::halo);
   container.addHaloParticle(p);
 
   EXPECT_EQ(container.size(), 1);
@@ -175,10 +181,12 @@ void AllContainersTestsBothUpdates::testUpdateContainerDeletesDummy(bool previou
   // Add particle
   {
     const double pos = previouslyOwned ? 0.5 : -0.5;
-    const TestParticle p({pos, pos, pos}, {0, 0, 0}, 42);
+    TestParticle p({pos, pos, pos}, {0, 0, 0}, 42);
     if (previouslyOwned) {
+      p.setOwnershipState(autopas::OwnershipState::owned);
       container.addParticle(p);
     } else {
+      p.setOwnershipState(autopas::OwnershipState::halo);
       container.addHaloParticle(p);
     }
   }
@@ -230,17 +238,20 @@ TEST_P(AllContainersTests, testUpdateContainerKeepsNeighborListsValidIfSpecified
   auto &container = getInitializedContainer(std::get<0>(GetParam()));
 
   {
-    const Particle p({-.1, -.1, -.1}, {0., 0., 0.}, 0);
+    Particle p({-.1, -.1, -.1}, {0., 0., 0.}, 0);
+    p.setOwnershipState(autopas::OwnershipState::halo);
     container.addHaloParticle(p);
   }
 
   {
-    const Particle p({.02, .1, .1}, {0., 0., 0.}, 1);
+    Particle p({.02, .1, .1}, {0., 0., 0.}, 1);
+    p.setOwnershipState(autopas::OwnershipState::owned);
     container.addParticle(p);
   }
 
   {
-    const Particle p({1.23, .1, .1}, {0., 0., 0.}, 2);
+    Particle p({1.23, .1, .1}, {0., 0., 0.}, 2);
+    p.setOwnershipState(autopas::OwnershipState::owned);
     container.addParticle(p);
   }
   struct Values {

--- a/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
@@ -34,11 +34,11 @@ TYPED_TEST_P(LinkedCellsTest, testUpdateContainer) {
   };
 
   // These are going to be halo particles
-  std::vector<autopas::Particle> haloParticles{
-      {{-0.5, +1.5, +1.5}, zero, 5},
-      {{+5.0, +1.5, +1.5}, zero, 6},
-      {{+1.5, -0.5, +1.5}, zero, 7},
-      {{+1.5, +1.5, -0.5}, zero, 8},
+  const std::vector<autopas::Particle> haloParticles{
+      {{-0.5, +1.5, +1.5}, zero, 5, autopas::OwnershipState::halo},
+      {{+5.0, +1.5, +1.5}, zero, 6, autopas::OwnershipState::halo},
+      {{+1.5, -0.5, +1.5}, zero, 7, autopas::OwnershipState::halo},
+      {{+1.5, +1.5, -0.5}, zero, 8, autopas::OwnershipState::halo},
   };
 
   // calculate the cell IDs for each particle
@@ -56,16 +56,12 @@ TYPED_TEST_P(LinkedCellsTest, testUpdateContainer) {
   // we insert owned and halo particles alternating. This way we can check if references are updated correctly when
   // using LinkedCellsReferences
   linkedCells.addParticle(ownedParticles[0]);
-  haloParticles[0].setOwnershipState(autopas::OwnershipState::halo);
   linkedCells.addHaloParticle(haloParticles[0]);
   linkedCells.addParticle(ownedParticles[1]);
-  haloParticles[1].setOwnershipState(autopas::OwnershipState::halo);
   linkedCells.addHaloParticle(haloParticles[1]);
   linkedCells.addParticle(ownedParticles[2]);
-  haloParticles[2].setOwnershipState(autopas::OwnershipState::halo);
   linkedCells.addHaloParticle(haloParticles[2]);
   linkedCells.addParticle(ownedParticles[3]);
-  haloParticles[3].setOwnershipState(autopas::OwnershipState::halo);
   linkedCells.addHaloParticle(haloParticles[3]);
   linkedCells.addParticle(ownedParticles[4]);
 

--- a/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
@@ -34,7 +34,7 @@ TYPED_TEST_P(LinkedCellsTest, testUpdateContainer) {
   };
 
   // These are going to be halo particles
-  const std::vector<autopas::Particle> haloParticles{
+  std::vector<autopas::Particle> haloParticles{
       {{-0.5, +1.5, +1.5}, zero, 5},
       {{+5.0, +1.5, +1.5}, zero, 6},
       {{+1.5, -0.5, +1.5}, zero, 7},
@@ -56,12 +56,16 @@ TYPED_TEST_P(LinkedCellsTest, testUpdateContainer) {
   // we insert owned and halo particles alternating. This way we can check if references are updated correctly when
   // using LinkedCellsReferences
   linkedCells.addParticle(ownedParticles[0]);
+  haloParticles[0].setOwnershipState(autopas::OwnershipState::halo);
   linkedCells.addHaloParticle(haloParticles[0]);
   linkedCells.addParticle(ownedParticles[1]);
+  haloParticles[1].setOwnershipState(autopas::OwnershipState::halo);
   linkedCells.addHaloParticle(haloParticles[1]);
   linkedCells.addParticle(ownedParticles[2]);
+  haloParticles[2].setOwnershipState(autopas::OwnershipState::halo);
   linkedCells.addHaloParticle(haloParticles[2]);
   linkedCells.addParticle(ownedParticles[3]);
+  haloParticles[3].setOwnershipState(autopas::OwnershipState::halo);
   linkedCells.addHaloParticle(haloParticles[3]);
   linkedCells.addParticle(ownedParticles[4]);
 

--- a/tests/testAutopas/tests/containers/octree/OctreeTests.cpp
+++ b/tests/testAutopas/tests/containers/octree/OctreeTests.cpp
@@ -499,6 +499,7 @@ OctreeTest::calculateForcesAndPairs(autopas::ContainerOption containerOption, au
   for (int unsigned i = 0; i < numHaloParticles; ++i) {
     auto position = haloParticlePositions[i];
     auto particle = Molecule(position, {0, 0, 0}, numParticles + i);
+    particle.setOwnershipState(autopas::OwnershipState::halo);
     container.addHaloParticle(particle);
   }
 

--- a/tests/testAutopas/tests/containers/verletListsCellBased/varVerletLists/VarVerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/varVerletLists/VarVerletListsTest.cpp
@@ -230,8 +230,7 @@ TEST_F(VarVerletListsTest, testVerletListBuildHalo) {
       min, max, cutoff, skinPerTimestep, rebuildFrequency);
 
   std::array<double, 3> r = {0.9, 0.9, 0.9};
-  Particle p(r, {0., 0., 0.}, 0);
-  p.setOwnershipState(autopas::OwnershipState::halo);
+  Particle p(r, {0., 0., 0.}, 0, autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p);
   std::array<double, 3> r2 = {1.1, 1.1, 1.1};
   Particle p2(r2, {0., 0., 0.}, 1);
@@ -268,8 +267,7 @@ TEST_F(VarVerletListsTest, testUpdateHaloParticle) {
   autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(
       {0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 1);
 
-  Particle p({-.1, 10.1, -.1}, {0., 0., 0.}, 1);
-  p.setOwnershipState(autopas::OwnershipState::halo);
+  Particle p({-.1, 10.1, -.1}, {0., 0., 0.}, 1, autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p);
 
   // test same position, change velocity
@@ -296,24 +294,20 @@ TEST_F(VarVerletListsTest, testUpdateHaloParticle) {
   EXPECT_TRUE(moveUpdateAndExpectEqual(verletLists, p, {.05, 9.95, .05}));
 
   // check for particle with wrong id
-  Particle p2({-.1, -.1, -.1}, {0., 0., 0.}, 2);
-  p2.setOwnershipState(autopas::OwnershipState::halo);
+  Particle p2({-.1, -.1, -.1}, {0., 0., 0.}, 2, autopas::OwnershipState::halo);
   EXPECT_FALSE(verletLists.updateHaloParticle(p2));
 
   // test move far, expect throw
   EXPECT_FALSE(moveUpdateAndExpectEqual(verletLists, p, {3, 3, 3}));
 
   // test particles at intermediate positions (not at corners)
-  Particle p3({-1., 4., 2.}, {0., 0., 0.}, 3);
-  p3.setOwnershipState(autopas::OwnershipState::halo);
+  Particle p3({-1., 4., 2.}, {0., 0., 0.}, 3, autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p3);
   EXPECT_TRUE(verletLists.updateHaloParticle(p3));
-  Particle p4({4., 10.2, 2.}, {0., 0., 0.}, 4);
-  p4.setOwnershipState(autopas::OwnershipState::halo);
+  Particle p4({4., 10.2, 2.}, {0., 0., 0.}, 4, autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p4);
   EXPECT_TRUE(verletLists.updateHaloParticle(p4));
-  Particle p5({5., 4., 10.2}, {0., 0., 0.}, 3);
-  p5.setOwnershipState(autopas::OwnershipState::halo);
+  Particle p5({5., 4., 10.2}, {0., 0., 0.}, 3, autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p5);
   EXPECT_TRUE(verletLists.updateHaloParticle(p5));
 }

--- a/tests/testAutopas/tests/containers/verletListsCellBased/varVerletLists/VarVerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/varVerletLists/VarVerletListsTest.cpp
@@ -231,6 +231,7 @@ TEST_F(VarVerletListsTest, testVerletListBuildHalo) {
 
   std::array<double, 3> r = {0.9, 0.9, 0.9};
   Particle p(r, {0., 0., 0.}, 0);
+  p.setOwnershipState(autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p);
   std::array<double, 3> r2 = {1.1, 1.1, 1.1};
   Particle p2(r2, {0., 0., 0.}, 1);
@@ -268,6 +269,7 @@ TEST_F(VarVerletListsTest, testUpdateHaloParticle) {
       {0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 1);
 
   Particle p({-.1, 10.1, -.1}, {0., 0., 0.}, 1);
+  p.setOwnershipState(autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p);
 
   // test same position, change velocity
@@ -295,6 +297,7 @@ TEST_F(VarVerletListsTest, testUpdateHaloParticle) {
 
   // check for particle with wrong id
   Particle p2({-.1, -.1, -.1}, {0., 0., 0.}, 2);
+  p2.setOwnershipState(autopas::OwnershipState::halo);
   EXPECT_FALSE(verletLists.updateHaloParticle(p2));
 
   // test move far, expect throw
@@ -302,12 +305,15 @@ TEST_F(VarVerletListsTest, testUpdateHaloParticle) {
 
   // test particles at intermediate positions (not at corners)
   Particle p3({-1., 4., 2.}, {0., 0., 0.}, 3);
+  p3.setOwnershipState(autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p3);
   EXPECT_TRUE(verletLists.updateHaloParticle(p3));
   Particle p4({4., 10.2, 2.}, {0., 0., 0.}, 4);
+  p4.setOwnershipState(autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p4);
   EXPECT_TRUE(verletLists.updateHaloParticle(p4));
   Particle p5({5., 4., 10.2}, {0., 0., 0.}, 3);
+  p5.setOwnershipState(autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p5);
   EXPECT_TRUE(verletLists.updateHaloParticle(p5));
 }

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.cpp
@@ -180,6 +180,7 @@ TEST_P(VerletListsTest, testVerletListBuildHalo) {
 
   std::array<double, 3> r = {0.9, 0.9, 0.9};
   Particle p(r, {0., 0., 0.}, 0);
+  p.setOwnershipState(autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p);
   std::array<double, 3> r2 = {1.1, 1.1, 1.1};
   Particle p2(r2, {0., 0., 0.}, 1);
@@ -224,6 +225,7 @@ TEST_P(VerletListsTest, testUpdateHaloParticle) {
                                              cellSizeFactor);
 
   Particle p({-.1, 10.1, -.1}, {0., 0., 0.}, 1);
+  p.setOwnershipState(autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p);
 
   // test same position, change velocity
@@ -251,6 +253,7 @@ TEST_P(VerletListsTest, testUpdateHaloParticle) {
 
   // check for particle with wrong id
   Particle p2({-.1, -.1, -.1}, {0., 0., 0.}, 2);
+  p2.setOwnershipState(autopas::OwnershipState::halo);
   EXPECT_FALSE(verletLists.updateHaloParticle(p2));
 
   // test move far, expect throw
@@ -258,12 +261,15 @@ TEST_P(VerletListsTest, testUpdateHaloParticle) {
 
   // test particles at intermediate positions (not at corners)
   Particle p3({-1., 4., 2.}, {0., 0., 0.}, 3);
+  p3.setOwnershipState(autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p3);
   EXPECT_TRUE(verletLists.updateHaloParticle(p3));
   Particle p4({4., 10.2, 2.}, {0., 0., 0.}, 4);
+  p4.setOwnershipState(autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p4);
   EXPECT_TRUE(verletLists.updateHaloParticle(p4));
   Particle p5({5., 4., 10.2}, {0., 0., 0.}, 3);
+  p5.setOwnershipState(autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p5);
   EXPECT_TRUE(verletLists.updateHaloParticle(p5));
 }
@@ -278,6 +284,7 @@ TEST_P(VerletListsTest, LoadExtractSoA) {
                                              cellSizeFactor);
 
   Particle p({-.1, 10.1, -.1}, {0., 0., 0.}, 1);
+  p.setOwnershipState(autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p);
 
   MockFunctor<Particle> mockFunctor;
@@ -305,6 +312,7 @@ TEST_P(VerletListsTest, LoadExtractSoALJ) {
       autopas::VerletLists<Molecule>::BuildVerletListType::VerletSoA, cellSizeFactor);
 
   Molecule p({-.1, 10.1, -.1}, {0., 0., 0.}, 1, 0);
+  p.setOwnershipState(autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p);
   LJFunctorType<> ljFunctor(cutoff);
   ljFunctor.setParticleProperties(1., 1.);

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.cpp
@@ -179,8 +179,7 @@ TEST_P(VerletListsTest, testVerletListBuildHalo) {
                                              cellSizeFactor);
 
   std::array<double, 3> r = {0.9, 0.9, 0.9};
-  Particle p(r, {0., 0., 0.}, 0);
-  p.setOwnershipState(autopas::OwnershipState::halo);
+  Particle p(r, {0., 0., 0.}, 0, autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p);
   std::array<double, 3> r2 = {1.1, 1.1, 1.1};
   Particle p2(r2, {0., 0., 0.}, 1);
@@ -224,8 +223,7 @@ TEST_P(VerletListsTest, testUpdateHaloParticle) {
                                              autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA,
                                              cellSizeFactor);
 
-  Particle p({-.1, 10.1, -.1}, {0., 0., 0.}, 1);
-  p.setOwnershipState(autopas::OwnershipState::halo);
+  Particle p({-.1, 10.1, -.1}, {0., 0., 0.}, 1, autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p);
 
   // test same position, change velocity
@@ -252,24 +250,20 @@ TEST_P(VerletListsTest, testUpdateHaloParticle) {
   EXPECT_TRUE(moveUpdateAndExpectEqual(verletLists, p, {.05, 9.95, .05}));
 
   // check for particle with wrong id
-  Particle p2({-.1, -.1, -.1}, {0., 0., 0.}, 2);
-  p2.setOwnershipState(autopas::OwnershipState::halo);
+  Particle p2({-.1, -.1, -.1}, {0., 0., 0.}, 2, autopas::OwnershipState::halo);
   EXPECT_FALSE(verletLists.updateHaloParticle(p2));
 
   // test move far, expect throw
   EXPECT_FALSE(moveUpdateAndExpectEqual(verletLists, p, {3, 3, 3}));
 
   // test particles at intermediate positions (not at corners)
-  Particle p3({-1., 4., 2.}, {0., 0., 0.}, 3);
-  p3.setOwnershipState(autopas::OwnershipState::halo);
+  Particle p3({-1., 4., 2.}, {0., 0., 0.}, 3, autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p3);
   EXPECT_TRUE(verletLists.updateHaloParticle(p3));
-  Particle p4({4., 10.2, 2.}, {0., 0., 0.}, 4);
-  p4.setOwnershipState(autopas::OwnershipState::halo);
+  Particle p4({4., 10.2, 2.}, {0., 0., 0.}, 4, autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p4);
   EXPECT_TRUE(verletLists.updateHaloParticle(p4));
-  Particle p5({5., 4., 10.2}, {0., 0., 0.}, 3);
-  p5.setOwnershipState(autopas::OwnershipState::halo);
+  Particle p5({5., 4., 10.2}, {0., 0., 0.}, 3, autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p5);
   EXPECT_TRUE(verletLists.updateHaloParticle(p5));
 }
@@ -283,8 +277,7 @@ TEST_P(VerletListsTest, LoadExtractSoA) {
                                              autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA,
                                              cellSizeFactor);
 
-  Particle p({-.1, 10.1, -.1}, {0., 0., 0.}, 1);
-  p.setOwnershipState(autopas::OwnershipState::halo);
+  Particle p({-.1, 10.1, -.1}, {0., 0., 0.}, 1, autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p);
 
   MockFunctor<Particle> mockFunctor;

--- a/tests/testAutopas/tests/tuning/selectors/ContainerSelectorTestFromTo.cpp
+++ b/tests/testAutopas/tests/tuning/selectors/ContainerSelectorTestFromTo.cpp
@@ -73,6 +73,7 @@ TEST_P(ContainerSelectorTestFromTo, testContainerConversion) {
           if (autopas::utils::inBox(pos, bBoxMin, bBoxMax)) {
             container.addParticle(p);
           } else {
+            p.setOwnershipState(autopas::OwnershipState::halo);
             container.addHaloParticle(p);
           }
           ++id;

--- a/tools/autopasTools/generators/UniformGenerator.h
+++ b/tools/autopasTools/generators/UniformGenerator.h
@@ -9,6 +9,7 @@
 #include <array>
 #include <random>
 
+#include "autopas/particles/OwnershipState.h"
 #include "autopas/utils/inBox.h"
 
 namespace autopasTools::generators {
@@ -75,7 +76,11 @@ void fillWithHaloParticles(Container &container, const Particle &defaultParticle
                            unsigned long numParticles, unsigned int seed = 42) {
   fillWithHaloParticles(
       container, defaultParticle, haloWidth, numParticles,
-      [](Container &c, const Particle &p) { c.addHaloParticle(p); }, seed);
+      [](Container &c, Particle &p) {
+        p.setOwnershipState(autopas::OwnershipState::halo);
+        c.addHaloParticle(p);
+      },
+      seed);
 }
 };  // namespace UniformGenerator
 
@@ -89,6 +94,7 @@ void UniformGenerator::fillWithParticles(Container &container, const Particle &d
     Particle particle(defaultParticle);
     particle.setR(randomPosition(generator, boxMin, boxMax));
     particle.setID(i);
+    particle.setOwnershipState(autopas::OwnershipState::owned);
     container.addParticle(particle);
   }
 }


### PR DESCRIPTION
# Description

Removing setting particle ownership in containers. This is now completely handled by [LogicHandler](https://github.com/AutoPas/AutoPas/commit/5d22b5c25d11d14549f580253c7969a0a7896aed) (as already updated in #931) 

## Related Pull Requests

- #821 (simplifies by merging this change here)

## Resolved Issues

- [x] fixes #522 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Comparing `total runtime` and `numHalos` at the end of simulation for **explodingLiquid** and **SpinodalDecomposition** scenario
