### PR TITLE
Rank-based splitting of md-flexible log files

### DIFF
--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -102,13 +102,13 @@ Simulation::Simulation(const MDFlexConfig &configuration,
   const auto *fillerAfterSuffix =
       _configuration.outputSuffix.value.empty() or _configuration.outputSuffix.value.back() == '_' ? "" : "_";
   const auto outputSuffix =
-      "_Rank" + std::to_string(rank) + fillerBeforeSuffix + _configuration.outputSuffix.value + fillerAfterSuffix;
+      "Rank" + std::to_string(rank) + fillerBeforeSuffix + _configuration.outputSuffix.value + fillerAfterSuffix;
 
   if (_configuration.logFileName.value.empty()) {
     _outputStream = &std::cout;
   } else {
     _logFile = std::make_shared<std::ofstream>();
-    _logFile->open(_configuration.logFileName.value + outputSuffix);
+    _logFile->open(_configuration.logFileName.value + "_" + outputSuffix);
     _outputStream = &(*_logFile);
   }
 

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -101,8 +101,8 @@ Simulation::Simulation(const MDFlexConfig &configuration,
       _configuration.outputSuffix.value.empty() or _configuration.outputSuffix.value.front() == '_' ? "" : "_";
   const auto *fillerAfterSuffix =
       _configuration.outputSuffix.value.empty() or _configuration.outputSuffix.value.back() == '_' ? "" : "_";
-  const auto outputSuffix = "_Rank" + std::to_string(rank) + fillerBeforeSuffix +
-                            _configuration.outputSuffix.value + fillerAfterSuffix;
+  const auto outputSuffix =
+      "_Rank" + std::to_string(rank) + fillerBeforeSuffix + _configuration.outputSuffix.value + fillerAfterSuffix;
 
   if (_configuration.logFileName.value.empty()) {
     _outputStream = &std::cout;

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -96,11 +96,19 @@ Simulation::Simulation(const MDFlexConfig &configuration,
                                             std::to_string(_configuration.iterations.value).size());
   }
 
+  const auto rank = _domainDecomposition->getDomainIndex();
+  const auto *fillerBeforeSuffix =
+      _configuration.outputSuffix.value.empty() or _configuration.outputSuffix.value.front() == '_' ? "" : "_";
+  const auto *fillerAfterSuffix =
+      _configuration.outputSuffix.value.empty() or _configuration.outputSuffix.value.back() == '_' ? "" : "_";
+  const auto outputSuffix = "Rank" + std::to_string(rank) + fillerBeforeSuffix +
+                            _configuration.outputSuffix.value + fillerAfterSuffix;
+
   if (_configuration.logFileName.value.empty()) {
     _outputStream = &std::cout;
   } else {
     _logFile = std::make_shared<std::ofstream>();
-    _logFile->open(_configuration.logFileName.value);
+    _logFile->open(_configuration.logFileName.value + outputSuffix);
     _outputStream = &(*_logFile);
   }
 
@@ -165,13 +173,7 @@ Simulation::Simulation(const MDFlexConfig &configuration,
   _autoPasContainer->setAcquisitionFunction(_configuration.acquisitionFunctionOption.value);
   _autoPasContainer->setUseTuningLogger(_configuration.useTuningLogger.value);
   _autoPasContainer->setSortingThreshold(_configuration.sortingThreshold.value);
-  const auto rank = _domainDecomposition->getDomainIndex();
-  const auto *fillerBeforeSuffix =
-      _configuration.outputSuffix.value.empty() or _configuration.outputSuffix.value.front() == '_' ? "" : "_";
-  const auto *fillerAfterSuffix =
-      _configuration.outputSuffix.value.empty() or _configuration.outputSuffix.value.back() == '_' ? "" : "_";
-  _autoPasContainer->setOutputSuffix("Rank" + std::to_string(rank) + fillerBeforeSuffix +
-                                     _configuration.outputSuffix.value + fillerAfterSuffix);
+  _autoPasContainer->setOutputSuffix(outputSuffix);
   autopas::Logger::get()->set_level(_configuration.logLevel.value);
 
   _autoPasContainer->init();


### PR DESCRIPTION
# Description

When a log filename is provided to md-flexible, this is split into a log file per rank. This makes it much easier to follow individual series of log messages for each rank, particularly when using TRACE-level logging.

If no log filename is provided, nothing is changed (all log messages are written as normal)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Manually checking produced log files
