### PR TITLE
Fix `FuzzyTuningTest::testParseRuleFile()`

### DIFF
--- a/tests/testAutopas/tests/tuning/tuningStrategy/fuzzyTuning/FuzzyTuningTest.cpp
+++ b/tests/testAutopas/tests/tuning/tuningStrategy/fuzzyTuning/FuzzyTuningTest.cpp
@@ -473,7 +473,7 @@ TEST(FuzzyTuningTest, testMaxDefuzzification) {
 TEST(FuzzyTuningTest, testParseRuleFile) {
   autopas::Logger::create();
 
-  std::string fileContent = R"(
+  const std::string fileContent = R"(
 # Define the settings of the fuzzy control system
 FuzzySystemSettings:
      defuzzificationMethod: "meanOfMaximum"
@@ -509,9 +509,11 @@ if ("homogeneity" == "lower than 0.041") && ("particlesPerCellStdDev" == "lower 
 )";
 
   // make temporary file in /tmp
-  std::string fileName = std::filesystem::temp_directory_path().string() + "/fuzzyRules.frule";
+  const std::string fileName = std::filesystem::temp_directory_path().string() + "/fuzzyRules.frule";
   std::ofstream file(fileName);
   file << fileContent;
+  // make sure the file is written before we use it.
+  file.close();
 
   // parse the file
   autopas::FuzzyTuning tuner{fileName};


### PR DESCRIPTION
# Description

The test writes a rule file and then tries to parse it. The `ofstream` was not closed before parsing thus, it could happen that the file was not written yet. Happend [here](https://github.com/AutoPas/AutoPas/actions/runs/11295866924/job/31419527790?pr=955).

## ~Related Pull Requests~

## Resolved Issues

# How Has This Been Tested?

- [x] CI