### PR TITLE
Fixing homogeneity in zero particle scenario

### DIFF
--- a/src/autopas/utils/SimilarityFunctions.h
+++ b/src/autopas/utils/SimilarityFunctions.h
@@ -19,6 +19,9 @@ namespace autopas::utils {
  * homogeneity > 0.0, normally < 1.0, but for extreme scenarios > 1.0
  * maxDensity > 0.0, normally < 3.0, but for extreme scenarios > 3.0
  *
+ * A homogeneity of 0 describes a perfectly homogeneous scenario, and as the scenario becomes more heterogeneous, this
+ * becomes greater. If there are no particles, homogeneity is forced as 0 as this scenario is perfectly homogeneous.
+ *
  * These values are calculated by dividing the container's domain into bins of perfectly equal cuboid shapes.
  *
  * @note The bin shapes between different AutoPas containers will not match if the dimensions of their domains don't
@@ -119,8 +122,9 @@ std::pair<double, double> calculateHomogeneityAndMaxDensity(const ParticleContai
 
   const auto densityVariance = densityDifferenceSquaredSum / numberOfBins;
 
-  // finally calculate standard deviation
-  const double homogeneity = std::sqrt(densityVariance);
+  // finally calculate standard deviation. If there are no particles, the above calculation leads to nan. This should
+  // be forced to 0.
+  const double homogeneity = numberOfParticles == 0 ? 0. : std::sqrt(densityVariance);
   // normally between 0.0 and 1.5
   if (homogeneity < 0.0) {
     utils::ExceptionHandler::exception(


### PR DESCRIPTION
# Description

Forces a homogeneity of 0 (i.e. a perfect homogeneity) in the case that there are no particles in a simulation domain as opposed to the previous `-nan` value.



## Resolved Issues

- [x] fixes #978 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Checking liveInfo output
- [x] CI
