### PR TITLE
AoS Remiander Traversal

### DIFF
--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctor.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctor.h
@@ -198,7 +198,7 @@ class LJFunctor
    * @copydoc autopas::PairwiseFunctor::SoAFunctorSingle()
    * This functor will always use a newton3 like traversal of the soa.
    */
-  void SoAFunctorSingle(autopas::SoAView<SoAArraysType> soa, bool /*newton3*/) final {
+  void SoAFunctorSingle(autopas::SoAView<SoAArraysType> soa, bool newton3) final {
     if (soa.size() == 0) return;
 
     const auto threadnum = autopas::autopas_get_thread_num();

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctor.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctor.h
@@ -197,9 +197,8 @@ class LJFunctor
   /**
    * @copydoc autopas::PairwiseFunctor::SoAFunctorSingle()
    * This functor will always use a newton3 like traversal of the soa.
-   * However, it still needs to know about newton3 to correctly add up the global values.
    */
-  void SoAFunctorSingle(autopas::SoAView<SoAArraysType> soa, bool newton3) final {
+  void SoAFunctorSingle(autopas::SoAView<SoAArraysType> soa, bool /*newton3*/) final {
     if (soa.size() == 0) return;
 
     const auto threadnum = autopas::autopas_get_thread_num();
@@ -354,8 +353,6 @@ class LJFunctor
       _aosThreadDataFLOPs[threadnum].numGlobalCalcsN3 += numGlobalCalcsSum;  // Always N3 in Single SoAFunctor
     }
     if (calculateGlobals) {
-      const int threadnum = autopas::autopas_get_thread_num();
-
       _aosThreadDataGlobals[threadnum].potentialEnergySum += potentialEnergySum;
       _aosThreadDataGlobals[threadnum].virialSum[0] += virialSumX;
       _aosThreadDataGlobals[threadnum].virialSum[1] += virialSumY;

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorAVX.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorAVX.h
@@ -181,14 +181,9 @@ class LJFunctorAVX
   /**
    * @copydoc autopas::PairwiseFunctor::SoAFunctorSingle()
    * This functor will always do a newton3 like traversal of the soa.
-   * However, it still needs to know about newton3 to correctly add up the global values.
    */
-  inline void SoAFunctorSingle(autopas::SoAView<SoAArraysType> soa, bool newton3) final {
-    if (newton3) {
-      SoAFunctorSingleImpl<true>(soa);
-    } else {
-      SoAFunctorSingleImpl<false>(soa);
-    }
+  inline void SoAFunctorSingle(autopas::SoAView<SoAArraysType> soa, bool /*newton3*/) final {
+    SoAFunctorSingleImpl(soa);
   }
 
   // clang-format off
@@ -208,10 +203,8 @@ class LJFunctorAVX
  private:
   /**
    * Templatized version of SoAFunctorSingle actually doing what the latter should.
-   * @tparam newton3
    * @param soa
    */
-  template <bool newton3>
   inline void SoAFunctorSingleImpl(autopas::SoAView<SoAArraysType> soa) {
 #ifdef __AVX__
     if (soa.size() == 0) return;

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorAVX.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorAVX.h
@@ -182,9 +182,7 @@ class LJFunctorAVX
    * @copydoc autopas::PairwiseFunctor::SoAFunctorSingle()
    * This functor will always do a newton3 like traversal of the soa.
    */
-  inline void SoAFunctorSingle(autopas::SoAView<SoAArraysType> soa, bool /*newton3*/) final {
-    SoAFunctorSingleImpl(soa);
-  }
+  inline void SoAFunctorSingle(autopas::SoAView<SoAArraysType> soa, bool newton3) final { SoAFunctorSingleImpl(soa); }
 
   // clang-format off
   /**

--- a/docs/userdoc/CustomApplications.md
+++ b/docs/userdoc/CustomApplications.md
@@ -34,8 +34,10 @@ These classes suggest how to calculate and store the interactions, as well as so
 The critical elements to implement are:
 - `AoSFunctor()`:
   This function defines how particles interact if both are stored in the Array-of-Structs format, which is exactly what was previously defined as particle class.
+  This always has to be implemented.
 - All versions of `SoAFunctor()`:
   This function defines the same interaction as `AoSFunctor`, but optimized for different data structure layouts.
+  It is possible to not implement this and avoid its usage by never allowing `DataLayout::soa`.
 - `allowsNewton3()` and `allowsNonNewton3()`:
   Indicator functions to tell AutoPas if the functor supports optimizations using Newton's third law of motion.
   Should the functor calculate global forces, e.g. potential energy or virial, this must be implemented in a way that supports a mixture of all supported Newton3 modes within one iteration.

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -101,8 +101,8 @@ Simulation::Simulation(const MDFlexConfig &configuration,
       _configuration.outputSuffix.value.empty() or _configuration.outputSuffix.value.front() == '_' ? "" : "_";
   const auto *fillerAfterSuffix =
       _configuration.outputSuffix.value.empty() or _configuration.outputSuffix.value.back() == '_' ? "" : "_";
-  const auto outputSuffix = "Rank" + std::to_string(rank) + fillerBeforeSuffix +
-                            _configuration.outputSuffix.value + fillerAfterSuffix;
+  const auto outputSuffix =
+      "Rank" + std::to_string(rank) + fillerBeforeSuffix + _configuration.outputSuffix.value + fillerAfterSuffix;
 
   if (_configuration.logFileName.value.empty()) {
     _outputStream = &std::cout;

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -1207,7 +1207,7 @@ void LogicHandler<Particle>::computeRemainderInteractions2B(
   // steps 1 & 2.
   // particleBuffer with all particles close in container
   // and haloParticleBuffer with owned, close particles in container.
-  // This is always AoS based because the contaienr particles are found with region iterators,
+  // This is always AoS-based because the container particles are found with region iterators,
   // which don't have an SoA interface.
   remainderHelperBufferContainerAoS<newton3>(f, container, particleBuffers, haloParticleBuffers);
 
@@ -1389,15 +1389,17 @@ void LogicHandler<Particle>::remainderHelperBufferBufferAoS(PairwiseFunctor *f,
       if (bufferIdxI == bufferIdxJ) {
         // CASE Same buffer
         // Only use Newton3 if it is allowed, and we are working on only one buffer. This avoids data races.
-        const bool useNewton3 = newton3 and bufferIdxI == bufferIdxJ;
-        for (auto i = 0; i < particleBuffers[bufferIdxI].size(); ++i) {
-          auto &p1 = particleBuffers[bufferIdxI][i];
+        const bool useNewton3 = newton3;
+        auto &bufferRef = particleBuffers[bufferIdxI];
+        const auto bufferSize = bufferRef.size();
+        for (auto i = 0; i < bufferSize; ++i) {
+          auto &p1 = bufferRef[i];
           // If Newton3 is disabled run over the whole buffer, otherwise only what is ahead
-          for (auto j = useNewton3 ? i + 1 : 0; j < particleBuffers[bufferIdxJ].size(); ++j) {
+          for (auto j = useNewton3 ? i + 1 : 0; j < bufferSize; ++j) {
             if (i == j) {
               continue;
             }
-            auto &p2 = particleBuffers[bufferIdxJ][j];
+            auto &p2 = bufferRef[j];
             f->AoSFunctor(p1, p2, useNewton3);
           }
         }

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -1524,14 +1524,14 @@ void LogicHandler<Particle>::remainderHelperBufferBufferSoA(PairwiseFunctor *f,
   for (size_t i = 0; i < particleBuffers.size(); ++i) {
     for (size_t jj = 0; jj < particleBuffers.size(); ++jj) {
       auto *particleBufferSoAA = &particleBuffers[i]._particleSoABuffer;
+      // instead of starting every (parallel) iteration i at j == 0 offset them by i to minimize waiting times at locks
       const auto j = (i + jj) % particleBuffers.size();
       if (i == j) {
         // For buffer interactions where bufferA == bufferB we can always enable newton3 if it is allowed.
         f->SoAFunctorSingle(*particleBufferSoAA, newton3);
       } else {
-        // For buffer interactions where bufferA == bufferB we can always enable newton3. For all interactions between
-        // different buffers we turn newton3 always off, which ensures that only one thread at a time is writing to a
-        // buffer. This saves expensive locks.
+        // For all interactions between different buffers we turn newton3 always off,
+        // which ensures that only one thread at a time is writing to a buffer. This saves expensive locks.
         auto *particleBufferSoAB = &particleBuffers[j]._particleSoABuffer;
         f->SoAFunctorPair(*particleBufferSoAA, *particleBufferSoAB, false);
       }

--- a/tests/testAutopas/tests/RemainderTraversalTest.cpp
+++ b/tests/testAutopas/tests/RemainderTraversalTest.cpp
@@ -30,7 +30,7 @@ void testIteratePairwiseSteps(std::vector<Molecule> &particlesContainerOwned,
                               std::vector<Molecule> &particlesContainerHalo,
                               std::vector<autopas::FullParticleCell<Molecule>> &particlesBuffers,
                               std::vector<autopas::FullParticleCell<Molecule>> &particlesHaloBuffers,
-                              autopas::Newton3Option n3) {
+                              autopas::Newton3Option n3, autopas::DataLayoutOption dataLayout) {
   // sanity check that there are exactly two particles in the test
   const auto numParticlesInBuffers = std::transform_reduce(particlesBuffers.begin(), particlesBuffers.end(), 0,
                                                            std::plus<>(), [](const auto &cell) { return cell.size(); });
@@ -63,8 +63,7 @@ void testIteratePairwiseSteps(std::vector<Molecule> &particlesContainerOwned,
 
   const std::set<autopas::Configuration> searchSpace(
       {{autopas::ContainerOption::linkedCells, cellSizeFactor, autopas::TraversalOption::lc_c08,
-        autopas::LoadEstimatorOption::none, autopas::DataLayoutOption::aos, n3,
-        autopas::InteractionTypeOption::pairwise}});
+        autopas::LoadEstimatorOption::none, dataLayout, n3, autopas::InteractionTypeOption::pairwise}});
   std::unordered_map<autopas::InteractionTypeOption::Value, std::unique_ptr<autopas::AutoTuner>> tunerMap;
   tunerMap.emplace(
       autopas::InteractionTypeOption::pairwise,
@@ -128,6 +127,10 @@ void testIteratePairwiseSteps(std::vector<Molecule> &particlesContainerOwned,
       4 * epsilon * (std::pow(sigma / expectedDist, 12.) - std::pow(sigma / expectedDist, 6.)) *
       ((numParticlesHaloBuffers != 0 or not particlesContainerHalo.empty()) ? 0.5 : 1);
   EXPECT_NEAR(expectedPotentialEnergy, functor.getPotentialEnergy(), 1e-12);
+
+  if (::testing::Test::HasFailure()) {
+    std::cout << "Failures occurred for DataLayout: " << dataLayout << std::endl;
+  }
 }
 
 TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_container_container_NoN3) {
@@ -138,8 +141,10 @@ TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_container_containe
   std::vector<Molecule> particlesContainerHalo{};
   std::vector<autopas::FullParticleCell<Molecule>> particlesBuffers{numBuffers};
   std::vector<autopas::FullParticleCell<Molecule>> particlesHaloBuffers{numBuffers};
-  testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
-                           autopas::Newton3Option::disabled);
+  for (const auto dataLayout : autopas::DataLayoutOption::getAllOptions()) {
+    testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
+                             autopas::Newton3Option::disabled, dataLayout);
+  }
 }
 
 TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_container_containerHalo_NoN3) {
@@ -151,8 +156,10 @@ TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_container_containe
   };
   std::vector<autopas::FullParticleCell<Molecule>> particlesBuffers{numBuffers};
   std::vector<autopas::FullParticleCell<Molecule>> particlesHaloBuffers{numBuffers};
-  testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
-                           autopas::Newton3Option::disabled);
+  for (const auto dataLayout : autopas::DataLayoutOption::getAllOptions()) {
+    testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
+                             autopas::Newton3Option::disabled, dataLayout);
+  }
 }
 
 TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_particleBuffer_container_NoN3) {
@@ -163,8 +170,10 @@ TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_particleBuffer_con
   std::vector<autopas::FullParticleCell<Molecule>> particlesBuffers{numBuffers};
   particlesBuffers[0].addParticle(Molecule{{1., 1., 1.}, {0., 0., 0.}, 0, 0});
   std::vector<autopas::FullParticleCell<Molecule>> particlesHaloBuffers{numBuffers};
-  testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
-                           autopas::Newton3Option::disabled);
+  for (const auto dataLayout : autopas::DataLayoutOption::getAllOptions()) {
+    testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
+                             autopas::Newton3Option::disabled, dataLayout);
+  }
 }
 
 TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_particleBuffer_containerHalo_NoN3) {
@@ -175,8 +184,10 @@ TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_particleBuffer_con
   std::vector<autopas::FullParticleCell<Molecule>> particlesBuffers{numBuffers};
   particlesBuffers[0].addParticle(Molecule{{0.5, 1., 1.}, {0., 0., 0.}, 0, 0});
   std::vector<autopas::FullParticleCell<Molecule>> particlesHaloBuffers{numBuffers};
-  testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
-                           autopas::Newton3Option::disabled);
+  for (const auto dataLayout : autopas::DataLayoutOption::getAllOptions()) {
+    testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
+                             autopas::Newton3Option::disabled, dataLayout);
+  }
 }
 
 TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_particleBufferA_particleBufferA_NoN3) {
@@ -186,8 +197,10 @@ TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_particleBufferA_pa
   particlesBuffers[0].addParticle(Molecule{{1., 1., 1.}, {0., 0., 0.}, 0, 0});
   particlesBuffers[0].addParticle(Molecule{{2., 1., 1.}, {0., 0., 0.}, 1, 0});
   std::vector<autopas::FullParticleCell<Molecule>> particlesHaloBuffers{numBuffers};
-  testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
-                           autopas::Newton3Option::disabled);
+  for (const auto dataLayout : autopas::DataLayoutOption::getAllOptions()) {
+    testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
+                             autopas::Newton3Option::disabled, dataLayout);
+  }
 }
 
 // This test is not possible without OpenMP because there only exists one buffer
@@ -200,8 +213,10 @@ TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_particleBufferA_pa
   particlesBuffers[0].addParticle(Molecule{{1., 1., 1.}, {0., 0., 0.}, 0, 0});
   particlesBuffers[1].addParticle(Molecule{{2., 1., 1.}, {0., 0., 0.}, 1, 0});
   std::vector<autopas::FullParticleCell<Molecule>> particlesHaloBuffers(2);
-  testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
-                           autopas::Newton3Option::disabled);
+  for (const auto dataLayout : autopas::DataLayoutOption::getAllOptions()) {
+    testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
+                             autopas::Newton3Option::disabled, dataLayout);
+  }
 }
 #endif
 
@@ -213,8 +228,10 @@ TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_haloBuffer_contain
   std::vector<autopas::FullParticleCell<Molecule>> particlesBuffers{numBuffers};
   std::vector<autopas::FullParticleCell<Molecule>> particlesHaloBuffers{numBuffers};
   particlesHaloBuffers[0].addParticle(Molecule{{1., 1., 1.}, {0., 0., 0.}, 0, 0});
-  testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
-                           autopas::Newton3Option::disabled);
+  for (const auto dataLayout : autopas::DataLayoutOption::getAllOptions()) {
+    testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
+                             autopas::Newton3Option::disabled, dataLayout);
+  }
 }
 
 TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_haloBuffer_particleBuffer_NoN3) {
@@ -224,8 +241,10 @@ TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_haloBuffer_particl
   particlesBuffers[0].addParticle(Molecule{{1., 1., 1.}, {0., 0., 0.}, 0, 0});
   std::vector<autopas::FullParticleCell<Molecule>> particlesHaloBuffers{numBuffers};
   particlesHaloBuffers[0].addParticle(Molecule{{2., 1., 1.}, {0., 0., 0.}, 1, 0});
-  testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
-                           autopas::Newton3Option::disabled);
+  for (const auto dataLayout : autopas::DataLayoutOption::getAllOptions()) {
+    testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
+                             autopas::Newton3Option::disabled, dataLayout);
+  }
 }
 
 /// Newton 3 enabled
@@ -237,8 +256,10 @@ TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_container_containe
   std::vector<Molecule> particlesContainerHalo{};
   std::vector<autopas::FullParticleCell<Molecule>> particlesBuffers{numBuffers};
   std::vector<autopas::FullParticleCell<Molecule>> particlesHaloBuffers{numBuffers};
-  testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
-                           autopas::Newton3Option::enabled);
+  for (const auto dataLayout : autopas::DataLayoutOption::getAllOptions()) {
+    testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
+                             autopas::Newton3Option::enabled, dataLayout);
+  }
 }
 
 TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_container_containerHalo_N3) {
@@ -250,8 +271,10 @@ TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_container_containe
   };
   std::vector<autopas::FullParticleCell<Molecule>> particlesBuffers{numBuffers};
   std::vector<autopas::FullParticleCell<Molecule>> particlesHaloBuffers{numBuffers};
-  testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
-                           autopas::Newton3Option::enabled);
+  for (const auto dataLayout : autopas::DataLayoutOption::getAllOptions()) {
+    testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
+                             autopas::Newton3Option::enabled, dataLayout);
+  }
 }
 
 TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_particleBuffer_container_N3) {
@@ -262,8 +285,10 @@ TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_particleBuffer_con
   std::vector<autopas::FullParticleCell<Molecule>> particlesBuffers{numBuffers};
   particlesBuffers[0].addParticle(Molecule{{1., 1., 1.}, {0., 0., 0.}, 0, 0});
   std::vector<autopas::FullParticleCell<Molecule>> particlesHaloBuffers{numBuffers};
-  testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
-                           autopas::Newton3Option::enabled);
+  for (const auto dataLayout : autopas::DataLayoutOption::getAllOptions()) {
+    testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
+                             autopas::Newton3Option::enabled, dataLayout);
+  }
 }
 
 TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_particleBuffer_containerHalo_N3) {
@@ -274,8 +299,10 @@ TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_particleBuffer_con
   std::vector<autopas::FullParticleCell<Molecule>> particlesBuffers{numBuffers};
   particlesBuffers[0].addParticle(Molecule{{0.5, 1., 1.}, {0., 0., 0.}, 0, 0});
   std::vector<autopas::FullParticleCell<Molecule>> particlesHaloBuffers{numBuffers};
-  testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
-                           autopas::Newton3Option::enabled);
+  for (const auto dataLayout : autopas::DataLayoutOption::getAllOptions()) {
+    testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
+                             autopas::Newton3Option::enabled, dataLayout);
+  }
 }
 
 TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_particleBufferA_particleBufferA_N3) {
@@ -285,8 +312,10 @@ TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_particleBufferA_pa
   particlesBuffers[0].addParticle(Molecule{{1., 1., 1.}, {0., 0., 0.}, 0, 0});
   particlesBuffers[0].addParticle(Molecule{{2., 1., 1.}, {0., 0., 0.}, 1, 0});
   std::vector<autopas::FullParticleCell<Molecule>> particlesHaloBuffers{numBuffers};
-  testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
-                           autopas::Newton3Option::enabled);
+  for (const auto dataLayout : autopas::DataLayoutOption::getAllOptions()) {
+    testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
+                             autopas::Newton3Option::enabled, dataLayout);
+  }
 }
 
 #ifdef AUTOPAS_USE_OPENMP
@@ -298,8 +327,10 @@ TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_particleBufferA_pa
   particlesBuffers[0].addParticle(Molecule{{1., 1., 1.}, {0., 0., 0.}, 0, 0});
   particlesBuffers[1].addParticle(Molecule{{2., 1., 1.}, {0., 0., 0.}, 1, 0});
   std::vector<autopas::FullParticleCell<Molecule>> particlesHaloBuffers(2);
-  testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
-                           autopas::Newton3Option::enabled);
+  for (const auto dataLayout : autopas::DataLayoutOption::getAllOptions()) {
+    testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
+                             autopas::Newton3Option::enabled, dataLayout);
+  }
 }
 #endif
 
@@ -311,8 +342,10 @@ TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_haloBuffer_contain
   std::vector<autopas::FullParticleCell<Molecule>> particlesBuffers{numBuffers};
   std::vector<autopas::FullParticleCell<Molecule>> particlesHaloBuffers{numBuffers};
   particlesHaloBuffers[0].addParticle(Molecule{{1., 1., 1.}, {0., 0., 0.}, 0, 0});
-  testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
-                           autopas::Newton3Option::enabled);
+  for (const auto dataLayout : autopas::DataLayoutOption::getAllOptions()) {
+    testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
+                             autopas::Newton3Option::enabled, dataLayout);
+  }
 }
 
 TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_haloBuffer_particleBuffer_N3) {
@@ -322,13 +355,16 @@ TEST_F(RemainderTraversalTest, testRemainderTraversalDirectly_haloBuffer_particl
   particlesBuffers[0].addParticle(Molecule{{1., 1., 1.}, {0., 0., 0.}, 0, 0});
   std::vector<autopas::FullParticleCell<Molecule>> particlesHaloBuffers{numBuffers};
   particlesHaloBuffers[0].addParticle(Molecule{{2., 1., 1.}, {0., 0., 0.}, 1, 0});
-  testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
-                           autopas::Newton3Option::enabled);
+  for (const auto dataLayout : autopas::DataLayoutOption::getAllOptions()) {
+    testIteratePairwiseSteps(particlesContainerOwned, particlesContainerHalo, particlesBuffers, particlesHaloBuffers,
+                             autopas::Newton3Option::enabled, dataLayout);
+  }
 }
 
 void testRemainderTraversal(const std::vector<Molecule> &particles, const std::vector<Molecule> &haloParticles,
                             std::vector<autopas::FullParticleCell<Molecule>> &particlesBuffer,
-                            std::vector<autopas::FullParticleCell<Molecule>> &haloParticlesBuffer) {
+                            std::vector<autopas::FullParticleCell<Molecule>> &haloParticlesBuffer,
+                            autopas::DataLayoutOption dataLayout) {
   /// Setup AutoTuner
   constexpr double cellSizeFactor = 1.;
   constexpr unsigned int verletRebuildFrequency = 10;
@@ -346,7 +382,7 @@ void testRemainderTraversal(const std::vector<Molecule> &particles, const std::v
 
   const std::set<autopas::Configuration> searchSpace(
       {{autopas::ContainerOption::linkedCells, cellSizeFactor, autopas::TraversalOption::lc_c08,
-        autopas::LoadEstimatorOption::none, autopas::DataLayoutOption::aos, autopas::Newton3Option::enabled,
+        autopas::LoadEstimatorOption::none, dataLayout, autopas::Newton3Option::enabled,
         autopas::InteractionTypeOption::pairwise}});
   std::unordered_map<autopas::InteractionTypeOption::Value, std::unique_ptr<autopas::AutoTuner>> tunerMap;
   tunerMap.emplace(
@@ -376,14 +412,14 @@ void testRemainderTraversal(const std::vector<Molecule> &particles, const std::v
   for (const auto &p : logicHandler.getContainer()) {
     EXPECT_THAT(p.getF(), testing::Not(::testing::ElementsAreArray({0., 0., 0.})))
         << "Particle in container had no interaction!\n"
-        << p;
+        << p << "\nwith Data Layout " << dataLayout;
   }
   const auto &[logicHandlerParticlesBuffer, logicHandlerHaloBuffer] = logicHandler.getParticleBuffers();
   for (const auto &buffer : logicHandlerParticlesBuffer) {
     for (const auto &p : buffer) {
       EXPECT_THAT(p.getF(), testing::Not(::testing::ElementsAreArray({0., 0., 0.})))
           << "Particle in particlesBuffer had no interaction!\n"
-          << p;
+          << p << "\nwith Data Layout " << dataLayout;
     }
   }
 }
@@ -437,7 +473,10 @@ TEST_P(RemainderTraversalTest, testRemainderTraversal) {
   }
 
   /// TEST
-  testRemainderTraversal(containerParticles, containerHaloParticles, bufferParticles, bufferHaloParticles);
+  for (const auto dataLayout : autopas::DataLayoutOption::getAllOptions()) {
+    testRemainderTraversal(containerParticles, containerHaloParticles, bufferParticles, bufferHaloParticles,
+                           dataLayout);
+  }
 }
 
 INSTANTIATE_TEST_SUITE_P(Generated, RemainderTraversalTest,


### PR DESCRIPTION
# Description

The remainder traversal for 2B always used AoS AND SoA functor calls, forcing the user to implement both. This is potentially problematic / annoying (see LADDS).

This PR introduces a mechanic that SoA is only used if the current configuration asks for it. Otherwise only AoS is used.

## ~Related Pull Requests~

## ~Resolved Issues~

# How Has This Been Tested?

- [x] Extended existing tests to cover all data layouts 66e1f67d479fba8e6cb7210a6d5df3e9ba5851b3
