### PR TITLE
Dynamic rebuild frequency estimation

### DIFF
--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -101,8 +101,8 @@ Simulation::Simulation(const MDFlexConfig &configuration,
       _configuration.outputSuffix.value.empty() or _configuration.outputSuffix.value.front() == '_' ? "" : "_";
   const auto *fillerAfterSuffix =
       _configuration.outputSuffix.value.empty() or _configuration.outputSuffix.value.back() == '_' ? "" : "_";
-  const auto outputSuffix = "Rank" + std::to_string(rank) + fillerBeforeSuffix +
-                            _configuration.outputSuffix.value + fillerAfterSuffix;
+  const auto outputSuffix =
+      "Rank" + std::to_string(rank) + fillerBeforeSuffix + _configuration.outputSuffix.value + fillerAfterSuffix;
 
   if (_configuration.logFileName.value.empty()) {
     _outputStream = &std::cout;

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -600,6 +600,8 @@ class LogicHandler {
    * Helpful for determining the frequency for the dynamic containers
    * This function is only used for dynamic containers currently but returns user defined rebuild frequency for static
    * case for safety.
+   * @param onlyLastSimulationPhase Bool to determine if mean rebuild frequency is to be calculated over entire
+   * iterations or only during the simulation phase.
    * @return value of the mean frequency as double
    */
   [[nodiscard]] double getMeanRebuildFrequency(bool onlyLastSimulationPhase = false) const {

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -607,12 +607,12 @@ class LogicHandler {
   [[nodiscard]] double getMeanRebuildFrequency(bool onlyLastSimulationPhase = false) const {
 #ifdef AUTOPAS_ENABLE_DYNAMIC_CONTAINERS
     auto numRebuilds = onlyLastSimulationPhase ? _numRebuildsInSimulationPhase : _numRebuilds;
-    auto iteration = onlyLastSimulationPhase ? _iteration - _iterationAtEndOfLastTuningPhase : _iteration;
+    auto iterationCount = onlyLastSimulationPhase ? _iteration - _iterationAtEndOfLastTuningPhase : _iteration + 1;
     if (numRebuilds == 0) {
       return static_cast<double>(_neighborListRebuildFrequency);
     } else {
       // The total number of iterations is iteration + 1
-      return static_cast<double>(iteration + 1) / numRebuilds;
+      return static_cast<double>(iterationCount) / numRebuilds;
     }
 #else
     return static_cast<double>(_neighborListRebuildFrequency);

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -606,11 +606,12 @@ class LogicHandler {
    * non-rebuild samples.
    * @return value of the mean frequency as double
    */
-  [[nodiscard]] double getMeanRebuildFrequency(bool onlyLastNonTuningPhase = false) const {
+  [[nodiscard]] double getMeanRebuildFrequency(bool considerOnlyLastNonTuningPhase = false) const {
 #ifdef AUTOPAS_ENABLE_DYNAMIC_CONTAINERS
-    const auto numRebuilds = onlyLastNonTuningPhase ? _numRebuildsInNonTuningPhase : _numRebuilds;
+    const auto numRebuilds = considerOnlyLastNonTuningPhase ? _numRebuildsInNonTuningPhase : _numRebuilds;
     // The total number of iterations is iteration + 1
-    const auto iterationCount = onlyLastNonTuningPhase ? _iteration - _iterationAtEndOfLastTuningPhase : _iteration + 1;
+    const auto iterationCount =
+        considerOnlyLastNonTuningPhase ? _iteration - _iterationAtEndOfLastTuningPhase : _iteration + 1;
     if (numRebuilds == 0) {
       return static_cast<double>(_neighborListRebuildFrequency);
     } else {
@@ -1188,7 +1189,7 @@ IterationMeasurements LogicHandler<Particle>::computeInteractions(Functor &funct
   auto &container = _containerSelector.getCurrentContainer();
 #ifdef AUTOPAS_ENABLE_DYNAMIC_CONTAINERS
   if (autoTuner.inFirstTuningIteration()) {
-    autoTuner.setRebuildFrequency(getMeanRebuildFrequency(/* onlyLastNonTuningPhase */ true));
+    autoTuner.setRebuildFrequency(getMeanRebuildFrequency(/* considerOnlyLastNonTuningPhase */ true));
     _numRebuildsInNonTuningPhase = 0;
   }
 #endif

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -603,7 +603,8 @@ class LogicHandler {
     if (_numRebuilds == 0) {
       return static_cast<double>(_neighborListRebuildFrequency);
     } else {
-      return static_cast<double>(_iteration) / _numRebuilds;
+      // The total number of iterations is _iteration + 1
+      return static_cast<double>(_iteration + 1) / _numRebuilds;
     }
 #else
     return static_cast<double>(_neighborListRebuildFrequency);
@@ -927,11 +928,6 @@ class LogicHandler {
    * This is used to store the total number of neighbour lists rebuild.
    */
   size_t _numRebuilds{0};
-
-  /**
-   * This is used to store the square of maximum distance travelled by a particle in the current step.
-   */
-  size_t _maxDistanceSquaredInCurrentStep{0};
 
   /**
    * Number of particles in two cells from which sorting should be performed for traversal that use the CellFunctor

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -1170,7 +1170,7 @@ IterationMeasurements LogicHandler<Particle>::computeInteractions(Functor &funct
   const bool newton3 = autoTuner.getCurrentConfig().newton3;
   auto &container = _containerSelector.getCurrentContainer();
 #ifdef AUTOPAS_ENABLE_DYNAMIC_CONTAINERS
-  if (autoTuner.inFirstTuningStep) {
+  if (autoTuner.inFirstTuningStep()) {
     autoTuner.setRebuildFrequency(static_cast<double>(_iteration) / _numRebuildsInSimulationPhase);
     _numRebuildsInSimulationPhase = 0;
   }

--- a/src/autopas/tuning/AutoTuner.cpp
+++ b/src/autopas/tuning/AutoTuner.cpp
@@ -444,4 +444,6 @@ bool AutoTuner::inTuningPhase() const {
 const EvidenceCollection &AutoTuner::getEvidenceCollection() const { return _evidenceCollection; }
 
 bool AutoTuner::canMeasureEnergy() const { return _energyMeasurementPossible; }
+
+void AutoTuner::setRebuildFrequency(unsigned int rebuildFrequency) {_rebuildFrequency = rebuildFrequency;}
 }  // namespace autopas

--- a/src/autopas/tuning/AutoTuner.cpp
+++ b/src/autopas/tuning/AutoTuner.cpp
@@ -441,9 +441,11 @@ bool AutoTuner::inTuningPhase() const {
   return (_iteration % _tuningInterval == 0 or _isTuning or _forceRetune) and not searchSpaceIsTrivial();
 }
 
+bool AutoTuner::inFirstTuningStep() const { return (_iteration % _tuningInterval == 0); }
+
 const EvidenceCollection &AutoTuner::getEvidenceCollection() const { return _evidenceCollection; }
 
 bool AutoTuner::canMeasureEnergy() const { return _energyMeasurementPossible; }
 
-void AutoTuner::setRebuildFrequency(unsigned int rebuildFrequency) {_rebuildFrequency = rebuildFrequency;}
+void AutoTuner::setRebuildFrequency(double rebuildFrequency) { _rebuildFrequency = rebuildFrequency; }
 }  // namespace autopas

--- a/src/autopas/tuning/AutoTuner.cpp
+++ b/src/autopas/tuning/AutoTuner.cpp
@@ -442,9 +442,9 @@ bool AutoTuner::inTuningPhase() const {
   return (_iteration % _tuningInterval == 0 or _isTuning or _forceRetune) and not searchSpaceIsTrivial();
 }
 
-bool AutoTuner::inFirstTuningStep() const { return (_iteration % _tuningInterval == 0); }
+bool AutoTuner::inFirstTuningIteration() const { return (_iteration % _tuningInterval == 0); }
 
-bool AutoTuner::inLastTuningStep() const { return _endOfTuningPhase; }
+bool AutoTuner::inLastTuningIteration() const { return _endOfTuningPhase; }
 
 const EvidenceCollection &AutoTuner::getEvidenceCollection() const { return _evidenceCollection; }
 

--- a/src/autopas/tuning/AutoTuner.cpp
+++ b/src/autopas/tuning/AutoTuner.cpp
@@ -312,11 +312,10 @@ void AutoTuner::bumpIterationCounters(bool needToWait) {
 
 bool AutoTuner::willRebuildNeighborLists() const {
   // AutoTuner only triggers rebuild during the tuning phase
-  const auto iterationsPerRebuild = this->inTuningPhase() ? _maxSamples : std::numeric_limits<unsigned int>::max();
-  ;
+  const auto iterationsPerConfig = this->inTuningPhase() ? _maxSamples : std::numeric_limits<unsigned int>::max();
   // _iterationBaseLine + 1 since we want to look ahead to the next iteration
   const auto iterationBaselineNextStep = _forceRetune ? _iterationBaseline : _iterationBaseline + 1;
-  return (iterationBaselineNextStep % iterationsPerRebuild) == 0;
+  return (iterationBaselineNextStep % iterationsPerConfig) == 0;
 }
 
 bool AutoTuner::initEnergy() {

--- a/src/autopas/tuning/AutoTuner.cpp
+++ b/src/autopas/tuning/AutoTuner.cpp
@@ -311,8 +311,9 @@ void AutoTuner::bumpIterationCounters(bool needToWait) {
 }
 
 bool AutoTuner::willRebuildNeighborLists() const {
-  // What is the rebuild rhythm?
-  const auto iterationsPerRebuild = this->inTuningPhase() ? _maxSamples : _rebuildFrequency;
+  // AutoTuner only triggers rebuild during the tuning phase
+  const auto iterationsPerRebuild = this->inTuningPhase() ? _maxSamples : std::numeric_limits<unsigned int>::max();
+  ;
   // _iterationBaseLine + 1 since we want to look ahead to the next iteration
   const auto iterationBaselineNextStep = _forceRetune ? _iterationBaseline : _iterationBaseline + 1;
   return (iterationBaselineNextStep % iterationsPerRebuild) == 0;

--- a/src/autopas/tuning/AutoTuner.cpp
+++ b/src/autopas/tuning/AutoTuner.cpp
@@ -286,7 +286,7 @@ void AutoTuner::addMeasurement(long sample, bool neighborListRebuilt) {
         }());
 
     _tuningDataLogger.logTuningData(currentConfig, _samplesRebuildingNeighborLists, _samplesNotRebuildingNeighborLists,
-                                    _iteration, reducedValue, smoothedValue);
+                                    _iteration, reducedValue, smoothedValue, _rebuildFrequency);
   }
 }
 
@@ -443,6 +443,8 @@ bool AutoTuner::inTuningPhase() const {
 }
 
 bool AutoTuner::inFirstTuningStep() const { return (_iteration % _tuningInterval == 0); }
+
+bool AutoTuner::inLastTuningStep() const { return _endOfTuningPhase; }
 
 const EvidenceCollection &AutoTuner::getEvidenceCollection() const { return _evidenceCollection; }
 

--- a/src/autopas/tuning/AutoTuner.h
+++ b/src/autopas/tuning/AutoTuner.h
@@ -223,6 +223,12 @@ class AutoTuner {
   bool inFirstTuningStep() const;
 
   /**
+   * Indicate if the tuner is in the last iteration of the tuning phase.
+   * @return
+   */
+  bool inLastTuningStep() const;
+
+  /**
    * Getter for the internal evidence collection.
    * @return
    */

--- a/src/autopas/tuning/AutoTuner.h
+++ b/src/autopas/tuning/AutoTuner.h
@@ -220,13 +220,13 @@ class AutoTuner {
    * Indicate if the tuner is in the first iteration of a tuning phase.
    * @return
    */
-  bool inFirstTuningStep() const;
+  bool inFirstTuningIteration() const;
 
   /**
    * Indicate if the tuner is in the last iteration of the tuning phase.
    * @return
    */
-  bool inLastTuningStep() const;
+  bool inLastTuningIteration() const;
 
   /**
    * Getter for the internal evidence collection.
@@ -328,7 +328,8 @@ class AutoTuner {
 
   /**
    * The rebuild frequency this instance of AutoPas uses.
-   * In case of dynamic containers, this reflects the current estimate of rebuild frequency.
+   * In the case of dynamic containers, this reflects the current estimate of the average rebuild frequency.
+   * As the estimate is an average of integers, it can be a fraction and so double is used here.
    * In static containers, this is set to user-defined rebuild frequency.
    */
   double _rebuildFrequency;

--- a/src/autopas/tuning/AutoTuner.h
+++ b/src/autopas/tuning/AutoTuner.h
@@ -228,6 +228,12 @@ class AutoTuner {
    */
   bool canMeasureEnergy() const;
 
+  /**
+  * Sets the _rebuildFrequency.
+  * This is used to dynamically change the _rebuildFrequency based on estimate in case of dynamic containers.
+  */
+  void setRebuildFrequency(unsigned int rebuildFrequency);
+
  private:
   /**
    * Measures consumed energy for tuning
@@ -308,6 +314,8 @@ class AutoTuner {
 
   /**
    * The rebuild frequency this instance of AutoPas uses.
+   * In case of dynamic containers, this reflects the current estimate of rebuild frequency.
+   * In static containers, this is set to user-defined rebuild frequency.
    */
   unsigned int _rebuildFrequency;
 

--- a/src/autopas/tuning/AutoTuner.h
+++ b/src/autopas/tuning/AutoTuner.h
@@ -217,6 +217,12 @@ class AutoTuner {
   bool inTuningPhase() const;
 
   /**
+   * Indicate if the tuner is in the first iteration of a tuning phase.
+   * @return
+   */
+  bool inFirstTuningStep() const;
+
+  /**
    * Getter for the internal evidence collection.
    * @return
    */
@@ -229,10 +235,10 @@ class AutoTuner {
   bool canMeasureEnergy() const;
 
   /**
-  * Sets the _rebuildFrequency.
-  * This is used to dynamically change the _rebuildFrequency based on estimate in case of dynamic containers.
-  */
-  void setRebuildFrequency(unsigned int rebuildFrequency);
+   * Sets the _rebuildFrequency.
+   * This is used to dynamically change the _rebuildFrequency based on estimate in case of dynamic containers.
+   */
+  void setRebuildFrequency(double rebuildFrequency);
 
  private:
   /**
@@ -317,7 +323,7 @@ class AutoTuner {
    * In case of dynamic containers, this reflects the current estimate of rebuild frequency.
    * In static containers, this is set to user-defined rebuild frequency.
    */
-  unsigned int _rebuildFrequency;
+  double _rebuildFrequency;
 
   /**
    * How many times each configuration should be tested.

--- a/src/autopas/tuning/AutoTuner.h
+++ b/src/autopas/tuning/AutoTuner.h
@@ -107,10 +107,11 @@ class AutoTuner {
   void bumpIterationCounters(bool needToWait = false);
 
   /**
-   * Returns whether rebuildNeighborLists() will be triggered in the next iteration.
-   * This might also indicate a container change.
-   *
-   * @return True if the current iteration counters indicate a rebuild in the next iteration.
+   * Returns whether rebuildNeighborLists() should be triggered in the next iteration.
+   * This indicates a configuration change.
+   * In the non-tuning phase, the rebuildNeighborLists() is triggered in LogicHandler.
+   * @return True if the current iteration counters indicate a rebuild in the next iteration due to a configuration
+   * change.
    */
   bool willRebuildNeighborLists() const;
 
@@ -241,7 +242,7 @@ class AutoTuner {
   bool canMeasureEnergy() const;
 
   /**
-   * Sets the _rebuildFrequency.
+   * Sets the _rebuildFrequency. This is the average number of iterations per rebuild.
    * This is used to dynamically change the _rebuildFrequency based on estimate in case of dynamic containers.
    * @param rebuildFrequency Current rebuild frequency in this instance of autopas, used by autopas for weighing rebuild
    * and non-rebuild iterations

--- a/src/autopas/tuning/AutoTuner.h
+++ b/src/autopas/tuning/AutoTuner.h
@@ -243,6 +243,8 @@ class AutoTuner {
   /**
    * Sets the _rebuildFrequency.
    * This is used to dynamically change the _rebuildFrequency based on estimate in case of dynamic containers.
+   * @param rebuildFrequency Current rebuild frequency in this instance of autopas, used by autopas for weighing rebuild
+   * and non-rebuild iterations
    */
   void setRebuildFrequency(double rebuildFrequency);
 

--- a/src/autopas/utils/logging/TuningDataLogger.cpp
+++ b/src/autopas/utils/logging/TuningDataLogger.cpp
@@ -26,7 +26,7 @@ autopas::TuningDataLogger::TuningDataLogger(size_t numSamples, const std::string
     samplesHeader << ",sample" << i;
   }
   // print csv header
-  headerLogger->info("Date,Iteration,{}{},Reduced,Smoothed, Mean Rebuild Frequency", Configuration().getCSVHeader(),
+  headerLogger->info("Date,Iteration,{}{},Reduced,Smoothed,Mean Rebuild Frequency", Configuration().getCSVHeader(),
                      samplesHeader.str());
   spdlog::drop(headerLoggerName);
   // End of workaround

--- a/src/autopas/utils/logging/TuningDataLogger.cpp
+++ b/src/autopas/utils/logging/TuningDataLogger.cpp
@@ -51,7 +51,7 @@ void autopas::TuningDataLogger::logTuningData(const autopas::Configuration &conf
                                               double meanRebuildFrequency) const {
 #ifdef AUTOPAS_LOG_TUNINGDATA
   spdlog::get(_loggerName)
-      ->info("{},{},{},{},{},{}", iteration, configuration.getCSVLine(),
+      ->info("{},{},{},{},{},{},{}", iteration, configuration.getCSVLine(),
              utils::ArrayUtils::to_string(samplesRebuildingNeighborLists, ",", {"", ""}),
              utils::ArrayUtils::to_string(samplesNotRebuildingNeighborLists, ",", {"", ""}), reducedValue,
              smoothedValue, meanRebuildFrequency);

--- a/src/autopas/utils/logging/TuningDataLogger.cpp
+++ b/src/autopas/utils/logging/TuningDataLogger.cpp
@@ -26,7 +26,8 @@ autopas::TuningDataLogger::TuningDataLogger(size_t numSamples, const std::string
     samplesHeader << ",sample" << i;
   }
   // print csv header
-  headerLogger->info("Date,Iteration,{}{},Reduced,Smoothed", Configuration().getCSVHeader(), samplesHeader.str());
+  headerLogger->info("Date,Iteration,{}{},Reduced,Smoothed, Mean Rebuild Frequency", Configuration().getCSVHeader(),
+                     samplesHeader.str());
   spdlog::drop(headerLoggerName);
   // End of workaround
 
@@ -46,12 +47,13 @@ autopas::TuningDataLogger::~TuningDataLogger() {
 void autopas::TuningDataLogger::logTuningData(const autopas::Configuration &configuration,
                                               const std::vector<long> &samplesRebuildingNeighborLists,
                                               const std::vector<long> &samplesNotRebuildingNeighborLists,
-                                              size_t iteration, long reducedValue, long smoothedValue) const {
+                                              size_t iteration, long reducedValue, long smoothedValue,
+                                              double meanRebuildFrequency) const {
 #ifdef AUTOPAS_LOG_TUNINGDATA
   spdlog::get(_loggerName)
       ->info("{},{},{},{},{},{}", iteration, configuration.getCSVLine(),
              utils::ArrayUtils::to_string(samplesRebuildingNeighborLists, ",", {"", ""}),
              utils::ArrayUtils::to_string(samplesNotRebuildingNeighborLists, ",", {"", ""}), reducedValue,
-             smoothedValue);
+             smoothedValue, meanRebuildFrequency);
 #endif
 }

--- a/src/autopas/utils/logging/TuningDataLogger.h
+++ b/src/autopas/utils/logging/TuningDataLogger.h
@@ -40,6 +40,7 @@ class TuningDataLogger {
    * @param iteration
    * @param reducedValue
    * @param smoothedVale
+   * @param meanRebuildFrequency
    */
   void logTuningData(const autopas::Configuration &configuration,
                      const std::vector<long> &samplesRebuildingNeighborLists,

--- a/src/autopas/utils/logging/TuningDataLogger.h
+++ b/src/autopas/utils/logging/TuningDataLogger.h
@@ -44,7 +44,7 @@ class TuningDataLogger {
   void logTuningData(const autopas::Configuration &configuration,
                      const std::vector<long> &samplesRebuildingNeighborLists,
                      const std::vector<long> &samplesNotRebuildingNeighborLists, size_t iteration, long reducedValue,
-                     long smoothedVale) const;
+                     long smoothedVale, double meanRebuildFrequency) const;
 
  private:
   std::string _loggerName;


### PR DESCRIPTION
# Description

This PR includes the following changes

1. Removes the `_rebuildInterval` vector, instead uses `_numRebuilds` to keep track of number of rebuilds and estimates mean rebuild frequency using `_iteration/_numRebuilds`
2. Estimates rebuild frequency for previous simulation phase to update the autoTuner `_rebuildFrequency` which is used for weighting rebuild and non-rebuild iterations and comparing different configurations. This is achieved by keeping track of `_numRebuildsInSimulationPhase` and `_iterationAtEndOfLastTuningPhase` as ``` (_iteration - _iterationAtEndOfLastTuningPhase) /  _numRebuildsInSimulationPhase```
3. `AutoTuner::willRebuildNeighborLists()` now only triggers rebuild in tuning phase now, rebuild outside tuning phase is handled by `LogicHandler`. This was also needed as rebuild frequency is no longer an `unsigned int` and so, the function would require some change to work.
4. Added `meanRebuildFrequency` to the `tuningDataLogger` so that we can keep track of what rebuild frequency was used to compute the estimate.

## Resolved Issues

- [x] fixes #991 
- [x] first solution to #954 (can be improved but would require some annoying changes)
- doesn't directly affect, but related to point 3 issue #783 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Checking wrt to tuning data collected - that optimum estimate is comuted using the estimated rebuild frequency from the previous simulation phase. In the first tuning phase, user-supplied `rebuildFrequency` is used.
- [ ] The coverage report shows all relevant lines are tested.
