### PR TITLE
Disable fuzzy tests when fuzzy tuning is not enabled with CMake

### DIFF
--- a/tests/testAutopas/tests/tuning/tuningStrategy/fuzzyTuning/FuzzyTuningTest.cpp
+++ b/tests/testAutopas/tests/tuning/tuningStrategy/fuzzyTuning/FuzzyTuningTest.cpp
@@ -4,11 +4,12 @@
  * @date 30.06.2024
  */
 
+// Disable these tests if fuzzy tuning is not enabled
+#ifdef AUTOPAS_ENABLE_RULES_BASED_AND_FUZZY_TUNING
 #include "FuzzyTuningTest.h"
 
 #include <filesystem>
 #include <fstream>
-#include <iostream>
 
 #include "autopas/tuning/tuningStrategy/fuzzyTuning/FuzzyTuning.h"
 #include "autopas/tuning/tuningStrategy/fuzzyTuning/fuzzyController/FuzzySetFactory.h"
@@ -572,3 +573,4 @@ if ("homogeneity" == "lower than 0.041") && ("particlesPerCellStdDev" == "lower 
   auto result = newtonSystem->predict(data);
   EXPECT_NEAR(result, 0.6667, 1e-2);
 }
+#endif //AUTOPAS_ENABLE_RULES_BASED_AND_FUZZY_TUNING

--- a/tests/testAutopas/tests/tuning/tuningStrategy/fuzzyTuning/FuzzyTuningTest.cpp
+++ b/tests/testAutopas/tests/tuning/tuningStrategy/fuzzyTuning/FuzzyTuningTest.cpp
@@ -573,4 +573,4 @@ if ("homogeneity" == "lower than 0.041") && ("particlesPerCellStdDev" == "lower 
   auto result = newtonSystem->predict(data);
   EXPECT_NEAR(result, 0.6667, 1e-2);
 }
-#endif //AUTOPAS_ENABLE_RULES_BASED_AND_FUZZY_TUNING
+#endif  // AUTOPAS_ENABLE_RULES_BASED_AND_FUZZY_TUNING


### PR DESCRIPTION
# Description

When setting `-DAUTOPAS_ENABLE_RULES_BASED_AND_FUZZY_TUNING=false`, the `runTests` target does not compile due to missing references to Fuzzy Tuning logic. (Some methods are not defined when this variable is not set)

I decided to fully take out the fuzzy tuning tests, when fuzzy tuning is not enabled.
It is still enabled and tested in our CI.

## Related Pull Requests

- Introduced with the addition of fuzzy tuning is #879 

# How Has This Been Tested?
- Compilation of autopas tests  works without enabling `-DAUTOPAS_ENABLE_RULES_BASED_AND_FUZZY_TUNING`
