### PR TITLE
Fixing md-flexible's calculation of Globals

### DIFF
--- a/.github/workflows/TestSuites.yaml
+++ b/.github/workflows/TestSuites.yaml
@@ -119,7 +119,6 @@ jobs:
             -DMD_FLEXIBLE_USE_MPI=${UseMPI} \
             -DMD_FLEXIBLE_MODE=${{ matrix.md-flex-mode }} \
             -DMD_FLEXIBLE_FUNCTOR_AUTOVEC=ON \
-            -DMD_FLEXIBLE_FUNCTOR_AUTOVEC_GLOBALS=OFF \
             -DMD_FLEXIBLE_FUNCTOR_AVX=${{ matrix.config[8] }} \
             -DMD_FLEXIBLE_FUNCTOR_SVE=OFF \
             -DMD_FLEXIBLE_ENABLE_ALLLBL=${UseMPI} \
@@ -130,7 +129,7 @@ jobs:
           entrypoint.sh cmake --build . --parallel 8 
       - name: Run tests ${{ matrix.part }}/2
         run: |
-          # If single-site & No MPI, run every other AutoPas and example test
+          # If single-site & No MPI, run every other AutoPas and example tests
           if [[ "${{ matrix.md-flex-mode }}" = 'singlesite' ]] && [[ "${{ matrix.config[1] }}" != 'mpicc' ]]
           then
             cd build

--- a/examples/md-flexible/CMakeLists.txt
+++ b/examples/md-flexible/CMakeLists.txt
@@ -16,18 +16,18 @@ option(MD_FLEXIBLE_USE_MPI "Enable MPI parallelism for md-flexible." OFF)
 
 target_link_libraries(md-flexible PUBLIC autopas autopasTools molecularDynamicsLibrary yaml-cpp  ${ALL_LIB} $<$<BOOL:${MD_FLEXIBLE_USE_MPI}>:MPI::MPI_CXX>)
 
-option(MD_FLEXIBLE_FUNCTOR_AUTOVEC "Compile AutoVec Functor without calculation of global values." OFF)
-option(MD_FLEXIBLE_FUNCTOR_AUTOVEC_GLOBALS "Compile AutoVec Functor with calculation of global values." OFF)
-option(MD_FLEXIBLE_FUNCTOR_AVX "If instruction set is available, compile AVX Functor without calculation of global values." ON)
-option(MD_FLEXIBLE_FUNCTOR_SVE "If instruction set is available, compile SVE Functor without calculation of global values." ON)
+option(MD_FLEXIBLE_FUNCTOR_AUTOVEC "Compile AutoVec Functor." OFF)
+option(MD_FLEXIBLE_FUNCTOR_AVX "If instruction set is available, compile AVX Functor." ON)
+option(MD_FLEXIBLE_FUNCTOR_SVE "If instruction set is available, compile SVE Functor." ON)
+option(MD_FLEXIBLE_CALC_GLOBALS "Compiles md-flexible Functors with calculation of globals, including calculation of shift offset." OFF)
 
 target_compile_definitions(
         md-flexible
         PUBLIC
         $<$<BOOL:${MD_FLEXIBLE_FUNCTOR_AUTOVEC}>:MD_FLEXIBLE_FUNCTOR_AUTOVEC>
-        $<$<BOOL:${MD_FLEXIBLE_FUNCTOR_AUTOVEC_GLOBALS}>:MD_FLEXIBLE_FUNCTOR_AUTOVEC_GLOBALS>
         $<$<BOOL:${MD_FLEXIBLE_FUNCTOR_AVX}>:MD_FLEXIBLE_FUNCTOR_AVX>
         $<$<BOOL:${MD_FLEXIBLE_FUNCTOR_SVE}>:MD_FLEXIBLE_FUNCTOR_SVE>
+        $<$<BOOL:${MD_FLEXIBLE_CALC_GLOBALS}>:MD_FLEXIBLE_CALC_GLOBALS>
 )
 
 # --- display warnings if single-/multi-site mode is used with a functor type that has not been implemented ---

