### PR TITLE
Fix MPI halo exchange for non-periodic BCs

### DIFF
--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -41,8 +41,7 @@ RegularGridDecomposition::RegularGridDecomposition(const MDFlexConfig &configura
   if (_subdomainCount == 1) {
     _mpiCommunicationNeeded = false;
   }
-  std::cout << "Boundaries: " << _boundaryType[0].to_string() << ", " << _boundaryType[1].to_string() << ", "
-            << _boundaryType[2].to_string() << std::endl;
+
   _decomposition = DomainTools::generateDecomposition(_subdomainCount, configuration.subdivideDimension.value);
 
   // For reflection, we interact particles with their 'mirror' only if it would cause a repulsive force. This occurs

--- a/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
@@ -219,8 +219,10 @@ TEST_P(RegularGridDecompositionTest, testExchangeHaloParticles) {
     }();
 
     // Expect halos only between domains, not at global boundaries, when they are not periodic.
-    const auto haloNumber =
-        (localBoxMin[0] == globalMin[0] or localBoxMax[0] == globalMax[0]) ? (numberOfProcesses == 1 ? 0 : 9) : 18;
+    const auto haloNumber = autopas::utils::ArrayMath::isNearRel(localBoxMin, globalMin) or
+                                    autopas::utils::ArrayMath::isNearRel(localBoxMax, globalMax)
+                                ? (numberOfProcesses == 1 ? 0 : 9)
+                                : 18;
 
     EXPECT_EQ(autoPasContainer->getNumberOfParticles(autopas::IteratorBehavior::halo), haloNumber);
   }
