### PR TITLE
Thermostat for multi-site molecules fix

### DIFF
--- a/examples/md-flexible/src/Thermostat.h
+++ b/examples/md-flexible/src/Thermostat.h
@@ -77,12 +77,19 @@ auto calcTemperatureComponent(const AutoPasTemplate &autopas,
   using autopas::utils::ArrayMath::dot;
   using namespace autopas::utils::ArrayMath::literals;
 
+  const auto numberComponents =
+#if MD_FLEXIBLE_MODE == SINGLESITE
+      particlePropertiesLibrary.getNumberRegisteredSiteTypes();
+#elif MD_FLEXIBLE_MODE == MULTISITE
+      particlePropertiesLibrary.getNumberRegisteredMolTypes();
+#endif
+
   // map of: particle typeID -> kinetic energy times 2 for this type
   std::map<size_t, double> kineticEnergyMul2Map;
   // map of: particle typeID -> number of particles of this type
   std::map<size_t, size_t> numParticleMap;
 
-  for (int typeID = 0; typeID < particlePropertiesLibrary.getNumberRegisteredSiteTypes(); typeID++) {
+  for (int typeID = 0; typeID < numberComponents; typeID++) {
     kineticEnergyMul2Map[typeID] = 0.;
     numParticleMap[typeID] = 0ul;
   }
@@ -91,7 +98,7 @@ auto calcTemperatureComponent(const AutoPasTemplate &autopas,
     // create aggregators for each thread
     std::map<size_t, double> kineticEnergyMul2MapThread;
     std::map<size_t, size_t> numParticleMapThread;
-    for (int typeID = 0; typeID < particlePropertiesLibrary.getNumberRegisteredSiteTypes(); typeID++) {
+    for (int typeID = 0; typeID < numberComponents; typeID++) {
       kineticEnergyMul2MapThread[typeID] = 0.;
       numParticleMapThread[typeID] = 0ul;
     }
@@ -110,7 +117,7 @@ auto calcTemperatureComponent(const AutoPasTemplate &autopas,
     }
     // manual reduction
     AUTOPAS_OPENMP(critical) {
-      for (int typeID = 0; typeID < particlePropertiesLibrary.getNumberRegisteredSiteTypes(); typeID++) {
+      for (int typeID = 0; typeID < numberComponents; typeID++) {
         kineticEnergyMul2Map[typeID] += kineticEnergyMul2MapThread[typeID];
         numParticleMap[typeID] += numParticleMapThread[typeID];
       }
@@ -123,7 +130,7 @@ auto calcTemperatureComponent(const AutoPasTemplate &autopas,
   constexpr unsigned int degreesOfFreedom{3};
 #endif
 
-  for (int typeID = 0; typeID < particlePropertiesLibrary.getNumberRegisteredSiteTypes(); typeID++) {
+  for (int typeID = 0; typeID < numberComponents; typeID++) {
     // workaround for MPICH: send and receive buffer must not be the same.
     autopas::AutoPas_MPI_Allreduce(AUTOPAS_MPI_IN_PLACE, &kineticEnergyMul2Map[typeID], 1, AUTOPAS_MPI_DOUBLE,
                                    AUTOPAS_MPI_SUM, AUTOPAS_MPI_COMM_WORLD);
@@ -173,7 +180,14 @@ void addBrownianMotion(AutoPasTemplate &autopas, ParticlePropertiesLibraryTempla
   std::map<size_t, double> translationalVelocityScale;
   std::map<size_t, std::array<double, 3>> rotationalVelocityScale;
 
-  for (int typeID = 0; typeID < particlePropertiesLibrary.getNumberRegisteredSiteTypes(); typeID++) {
+  const auto numberComponents =
+#if MD_FLEXIBLE_MODE == SINGLESITE
+      particlePropertiesLibrary.getNumberRegisteredSiteTypes();
+#elif MD_FLEXIBLE_MODE == MULTISITE
+      particlePropertiesLibrary.getNumberRegisteredMolTypes();
+#endif
+
+  for (int typeID = 0; typeID < numberComponents; typeID++) {
     translationalVelocityScale.emplace(typeID,
                                        std::sqrt(targetTemperature / particlePropertiesLibrary.getMolMass(typeID)));
 #if MD_FLEXIBLE_MODE == MULTISITE

--- a/examples/md-flexible/tests/ThermostatTest.cpp
+++ b/examples/md-flexible/tests/ThermostatTest.cpp
@@ -137,7 +137,7 @@ TEST_F(ThermostatTest, MultiComponentTest) {
   std::vector<double> scalingFactors{};
   scalingFactors.reserve(temperatureMap.size());
   for (size_t i = 0; i < temperatureMap.size(); ++i) {
-    scalingFactors[i] = std::sqrt(targetTemperature2/temperatureMap[i]);
+    scalingFactors[i] = std::sqrt(targetTemperature2 / temperatureMap[i]);
   }
 
   // apply thermostat
@@ -156,7 +156,6 @@ TEST_F(ThermostatTest, MultiComponentTest) {
       EXPECT_NEAR(iter->getV()[dim], iter->getOldF()[dim] * scalingFactors[iter->getTypeId()], 1e-12);
     }
   }
-
 }
 
 /**

--- a/examples/md-flexible/tests/ThermostatTest.h
+++ b/examples/md-flexible/tests/ThermostatTest.h
@@ -24,6 +24,7 @@ class ThermostatTest : public AutoPasTestBase,
     _particlePropertiesLibrary.addMolType(0, {0}, {{0., 0., 0.}}, {1., 1., 1.});
     _particlePropertiesLibrary.addMolType(1, {0, 0, 1}, {{0., -0.05, 0.}, {0.5, 0., 0.}, {0., 0.25, 0.25}},
                                           {1., 1., 1.});
+    _particlePropertiesLibrary.addMolType(2, {1}, {{0., 0., 0.}}, {1., 1., 1.});
 #endif
     _particlePropertiesLibrary.calculateMixingCoefficients();
   }


### PR DESCRIPTION
# Description

Previously, the handling of the thermostat with multiple multi-site molecule types was incorrect. This PR fixes this issue and extends the relevant unit test to ensure such a mistake is not repeated. In particular, the unit test was changes such that #molecule types != #site types in the multi-site case and the unit test actually checks the particle's velocities has appropriately changed as opposed to purely relying on the Thermostat classes `calcTemperatureComponent` function.

## Resolved Issues

- [x] fixes #962 

# How Has This Been Tested?

- [ ] CI with existing unit tests including the extended `Thermostat::MultiComponentTest`.
- [ ] The coverage report shows all relevant lines are tested.
