### PR TITLE
Taking AVG over simulation for global values

### DIFF
--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -672,8 +672,8 @@ void Simulation::logMeasurements() {
        1e-6 / (static_cast<double>(forceUpdateTotal) * 1e-9);  // 1e-9 for ns to s, 1e-6 for M in MFUPs
    std::cout << "MFUPs/sec                          : " << mfups << "\n";
 
-   _potentialEnergy = _potentialEnergy2B + _potentialEnergy3B;
-   _virial = _virial2B + _virial3B;
+   _potentialEnergy = (_potentialEnergy2B + _potentialEnergy3B)/_iteration;
+   _virial = (_virial2B + _virial3B)/_iteration;
    std::cout << "Potential Energy: " << _potentialEnergy << " K" << "\n";
    std::cout << "Virial: " << _virial << " K nm" << "\n";
  }


### PR DESCRIPTION
For the potential energy of the system and the viral of the forces, the average values over the simulation run are taken into consideration by summing the global values calculated at each iteration and dividing this sum by the number of iterations at the end of the simulation.
```cpp
_potentialEnergy = (_potentialEnergy2B + _potentialEnergy3B)/_iteration;
 _virial = (_virial2B + _virial3B)/_iteration;
```
where `_potentialEnergy2B `, `_potentialEnergy3B `,  `_virial2B ` and `_virial3B ` are incremented at each functor call
in `Simulation::calculatePairwiseForces` and `Simulation::calculateTriwiseForces`.

Previously, the global values were simply being summed, leading to meaningless results.