### PR TITLE
removing distance check for zero skin case

### DIFF
--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -332,7 +332,6 @@ class LogicHandler {
       if (not updated) {
         // If we couldn't find an existing particle, add it to the halo particle buffer.
         _haloParticleBuffer[autopas_get_thread_num()].addParticle(haloParticleCopy);
-        _haloParticleBuffer[autopas_get_thread_num()]._particles.back().setOwnershipState(OwnershipState::halo);
       }
     }
     _numParticlesHalo.fetch_add(1, std::memory_order_relaxed);

--- a/src/autopas/particles/ParticleBase.h
+++ b/src/autopas/particles/ParticleBase.h
@@ -169,7 +169,8 @@ class ParticleBase {
     const auto distanceVec = r - _r;
     const double distanceSquared = utils::ArrayMath::dot(distanceVec, distanceVec);
     setR(r);
-    const bool distanceIsFine = distanceSquared < maxDistSquared or maxDistSquared == 0;
+    const bool distanceIsFine =
+        distanceSquared < maxDistSquared or autopas::utils::Math::isNearAbs(maxDistSquared, 0., 1e-12);
     if (not distanceIsFine) {
       AutoPasLog(WARN, "Particle {}: Distance between old and new position is larger than expected: {} > {}", _id,
                  distanceSquared, maxDistSquared);

--- a/src/autopas/particles/ParticleBase.h
+++ b/src/autopas/particles/ParticleBase.h
@@ -169,7 +169,7 @@ class ParticleBase {
     const auto distanceVec = r - _r;
     const double distanceSquared = utils::ArrayMath::dot(distanceVec, distanceVec);
     setR(r);
-    const bool distanceIsFine = distanceSquared < maxDistSquared;
+    const bool distanceIsFine = distanceSquared < maxDistSquared or maxDistSquared == 0;
     if (not distanceIsFine) {
       AutoPasLog(WARN, "Particle {}: Distance between old and new position is larger than expected: {} > {}", _id,
                  distanceSquared, maxDistSquared);


### PR DESCRIPTION
# Description

This PR contains two main changes:
- Currently the distance check in `ParticleBase.h` in `setRDistanceCheck()` doesn't consider the case of skin=0. In that case, it always gives out a WARN statement (which affects performance if compiled with logger, even when logger is turned off at runtime). Zero skin condition is handled here.
- In `LogicHandler.h`, we already add a haloParticle to the buffer, so adding ownership again after it has been added is not needed. And so, this is removed.

## Related Pull Requests

- #931 ownership set in LogicHandler

# How Has This Been Tested?

Verified by running cases with zero skin.