@@ -228,9 +230,7 @@ TEST_P(RegularGridDecompositionTest, testExchangeHaloParticles) {
 
 INSTANTIATE_TEST_SUITE_P(TestHaloParticles, RegularGridDecompositionTest,
                          testing::Values(options::BoundaryTypeOption::periodic, options::BoundaryTypeOption::reflective,
-                                         options::BoundaryTypeOption::none)
-                         //    ,RegularGridDecompositionTest::PrintToStringParamName());
-);
+                                         options::BoundaryTypeOption::none));
 
 /**
  * This test is designed to check if particles are properly being migrated.

--- a/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
@@ -18,13 +18,13 @@ extern template class autopas::AutoPas<ParticleType>;
 
 /**
  * Generate a simulation setup depending on the number of MPI ranks available.
+ * The domain will be a stacked tower along the x-axis.
  * @return tuple(autoPasContainer, domainDecomposition)
  */
 auto initDomain(options::BoundaryTypeOption boundaryType) {
   const int numberOfProcesses = []() {
     int result;
     autopas::AutoPas_MPI_Comm_size(AUTOPAS_MPI_COMM_WORLD, &result);
-    std::cout << "Process size: " << result << std::endl;
     return result;
   }();
 

--- a/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
@@ -20,10 +20,11 @@ extern template class autopas::AutoPas<ParticleType>;
  * Generate a simulation setup depending on the number of MPI ranks available.
  * @return tuple(autoPasContainer, domainDecomposition)
  */
-auto initDomain() {
+auto initDomain(options::BoundaryTypeOption boundaryType) {
   const int numberOfProcesses = []() {
     int result;
     autopas::AutoPas_MPI_Comm_size(AUTOPAS_MPI_COMM_WORLD, &result);
+    std::cout << "Process size: " << result << std::endl;
     return result;
   }();
 
@@ -34,12 +35,12 @@ auto initDomain() {
   configuration.verletRebuildFrequency.value = 2;
   const double interactionLength = configuration.cutoff.value + configuration.verletSkinRadiusPerTimestep.value *
                                                                     configuration.verletRebuildFrequency.value;
-  // make sure evey rank gets exactly 3x3x3 cells
+  // make sure evey rank gets exactly 3x3x3 cells, domain split along x-axis
   const double localBoxLength = 3. * interactionLength;
   const double globalBoxLength = localBoxLength * numberOfProcesses;
-  configuration.boxMax.value = {globalBoxLength, globalBoxLength, globalBoxLength};
-  configuration.boundaryOption.value = {options::BoundaryTypeOption::periodic, options::BoundaryTypeOption::periodic,
-                                        options::BoundaryTypeOption::periodic};
+  configuration.subdivideDimension.value = {true, false, false};
+  configuration.boxMax.value = {globalBoxLength, localBoxLength, localBoxLength};
+  configuration.boundaryOption.value = {boundaryType, boundaryType, boundaryType};
 
   auto domainDecomposition = std::make_shared<RegularGridDecomposition>(configuration);
   const auto &localBoxMin = domainDecomposition->getLocalBoxMin();
@@ -136,9 +137,12 @@ auto generatePositionsOutsideDomain(const autopas::AutoPas<ParticleType> &autoPa
   return positions;
 }
 
+/**
+ * Check if RegularGridDecomposition correctly splits the global domain into equal sized subdomains.
+ */
 TEST_F(RegularGridDecompositionTest, testGetLocalDomain) {
   using namespace autopas::utils::ArrayMath::literals;
-  auto [autoPasContainer, domainDecomposition] = initDomain();
+  auto [autoPasContainer, domainDecomposition] = initDomain(options::BoundaryTypeOption::periodic);
 
   const auto globalBoxExtend = domainDecomposition->getGlobalBoxMax() - domainDecomposition->getGlobalBoxMin();
   const auto decomposition = domainDecomposition->getDecomposition();
@@ -161,8 +165,9 @@ TEST_F(RegularGridDecompositionTest, testGetLocalDomain) {
  * Create a grid of particles at the border of each rank, then check if halo particles appear in the expected positions
  * and nowhere else.
  */
-TEST_F(RegularGridDecompositionTest, testExchangeHaloParticles) {
-  auto [autoPasContainer, domainDecomposition] = initDomain();
+TEST_P(RegularGridDecompositionTest, testExchangeHaloParticles) {
+  const auto boundaryType = GetParam();
+  auto [autoPasContainer, domainDecomposition] = initDomain(boundaryType);
   const auto &localBoxMin = autoPasContainer->getBoxMin();
   const auto &localBoxMax = autoPasContainer->getBoxMax();
 
@@ -191,18 +196,35 @@ TEST_F(RegularGridDecompositionTest, testExchangeHaloParticles) {
   EXPECT_EQ(autoPasContainer->getNumberOfParticles(autopas::IteratorBehavior::owned), 27)
       << "Owned particles missing after halo exchange!";
 
-  // expect particles to be all around the box since every particle creates multiple halo particles.
-  const auto expectedHaloParticlePositions = generatePositionsOutsideDomain(*autoPasContainer);
-  ASSERT_EQ(expectedHaloParticlePositions.size(), 98) << "Expectation setup faulty!";
+  if (boundaryType == options::BoundaryTypeOption::periodic) {
+    // expect particles to be all around the box since every particle creates multiple halo particles.
+    const auto expectedHaloParticlePositions = generatePositionsOutsideDomain(*autoPasContainer);
+    ASSERT_EQ(expectedHaloParticlePositions.size(), 98) << "Expectation setup faulty!";
 
-  EXPECT_EQ(autoPasContainer->getNumberOfParticles(autopas::IteratorBehavior::halo),
-            expectedHaloParticlePositions.size());
+    EXPECT_EQ(autoPasContainer->getNumberOfParticles(autopas::IteratorBehavior::halo),
+              expectedHaloParticlePositions.size());
 
-  for (auto particleIter = autoPasContainer->begin(autopas::IteratorBehavior::halo); particleIter.isValid();
-       ++particleIter) {
-    EXPECT_THAT(expectedHaloParticlePositions, ::testing::Contains(particleIter->getR()));
+    for (auto particleIter = autoPasContainer->begin(autopas::IteratorBehavior::halo); particleIter.isValid();
+         ++particleIter) {
+      EXPECT_THAT(expectedHaloParticlePositions, ::testing::Contains(particleIter->getR()));
+         }
+  } else {
+    const auto globalMin = domainDecomposition->getGlobalBoxMin();
+    const auto globalMax = domainDecomposition->getGlobalBoxMax();
+
+    // Expect halos only between domains, not at global boundaries, when they are not periodic.
+    const auto haloNumber = (localBoxMin[0] == globalMin[0] or localBoxMax[0] == globalMax[0]) ? 9 : 18;
+
+    EXPECT_EQ(autoPasContainer->getNumberOfParticles(autopas::IteratorBehavior::halo), haloNumber);
   }
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    TestHaloParticles, RegularGridDecompositionTest,
+    testing::Values(options::BoundaryTypeOption::periodic, options::BoundaryTypeOption::reflective, options::BoundaryTypeOption::none)
+    //    ,RegularGridDecompositionTest::PrintToStringParamName());
+);
+
 
 /**
  * This test is designed to check if particles are properly being migrated.
@@ -210,7 +232,7 @@ TEST_F(RegularGridDecompositionTest, testExchangeHaloParticles) {
  * For more information see the comments in the test.
  */
 TEST_F(RegularGridDecompositionTest, testExchangeMigratingParticles) {
-  auto [autoPasContainer, domainDecomposition] = initDomain();
+  auto [autoPasContainer, domainDecomposition] = initDomain(options::BoundaryTypeOption::periodic);
 
   const auto positionsOutsideSubdomain = generatePositionsOutsideDomain(*autoPasContainer);
   ASSERT_THAT(positionsOutsideSubdomain, ::testing::SizeIs(98));

--- a/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
@@ -207,7 +207,7 @@ TEST_P(RegularGridDecompositionTest, testExchangeHaloParticles) {
     for (auto particleIter = autoPasContainer->begin(autopas::IteratorBehavior::halo); particleIter.isValid();
          ++particleIter) {
       EXPECT_THAT(expectedHaloParticlePositions, ::testing::Contains(particleIter->getR()));
-         }
+    }
   } else {
     const auto globalMin = domainDecomposition->getGlobalBoxMin();
     const auto globalMax = domainDecomposition->getGlobalBoxMax();
@@ -219,12 +219,11 @@ TEST_P(RegularGridDecompositionTest, testExchangeHaloParticles) {
   }
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    TestHaloParticles, RegularGridDecompositionTest,
-    testing::Values(options::BoundaryTypeOption::periodic, options::BoundaryTypeOption::reflective, options::BoundaryTypeOption::none)
-    //    ,RegularGridDecompositionTest::PrintToStringParamName());
+INSTANTIATE_TEST_SUITE_P(TestHaloParticles, RegularGridDecompositionTest,
+                         testing::Values(options::BoundaryTypeOption::periodic, options::BoundaryTypeOption::reflective,
+                                         options::BoundaryTypeOption::none)
+                         //    ,RegularGridDecompositionTest::PrintToStringParamName());
 );
-
 
 /**
  * This test is designed to check if particles are properly being migrated.

--- a/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
+++ b/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.cpp
@@ -212,8 +212,15 @@ TEST_P(RegularGridDecompositionTest, testExchangeHaloParticles) {
     const auto globalMin = domainDecomposition->getGlobalBoxMin();
     const auto globalMax = domainDecomposition->getGlobalBoxMax();
 
+    const int numberOfProcesses = []() {
+      int result;
+      autopas::AutoPas_MPI_Comm_size(AUTOPAS_MPI_COMM_WORLD, &result);
+      return result;
+    }();
+
     // Expect halos only between domains, not at global boundaries, when they are not periodic.
-    const auto haloNumber = (localBoxMin[0] == globalMin[0] or localBoxMax[0] == globalMax[0]) ? 9 : 18;
+    const auto haloNumber =
+        (localBoxMin[0] == globalMin[0] or localBoxMax[0] == globalMax[0]) ? (numberOfProcesses == 1 ? 0 : 9) : 18;
 
     EXPECT_EQ(autoPasContainer->getNumberOfParticles(autopas::IteratorBehavior::halo), haloNumber);
   }

--- a/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.h
+++ b/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.h
@@ -8,11 +8,13 @@
 #include <gtest/gtest.h>
 
 #include "AutoPasTestBase.h"
+#include "src/options/BoundaryTypeOption.h"
 
 /**
  * Test class for the RegularGridDecomposition domain decomposition class.
  */
-class RegularGridDecompositionTest : public AutoPasTestBase {
+class RegularGridDecompositionTest : public AutoPasTestBase,
+                                      public ::testing::WithParamInterface<options::BoundaryTypeOption> {
  public:
   /**
    * Constructor.

--- a/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.h
+++ b/examples/md-flexible/tests/domainDecomposition/RegularGridDecompositionTest.h
@@ -14,7 +14,7 @@
  * Test class for the RegularGridDecomposition domain decomposition class.
  */
 class RegularGridDecompositionTest : public AutoPasTestBase,
-                                      public ::testing::WithParamInterface<options::BoundaryTypeOption> {
+                                     public ::testing::WithParamInterface<options::BoundaryTypeOption> {
  public:
   /**
    * Constructor.


### PR DESCRIPTION
# Description

In the case of more than one MPI domain, md-flexible creates halo particles around the global boundaries, even when the boundaries are non-periodic.
This leads to wrong results, as interactions with these wrongly created halo particles will still be done.

# How Has This Been Tested?

Extended the test for halo particle exchange to test also  for boundaries `reflective` and `none`

