### PR TITLE
Strip whitespaces from LiveInfoLogger header

### DIFF
--- a/src/autopas/tuning/tuningStrategy/LiveInfo.h
+++ b/src/autopas/tuning/tuningStrategy/LiveInfo.h
@@ -289,10 +289,11 @@ class LiveInfo {
    * @return A pair of strings in the form of (header, line).
    */
   [[nodiscard]] std::pair<std::string, std::string> getCSVLine() const {
-    // match all words that are followed by a '=' ignoring the 'Live Info: ' prefix
-    auto keyRegex = std::regex("([^=]+)=[^ ]*");
+    // match all words (anything that is neither a ' ' or '='), that are followed by a '=',
+    // ignoring the 'Live Info: ' prefix
+    const auto keyRegex = std::regex("([^= ]+)=[^ ]*");
     // match all words that are preceded by a '='
-    auto valueRegex = std::regex("=([^ ]+)");
+    const auto valueRegex = std::regex("=([^ ]+)");
 
     auto searchString = toString();
     // remove leading Live Info:


### PR DESCRIPTION
# Description

The csv from the live info logger contained whitespaces between the column head names and the ','. This is inconsistent to our other loggers and inconvenient to parse.

This PR removes the whitespaces by adapting the way the header is generated from the `toString()` method.

## ~Related Pull Requests~

## ~Resolved Issues~

# How Has This Been Tested?

- [x] Generated a live info csv and looked at it.
