### PR TITLE
Add box padding warning

### DIFF
--- a/examples/md-flexible/src/configuration/MDFlexConfig.cpp
+++ b/examples/md-flexible/src/configuration/MDFlexConfig.cpp
@@ -453,6 +453,8 @@ std::string MDFlexConfig::to_string() const {
 
 void MDFlexConfig::calcSimulationBox() {
   const double interactionLength = cutoff.value + verletSkinRadiusPerTimestep.value * verletRebuildFrequency.value;
+  const auto preBoxMin = boxMin.value;
+  const auto preBoxMax = boxMax.value;
 
   // helper function so that we can do the same for every object collection
   // resizes the domain to the maximal extents of all objects
@@ -476,6 +478,10 @@ void MDFlexConfig::calcSimulationBox() {
   resizeToObjectLimits(cubeUniformObjects);
   resizeToObjectLimits(sphereObjects);
   resizeToObjectLimits(cubeClosestPackedObjects);
+
+  if (boxMin.value != preBoxMin or boxMax.value != preBoxMax) {
+    std::cout << "WARNING: Simulation box increased due to particles being too close to the boundaries." << std::endl;
+  }
 
   // guarantee the box is at least of size interationLength
   for (int i = 0; i < 3; i++) {


### PR DESCRIPTION
# Description

When particles are generated on or close to the simulation box boundaries, we add some padding to avoid particles being too close to the boundary.
This can lead to confusion since the simulation has a different density than expected. I had problems with this myself and many students as well. That's why I think a warning is adequate.

## How was this tested?
- [x] Check manually.
- [x] CI