### PR TITLE
Fix SVE Functor

### DIFF
--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorSVE.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorSVE.h
@@ -73,7 +73,7 @@ class LJFunctorSVE : public autopas::Functor<Particle, LJFunctorSVE<Particle, ap
       _aosThreadData.resize(autopas::autopas_get_max_threads());
     }
     if constexpr (countFLOPs) {
-      AutoPasLog(DEBUG, "Using LJFunctorSVE with countFLOPs but FLOP counting is not implemented."););
+      AutoPasLog(DEBUG, "Using LJFunctorSVE with countFLOPs but FLOP counting is not implemented.");
     }
   }
 #else

--- a/applicationLibrary/molecularDynamics/tests/singleSiteTests/LJFunctorTestVs.cpp
+++ b/applicationLibrary/molecularDynamics/tests/singleSiteTests/LJFunctorTestVs.cpp
@@ -47,10 +47,8 @@ TYPED_TEST_P(LJFunctorTestVs, testSetPropertiesVSPPLSoA) {
 
   for (size_t i = 0; i < numParticlesPerCell; ++i) {
     for (size_t j = 0; j < 3; ++j) {
-      EXPECT_EQ(cell1NoPPL[i], cell1PPL[i]) << "cell1NoPPL[i] = " << cell1NoPPL[i].toString() << std::endl
-                                            << "cell1PPL[i] = " << cell1PPL[i].toString();
-      EXPECT_EQ(cell2NoPPL[i], cell2PPL[i]) << "cell2NoPPL[i] = " << cell2NoPPL[i].toString() << std::endl
-                                            << "cell2PPL[i] = " << cell2PPL[i].toString();
+      EXPECT_NEAR(cell1NoPPL[i].getF()[j], cell1PPL[i].getF()[j], 1e-13);
+      EXPECT_NEAR(cell2NoPPL[i].getF()[j], cell2PPL[i].getF()[j], 1e-13);
     }
   }
 }


### PR DESCRIPTION
# Description

Fixes compilation of SVE functor. Furthermore, it fixes tests comparing with and without PPL versions of the SVE functor by providing some margin for floating point error.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] CI
- [x] Compilation of `all` followed by `ctest` (i.e. all tests tested) on the ARM minicluster