--- a/examples/md-flexible/src/TypeDefinitions.h
+++ b/examples/md-flexible/src/TypeDefinitions.h
@@ -79,15 +79,14 @@ constexpr bool calcGlobals =
  * MD_FLEXIBLE_MODE.
  */
 #if MD_FLEXIBLE_MODE == MULTISITE
-using LJFunctorTypeAutovec = mdLib::LJMultisiteFunctor<ParticleType, true, true, autopas::FunctorN3Modes::Both, calcGlobals,
-                                                       mdFlexibleTypeDefs::countFLOPs>;
+using LJFunctorTypeAutovec = mdLib::LJMultisiteFunctor<ParticleType, true, true, autopas::FunctorN3Modes::Both,
+                                                       calcGlobals, mdFlexibleTypeDefs::countFLOPs>;
 #else
-using LJFunctorTypeAutovec =
-    mdLib::LJFunctor<ParticleType, true, true, autopas::FunctorN3Modes::Both, mdFlexibleTypeDefs::calcGlobals, mdFlexibleTypeDefs::countFLOPs>;
+using LJFunctorTypeAutovec = mdLib::LJFunctor<ParticleType, true, true, autopas::FunctorN3Modes::Both,
+                                              mdFlexibleTypeDefs::calcGlobals, mdFlexibleTypeDefs::countFLOPs>;
 #endif
 
 #endif
-
 
 #if defined(MD_FLEXIBLE_FUNCTOR_AVX)
 /**
@@ -99,8 +98,8 @@ using LJFunctorTypeAutovec =
 #if MD_FLEXIBLE_MODE == MULTISITE
 #error "Multi-Site Lennard-Jones Functor does not have AVX support!"
 #else
-using LJFunctorTypeAVX =
-    mdLib::LJFunctorAVX<ParticleType, true, true, autopas::FunctorN3Modes::Both, mdFlexibleTypeDefs::calcGlobals, mdFlexibleTypeDefs::countFLOPs>;
+using LJFunctorTypeAVX = mdLib::LJFunctorAVX<ParticleType, true, true, autopas::FunctorN3Modes::Both,
+                                             mdFlexibleTypeDefs::calcGlobals, mdFlexibleTypeDefs::countFLOPs>;
 #endif
 
 #endif
@@ -115,8 +114,8 @@ using LJFunctorTypeAVX =
 #if MD_FLEXIBLE_MODE == MULTISITE
 #error "Multi-Site Lennard-Jones Functor does not have SVE support!"
 #else
-using LJFunctorTypeSVE =
-    mdLib::LJFunctorSVE<ParticleType, true, true, autopas::FunctorN3Modes::Both, mdFlexibleTypeDefs::calcGlobals, mdFlexibleTypeDefs::countFLOPs>;
+using LJFunctorTypeSVE = mdLib::LJFunctorSVE<ParticleType, true, true, autopas::FunctorN3Modes::Both,
+                                             mdFlexibleTypeDefs::calcGlobals, mdFlexibleTypeDefs::countFLOPs>;
 #endif
 
 #endif

--- a/examples/md-flexible/src/TypeDefinitions.h
+++ b/examples/md-flexible/src/TypeDefinitions.h
@@ -60,6 +60,16 @@ constexpr bool countFLOPs =
 #else
     false;
 #endif
+
+/**
+ * If md-flexible is compiled with globals calculations enabled, use functors which calculate globals.
+ */
+constexpr bool calcGlobals =
+#ifdef MD_FLEXIBLE_CALC_GLOBALS
+    true;
+#else
+    false;
+#endif
 }  // namespace mdFlexibleTypeDefs
 
 #if defined(MD_FLEXIBLE_FUNCTOR_AUTOVEC)
@@ -69,30 +79,15 @@ constexpr bool countFLOPs =
  * MD_FLEXIBLE_MODE.
  */
 #if MD_FLEXIBLE_MODE == MULTISITE
