### PR TITLE
Change VTK Rank Output to UnstructuredGrid

### DIFF
--- a/examples/md-flexible/README.md
+++ b/examples/md-flexible/README.md
@@ -120,8 +120,8 @@ For examples how to define and configure each object see [`input/AllOptions.yaml
   the domain decomposition.
 The cells contain additional information about the configuration of the AutoPas
   container responsible for simulating the cell.
-To visualize the particle records load the .pvtu files in ParaView. To visualize
-  the cells of the decomposition load the .pvts files in ParaView.
+To visualize the particle records load the `Particles*.pvtu` files in ParaView. To visualize
+  the cells of the decomposition load the `Ranks*.pvtu` files in ParaView.
 
 
 ### Checkpoints

--- a/examples/md-flexible/scripts/convertMDFlexStrucToUnstrucGrids.sh
+++ b/examples/md-flexible/scripts/convertMDFlexStrucToUnstrucGrids.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Script to convert the old StructuredGrid vts files for the Rank information to UnstructuredGrid vtu files.
+# This is useful because ParaView doesn't render inner surfaces in StructuredGrids.
+# For more Information see: https://github.com/AutoPas/AutoPas/pull/955
+
+# Check if the filename is provided
+if [ -z "$1" ]; then
+    echo "Usage: $(basename $0) <filename.vts>"
+    echo
+    echo "The scripts prints the new file to stdout. To create a new file pipe the output:"
+    echo "  $(basename $0) foo.vts > foo_Ranks.vtu"
+    exit 1
+fi
+
+InputFile=$1
+
+# Perform the replacements and modifications
+awk '
+    # Replace StructuredGrid with UnstructuredGrid (and trailing spaces)
+    {
+        gsub(/StructuredGrid */, "UnstructuredGrid");
+    }
+
+    # Remove WholeExtent=".*"
+    {
+        gsub(/WholeExtent="[^"]*"/, "");
+    }
+
+    # Replace Extent=".*" with NumberOfPoints="8" NumberOfCells="1"
+    {
+        gsub(/Extent="[^"]*"/, "NumberOfPoints=\"8\" NumberOfCells=\"1\"");
+    }
+
+    # Print any other line
+    {
+        print;
+    }
+
+    # Insert the Cells block after </Points> line
+    /<\/Points>/ {
+        print "      <Cells>";
+        print "        <DataArray type=\"Int32\" Name=\"connectivity\" format=\"ascii\">";
+        print "          0 1 2 3 4 5 6 7";
+        print "        </DataArray>";
+        print "        <DataArray type=\"Int32\" Name=\"offsets\" format=\"ascii\">";
+        print "          8";
+        print "        </DataArray>";
+        print "        <DataArray type=\"UInt8\" Name=\"types\" format=\"ascii\">";
+        print "          11";
+        print "        </DataArray>";
+        print "      </Cells>";
+    }
+' "$InputFile"
+

--- a/examples/md-flexible/src/ParallelVtkWriter.cpp
+++ b/examples/md-flexible/src/ParallelVtkWriter.cpp
@@ -58,7 +58,7 @@ void ParallelVtkWriter::recordParticleStates(size_t currentIteration,
   }
 
   std::ostringstream timestepFileName;
-  generateFilename("vtu", currentIteration, timestepFileName);
+  generateFilename("Particles", "vtu", currentIteration, timestepFileName);
 
   std::ofstream timestepFile;
   timestepFile.open(timestepFileName.str(), std::ios::out | std::ios::binary);
@@ -408,8 +408,8 @@ void ParallelVtkWriter::tryCreateFolder(const std::string &name, const std::stri
   }
 }
 
-void ParallelVtkWriter::generateFilename(const std::string &filetype, size_t currentIteration,
-                                         std::ostringstream &filenameStream) {
-  filenameStream << _dataFolderPath << _sessionName << "_" << _mpiRank << "_" << std::setfill('0')
-                 << std::setw(_maximumNumberOfDigitsInIteration) << currentIteration << "." << filetype;
+void ParallelVtkWriter::generateFilename(const std::string &tag, const std::string &fileExtension,
+                                         size_t currentIteration, std::ostringstream &filenameStream) const {
+  filenameStream << _dataFolderPath << _sessionName << "_" << tag << "_" << _mpiRank << "_" << std::setfill('0')
+                 << std::setw(_maximumNumberOfDigitsInIteration) << currentIteration << "." << fileExtension;
 }

--- a/examples/md-flexible/src/ParallelVtkWriter.cpp
+++ b/examples/md-flexible/src/ParallelVtkWriter.cpp
@@ -54,7 +54,7 @@ void ParallelVtkWriter::recordTimestep(size_t currentIteration, const autopas::A
 void ParallelVtkWriter::recordParticleStates(size_t currentIteration,
                                              const autopas::AutoPas<ParticleType> &autoPasContainer) {
   if (_mpiRank == 0) {
-    createPvtuFile(currentIteration);
+    createParticlesPvtuFile(currentIteration);
   }
 
   std::ostringstream timestepFileName;
@@ -294,9 +294,9 @@ void ParallelVtkWriter::tryCreateSessionAndDataFolders(const std::string &name, 
   tryCreateFolder("data", _sessionFolderPath);
 }
 
-void ParallelVtkWriter::createPvtuFile(size_t currentIteration) {
+void ParallelVtkWriter::createParticlesPvtuFile(size_t currentIteration) const {
   std::ostringstream filename;
-  filename << _sessionFolderPath << _sessionName << "_" << std::setfill('0')
+  filename << _sessionFolderPath << _sessionName << "_Particles_" << std::setfill('0')
            << std::setw(_maximumNumberOfDigitsInIteration) << currentIteration << ".pvtu";
 
   std::ofstream timestepFile;
@@ -332,7 +332,7 @@ void ParallelVtkWriter::createPvtuFile(size_t currentIteration) {
   timestepFile << "    </PCells>\n";
 
   for (int i = 0; i < _numberOfRanks; ++i) {
-    timestepFile << "    <Piece Source=\"./data/" << _sessionName << "_" << i << "_" << std::setfill('0')
+    timestepFile << "    <Piece Source=\"./data/" << _sessionName << "_Particles_" << i << "_" << std::setfill('0')
                  << std::setw(_maximumNumberOfDigitsInIteration) << currentIteration << ".vtu\"/>\n";
   }
 

--- a/examples/md-flexible/src/ParallelVtkWriter.h
+++ b/examples/md-flexible/src/ParallelVtkWriter.h
@@ -41,7 +41,7 @@ class ParallelVtkWriter {
    * @param decomposition: The decomposition of the global domain.
    */
   void recordTimestep(size_t currentIteration, const autopas::AutoPas<ParticleType> &autoPasContainer,
-                      const RegularGridDecomposition &decomposition);
+                      const RegularGridDecomposition &decomposition) const;
 
  private:
   /**
@@ -98,7 +98,7 @@ class ParallelVtkWriter {
    * @param currentIteration: The simulations current iteration.
    * @param autoPasContainer The AutoPas container whose owned particles will be logged.
    */
-  void recordParticleStates(size_t currentIteration, const autopas::AutoPas<ParticleType> &autoPasContainer);
+  void recordParticleStates(size_t currentIteration, const autopas::AutoPas<ParticleType> &autoPasContainer) const;
 
   /**
    * Writes the current domain subdivision into vtk files.
@@ -107,17 +107,7 @@ class ParallelVtkWriter {
    * @param decomposition: The simulations domain decomposition.
    */
   void recordDomainSubdivision(size_t currentIteration, const autopas::Configuration &autoPasConfiguration,
-                               const RegularGridDecomposition &decomposition);
-
-  /**
-   * Calculates the whole extent of the decompositions local domain.
-   * The whole extent defines the space this local domain is occupying in the global domain.
-   * The layout of the returned array is [ xmin, xmax, ymin, ymax, zmin, zmax ], where x, y and z are coordinates in
-   * in the decomposition grid.
-   * @param domainDecomposition: The simulations domain decomposition.
-   * @return the whole extent of the local domain.
-   */
-  static std::array<int, 6> calculateWholeExtent(const RegularGridDecomposition &domainDecomposition);
+                               const RegularGridDecomposition &decomposition) const;
 
   /**
    * Tries to create a folder for the current writer session and stores it in _sessionFolderPath.

--- a/examples/md-flexible/src/ParallelVtkWriter.h
+++ b/examples/md-flexible/src/ParallelVtkWriter.h
@@ -125,10 +125,13 @@ class ParallelVtkWriter {
   void tryCreateSessionAndDataFolders(const std::string &name, const std::string &location);
 
   /**
-   * Creates the .pvtu file required to load unstructured grid data from multiple ranks into ParaView.
+   * Creates the .pvtu file for particle data that references all particle data vtu files from this timestep.
+   *
+   * @note For visualization in ParaView the .pvtu files need to be loaded.
+   *
    * @param currentIteration: The simulation's current iteration.
    */
-  void createPvtuFile(size_t currentIteration);
+  void createParticlesPvtuFile(size_t currentIteration) const;
 
   /**
    * Creates the .pvtu file for rank data that references all rank data vtu files from this timestep

--- a/examples/md-flexible/src/ParallelVtkWriter.h
+++ b/examples/md-flexible/src/ParallelVtkWriter.h
@@ -131,11 +131,14 @@ class ParallelVtkWriter {
   void createPvtuFile(size_t currentIteration);
 
   /**
-   * Creates the .pvts file required to load structured grid data from multiple ranks into ParaView.
+   * Creates the .pvtu file for rank data that references all rank data vtu files from this timestep
+   *
+   * @note For visualization in ParaView the .pvtu files need to be loaded.
+   *
    * @param currentIteration: The simulation's current iteration.
    * @param decomposition: The decomposition of the domain.
    */
-  void createPvtsFile(size_t currentIteration, const RegularGridDecomposition &decomposition);
+  void createRanksPvtuFile(size_t currentIteration, const RegularGridDecomposition &decomposition) const;
 
   /**
    * Tries to create a folder at a location.

--- a/examples/md-flexible/src/ParallelVtkWriter.h
+++ b/examples/md-flexible/src/ParallelVtkWriter.h
@@ -150,9 +150,11 @@ class ParallelVtkWriter {
 
   /**
    * Generates the file name for a given vtk file type.
+   * @param tag String tag that is inserted in the file name
    * @param currentIteration: The current iteration to record.
-   * @param filetype: The vtk file type extension. Pass the extension without the '.'.
-   * @param filenameStream: The output string string for the filename.
+   * @param fileExtension: The vtk file type extension. Pass the extension without the '.'.
+   * @param filenameStream: The output string for the filename.
    */
-  void generateFilename(const std::string &filetype, size_t currentIteration, std::ostringstream &filenameStream);
+  void generateFilename(const std::string &tag, const std::string &fileExtension, size_t currentIteration,
+                        std::ostringstream &filenameStream) const;
 };

--- a/examples/md-flexible/src/configuration/MDFlexConfig.cpp
+++ b/examples/md-flexible/src/configuration/MDFlexConfig.cpp
@@ -86,7 +86,7 @@ size_t getNumPiecesInCheckpoint(const std::string &filename) {
  * Loads the particles from a checkpoint written with a specific rank.
  * @param filename The name of the pvtu file.
  * @param rank The rank which created the respective vtu file.
- * @param particles Container for the particles recorded in the respective vts file.
+ * @param particles Container for the particles recorded in the respective vtu file.
  */
 void loadParticlesFromRankRecord(std::string_view filename, const size_t &rank, std::vector<ParticleType> &particles) {
   // Parse filename into path and filename: some/long/path/filename


### PR DESCRIPTION
# Description

- [x] VTK files for Rank information is now in `UnstructuredGrid` (before `StructuredGrid`)
- [x] Add tags to the filenames to better indicate their contents (`Particles`, `Ranks`)
- [x] `const` (almost) all functions in the `ParallelVTKWriter`.
- [x] Converter script from the old file format to the new.

## ~Related Pull Requests~

## Resolved Issues 

The issue was that Paraview would not render surfaces of rank boxes that aren't at the outside of the full domain box (or short: inner surfaces are invisible). It turns out this is a "feature" of the `StructuredGrid`. For us, this is highly undesirable because we want to visualize all volumes. With `UnstructuredGrid` Paraview renders everything.

# How Has This Been Tested?

1. Create some output:
   ```bash
   mpirun -n 4 md-flexible --particles-per-dimension 20 --vtk-filename foo --vtk-write-frequency 1
   ```
2. Check output/foo
3. Load everything into Paraview
4. ???
5. Profit
