### PR TITLE
Adjust the `verlet-skin-radius-per-timestep` in exploding liquid to not lead to too fast particles

### DIFF
--- a/examples/md-flexible/input/explodingLiquid.yaml
+++ b/examples/md-flexible/input/explodingLiquid.yaml
@@ -5,7 +5,7 @@
 # data-layout                      :  [AoS, SoA]
 # newton3                          :  [disabled, enabled]
 verlet-rebuild-frequency         :  10
-verlet-skin-radius-per-timestep  :  0.02
+verlet-skin-radius-per-timestep  :  0.05
 verlet-cluster-size              :  4
 selector-strategy                :  Fastest-Mean-Value
 tuning-strategies                :  [predictive-tuning]


### PR DESCRIPTION
# Description

`verlet-skin-radius-per-timestep` in `explodingLiquid.yaml` is currently set too small leading to fast particle warnings. This pull request simply increases this value.

The new `verlet-skin-radius-per-timestep` is not heavily optimised. But `0.04` leads to fast particle warnings whereas `0.05` does not, so I changed it to `0.05`. 

# How Has This Been Tested?

- [x] Running exploding liquid with a range of `verlet-skin-radius-per-timestep`s.
- [ ] CI