-using LJFunctorTypeAutovec = mdLib::LJMultisiteFunctor<ParticleType, true, true, autopas::FunctorN3Modes::Both, false,
+using LJFunctorTypeAutovec = mdLib::LJMultisiteFunctor<ParticleType, true, true, autopas::FunctorN3Modes::Both, calcGlobals,
                                                        mdFlexibleTypeDefs::countFLOPs>;
 #else
 using LJFunctorTypeAutovec =
-    mdLib::LJFunctor<ParticleType, true, true, autopas::FunctorN3Modes::Both, false, mdFlexibleTypeDefs::countFLOPs>;
+    mdLib::LJFunctor<ParticleType, true, true, autopas::FunctorN3Modes::Both, mdFlexibleTypeDefs::calcGlobals, mdFlexibleTypeDefs::countFLOPs>;
 #endif
 
 #endif
 
-#if defined(MD_FLEXIBLE_FUNCTOR_AUTOVEC_GLOBALS)
-/**
- * Type of LJFunctorTypeAutovecGlobals used in md-flexible.
- * Switches between mdLib::LJFunctor and mdLib::LJMultisiteFunctor as determined by CMake flag
- * MD_FLEXIBLE_MODE.
- */
-#if MD_FLEXIBLE_MODE == MULTISITE
-using LJFunctorTypeAutovecGlobals = mdLib::LJMultisiteFunctor<ParticleType, true, true, autopas::FunctorN3Modes::Both,
-                                                              true, mdFlexibleTypeDefs::countFLOPs>;
-#else
-using LJFunctorTypeAutovecGlobals =
-    mdLib::LJFunctor<ParticleType, true, true, autopas::FunctorN3Modes::Both, true, mdFlexibleTypeDefs::countFLOPs>;
-#endif
-
-#endif
 
 #if defined(MD_FLEXIBLE_FUNCTOR_AVX)
 /**
@@ -105,7 +100,7 @@ using LJFunctorTypeAutovecGlobals =
 #error "Multi-Site Lennard-Jones Functor does not have AVX support!"
 #else
 using LJFunctorTypeAVX =
-    mdLib::LJFunctorAVX<ParticleType, true, true, autopas::FunctorN3Modes::Both, true, mdFlexibleTypeDefs::countFLOPs>;
+    mdLib::LJFunctorAVX<ParticleType, true, true, autopas::FunctorN3Modes::Both, mdFlexibleTypeDefs::calcGlobals, mdFlexibleTypeDefs::countFLOPs>;
 #endif
 
 #endif
@@ -121,7 +116,7 @@ using LJFunctorTypeAVX =
 #error "Multi-Site Lennard-Jones Functor does not have SVE support!"
 #else
 using LJFunctorTypeSVE =
-    mdLib::LJFunctorSVE<ParticleType, true, true, autopas::FunctorN3Modes::Both, true, mdFlexibleTypeDefs::countFLOPs>;
+    mdLib::LJFunctorSVE<ParticleType, true, true, autopas::FunctorN3Modes::Both, mdFlexibleTypeDefs::calcGlobals, mdFlexibleTypeDefs::countFLOPs>;
 #endif
 
 #endif


### PR DESCRIPTION
# Description

md-flexible currently compiles the calculate globals version of the AVX and SVE functors, despite the CMake variable description suggesting otherwise. Furthermore, it is not suitable that global calculations cannot be switched on and off for the AVX and SVE functors anyway.

This PR creates a separate CMake variable for switching on and off globals calculations and removes the `MD_FLEXIBLE_FUNCTOR_AUTOVEC_GLOBALS` CMake variable as it is now redundant. 

Shifting is always applied when globals are calculated. The reasoning for this is

- This PR provides a high-priority fix, so I don't want to add any unnecessary features.
- Even with the existing AutoVec globals functors, we always applied shift, so this never was a feature in md-flexible.
- Applying shift is not expected to impose a significant performance cost.

## Resolved Issues

- [x] fixes #964 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Current CI
- [x] Testing compiling md-flexible with globals on and off for both the AutoVec and AVX functors

The SVE functor has not been tested because there is a separate bug there. As the AVX fix is a high priority, and the SVE fix is a low priority, I do not wish to wait for that separate fix to be merged.
