### PR TITLE
Particle Alias/Typename fix

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,6 +19,7 @@ Please keep in mind the following notes while working.
 
 ### Code Style
 * Private attributes are prefixed with `_`.
+* Postfix template class/typename parameters with `T`. (This has not been applied retroactively and so there are plenty of cases where this is not yet the case, but should be applied for new contributions.
 * Every (abstract) class gets its own file, named exactly like the class.
 * Class names start with a capital letter.
 * Use `camelCase` over `snake_case`.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Please keep in mind the following notes while working.
 
 ### Code Style
 * Private attributes are prefixed with `_`.
-* Postfix template class/typename parameters with `T`. (This has not been applied retroactively and so there are plenty of cases where this is not yet the case, but should be applied for new contributions.
+* Postfix template class/typename parameters with `_T`. (This has not been applied retroactively and so there are plenty of cases where this is not yet the case, but should be applied for new contributions.
 * Every (abstract) class gets its own file, named exactly like the class.
 * Class names start with a capital letter.
 * Use `camelCase` over `snake_case`.

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/AxilrodTellerFunctor.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/AxilrodTellerFunctor.h
@@ -86,27 +86,27 @@ namespace mdLib {
  * A functor to handle Axilrod-Teller(-Muto) interactions between three particles (molecules).
  * This functor assumes that duplicated calculations are always happening, which is characteristic for a Full-Shell
  * scheme.
- * @tparam ParticleT The type of particle.
+ * @tparam Particle_T The type of particle.
  * @tparam useMixing Switch for the functor to be used with multiple particle types.
  * If set to false, _epsilon and _sigma need to be set and the constructor with PPL can be omitted.
  * @tparam useNewton3 Switch for the functor to support newton3 on, off or both. See FunctorN3Modes for possible values.
  * @tparam calculateGlobals Defines whether the global values are to be calculated (energy, virial).
  * @tparam countFLOPs counts FLOPs and hitrate
  */
-template <class ParticleT, bool useMixing = false, autopas::FunctorN3Modes useNewton3 = autopas::FunctorN3Modes::Both,
+template <class Particle_T, bool useMixing = false, autopas::FunctorN3Modes useNewton3 = autopas::FunctorN3Modes::Both,
           bool calculateGlobals = false, bool countFLOPs = false>
 class AxilrodTellerFunctor
     : public autopas::TriwiseFunctor<
-          ParticleT, AxilrodTellerFunctor<ParticleT, useMixing, useNewton3, calculateGlobals, countFLOPs>> {
+          Particle_T, AxilrodTellerFunctor<Particle_T, useMixing, useNewton3, calculateGlobals, countFLOPs>> {
   /**
    * Structure of the SoAs defined by the particle.
    */
-  using SoAArraysType = typename ParticleT::SoAArraysType;
+  using SoAArraysType = typename Particle_T::SoAArraysType;
 
   /**
    * Precision of SoA entries.
    */
-  using SoAFloatPrecision = typename ParticleT::ParticleSoAFloatPrecision;
+  using SoAFloatPrecision = typename Particle_T::ParticleSoAFloatPrecision;
 
  public:
   /**
@@ -121,8 +121,8 @@ class AxilrodTellerFunctor
    * @note param dummy is unused, only there to make the signature different from the public constructor.
    */
   explicit AxilrodTellerFunctor(double cutoff, void * /*dummy*/)
-      : autopas::TriwiseFunctor<ParticleT,
-                                AxilrodTellerFunctor<ParticleT, useMixing, useNewton3, calculateGlobals, countFLOPs>>(
+      : autopas::TriwiseFunctor<Particle_T,
+                                AxilrodTellerFunctor<Particle_T, useMixing, useNewton3, calculateGlobals, countFLOPs>>(
             cutoff),
         _cutoffSquared{cutoff * cutoff},
         _potentialEnergySum{0.},
@@ -178,7 +178,7 @@ class AxilrodTellerFunctor
     return useNewton3 == autopas::FunctorN3Modes::Newton3Off or useNewton3 == autopas::FunctorN3Modes::Both;
   }
 
-  void AoSFunctor(ParticleT &i, ParticleT &j, ParticleT &k, bool newton3) final {
+  void AoSFunctor(Particle_T &i, Particle_T &j, Particle_T &k, bool newton3) final {
     using namespace autopas::utils::ArrayMath::literals;
 
     if (i.isDummy() or j.isDummy() or k.isDummy()) {
@@ -300,32 +300,33 @@ class AxilrodTellerFunctor
    * @copydoc autopas::Functor::getNeededAttr()
    */
   constexpr static auto getNeededAttr() {
-    return std::array<typename ParticleT::AttributeNames, 9>{ParticleT::AttributeNames::id,
-                                                             ParticleT::AttributeNames::posX,
-                                                             ParticleT::AttributeNames::posY,
-                                                             ParticleT::AttributeNames::posZ,
-                                                             ParticleT::AttributeNames::forceX,
-                                                             ParticleT::AttributeNames::forceY,
-                                                             ParticleT::AttributeNames::forceZ,
-                                                             ParticleT::AttributeNames::typeId,
-                                                             ParticleT::AttributeNames::ownershipState};
+    return std::array<typename Particle_T::AttributeNames, 9>{Particle_T::AttributeNames::id,
+                                                              Particle_T::AttributeNames::posX,
+                                                              Particle_T::AttributeNames::posY,
+                                                              Particle_T::AttributeNames::posZ,
+                                                              Particle_T::AttributeNames::forceX,
+                                                              Particle_T::AttributeNames::forceY,
+                                                              Particle_T::AttributeNames::forceZ,
+                                                              Particle_T::AttributeNames::typeId,
+                                                              Particle_T::AttributeNames::ownershipState};
   }
 
   /**
    * @copydoc autopas::Functor::getNeededAttr(std::false_type)
    */
   constexpr static auto getNeededAttr(std::false_type) {
-    return std::array<typename ParticleT::AttributeNames, 6>{
-        ParticleT::AttributeNames::id,   ParticleT::AttributeNames::posX,   ParticleT::AttributeNames::posY,
-        ParticleT::AttributeNames::posZ, ParticleT::AttributeNames::typeId, ParticleT::AttributeNames::ownershipState};
+    return std::array<typename Particle_T::AttributeNames, 6>{
+        Particle_T::AttributeNames::id,     Particle_T::AttributeNames::posX,
+        Particle_T::AttributeNames::posY,   Particle_T::AttributeNames::posZ,
+        Particle_T::AttributeNames::typeId, Particle_T::AttributeNames::ownershipState};
   }
 
   /**
    * @copydoc autopas::Functor::getComputedAttr()
    */
   constexpr static auto getComputedAttr() {
-    return std::array<typename ParticleT::AttributeNames, 3>{
-        ParticleT::AttributeNames::forceX, ParticleT::AttributeNames::forceY, ParticleT::AttributeNames::forceZ};
+    return std::array<typename Particle_T::AttributeNames, 3>{
+        Particle_T::AttributeNames::forceX, Particle_T::AttributeNames::forceY, Particle_T::AttributeNames::forceZ};
   }
 
   /**

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/AxilrodTellerFunctor.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/AxilrodTellerFunctor.h
@@ -86,27 +86,27 @@ namespace mdLib {
  * A functor to handle Axilrod-Teller(-Muto) interactions between three particles (molecules).
  * This functor assumes that duplicated calculations are always happening, which is characteristic for a Full-Shell
  * scheme.
- * @tparam Particle The type of particle.
+ * @tparam ParticleT The type of particle.
  * @tparam useMixing Switch for the functor to be used with multiple particle types.
  * If set to false, _epsilon and _sigma need to be set and the constructor with PPL can be omitted.
  * @tparam useNewton3 Switch for the functor to support newton3 on, off or both. See FunctorN3Modes for possible values.
  * @tparam calculateGlobals Defines whether the global values are to be calculated (energy, virial).
  * @tparam countFLOPs counts FLOPs and hitrate
  */
-template <class Particle, bool useMixing = false, autopas::FunctorN3Modes useNewton3 = autopas::FunctorN3Modes::Both,
+template <class ParticleT, bool useMixing = false, autopas::FunctorN3Modes useNewton3 = autopas::FunctorN3Modes::Both,
           bool calculateGlobals = false, bool countFLOPs = false>
 class AxilrodTellerFunctor
     : public autopas::TriwiseFunctor<
-          Particle, AxilrodTellerFunctor<Particle, useMixing, useNewton3, calculateGlobals, countFLOPs>> {
+          ParticleT, AxilrodTellerFunctor<ParticleT, useMixing, useNewton3, calculateGlobals, countFLOPs>> {
   /**
    * Structure of the SoAs defined by the particle.
    */
-  using SoAArraysType = typename Particle::SoAArraysType;
+  using SoAArraysType = typename ParticleT::SoAArraysType;
 
   /**
    * Precision of SoA entries.
    */
-  using SoAFloatPrecision = typename Particle::ParticleSoAFloatPrecision;
+  using SoAFloatPrecision = typename ParticleT::ParticleSoAFloatPrecision;
 
  public:
   /**
@@ -121,8 +121,8 @@ class AxilrodTellerFunctor
    * @note param dummy is unused, only there to make the signature different from the public constructor.
    */
   explicit AxilrodTellerFunctor(double cutoff, void * /*dummy*/)
-      : autopas::TriwiseFunctor<Particle,
-                                AxilrodTellerFunctor<Particle, useMixing, useNewton3, calculateGlobals, countFLOPs>>(
+      : autopas::TriwiseFunctor<ParticleT,
+                                AxilrodTellerFunctor<ParticleT, useMixing, useNewton3, calculateGlobals, countFLOPs>>(
             cutoff),
         _cutoffSquared{cutoff * cutoff},
         _potentialEnergySum{0.},
@@ -178,7 +178,7 @@ class AxilrodTellerFunctor
     return useNewton3 == autopas::FunctorN3Modes::Newton3Off or useNewton3 == autopas::FunctorN3Modes::Both;
   }
 
-  void AoSFunctor(Particle &i, Particle &j, Particle &k, bool newton3) final {
+  void AoSFunctor(ParticleT &i, ParticleT &j, ParticleT &k, bool newton3) final {
     using namespace autopas::utils::ArrayMath::literals;
 
     if (i.isDummy() or j.isDummy() or k.isDummy()) {
@@ -300,27 +300,32 @@ class AxilrodTellerFunctor
    * @copydoc autopas::Functor::getNeededAttr()
    */
   constexpr static auto getNeededAttr() {
-    return std::array<typename Particle::AttributeNames, 9>{
-        Particle::AttributeNames::id,     Particle::AttributeNames::posX,   Particle::AttributeNames::posY,
-        Particle::AttributeNames::posZ,   Particle::AttributeNames::forceX, Particle::AttributeNames::forceY,
-        Particle::AttributeNames::forceZ, Particle::AttributeNames::typeId, Particle::AttributeNames::ownershipState};
+    return std::array<typename ParticleT::AttributeNames, 9>{ParticleT::AttributeNames::id,
+                                                             ParticleT::AttributeNames::posX,
+                                                             ParticleT::AttributeNames::posY,
+                                                             ParticleT::AttributeNames::posZ,
+                                                             ParticleT::AttributeNames::forceX,
+                                                             ParticleT::AttributeNames::forceY,
+                                                             ParticleT::AttributeNames::forceZ,
+                                                             ParticleT::AttributeNames::typeId,
+                                                             ParticleT::AttributeNames::ownershipState};
   }
 
   /**
    * @copydoc autopas::Functor::getNeededAttr(std::false_type)
    */
   constexpr static auto getNeededAttr(std::false_type) {
-    return std::array<typename Particle::AttributeNames, 6>{
-        Particle::AttributeNames::id,   Particle::AttributeNames::posX,   Particle::AttributeNames::posY,
-        Particle::AttributeNames::posZ, Particle::AttributeNames::typeId, Particle::AttributeNames::ownershipState};
+    return std::array<typename ParticleT::AttributeNames, 6>{
+        ParticleT::AttributeNames::id,   ParticleT::AttributeNames::posX,   ParticleT::AttributeNames::posY,
+        ParticleT::AttributeNames::posZ, ParticleT::AttributeNames::typeId, ParticleT::AttributeNames::ownershipState};
   }
 
   /**
    * @copydoc autopas::Functor::getComputedAttr()
    */
   constexpr static auto getComputedAttr() {
-    return std::array<typename Particle::AttributeNames, 3>{
-        Particle::AttributeNames::forceX, Particle::AttributeNames::forceY, Particle::AttributeNames::forceZ};
+    return std::array<typename ParticleT::AttributeNames, 3>{
+        ParticleT::AttributeNames::forceX, ParticleT::AttributeNames::forceY, ParticleT::AttributeNames::forceZ};
   }
 
   /**

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctor.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctor.h
@@ -37,8 +37,8 @@ template <class ParticleT, bool applyShift = false, bool useMixing = false,
           autopas::FunctorN3Modes useNewton3 = autopas::FunctorN3Modes::Both, bool calculateGlobals = false,
           bool countFLOPs = false, bool relevantForTuning = true>
 class LJFunctor
-    : public autopas::PairwiseFunctor<ParticleT, LJFunctor<ParticleT, applyShift, useMixing, useNewton3, calculateGlobals,
-                                                          countFLOPs, relevantForTuning>> {
+    : public autopas::PairwiseFunctor<ParticleT, LJFunctor<ParticleT, applyShift, useMixing, useNewton3,
+                                                           calculateGlobals, countFLOPs, relevantForTuning>> {
   /**
    * Structure of the SoAs defined by the particle.
    */
@@ -63,7 +63,7 @@ class LJFunctor
    */
   explicit LJFunctor(double cutoff, void * /*dummy*/)
       : autopas::PairwiseFunctor<ParticleT, LJFunctor<ParticleT, applyShift, useMixing, useNewton3, calculateGlobals,
-                                                     countFLOPs, relevantForTuning>>(cutoff),
+                                                      countFLOPs, relevantForTuning>>(cutoff),
         _cutoffSquared{cutoff * cutoff},
         _potentialEnergySum{0.},
         _virialSum{0., 0., 0.},

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctor.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctor.h
@@ -24,7 +24,7 @@ namespace mdLib {
  * A functor to handle lennard-jones interactions between two particles (molecules).
  * This functor assumes that duplicated calculations are always happening, which is characteristic for a Full-Shell
  * scheme.
- * @tparam Particle The type of particle.
+ * @tparam ParticleT The type of particle.
  * @tparam applyShift Switch for the lj potential to be truncated shifted.
  * @tparam useMixing Switch for the functor to be used with multiple particle types.
  * If set to false, _epsilon and _sigma need to be set and the constructor with PPL can be omitted.
@@ -33,21 +33,21 @@ namespace mdLib {
  * @tparam countFLOPs counts FLOPs and hitrate
  * @tparam relevantForTuning Whether or not the auto-tuner should consider this functor.
  */
-template <class Particle, bool applyShift = false, bool useMixing = false,
+template <class ParticleT, bool applyShift = false, bool useMixing = false,
           autopas::FunctorN3Modes useNewton3 = autopas::FunctorN3Modes::Both, bool calculateGlobals = false,
           bool countFLOPs = false, bool relevantForTuning = true>
 class LJFunctor
-    : public autopas::PairwiseFunctor<Particle, LJFunctor<Particle, applyShift, useMixing, useNewton3, calculateGlobals,
+    : public autopas::PairwiseFunctor<ParticleT, LJFunctor<ParticleT, applyShift, useMixing, useNewton3, calculateGlobals,
                                                           countFLOPs, relevantForTuning>> {
   /**
    * Structure of the SoAs defined by the particle.
    */
-  using SoAArraysType = typename Particle::SoAArraysType;
+  using SoAArraysType = typename ParticleT::SoAArraysType;
 
   /**
    * Precision of SoA entries.
    */
-  using SoAFloatPrecision = typename Particle::ParticleSoAFloatPrecision;
+  using SoAFloatPrecision = typename ParticleT::ParticleSoAFloatPrecision;
 
  public:
   /**
@@ -62,7 +62,7 @@ class LJFunctor
    * @note param dummy is unused, only there to make the signature different from the public constructor.
    */
   explicit LJFunctor(double cutoff, void * /*dummy*/)
-      : autopas::PairwiseFunctor<Particle, LJFunctor<Particle, applyShift, useMixing, useNewton3, calculateGlobals,
+      : autopas::PairwiseFunctor<ParticleT, LJFunctor<ParticleT, applyShift, useMixing, useNewton3, calculateGlobals,
                                                      countFLOPs, relevantForTuning>>(cutoff),
         _cutoffSquared{cutoff * cutoff},
         _potentialEnergySum{0.},
@@ -117,7 +117,7 @@ class LJFunctor
     return useNewton3 == autopas::FunctorN3Modes::Newton3Off or useNewton3 == autopas::FunctorN3Modes::Both;
   }
 
-  void AoSFunctor(Particle &i, Particle &j, bool newton3) final {
+  void AoSFunctor(ParticleT &i, ParticleT &j, bool newton3) final {
     using namespace autopas::utils::ArrayMath::literals;
 
     if (i.isDummy() or j.isDummy()) {
@@ -203,16 +203,16 @@ class LJFunctor
 
     const auto threadnum = autopas::autopas_get_thread_num();
 
-    const auto *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
-    const auto *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
-    const auto *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
-    const auto *const __restrict ownedStatePtr = soa.template begin<Particle::AttributeNames::ownershipState>();
+    const auto *const __restrict xptr = soa.template begin<ParticleT::AttributeNames::posX>();
+    const auto *const __restrict yptr = soa.template begin<ParticleT::AttributeNames::posY>();
+    const auto *const __restrict zptr = soa.template begin<ParticleT::AttributeNames::posZ>();
+    const auto *const __restrict ownedStatePtr = soa.template begin<ParticleT::AttributeNames::ownershipState>();
 
-    SoAFloatPrecision *const __restrict fxptr = soa.template begin<Particle::AttributeNames::forceX>();
-    SoAFloatPrecision *const __restrict fyptr = soa.template begin<Particle::AttributeNames::forceY>();
-    SoAFloatPrecision *const __restrict fzptr = soa.template begin<Particle::AttributeNames::forceZ>();
+    SoAFloatPrecision *const __restrict fxptr = soa.template begin<ParticleT::AttributeNames::forceX>();
+    SoAFloatPrecision *const __restrict fyptr = soa.template begin<ParticleT::AttributeNames::forceY>();
+    SoAFloatPrecision *const __restrict fzptr = soa.template begin<ParticleT::AttributeNames::forceZ>();
 
-    [[maybe_unused]] auto *const __restrict typeptr = soa.template begin<Particle::AttributeNames::typeId>();
+    [[maybe_unused]] auto *const __restrict typeptr = soa.template begin<ParticleT::AttributeNames::typeId>();
     // the local redeclaration of the following values helps the SoAFloatPrecision-generation of various compilers.
     const SoAFloatPrecision cutoffSquared = _cutoffSquared;
 
@@ -386,23 +386,23 @@ class LJFunctor
 
     const auto threadnum = autopas::autopas_get_thread_num();
 
-    const auto *const __restrict x1ptr = soa1.template begin<Particle::AttributeNames::posX>();
-    const auto *const __restrict y1ptr = soa1.template begin<Particle::AttributeNames::posY>();
-    const auto *const __restrict z1ptr = soa1.template begin<Particle::AttributeNames::posZ>();
-    const auto *const __restrict x2ptr = soa2.template begin<Particle::AttributeNames::posX>();
-    const auto *const __restrict y2ptr = soa2.template begin<Particle::AttributeNames::posY>();
-    const auto *const __restrict z2ptr = soa2.template begin<Particle::AttributeNames::posZ>();
-    const auto *const __restrict ownedStatePtr1 = soa1.template begin<Particle::AttributeNames::ownershipState>();
-    const auto *const __restrict ownedStatePtr2 = soa2.template begin<Particle::AttributeNames::ownershipState>();
+    const auto *const __restrict x1ptr = soa1.template begin<ParticleT::AttributeNames::posX>();
+    const auto *const __restrict y1ptr = soa1.template begin<ParticleT::AttributeNames::posY>();
+    const auto *const __restrict z1ptr = soa1.template begin<ParticleT::AttributeNames::posZ>();
+    const auto *const __restrict x2ptr = soa2.template begin<ParticleT::AttributeNames::posX>();
+    const auto *const __restrict y2ptr = soa2.template begin<ParticleT::AttributeNames::posY>();
+    const auto *const __restrict z2ptr = soa2.template begin<ParticleT::AttributeNames::posZ>();
+    const auto *const __restrict ownedStatePtr1 = soa1.template begin<ParticleT::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr2 = soa2.template begin<ParticleT::AttributeNames::ownershipState>();
 
-    auto *const __restrict fx1ptr = soa1.template begin<Particle::AttributeNames::forceX>();
-    auto *const __restrict fy1ptr = soa1.template begin<Particle::AttributeNames::forceY>();
-    auto *const __restrict fz1ptr = soa1.template begin<Particle::AttributeNames::forceZ>();
-    auto *const __restrict fx2ptr = soa2.template begin<Particle::AttributeNames::forceX>();
-    auto *const __restrict fy2ptr = soa2.template begin<Particle::AttributeNames::forceY>();
-    auto *const __restrict fz2ptr = soa2.template begin<Particle::AttributeNames::forceZ>();
-    [[maybe_unused]] auto *const __restrict typeptr1 = soa1.template begin<Particle::AttributeNames::typeId>();
-    [[maybe_unused]] auto *const __restrict typeptr2 = soa2.template begin<Particle::AttributeNames::typeId>();
+    auto *const __restrict fx1ptr = soa1.template begin<ParticleT::AttributeNames::forceX>();
+    auto *const __restrict fy1ptr = soa1.template begin<ParticleT::AttributeNames::forceY>();
+    auto *const __restrict fz1ptr = soa1.template begin<ParticleT::AttributeNames::forceZ>();
+    auto *const __restrict fx2ptr = soa2.template begin<ParticleT::AttributeNames::forceX>();
+    auto *const __restrict fy2ptr = soa2.template begin<ParticleT::AttributeNames::forceY>();
+    auto *const __restrict fz2ptr = soa2.template begin<ParticleT::AttributeNames::forceZ>();
+    [[maybe_unused]] auto *const __restrict typeptr1 = soa1.template begin<ParticleT::AttributeNames::typeId>();
+    [[maybe_unused]] auto *const __restrict typeptr2 = soa2.template begin<ParticleT::AttributeNames::typeId>();
 
     // Checks whether the cells are halo cells.
     SoAFloatPrecision potentialEnergySum = 0.;
@@ -596,27 +596,32 @@ class LJFunctor
    * @copydoc autopas::Functor::getNeededAttr()
    */
   constexpr static auto getNeededAttr() {
-    return std::array<typename Particle::AttributeNames, 9>{
-        Particle::AttributeNames::id,     Particle::AttributeNames::posX,   Particle::AttributeNames::posY,
-        Particle::AttributeNames::posZ,   Particle::AttributeNames::forceX, Particle::AttributeNames::forceY,
-        Particle::AttributeNames::forceZ, Particle::AttributeNames::typeId, Particle::AttributeNames::ownershipState};
+    return std::array<typename ParticleT::AttributeNames, 9>{ParticleT::AttributeNames::id,
+                                                             ParticleT::AttributeNames::posX,
+                                                             ParticleT::AttributeNames::posY,
+                                                             ParticleT::AttributeNames::posZ,
+                                                             ParticleT::AttributeNames::forceX,
+                                                             ParticleT::AttributeNames::forceY,
+                                                             ParticleT::AttributeNames::forceZ,
+                                                             ParticleT::AttributeNames::typeId,
+                                                             ParticleT::AttributeNames::ownershipState};
   }
 
   /**
    * @copydoc autopas::Functor::getNeededAttr(std::false_type)
    */
   constexpr static auto getNeededAttr(std::false_type) {
-    return std::array<typename Particle::AttributeNames, 6>{
-        Particle::AttributeNames::id,   Particle::AttributeNames::posX,   Particle::AttributeNames::posY,
-        Particle::AttributeNames::posZ, Particle::AttributeNames::typeId, Particle::AttributeNames::ownershipState};
+    return std::array<typename ParticleT::AttributeNames, 6>{
+        ParticleT::AttributeNames::id,   ParticleT::AttributeNames::posX,   ParticleT::AttributeNames::posY,
+        ParticleT::AttributeNames::posZ, ParticleT::AttributeNames::typeId, ParticleT::AttributeNames::ownershipState};
   }
 
   /**
    * @copydoc autopas::Functor::getComputedAttr()
    */
   constexpr static auto getComputedAttr() {
-    return std::array<typename Particle::AttributeNames, 3>{
-        Particle::AttributeNames::forceX, Particle::AttributeNames::forceY, Particle::AttributeNames::forceZ};
+    return std::array<typename ParticleT::AttributeNames, 3>{
+        ParticleT::AttributeNames::forceX, ParticleT::AttributeNames::forceY, ParticleT::AttributeNames::forceZ};
   }
 
   /**
@@ -803,17 +808,17 @@ class LJFunctor
   template <bool newton3>
   void SoAFunctorVerletImpl(autopas::SoAView<SoAArraysType> soa, const size_t indexFirst,
                             const std::vector<size_t, autopas::AlignedAllocator<size_t>> &neighborList) {
-    const auto *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
-    const auto *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
-    const auto *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
+    const auto *const __restrict xptr = soa.template begin<ParticleT::AttributeNames::posX>();
+    const auto *const __restrict yptr = soa.template begin<ParticleT::AttributeNames::posY>();
+    const auto *const __restrict zptr = soa.template begin<ParticleT::AttributeNames::posZ>();
 
-    auto *const __restrict fxptr = soa.template begin<Particle::AttributeNames::forceX>();
-    auto *const __restrict fyptr = soa.template begin<Particle::AttributeNames::forceY>();
-    auto *const __restrict fzptr = soa.template begin<Particle::AttributeNames::forceZ>();
-    [[maybe_unused]] auto *const __restrict typeptr1 = soa.template begin<Particle::AttributeNames::typeId>();
-    [[maybe_unused]] auto *const __restrict typeptr2 = soa.template begin<Particle::AttributeNames::typeId>();
+    auto *const __restrict fxptr = soa.template begin<ParticleT::AttributeNames::forceX>();
+    auto *const __restrict fyptr = soa.template begin<ParticleT::AttributeNames::forceY>();
+    auto *const __restrict fzptr = soa.template begin<ParticleT::AttributeNames::forceZ>();
+    [[maybe_unused]] auto *const __restrict typeptr1 = soa.template begin<ParticleT::AttributeNames::typeId>();
+    [[maybe_unused]] auto *const __restrict typeptr2 = soa.template begin<ParticleT::AttributeNames::typeId>();
 
-    const auto *const __restrict ownedStatePtr = soa.template begin<Particle::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr = soa.template begin<ParticleT::AttributeNames::ownershipState>();
 
     const SoAFloatPrecision cutoffSquared = _cutoffSquared;
     SoAFloatPrecision shift6 = _shift6;

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctor.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctor.h
@@ -24,7 +24,7 @@ namespace mdLib {
  * A functor to handle lennard-jones interactions between two particles (molecules).
  * This functor assumes that duplicated calculations are always happening, which is characteristic for a Full-Shell
  * scheme.
- * @tparam ParticleT The type of particle.
+ * @tparam Particle_T The type of particle.
  * @tparam applyShift Switch for the lj potential to be truncated shifted.
  * @tparam useMixing Switch for the functor to be used with multiple particle types.
  * If set to false, _epsilon and _sigma need to be set and the constructor with PPL can be omitted.
@@ -33,21 +33,21 @@ namespace mdLib {
  * @tparam countFLOPs counts FLOPs and hitrate
  * @tparam relevantForTuning Whether or not the auto-tuner should consider this functor.
  */
-template <class ParticleT, bool applyShift = false, bool useMixing = false,
+template <class Particle_T, bool applyShift = false, bool useMixing = false,
           autopas::FunctorN3Modes useNewton3 = autopas::FunctorN3Modes::Both, bool calculateGlobals = false,
           bool countFLOPs = false, bool relevantForTuning = true>
 class LJFunctor
-    : public autopas::PairwiseFunctor<ParticleT, LJFunctor<ParticleT, applyShift, useMixing, useNewton3,
-                                                           calculateGlobals, countFLOPs, relevantForTuning>> {
+    : public autopas::PairwiseFunctor<Particle_T, LJFunctor<Particle_T, applyShift, useMixing, useNewton3,
+                                                            calculateGlobals, countFLOPs, relevantForTuning>> {
   /**
    * Structure of the SoAs defined by the particle.
    */
-  using SoAArraysType = typename ParticleT::SoAArraysType;
+  using SoAArraysType = typename Particle_T::SoAArraysType;
 
   /**
    * Precision of SoA entries.
    */
-  using SoAFloatPrecision = typename ParticleT::ParticleSoAFloatPrecision;
+  using SoAFloatPrecision = typename Particle_T::ParticleSoAFloatPrecision;
 
  public:
   /**
@@ -62,8 +62,8 @@ class LJFunctor
    * @note param dummy is unused, only there to make the signature different from the public constructor.
    */
   explicit LJFunctor(double cutoff, void * /*dummy*/)
-      : autopas::PairwiseFunctor<ParticleT, LJFunctor<ParticleT, applyShift, useMixing, useNewton3, calculateGlobals,
-                                                      countFLOPs, relevantForTuning>>(cutoff),
+      : autopas::PairwiseFunctor<Particle_T, LJFunctor<Particle_T, applyShift, useMixing, useNewton3, calculateGlobals,
+                                                       countFLOPs, relevantForTuning>>(cutoff),
         _cutoffSquared{cutoff * cutoff},
         _potentialEnergySum{0.},
         _virialSum{0., 0., 0.},
@@ -117,7 +117,7 @@ class LJFunctor
     return useNewton3 == autopas::FunctorN3Modes::Newton3Off or useNewton3 == autopas::FunctorN3Modes::Both;
   }
 
-  void AoSFunctor(ParticleT &i, ParticleT &j, bool newton3) final {
+  void AoSFunctor(Particle_T &i, Particle_T &j, bool newton3) final {
     using namespace autopas::utils::ArrayMath::literals;
 
     if (i.isDummy() or j.isDummy()) {
@@ -203,16 +203,16 @@ class LJFunctor
 
     const auto threadnum = autopas::autopas_get_thread_num();
 
-    const auto *const __restrict xptr = soa.template begin<ParticleT::AttributeNames::posX>();
-    const auto *const __restrict yptr = soa.template begin<ParticleT::AttributeNames::posY>();
-    const auto *const __restrict zptr = soa.template begin<ParticleT::AttributeNames::posZ>();
-    const auto *const __restrict ownedStatePtr = soa.template begin<ParticleT::AttributeNames::ownershipState>();
+    const auto *const __restrict xptr = soa.template begin<Particle_T::AttributeNames::posX>();
+    const auto *const __restrict yptr = soa.template begin<Particle_T::AttributeNames::posY>();
+    const auto *const __restrict zptr = soa.template begin<Particle_T::AttributeNames::posZ>();
+    const auto *const __restrict ownedStatePtr = soa.template begin<Particle_T::AttributeNames::ownershipState>();
 
-    SoAFloatPrecision *const __restrict fxptr = soa.template begin<ParticleT::AttributeNames::forceX>();
-    SoAFloatPrecision *const __restrict fyptr = soa.template begin<ParticleT::AttributeNames::forceY>();
-    SoAFloatPrecision *const __restrict fzptr = soa.template begin<ParticleT::AttributeNames::forceZ>();
+    SoAFloatPrecision *const __restrict fxptr = soa.template begin<Particle_T::AttributeNames::forceX>();
+    SoAFloatPrecision *const __restrict fyptr = soa.template begin<Particle_T::AttributeNames::forceY>();
+    SoAFloatPrecision *const __restrict fzptr = soa.template begin<Particle_T::AttributeNames::forceZ>();
 
-    [[maybe_unused]] auto *const __restrict typeptr = soa.template begin<ParticleT::AttributeNames::typeId>();
+    [[maybe_unused]] auto *const __restrict typeptr = soa.template begin<Particle_T::AttributeNames::typeId>();
     // the local redeclaration of the following values helps the SoAFloatPrecision-generation of various compilers.
     const SoAFloatPrecision cutoffSquared = _cutoffSquared;
 
@@ -386,23 +386,23 @@ class LJFunctor
 
     const auto threadnum = autopas::autopas_get_thread_num();
 
-    const auto *const __restrict x1ptr = soa1.template begin<ParticleT::AttributeNames::posX>();
-    const auto *const __restrict y1ptr = soa1.template begin<ParticleT::AttributeNames::posY>();
-    const auto *const __restrict z1ptr = soa1.template begin<ParticleT::AttributeNames::posZ>();
-    const auto *const __restrict x2ptr = soa2.template begin<ParticleT::AttributeNames::posX>();
-    const auto *const __restrict y2ptr = soa2.template begin<ParticleT::AttributeNames::posY>();
-    const auto *const __restrict z2ptr = soa2.template begin<ParticleT::AttributeNames::posZ>();
-    const auto *const __restrict ownedStatePtr1 = soa1.template begin<ParticleT::AttributeNames::ownershipState>();
-    const auto *const __restrict ownedStatePtr2 = soa2.template begin<ParticleT::AttributeNames::ownershipState>();
+    const auto *const __restrict x1ptr = soa1.template begin<Particle_T::AttributeNames::posX>();
+    const auto *const __restrict y1ptr = soa1.template begin<Particle_T::AttributeNames::posY>();
+    const auto *const __restrict z1ptr = soa1.template begin<Particle_T::AttributeNames::posZ>();
+    const auto *const __restrict x2ptr = soa2.template begin<Particle_T::AttributeNames::posX>();
+    const auto *const __restrict y2ptr = soa2.template begin<Particle_T::AttributeNames::posY>();
+    const auto *const __restrict z2ptr = soa2.template begin<Particle_T::AttributeNames::posZ>();
+    const auto *const __restrict ownedStatePtr1 = soa1.template begin<Particle_T::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr2 = soa2.template begin<Particle_T::AttributeNames::ownershipState>();
 
-    auto *const __restrict fx1ptr = soa1.template begin<ParticleT::AttributeNames::forceX>();
-    auto *const __restrict fy1ptr = soa1.template begin<ParticleT::AttributeNames::forceY>();
-    auto *const __restrict fz1ptr = soa1.template begin<ParticleT::AttributeNames::forceZ>();
-    auto *const __restrict fx2ptr = soa2.template begin<ParticleT::AttributeNames::forceX>();
-    auto *const __restrict fy2ptr = soa2.template begin<ParticleT::AttributeNames::forceY>();
-    auto *const __restrict fz2ptr = soa2.template begin<ParticleT::AttributeNames::forceZ>();
-    [[maybe_unused]] auto *const __restrict typeptr1 = soa1.template begin<ParticleT::AttributeNames::typeId>();
-    [[maybe_unused]] auto *const __restrict typeptr2 = soa2.template begin<ParticleT::AttributeNames::typeId>();
+    auto *const __restrict fx1ptr = soa1.template begin<Particle_T::AttributeNames::forceX>();
+    auto *const __restrict fy1ptr = soa1.template begin<Particle_T::AttributeNames::forceY>();
+    auto *const __restrict fz1ptr = soa1.template begin<Particle_T::AttributeNames::forceZ>();
+    auto *const __restrict fx2ptr = soa2.template begin<Particle_T::AttributeNames::forceX>();
+    auto *const __restrict fy2ptr = soa2.template begin<Particle_T::AttributeNames::forceY>();
+    auto *const __restrict fz2ptr = soa2.template begin<Particle_T::AttributeNames::forceZ>();
+    [[maybe_unused]] auto *const __restrict typeptr1 = soa1.template begin<Particle_T::AttributeNames::typeId>();
+    [[maybe_unused]] auto *const __restrict typeptr2 = soa2.template begin<Particle_T::AttributeNames::typeId>();
 
     // Checks whether the cells are halo cells.
     SoAFloatPrecision potentialEnergySum = 0.;
@@ -596,32 +596,33 @@ class LJFunctor
    * @copydoc autopas::Functor::getNeededAttr()
    */
   constexpr static auto getNeededAttr() {
-    return std::array<typename ParticleT::AttributeNames, 9>{ParticleT::AttributeNames::id,
-                                                             ParticleT::AttributeNames::posX,
-                                                             ParticleT::AttributeNames::posY,
-                                                             ParticleT::AttributeNames::posZ,
-                                                             ParticleT::AttributeNames::forceX,
-                                                             ParticleT::AttributeNames::forceY,
-                                                             ParticleT::AttributeNames::forceZ,
-                                                             ParticleT::AttributeNames::typeId,
-                                                             ParticleT::AttributeNames::ownershipState};
+    return std::array<typename Particle_T::AttributeNames, 9>{Particle_T::AttributeNames::id,
+                                                              Particle_T::AttributeNames::posX,
+                                                              Particle_T::AttributeNames::posY,
+                                                              Particle_T::AttributeNames::posZ,
+                                                              Particle_T::AttributeNames::forceX,
+                                                              Particle_T::AttributeNames::forceY,
+                                                              Particle_T::AttributeNames::forceZ,
+                                                              Particle_T::AttributeNames::typeId,
+                                                              Particle_T::AttributeNames::ownershipState};
   }
 
   /**
    * @copydoc autopas::Functor::getNeededAttr(std::false_type)
    */
   constexpr static auto getNeededAttr(std::false_type) {
-    return std::array<typename ParticleT::AttributeNames, 6>{
-        ParticleT::AttributeNames::id,   ParticleT::AttributeNames::posX,   ParticleT::AttributeNames::posY,
-        ParticleT::AttributeNames::posZ, ParticleT::AttributeNames::typeId, ParticleT::AttributeNames::ownershipState};
+    return std::array<typename Particle_T::AttributeNames, 6>{
+        Particle_T::AttributeNames::id,     Particle_T::AttributeNames::posX,
+        Particle_T::AttributeNames::posY,   Particle_T::AttributeNames::posZ,
+        Particle_T::AttributeNames::typeId, Particle_T::AttributeNames::ownershipState};
   }
 
   /**
    * @copydoc autopas::Functor::getComputedAttr()
    */
   constexpr static auto getComputedAttr() {
-    return std::array<typename ParticleT::AttributeNames, 3>{
-        ParticleT::AttributeNames::forceX, ParticleT::AttributeNames::forceY, ParticleT::AttributeNames::forceZ};
+    return std::array<typename Particle_T::AttributeNames, 3>{
+        Particle_T::AttributeNames::forceX, Particle_T::AttributeNames::forceY, Particle_T::AttributeNames::forceZ};
   }
 
   /**
@@ -808,17 +809,17 @@ class LJFunctor
   template <bool newton3>
   void SoAFunctorVerletImpl(autopas::SoAView<SoAArraysType> soa, const size_t indexFirst,
                             const std::vector<size_t, autopas::AlignedAllocator<size_t>> &neighborList) {
-    const auto *const __restrict xptr = soa.template begin<ParticleT::AttributeNames::posX>();
-    const auto *const __restrict yptr = soa.template begin<ParticleT::AttributeNames::posY>();
-    const auto *const __restrict zptr = soa.template begin<ParticleT::AttributeNames::posZ>();
+    const auto *const __restrict xptr = soa.template begin<Particle_T::AttributeNames::posX>();
+    const auto *const __restrict yptr = soa.template begin<Particle_T::AttributeNames::posY>();
+    const auto *const __restrict zptr = soa.template begin<Particle_T::AttributeNames::posZ>();
 
-    auto *const __restrict fxptr = soa.template begin<ParticleT::AttributeNames::forceX>();
-    auto *const __restrict fyptr = soa.template begin<ParticleT::AttributeNames::forceY>();
-    auto *const __restrict fzptr = soa.template begin<ParticleT::AttributeNames::forceZ>();
-    [[maybe_unused]] auto *const __restrict typeptr1 = soa.template begin<ParticleT::AttributeNames::typeId>();
-    [[maybe_unused]] auto *const __restrict typeptr2 = soa.template begin<ParticleT::AttributeNames::typeId>();
+    auto *const __restrict fxptr = soa.template begin<Particle_T::AttributeNames::forceX>();
+    auto *const __restrict fyptr = soa.template begin<Particle_T::AttributeNames::forceY>();
+    auto *const __restrict fzptr = soa.template begin<Particle_T::AttributeNames::forceZ>();
+    [[maybe_unused]] auto *const __restrict typeptr1 = soa.template begin<Particle_T::AttributeNames::typeId>();
+    [[maybe_unused]] auto *const __restrict typeptr2 = soa.template begin<Particle_T::AttributeNames::typeId>();
 
-    const auto *const __restrict ownedStatePtr = soa.template begin<ParticleT::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr = soa.template begin<Particle_T::AttributeNames::ownershipState>();
 
     const SoAFloatPrecision cutoffSquared = _cutoffSquared;
     SoAFloatPrecision shift6 = _shift6;

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorAVX.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorAVX.h
@@ -29,7 +29,7 @@ namespace mdLib {
  * This functor assumes that duplicated calculations are always happening, which is characteristic for a Full-Shell
  * scheme.
  * This Version is implemented using AVX intrinsics.
- * @tparam ParticleT The type of particle.
+ * @tparam Particle_T The type of particle.
  * @tparam ParticleCell The type of particlecell.
  * @tparam applyShift Switch for the lj potential to be truncated shifted.
  * @tparam useMixing Switch for the functor to be used with multiple particle types.
@@ -39,13 +39,13 @@ namespace mdLib {
  * @tparam relevantForTuning Whether or not the auto-tuner should consider this functor.
  * @tparam countFLOPs counts FLOPs and hitrate. Not implemented for this functor. Please use the AutoVec functor.
  */
-template <class ParticleT, bool applyShift = false, bool useMixing = false,
+template <class Particle_T, bool applyShift = false, bool useMixing = false,
           autopas::FunctorN3Modes useNewton3 = autopas::FunctorN3Modes::Both, bool calculateGlobals = false,
           bool countFLOPs = false, bool relevantForTuning = true>
 class LJFunctorAVX
-    : public autopas::PairwiseFunctor<ParticleT, LJFunctorAVX<ParticleT, applyShift, useMixing, useNewton3,
-                                                              calculateGlobals, countFLOPs, relevantForTuning>> {
-  using SoAArraysType = typename ParticleT::SoAArraysType;
+    : public autopas::PairwiseFunctor<Particle_T, LJFunctorAVX<Particle_T, applyShift, useMixing, useNewton3,
+                                                               calculateGlobals, countFLOPs, relevantForTuning>> {
+  using SoAArraysType = typename Particle_T::SoAArraysType;
 
  public:
   /**
@@ -61,8 +61,8 @@ class LJFunctorAVX
    */
   explicit LJFunctorAVX(double cutoff, void * /*dummy*/)
 #ifdef __AVX__
-      : autopas::PairwiseFunctor<ParticleT, LJFunctorAVX<ParticleT, applyShift, useMixing, useNewton3, calculateGlobals,
-                                                         countFLOPs, relevantForTuning>>(cutoff),
+      : autopas::PairwiseFunctor<Particle_T, LJFunctorAVX<Particle_T, applyShift, useMixing, useNewton3,
+                                                          calculateGlobals, countFLOPs, relevantForTuning>>(cutoff),
         _cutoffSquared{_mm256_set1_pd(cutoff * cutoff)},
         _cutoffSquaredAoS(cutoff * cutoff),
         _potentialEnergySum{0.},
@@ -77,9 +77,8 @@ class LJFunctorAVX
     }
   }
 #else
-      : autopas::Functor<
-            ParticleT, LJFunctorAVX<ParticleT, applyShift, useMixing, useNewton3, calculateGlobals, relevantForTuning>>(
-            cutoff) {
+      : autopas::Functor<Particle_T, LJFunctorAVX<Particle_T, applyShift, useMixing, useNewton3, calculateGlobals,
+                                                  relevantForTuning>>(cutoff) {
     autopas::utils::ExceptionHandler::exception("AutoPas was compiled without AVX support!");
   }
 #endif
@@ -124,7 +123,7 @@ class LJFunctorAVX
     return useNewton3 == autopas::FunctorN3Modes::Newton3Off or useNewton3 == autopas::FunctorN3Modes::Both;
   }
 
-  inline void AoSFunctor(ParticleT &i, ParticleT &j, bool newton3) final {
+  inline void AoSFunctor(Particle_T &i, Particle_T &j, bool newton3) final {
     using namespace autopas::utils::ArrayMath::literals;
     if (i.isDummy() or j.isDummy()) {
       return;
@@ -207,17 +206,17 @@ class LJFunctorAVX
 #ifdef __AVX__
     if (soa.size() == 0) return;
 
-    const auto *const __restrict xptr = soa.template begin<ParticleT::AttributeNames::posX>();
-    const auto *const __restrict yptr = soa.template begin<ParticleT::AttributeNames::posY>();
-    const auto *const __restrict zptr = soa.template begin<ParticleT::AttributeNames::posZ>();
+    const auto *const __restrict xptr = soa.template begin<Particle_T::AttributeNames::posX>();
+    const auto *const __restrict yptr = soa.template begin<Particle_T::AttributeNames::posY>();
+    const auto *const __restrict zptr = soa.template begin<Particle_T::AttributeNames::posZ>();
 
-    const auto *const __restrict ownedStatePtr = soa.template begin<ParticleT::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr = soa.template begin<Particle_T::AttributeNames::ownershipState>();
 
-    auto *const __restrict fxptr = soa.template begin<ParticleT::AttributeNames::forceX>();
-    auto *const __restrict fyptr = soa.template begin<ParticleT::AttributeNames::forceY>();
-    auto *const __restrict fzptr = soa.template begin<ParticleT::AttributeNames::forceZ>();
+    auto *const __restrict fxptr = soa.template begin<Particle_T::AttributeNames::forceX>();
+    auto *const __restrict fyptr = soa.template begin<Particle_T::AttributeNames::forceY>();
+    auto *const __restrict fzptr = soa.template begin<Particle_T::AttributeNames::forceZ>();
 
-    const auto *const __restrict typeIDptr = soa.template begin<ParticleT::AttributeNames::typeId>();
+    const auto *const __restrict typeIDptr = soa.template begin<Particle_T::AttributeNames::typeId>();
 
     __m256d virialSumX = _mm256_setzero_pd();
     __m256d virialSumY = _mm256_setzero_pd();
@@ -320,25 +319,25 @@ class LJFunctorAVX
 #ifdef __AVX__
     if (soa1.size() == 0 || soa2.size() == 0) return;
 
-    const auto *const __restrict x1ptr = soa1.template begin<ParticleT::AttributeNames::posX>();
-    const auto *const __restrict y1ptr = soa1.template begin<ParticleT::AttributeNames::posY>();
-    const auto *const __restrict z1ptr = soa1.template begin<ParticleT::AttributeNames::posZ>();
-    const auto *const __restrict x2ptr = soa2.template begin<ParticleT::AttributeNames::posX>();
-    const auto *const __restrict y2ptr = soa2.template begin<ParticleT::AttributeNames::posY>();
-    const auto *const __restrict z2ptr = soa2.template begin<ParticleT::AttributeNames::posZ>();
+    const auto *const __restrict x1ptr = soa1.template begin<Particle_T::AttributeNames::posX>();
+    const auto *const __restrict y1ptr = soa1.template begin<Particle_T::AttributeNames::posY>();
+    const auto *const __restrict z1ptr = soa1.template begin<Particle_T::AttributeNames::posZ>();
+    const auto *const __restrict x2ptr = soa2.template begin<Particle_T::AttributeNames::posX>();
+    const auto *const __restrict y2ptr = soa2.template begin<Particle_T::AttributeNames::posY>();
+    const auto *const __restrict z2ptr = soa2.template begin<Particle_T::AttributeNames::posZ>();
 
-    const auto *const __restrict ownedStatePtr1 = soa1.template begin<ParticleT::AttributeNames::ownershipState>();
-    const auto *const __restrict ownedStatePtr2 = soa2.template begin<ParticleT::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr1 = soa1.template begin<Particle_T::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr2 = soa2.template begin<Particle_T::AttributeNames::ownershipState>();
 
-    auto *const __restrict fx1ptr = soa1.template begin<ParticleT::AttributeNames::forceX>();
-    auto *const __restrict fy1ptr = soa1.template begin<ParticleT::AttributeNames::forceY>();
-    auto *const __restrict fz1ptr = soa1.template begin<ParticleT::AttributeNames::forceZ>();
-    auto *const __restrict fx2ptr = soa2.template begin<ParticleT::AttributeNames::forceX>();
-    auto *const __restrict fy2ptr = soa2.template begin<ParticleT::AttributeNames::forceY>();
-    auto *const __restrict fz2ptr = soa2.template begin<ParticleT::AttributeNames::forceZ>();
+    auto *const __restrict fx1ptr = soa1.template begin<Particle_T::AttributeNames::forceX>();
+    auto *const __restrict fy1ptr = soa1.template begin<Particle_T::AttributeNames::forceY>();
+    auto *const __restrict fz1ptr = soa1.template begin<Particle_T::AttributeNames::forceZ>();
+    auto *const __restrict fx2ptr = soa2.template begin<Particle_T::AttributeNames::forceX>();
+    auto *const __restrict fy2ptr = soa2.template begin<Particle_T::AttributeNames::forceY>();
+    auto *const __restrict fz2ptr = soa2.template begin<Particle_T::AttributeNames::forceZ>();
 
-    const auto *const __restrict typeID1ptr = soa1.template begin<ParticleT::AttributeNames::typeId>();
-    const auto *const __restrict typeID2ptr = soa2.template begin<ParticleT::AttributeNames::typeId>();
+    const auto *const __restrict typeID1ptr = soa1.template begin<Particle_T::AttributeNames::typeId>();
+    const auto *const __restrict typeID2ptr = soa2.template begin<Particle_T::AttributeNames::typeId>();
 
     __m256d virialSumX = _mm256_setzero_pd();
     __m256d virialSumY = _mm256_setzero_pd();
@@ -622,20 +621,20 @@ class LJFunctorAVX
   inline void SoAFunctorVerletImpl(autopas::SoAView<SoAArraysType> soa, const size_t indexFirst,
                                    const std::vector<size_t, autopas::AlignedAllocator<size_t>> &neighborList) {
 #ifdef __AVX__
-    const auto *const __restrict ownedStatePtr = soa.template begin<ParticleT::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr = soa.template begin<Particle_T::AttributeNames::ownershipState>();
     if (ownedStatePtr[indexFirst] == autopas::OwnershipState::dummy) {
       return;
     }
 
-    const auto *const __restrict xptr = soa.template begin<ParticleT::AttributeNames::posX>();
-    const auto *const __restrict yptr = soa.template begin<ParticleT::AttributeNames::posY>();
-    const auto *const __restrict zptr = soa.template begin<ParticleT::AttributeNames::posZ>();
+    const auto *const __restrict xptr = soa.template begin<Particle_T::AttributeNames::posX>();
+    const auto *const __restrict yptr = soa.template begin<Particle_T::AttributeNames::posY>();
+    const auto *const __restrict zptr = soa.template begin<Particle_T::AttributeNames::posZ>();
 
-    auto *const __restrict fxptr = soa.template begin<ParticleT::AttributeNames::forceX>();
-    auto *const __restrict fyptr = soa.template begin<ParticleT::AttributeNames::forceY>();
-    auto *const __restrict fzptr = soa.template begin<ParticleT::AttributeNames::forceZ>();
+    auto *const __restrict fxptr = soa.template begin<Particle_T::AttributeNames::forceX>();
+    auto *const __restrict fyptr = soa.template begin<Particle_T::AttributeNames::forceY>();
+    auto *const __restrict fzptr = soa.template begin<Particle_T::AttributeNames::forceZ>();
 
-    const auto *const __restrict typeIDptr = soa.template begin<ParticleT::AttributeNames::typeId>();
+    const auto *const __restrict typeIDptr = soa.template begin<Particle_T::AttributeNames::typeId>();
 
     // accumulators
     __m256d virialSumX = _mm256_setzero_pd();
@@ -809,32 +808,33 @@ class LJFunctorAVX
    * @copydoc autopas::Functor::getNeededAttr()
    */
   constexpr static auto getNeededAttr() {
-    return std::array<typename ParticleT::AttributeNames, 9>{ParticleT::AttributeNames::id,
-                                                             ParticleT::AttributeNames::posX,
-                                                             ParticleT::AttributeNames::posY,
-                                                             ParticleT::AttributeNames::posZ,
-                                                             ParticleT::AttributeNames::forceX,
-                                                             ParticleT::AttributeNames::forceY,
-                                                             ParticleT::AttributeNames::forceZ,
-                                                             ParticleT::AttributeNames::typeId,
-                                                             ParticleT::AttributeNames::ownershipState};
+    return std::array<typename Particle_T::AttributeNames, 9>{Particle_T::AttributeNames::id,
+                                                              Particle_T::AttributeNames::posX,
+                                                              Particle_T::AttributeNames::posY,
+                                                              Particle_T::AttributeNames::posZ,
+                                                              Particle_T::AttributeNames::forceX,
+                                                              Particle_T::AttributeNames::forceY,
+                                                              Particle_T::AttributeNames::forceZ,
+                                                              Particle_T::AttributeNames::typeId,
+                                                              Particle_T::AttributeNames::ownershipState};
   }
 
   /**
    * @copydoc autopas::Functor::getNeededAttr(std::false_type)
    */
   constexpr static auto getNeededAttr(std::false_type) {
-    return std::array<typename ParticleT::AttributeNames, 6>{
-        ParticleT::AttributeNames::id,   ParticleT::AttributeNames::posX,   ParticleT::AttributeNames::posY,
-        ParticleT::AttributeNames::posZ, ParticleT::AttributeNames::typeId, ParticleT::AttributeNames::ownershipState};
+    return std::array<typename Particle_T::AttributeNames, 6>{
+        Particle_T::AttributeNames::id,     Particle_T::AttributeNames::posX,
+        Particle_T::AttributeNames::posY,   Particle_T::AttributeNames::posZ,
+        Particle_T::AttributeNames::typeId, Particle_T::AttributeNames::ownershipState};
   }
 
   /**
    * @copydoc autopas::Functor::getComputedAttr()
    */
   constexpr static auto getComputedAttr() {
-    return std::array<typename ParticleT::AttributeNames, 3>{
-        ParticleT::AttributeNames::forceX, ParticleT::AttributeNames::forceY, ParticleT::AttributeNames::forceZ};
+    return std::array<typename Particle_T::AttributeNames, 3>{
+        Particle_T::AttributeNames::forceX, Particle_T::AttributeNames::forceY, Particle_T::AttributeNames::forceZ};
   }
 
   /**

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorAVX.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorAVX.h
@@ -44,7 +44,7 @@ template <class ParticleT, bool applyShift = false, bool useMixing = false,
           bool countFLOPs = false, bool relevantForTuning = true>
 class LJFunctorAVX
     : public autopas::PairwiseFunctor<ParticleT, LJFunctorAVX<ParticleT, applyShift, useMixing, useNewton3,
-                                                             calculateGlobals, countFLOPs, relevantForTuning>> {
+                                                              calculateGlobals, countFLOPs, relevantForTuning>> {
   using SoAArraysType = typename ParticleT::SoAArraysType;
 
  public:
@@ -62,7 +62,7 @@ class LJFunctorAVX
   explicit LJFunctorAVX(double cutoff, void * /*dummy*/)
 #ifdef __AVX__
       : autopas::PairwiseFunctor<ParticleT, LJFunctorAVX<ParticleT, applyShift, useMixing, useNewton3, calculateGlobals,
-                                                        countFLOPs, relevantForTuning>>(cutoff),
+                                                         countFLOPs, relevantForTuning>>(cutoff),
         _cutoffSquared{_mm256_set1_pd(cutoff * cutoff)},
         _cutoffSquaredAoS(cutoff * cutoff),
         _potentialEnergySum{0.},

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorSVE.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorSVE.h
@@ -30,7 +30,7 @@ namespace mdLib {
  * This functor assumes that duplicated calculations are always happening, which is characteristic for a Full-Shell
  * scheme.
  * This Version is implemented using SVE intrinsics.
- * @tparam Particle The type of particle.
+ * @tparam ParticleT The type of particle.
  * @tparam ParticleCell The type of particlecell.
  * @tparam applyShift Switch for the lj potential to be truncated shifted.
  * @tparam useMixing Switch for the functor to be used with multiple particle types.
@@ -40,13 +40,13 @@ namespace mdLib {
  * @tparam relevantForTuning Whether or not the auto-tuner should consider this functor.
  * @tparam countFLOPs counts FLOPs and hitrate. Not implemented for this functor. Please use the AutoVec functor.
  */
-template <class Particle, bool applyShift = false, bool useMixing = false,
+template <class ParticleT, bool applyShift = false, bool useMixing = false,
           autopas::FunctorN3Modes useNewton3 = autopas::FunctorN3Modes::Both, bool calculateGlobals = false,
           bool countFLOPs = false, bool relevantForTuning = true>
 class LJFunctorSVE
-    : public autopas::PairwiseFunctor<Particle, LJFunctorSVE<Particle, applyShift, useMixing, useNewton3,
+    : public autopas::PairwiseFunctor<ParticleT, LJFunctorSVE<ParticleT, applyShift, useMixing, useNewton3,
                                                              calculateGlobals, countFLOPs, relevantForTuning>> {
-  using SoAArraysType = typename Particle::SoAArraysType;
+  using SoAArraysType = typename ParticleT::SoAArraysType;
 
  public:
   /**
@@ -62,7 +62,7 @@ class LJFunctorSVE
    */
   explicit LJFunctorSVE(double cutoff, void * /*dummy*/)
 #ifdef __ARM_FEATURE_SVE
-      : autopas::PairwiseFunctor<Particle, LJFunctorSVE<Particle, applyShift, useMixing, useNewton3, calculateGlobals,
+      : autopas::PairwiseFunctor<ParticleT, LJFunctorSVE<ParticleT, applyShift, useMixing, useNewton3, calculateGlobals,
                                                         countFLOPs, relevantForTuning>>(cutoff),
         _cutoffSquared{cutoff * cutoff},
         _cutoffSquaredAoS(cutoff * cutoff),
@@ -78,7 +78,7 @@ class LJFunctorSVE
     }
   }
 #else
-      : autopas::PairwiseFunctor<Particle, LJFunctorSVE<Particle, applyShift, useMixing, useNewton3, calculateGlobals,
+      : autopas::PairwiseFunctor<ParticleT, LJFunctorSVE<ParticleT, applyShift, useMixing, useNewton3, calculateGlobals,
                                                         countFLOPs, relevantForTuning>>(cutoff) {
     autopas::utils::ExceptionHandler::exception("AutoPas was compiled without SVE support!");
   }
@@ -124,7 +124,7 @@ class LJFunctorSVE
     return useNewton3 == autopas::FunctorN3Modes::Newton3Off or useNewton3 == autopas::FunctorN3Modes::Both;
   }
 
-  void AoSFunctor(Particle &i, Particle &j, bool newton3) final {
+  void AoSFunctor(ParticleT &i, ParticleT &j, bool newton3) final {
     using namespace autopas::utils::ArrayMath::literals;
 
     if (i.isDummy() or j.isDummy()) {
@@ -217,17 +217,17 @@ class LJFunctorSVE
 #ifdef __ARM_FEATURE_SVE
     if (soa.size() == 0) return;
 
-    const auto *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
-    const auto *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
-    const auto *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
+    const auto *const __restrict xptr = soa.template begin<ParticleT::AttributeNames::posX>();
+    const auto *const __restrict yptr = soa.template begin<ParticleT::AttributeNames::posY>();
+    const auto *const __restrict zptr = soa.template begin<ParticleT::AttributeNames::posZ>();
 
-    const auto *const __restrict ownedStatePtr = soa.template begin<Particle::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr = soa.template begin<ParticleT::AttributeNames::ownershipState>();
 
-    auto *const __restrict fxptr = soa.template begin<Particle::AttributeNames::forceX>();
-    auto *const __restrict fyptr = soa.template begin<Particle::AttributeNames::forceY>();
-    auto *const __restrict fzptr = soa.template begin<Particle::AttributeNames::forceZ>();
+    auto *const __restrict fxptr = soa.template begin<ParticleT::AttributeNames::forceX>();
+    auto *const __restrict fyptr = soa.template begin<ParticleT::AttributeNames::forceY>();
+    auto *const __restrict fzptr = soa.template begin<ParticleT::AttributeNames::forceZ>();
 
-    const auto *const __restrict typeIDptr = soa.template begin<Particle::AttributeNames::typeId>();
+    const auto *const __restrict typeIDptr = soa.template begin<ParticleT::AttributeNames::typeId>();
 
     svfloat64_t virialSumX = svdup_f64(0.0);
     svfloat64_t virialSumY = svdup_f64(0.0);
@@ -294,25 +294,25 @@ class LJFunctorSVE
 #ifdef __ARM_FEATURE_SVE
     if (soa1.size() == 0 || soa2.size() == 0) return;
 
-    const auto *const __restrict x1ptr = soa1.template begin<Particle::AttributeNames::posX>();
-    const auto *const __restrict y1ptr = soa1.template begin<Particle::AttributeNames::posY>();
-    const auto *const __restrict z1ptr = soa1.template begin<Particle::AttributeNames::posZ>();
-    const auto *const __restrict x2ptr = soa2.template begin<Particle::AttributeNames::posX>();
-    const auto *const __restrict y2ptr = soa2.template begin<Particle::AttributeNames::posY>();
-    const auto *const __restrict z2ptr = soa2.template begin<Particle::AttributeNames::posZ>();
+    const auto *const __restrict x1ptr = soa1.template begin<ParticleT::AttributeNames::posX>();
+    const auto *const __restrict y1ptr = soa1.template begin<ParticleT::AttributeNames::posY>();
+    const auto *const __restrict z1ptr = soa1.template begin<ParticleT::AttributeNames::posZ>();
+    const auto *const __restrict x2ptr = soa2.template begin<ParticleT::AttributeNames::posX>();
+    const auto *const __restrict y2ptr = soa2.template begin<ParticleT::AttributeNames::posY>();
+    const auto *const __restrict z2ptr = soa2.template begin<ParticleT::AttributeNames::posZ>();
 
-    const auto *const __restrict ownedStatePtr1 = soa1.template begin<Particle::AttributeNames::ownershipState>();
-    const auto *const __restrict ownedStatePtr2 = soa2.template begin<Particle::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr1 = soa1.template begin<ParticleT::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr2 = soa2.template begin<ParticleT::AttributeNames::ownershipState>();
 
-    auto *const __restrict fx1ptr = soa1.template begin<Particle::AttributeNames::forceX>();
-    auto *const __restrict fy1ptr = soa1.template begin<Particle::AttributeNames::forceY>();
-    auto *const __restrict fz1ptr = soa1.template begin<Particle::AttributeNames::forceZ>();
-    auto *const __restrict fx2ptr = soa2.template begin<Particle::AttributeNames::forceX>();
-    auto *const __restrict fy2ptr = soa2.template begin<Particle::AttributeNames::forceY>();
-    auto *const __restrict fz2ptr = soa2.template begin<Particle::AttributeNames::forceZ>();
+    auto *const __restrict fx1ptr = soa1.template begin<ParticleT::AttributeNames::forceX>();
+    auto *const __restrict fy1ptr = soa1.template begin<ParticleT::AttributeNames::forceY>();
+    auto *const __restrict fz1ptr = soa1.template begin<ParticleT::AttributeNames::forceZ>();
+    auto *const __restrict fx2ptr = soa2.template begin<ParticleT::AttributeNames::forceX>();
+    auto *const __restrict fy2ptr = soa2.template begin<ParticleT::AttributeNames::forceY>();
+    auto *const __restrict fz2ptr = soa2.template begin<ParticleT::AttributeNames::forceZ>();
 
-    const auto *const __restrict typeID1ptr = soa1.template begin<Particle::AttributeNames::typeId>();
-    const auto *const __restrict typeID2ptr = soa2.template begin<Particle::AttributeNames::typeId>();
+    const auto *const __restrict typeID1ptr = soa1.template begin<ParticleT::AttributeNames::typeId>();
+    const auto *const __restrict typeID2ptr = soa2.template begin<ParticleT::AttributeNames::typeId>();
 
     svfloat64_t virialSumX = svdup_f64(0.0);
     svfloat64_t virialSumY = svdup_f64(0.0);
@@ -617,19 +617,19 @@ class LJFunctorSVE
   void SoAFunctorVerletImpl(autopas::SoAView<SoAArraysType> soa, const size_t indexFirst,
                             const std::vector<size_t, autopas::AlignedAllocator<size_t>> &neighborList) {
 #ifdef __ARM_FEATURE_SVE
-    const auto *const __restrict ownedStatePtr = soa.template begin<Particle::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr = soa.template begin<ParticleT::AttributeNames::ownershipState>();
     if (ownedStatePtr[indexFirst] == autopas::OwnershipState::dummy) {
       return;
     }
-    const auto *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
-    const auto *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
-    const auto *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
+    const auto *const __restrict xptr = soa.template begin<ParticleT::AttributeNames::posX>();
+    const auto *const __restrict yptr = soa.template begin<ParticleT::AttributeNames::posY>();
+    const auto *const __restrict zptr = soa.template begin<ParticleT::AttributeNames::posZ>();
 
-    auto *const __restrict fxptr = soa.template begin<Particle::AttributeNames::forceX>();
-    auto *const __restrict fyptr = soa.template begin<Particle::AttributeNames::forceY>();
-    auto *const __restrict fzptr = soa.template begin<Particle::AttributeNames::forceZ>();
+    auto *const __restrict fxptr = soa.template begin<ParticleT::AttributeNames::forceX>();
+    auto *const __restrict fyptr = soa.template begin<ParticleT::AttributeNames::forceY>();
+    auto *const __restrict fzptr = soa.template begin<ParticleT::AttributeNames::forceZ>();
 
-    const auto *const __restrict typeIDptr = soa.template begin<Particle::AttributeNames::typeId>();
+    const auto *const __restrict typeIDptr = soa.template begin<ParticleT::AttributeNames::typeId>();
 
     // accumulators
     svfloat64_t virialSumX = svdup_f64(0.0);
@@ -696,27 +696,32 @@ class LJFunctorSVE
    * @copydoc autopas::Functor::getNeededAttr()
    */
   constexpr static auto getNeededAttr() {
-    return std::array<typename Particle::AttributeNames, 9>{
-        Particle::AttributeNames::id,     Particle::AttributeNames::posX,   Particle::AttributeNames::posY,
-        Particle::AttributeNames::posZ,   Particle::AttributeNames::forceX, Particle::AttributeNames::forceY,
-        Particle::AttributeNames::forceZ, Particle::AttributeNames::typeId, Particle::AttributeNames::ownershipState};
+    return std::array<typename ParticleT::AttributeNames, 9>{ParticleT::AttributeNames::id,
+                                                             ParticleT::AttributeNames::posX,
+                                                             ParticleT::AttributeNames::posY,
+                                                             ParticleT::AttributeNames::posZ,
+                                                             ParticleT::AttributeNames::forceX,
+                                                             ParticleT::AttributeNames::forceY,
+                                                             ParticleT::AttributeNames::forceZ,
+                                                             ParticleT::AttributeNames::typeId,
+                                                             ParticleT::AttributeNames::ownershipState};
   }
 
   /**
    * @copydoc autopas::Functor::getNeededAttr(std::false_type)
    */
   constexpr static auto getNeededAttr(std::false_type) {
-    return std::array<typename Particle::AttributeNames, 6>{
-        Particle::AttributeNames::id,   Particle::AttributeNames::posX,   Particle::AttributeNames::posY,
-        Particle::AttributeNames::posZ, Particle::AttributeNames::typeId, Particle::AttributeNames::ownershipState};
+    return std::array<typename ParticleT::AttributeNames, 6>{
+        ParticleT::AttributeNames::id,   ParticleT::AttributeNames::posX,   ParticleT::AttributeNames::posY,
+        ParticleT::AttributeNames::posZ, ParticleT::AttributeNames::typeId, ParticleT::AttributeNames::ownershipState};
   }
 
   /**
    * @copydoc autopas::Functor::getComputedAttr()
    */
   constexpr static auto getComputedAttr() {
-    return std::array<typename Particle::AttributeNames, 3>{
-        Particle::AttributeNames::forceX, Particle::AttributeNames::forceY, Particle::AttributeNames::forceZ};
+    return std::array<typename ParticleT::AttributeNames, 3>{
+        ParticleT::AttributeNames::forceX, ParticleT::AttributeNames::forceY, ParticleT::AttributeNames::forceZ};
   }
 
   /**

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorSVE.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorSVE.h
@@ -45,7 +45,7 @@ template <class ParticleT, bool applyShift = false, bool useMixing = false,
           bool countFLOPs = false, bool relevantForTuning = true>
 class LJFunctorSVE
     : public autopas::PairwiseFunctor<ParticleT, LJFunctorSVE<ParticleT, applyShift, useMixing, useNewton3,
-                                                             calculateGlobals, countFLOPs, relevantForTuning>> {
+                                                              calculateGlobals, countFLOPs, relevantForTuning>> {
   using SoAArraysType = typename ParticleT::SoAArraysType;
 
  public:
@@ -63,7 +63,7 @@ class LJFunctorSVE
   explicit LJFunctorSVE(double cutoff, void * /*dummy*/)
 #ifdef __ARM_FEATURE_SVE
       : autopas::PairwiseFunctor<ParticleT, LJFunctorSVE<ParticleT, applyShift, useMixing, useNewton3, calculateGlobals,
-                                                        countFLOPs, relevantForTuning>>(cutoff),
+                                                         countFLOPs, relevantForTuning>>(cutoff),
         _cutoffSquared{cutoff * cutoff},
         _cutoffSquaredAoS(cutoff * cutoff),
         _potentialEnergySum{0.},
@@ -79,7 +79,7 @@ class LJFunctorSVE
   }
 #else
       : autopas::PairwiseFunctor<ParticleT, LJFunctorSVE<ParticleT, applyShift, useMixing, useNewton3, calculateGlobals,
-                                                        countFLOPs, relevantForTuning>>(cutoff) {
+                                                         countFLOPs, relevantForTuning>>(cutoff) {
     autopas::utils::ExceptionHandler::exception("AutoPas was compiled without SVE support!");
   }
 #endif

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJMultisiteFunctor.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJMultisiteFunctor.h
@@ -26,7 +26,7 @@ namespace mdLib {
 /**
  * A functor to handle Lennard-Jones interactions between two Multisite Molecules.
  *
- * @tparam ParticleT The type of particle.
+ * @tparam Particle_T The type of particle.
  * @tparam applyShift Flag for the LJ potential to have a truncated shift.
  * @tparam useMixing Flag for if the functor is to be used with multiple particle types. If set to false, _epsilon and
  * _sigma need to be set and the constructor with PPL can be omitted.
@@ -39,21 +39,21 @@ namespace mdLib {
  * @tparam countFLOPs counts FLOPs and hitrate. Currently not implemented as this functor is problematically bad and
  * will be replaced.
  */
-template <class ParticleT, bool applyShift = false, bool useMixing = false,
+template <class Particle_T, bool applyShift = false, bool useMixing = false,
           autopas::FunctorN3Modes useNewton3 = autopas::FunctorN3Modes::Both, bool calculateGlobals = false,
           bool countFLOPs = false, bool relevantForTuning = true>
 class LJMultisiteFunctor
-    : public autopas::PairwiseFunctor<ParticleT, LJMultisiteFunctor<ParticleT, applyShift, useMixing, useNewton3,
-                                                                    calculateGlobals, relevantForTuning, countFLOPs>> {
+    : public autopas::PairwiseFunctor<Particle_T, LJMultisiteFunctor<Particle_T, applyShift, useMixing, useNewton3,
+                                                                     calculateGlobals, relevantForTuning, countFLOPs>> {
   /**
    * Structure of the SoAs defined by the particle.
    */
-  using SoAArraysType = typename ParticleT::SoAArraysType;
+  using SoAArraysType = typename Particle_T::SoAArraysType;
 
   /**
    * Precision of SoA entries
    */
-  using SoAFloatPrecision = typename ParticleT::ParticleSoAFloatPrecision;
+  using SoAFloatPrecision = typename Particle_T::ParticleSoAFloatPrecision;
 
   /**
    * cutoff^2
@@ -113,8 +113,8 @@ class LJMultisiteFunctor
    * @note param dummy is unused, only there to make the signature different from the public constructor.
    */
   explicit LJMultisiteFunctor(SoAFloatPrecision cutoff, void * /*dummy*/)
-      : autopas::PairwiseFunctor<ParticleT, LJMultisiteFunctor<ParticleT, applyShift, useMixing, useNewton3,
-                                                               calculateGlobals, relevantForTuning, countFLOPs>>(
+      : autopas::PairwiseFunctor<Particle_T, LJMultisiteFunctor<Particle_T, applyShift, useMixing, useNewton3,
+                                                                calculateGlobals, relevantForTuning, countFLOPs>>(
             cutoff),
         _cutoffSquared{cutoff * cutoff},
         _potentialEnergySum{0.},
@@ -176,7 +176,7 @@ class LJMultisiteFunctor
    * @param particleB Particle B
    * @param newton3 Flag for if newton3 is used.
    */
-  void AoSFunctor(ParticleT &particleA, ParticleT &particleB, bool newton3) final {
+  void AoSFunctor(Particle_T &particleA, Particle_T &particleB, bool newton3) final {
     using namespace autopas::utils::ArrayMath::literals;
     if (particleA.isDummy() or particleB.isDummy()) {
       return;
@@ -279,26 +279,26 @@ class LJMultisiteFunctor
   void SoAFunctorSingle(autopas::SoAView<SoAArraysType> soa, bool newton3) final {
     if (soa.size() == 0) return;
 
-    const auto *const __restrict xptr = soa.template begin<ParticleT::AttributeNames::posX>();
-    const auto *const __restrict yptr = soa.template begin<ParticleT::AttributeNames::posY>();
-    const auto *const __restrict zptr = soa.template begin<ParticleT::AttributeNames::posZ>();
+    const auto *const __restrict xptr = soa.template begin<Particle_T::AttributeNames::posX>();
+    const auto *const __restrict yptr = soa.template begin<Particle_T::AttributeNames::posY>();
+    const auto *const __restrict zptr = soa.template begin<Particle_T::AttributeNames::posZ>();
 
-    const auto *const __restrict ownedStatePtr = soa.template begin<ParticleT::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr = soa.template begin<Particle_T::AttributeNames::ownershipState>();
 
-    const auto *const __restrict q0ptr = soa.template begin<ParticleT::AttributeNames::quaternion0>();
-    const auto *const __restrict q1ptr = soa.template begin<ParticleT::AttributeNames::quaternion1>();
-    const auto *const __restrict q2ptr = soa.template begin<ParticleT::AttributeNames::quaternion2>();
-    const auto *const __restrict q3ptr = soa.template begin<ParticleT::AttributeNames::quaternion3>();
+    const auto *const __restrict q0ptr = soa.template begin<Particle_T::AttributeNames::quaternion0>();
+    const auto *const __restrict q1ptr = soa.template begin<Particle_T::AttributeNames::quaternion1>();
+    const auto *const __restrict q2ptr = soa.template begin<Particle_T::AttributeNames::quaternion2>();
+    const auto *const __restrict q3ptr = soa.template begin<Particle_T::AttributeNames::quaternion3>();
 
-    SoAFloatPrecision *const __restrict fxptr = soa.template begin<ParticleT::AttributeNames::forceX>();
-    SoAFloatPrecision *const __restrict fyptr = soa.template begin<ParticleT::AttributeNames::forceY>();
-    SoAFloatPrecision *const __restrict fzptr = soa.template begin<ParticleT::AttributeNames::forceZ>();
+    SoAFloatPrecision *const __restrict fxptr = soa.template begin<Particle_T::AttributeNames::forceX>();
+    SoAFloatPrecision *const __restrict fyptr = soa.template begin<Particle_T::AttributeNames::forceY>();
+    SoAFloatPrecision *const __restrict fzptr = soa.template begin<Particle_T::AttributeNames::forceZ>();
 
-    SoAFloatPrecision *const __restrict txptr = soa.template begin<ParticleT::AttributeNames::torqueX>();
-    SoAFloatPrecision *const __restrict typtr = soa.template begin<ParticleT::AttributeNames::torqueY>();
-    SoAFloatPrecision *const __restrict tzptr = soa.template begin<ParticleT::AttributeNames::torqueZ>();
+    SoAFloatPrecision *const __restrict txptr = soa.template begin<Particle_T::AttributeNames::torqueX>();
+    SoAFloatPrecision *const __restrict typtr = soa.template begin<Particle_T::AttributeNames::torqueY>();
+    SoAFloatPrecision *const __restrict tzptr = soa.template begin<Particle_T::AttributeNames::torqueZ>();
 
-    [[maybe_unused]] auto *const __restrict typeptr = soa.template begin<ParticleT::AttributeNames::typeId>();
+    [[maybe_unused]] auto *const __restrict typeptr = soa.template begin<Particle_T::AttributeNames::typeId>();
 
     SoAFloatPrecision potentialEnergySum = 0.;
     SoAFloatPrecision virialSumX = 0.;
@@ -640,39 +640,39 @@ class LJMultisiteFunctor
    * @copydoc autopas::Functor::getNeededAttr()
    */
   constexpr static auto getNeededAttr() {
-    return std::array<typename ParticleT::AttributeNames, 16>{
-        ParticleT::AttributeNames::id,          ParticleT::AttributeNames::posX,
-        ParticleT::AttributeNames::posY,        ParticleT::AttributeNames::posZ,
-        ParticleT::AttributeNames::forceX,      ParticleT::AttributeNames::forceY,
-        ParticleT::AttributeNames::forceZ,      ParticleT::AttributeNames::quaternion0,
-        ParticleT::AttributeNames::quaternion1, ParticleT::AttributeNames::quaternion2,
-        ParticleT::AttributeNames::quaternion3, ParticleT::AttributeNames::torqueX,
-        ParticleT::AttributeNames::torqueY,     ParticleT::AttributeNames::torqueZ,
-        ParticleT::AttributeNames::typeId,      ParticleT::AttributeNames::ownershipState};
+    return std::array<typename Particle_T::AttributeNames, 16>{
+        Particle_T::AttributeNames::id,          Particle_T::AttributeNames::posX,
+        Particle_T::AttributeNames::posY,        Particle_T::AttributeNames::posZ,
+        Particle_T::AttributeNames::forceX,      Particle_T::AttributeNames::forceY,
+        Particle_T::AttributeNames::forceZ,      Particle_T::AttributeNames::quaternion0,
+        Particle_T::AttributeNames::quaternion1, Particle_T::AttributeNames::quaternion2,
+        Particle_T::AttributeNames::quaternion3, Particle_T::AttributeNames::torqueX,
+        Particle_T::AttributeNames::torqueY,     Particle_T::AttributeNames::torqueZ,
+        Particle_T::AttributeNames::typeId,      Particle_T::AttributeNames::ownershipState};
   }
 
   /**
    * @copydoc autopas::Functor::getNeededAttr(std::false_type)
    */
   constexpr static auto getNeededAttr(std::false_type) {
-    return std::array<typename ParticleT::AttributeNames, 16>{
-        ParticleT::AttributeNames::id,          ParticleT::AttributeNames::posX,
-        ParticleT::AttributeNames::posY,        ParticleT::AttributeNames::posZ,
-        ParticleT::AttributeNames::forceX,      ParticleT::AttributeNames::forceY,
-        ParticleT::AttributeNames::forceZ,      ParticleT::AttributeNames::quaternion0,
-        ParticleT::AttributeNames::quaternion1, ParticleT::AttributeNames::quaternion2,
-        ParticleT::AttributeNames::quaternion3, ParticleT::AttributeNames::torqueX,
-        ParticleT::AttributeNames::torqueY,     ParticleT::AttributeNames::torqueZ,
-        ParticleT::AttributeNames::typeId,      ParticleT::AttributeNames::ownershipState};
+    return std::array<typename Particle_T::AttributeNames, 16>{
+        Particle_T::AttributeNames::id,          Particle_T::AttributeNames::posX,
+        Particle_T::AttributeNames::posY,        Particle_T::AttributeNames::posZ,
+        Particle_T::AttributeNames::forceX,      Particle_T::AttributeNames::forceY,
+        Particle_T::AttributeNames::forceZ,      Particle_T::AttributeNames::quaternion0,
+        Particle_T::AttributeNames::quaternion1, Particle_T::AttributeNames::quaternion2,
+        Particle_T::AttributeNames::quaternion3, Particle_T::AttributeNames::torqueX,
+        Particle_T::AttributeNames::torqueY,     Particle_T::AttributeNames::torqueZ,
+        Particle_T::AttributeNames::typeId,      Particle_T::AttributeNames::ownershipState};
   }
 
   /**
    * @copydoc autopas::Functor::getComputedAttr()
    */
   constexpr static auto getComputedAttr() {
-    return std::array<typename ParticleT::AttributeNames, 6>{
-        ParticleT::AttributeNames::forceX,  ParticleT::AttributeNames::forceY,  ParticleT::AttributeNames::forceZ,
-        ParticleT::AttributeNames::torqueX, ParticleT::AttributeNames::torqueY, ParticleT::AttributeNames::torqueZ};
+    return std::array<typename Particle_T::AttributeNames, 6>{
+        Particle_T::AttributeNames::forceX,  Particle_T::AttributeNames::forceY,  Particle_T::AttributeNames::forceZ,
+        Particle_T::AttributeNames::torqueX, Particle_T::AttributeNames::torqueY, Particle_T::AttributeNames::torqueZ};
   }
 
   /**
@@ -794,41 +794,41 @@ class LJMultisiteFunctor
   void SoAFunctorPairImpl(autopas::SoAView<SoAArraysType> soaA, autopas::SoAView<SoAArraysType> soaB) {
     if (soaA.size() == 0 || soaB.size() == 0) return;
 
-    const auto *const __restrict xAptr = soaA.template begin<ParticleT::AttributeNames::posX>();
-    const auto *const __restrict yAptr = soaA.template begin<ParticleT::AttributeNames::posY>();
-    const auto *const __restrict zAptr = soaA.template begin<ParticleT::AttributeNames::posZ>();
-    const auto *const __restrict xBptr = soaB.template begin<ParticleT::AttributeNames::posX>();
-    const auto *const __restrict yBptr = soaB.template begin<ParticleT::AttributeNames::posY>();
-    const auto *const __restrict zBptr = soaB.template begin<ParticleT::AttributeNames::posZ>();
+    const auto *const __restrict xAptr = soaA.template begin<Particle_T::AttributeNames::posX>();
+    const auto *const __restrict yAptr = soaA.template begin<Particle_T::AttributeNames::posY>();
+    const auto *const __restrict zAptr = soaA.template begin<Particle_T::AttributeNames::posZ>();
+    const auto *const __restrict xBptr = soaB.template begin<Particle_T::AttributeNames::posX>();
+    const auto *const __restrict yBptr = soaB.template begin<Particle_T::AttributeNames::posY>();
+    const auto *const __restrict zBptr = soaB.template begin<Particle_T::AttributeNames::posZ>();
 
-    const auto *const __restrict ownedStatePtrA = soaA.template begin<ParticleT::AttributeNames::ownershipState>();
-    const auto *const __restrict ownedStatePtrB = soaB.template begin<ParticleT::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtrA = soaA.template begin<Particle_T::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtrB = soaB.template begin<Particle_T::AttributeNames::ownershipState>();
 
-    const auto *const __restrict q0Aptr = soaA.template begin<ParticleT::AttributeNames::quaternion0>();
-    const auto *const __restrict q1Aptr = soaA.template begin<ParticleT::AttributeNames::quaternion1>();
-    const auto *const __restrict q2Aptr = soaA.template begin<ParticleT::AttributeNames::quaternion2>();
-    const auto *const __restrict q3Aptr = soaA.template begin<ParticleT::AttributeNames::quaternion3>();
-    const auto *const __restrict q0Bptr = soaB.template begin<ParticleT::AttributeNames::quaternion0>();
-    const auto *const __restrict q1Bptr = soaB.template begin<ParticleT::AttributeNames::quaternion1>();
-    const auto *const __restrict q2Bptr = soaB.template begin<ParticleT::AttributeNames::quaternion2>();
-    const auto *const __restrict q3Bptr = soaB.template begin<ParticleT::AttributeNames::quaternion3>();
+    const auto *const __restrict q0Aptr = soaA.template begin<Particle_T::AttributeNames::quaternion0>();
+    const auto *const __restrict q1Aptr = soaA.template begin<Particle_T::AttributeNames::quaternion1>();
+    const auto *const __restrict q2Aptr = soaA.template begin<Particle_T::AttributeNames::quaternion2>();
+    const auto *const __restrict q3Aptr = soaA.template begin<Particle_T::AttributeNames::quaternion3>();
+    const auto *const __restrict q0Bptr = soaB.template begin<Particle_T::AttributeNames::quaternion0>();
+    const auto *const __restrict q1Bptr = soaB.template begin<Particle_T::AttributeNames::quaternion1>();
+    const auto *const __restrict q2Bptr = soaB.template begin<Particle_T::AttributeNames::quaternion2>();
+    const auto *const __restrict q3Bptr = soaB.template begin<Particle_T::AttributeNames::quaternion3>();
 
-    SoAFloatPrecision *const __restrict fxAptr = soaA.template begin<ParticleT::AttributeNames::forceX>();
-    SoAFloatPrecision *const __restrict fyAptr = soaA.template begin<ParticleT::AttributeNames::forceY>();
-    SoAFloatPrecision *const __restrict fzAptr = soaA.template begin<ParticleT::AttributeNames::forceZ>();
-    SoAFloatPrecision *const __restrict fxBptr = soaB.template begin<ParticleT::AttributeNames::forceX>();
-    SoAFloatPrecision *const __restrict fyBptr = soaB.template begin<ParticleT::AttributeNames::forceY>();
-    SoAFloatPrecision *const __restrict fzBptr = soaB.template begin<ParticleT::AttributeNames::forceZ>();
+    SoAFloatPrecision *const __restrict fxAptr = soaA.template begin<Particle_T::AttributeNames::forceX>();
+    SoAFloatPrecision *const __restrict fyAptr = soaA.template begin<Particle_T::AttributeNames::forceY>();
+    SoAFloatPrecision *const __restrict fzAptr = soaA.template begin<Particle_T::AttributeNames::forceZ>();
+    SoAFloatPrecision *const __restrict fxBptr = soaB.template begin<Particle_T::AttributeNames::forceX>();
+    SoAFloatPrecision *const __restrict fyBptr = soaB.template begin<Particle_T::AttributeNames::forceY>();
+    SoAFloatPrecision *const __restrict fzBptr = soaB.template begin<Particle_T::AttributeNames::forceZ>();
 
-    SoAFloatPrecision *const __restrict txAptr = soaA.template begin<ParticleT::AttributeNames::torqueX>();
-    SoAFloatPrecision *const __restrict tyAptr = soaA.template begin<ParticleT::AttributeNames::torqueY>();
-    SoAFloatPrecision *const __restrict tzAptr = soaA.template begin<ParticleT::AttributeNames::torqueZ>();
-    SoAFloatPrecision *const __restrict txBptr = soaB.template begin<ParticleT::AttributeNames::torqueX>();
-    SoAFloatPrecision *const __restrict tyBptr = soaB.template begin<ParticleT::AttributeNames::torqueY>();
-    SoAFloatPrecision *const __restrict tzBptr = soaB.template begin<ParticleT::AttributeNames::torqueZ>();
+    SoAFloatPrecision *const __restrict txAptr = soaA.template begin<Particle_T::AttributeNames::torqueX>();
+    SoAFloatPrecision *const __restrict tyAptr = soaA.template begin<Particle_T::AttributeNames::torqueY>();
+    SoAFloatPrecision *const __restrict tzAptr = soaA.template begin<Particle_T::AttributeNames::torqueZ>();
+    SoAFloatPrecision *const __restrict txBptr = soaB.template begin<Particle_T::AttributeNames::torqueX>();
+    SoAFloatPrecision *const __restrict tyBptr = soaB.template begin<Particle_T::AttributeNames::torqueY>();
+    SoAFloatPrecision *const __restrict tzBptr = soaB.template begin<Particle_T::AttributeNames::torqueZ>();
 
-    [[maybe_unused]] auto *const __restrict typeptrA = soaA.template begin<ParticleT::AttributeNames::typeId>();
-    [[maybe_unused]] auto *const __restrict typeptrB = soaB.template begin<ParticleT::AttributeNames::typeId>();
+    [[maybe_unused]] auto *const __restrict typeptrA = soaA.template begin<Particle_T::AttributeNames::typeId>();
+    [[maybe_unused]] auto *const __restrict typeptrB = soaB.template begin<Particle_T::AttributeNames::typeId>();
 
     SoAFloatPrecision potentialEnergySum = 0.;
     SoAFloatPrecision virialSumX = 0.;
@@ -1140,7 +1140,7 @@ class LJMultisiteFunctor
   template <bool newton3>
   void SoAFunctorVerletImpl(autopas::SoAView<SoAArraysType> soa, const size_t indexPrime,
                             const std::vector<size_t, autopas::AlignedAllocator<size_t>> &neighborList) {
-    const auto *const __restrict ownedStatePtr = soa.template begin<ParticleT::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr = soa.template begin<Particle_T::AttributeNames::ownershipState>();
 
     // Skip if primary particle is dummy
     const auto ownedStatePrime = ownedStatePtr[indexPrime];
@@ -1148,24 +1148,24 @@ class LJMultisiteFunctor
       return;
     }
 
-    const auto *const __restrict xptr = soa.template begin<ParticleT::AttributeNames::posX>();
-    const auto *const __restrict yptr = soa.template begin<ParticleT::AttributeNames::posY>();
-    const auto *const __restrict zptr = soa.template begin<ParticleT::AttributeNames::posZ>();
+    const auto *const __restrict xptr = soa.template begin<Particle_T::AttributeNames::posX>();
+    const auto *const __restrict yptr = soa.template begin<Particle_T::AttributeNames::posY>();
+    const auto *const __restrict zptr = soa.template begin<Particle_T::AttributeNames::posZ>();
 
-    const auto *const __restrict q0ptr = soa.template begin<ParticleT::AttributeNames::quaternion0>();
-    const auto *const __restrict q1ptr = soa.template begin<ParticleT::AttributeNames::quaternion1>();
-    const auto *const __restrict q2ptr = soa.template begin<ParticleT::AttributeNames::quaternion2>();
-    const auto *const __restrict q3ptr = soa.template begin<ParticleT::AttributeNames::quaternion3>();
+    const auto *const __restrict q0ptr = soa.template begin<Particle_T::AttributeNames::quaternion0>();
+    const auto *const __restrict q1ptr = soa.template begin<Particle_T::AttributeNames::quaternion1>();
+    const auto *const __restrict q2ptr = soa.template begin<Particle_T::AttributeNames::quaternion2>();
+    const auto *const __restrict q3ptr = soa.template begin<Particle_T::AttributeNames::quaternion3>();
 
-    SoAFloatPrecision *const __restrict fxptr = soa.template begin<ParticleT::AttributeNames::forceX>();
-    SoAFloatPrecision *const __restrict fyptr = soa.template begin<ParticleT::AttributeNames::forceY>();
-    SoAFloatPrecision *const __restrict fzptr = soa.template begin<ParticleT::AttributeNames::forceZ>();
+    SoAFloatPrecision *const __restrict fxptr = soa.template begin<Particle_T::AttributeNames::forceX>();
+    SoAFloatPrecision *const __restrict fyptr = soa.template begin<Particle_T::AttributeNames::forceY>();
+    SoAFloatPrecision *const __restrict fzptr = soa.template begin<Particle_T::AttributeNames::forceZ>();
 
-    SoAFloatPrecision *const __restrict txptr = soa.template begin<ParticleT::AttributeNames::torqueX>();
-    SoAFloatPrecision *const __restrict typtr = soa.template begin<ParticleT::AttributeNames::torqueY>();
-    SoAFloatPrecision *const __restrict tzptr = soa.template begin<ParticleT::AttributeNames::torqueZ>();
+    SoAFloatPrecision *const __restrict txptr = soa.template begin<Particle_T::AttributeNames::torqueX>();
+    SoAFloatPrecision *const __restrict typtr = soa.template begin<Particle_T::AttributeNames::torqueY>();
+    SoAFloatPrecision *const __restrict tzptr = soa.template begin<Particle_T::AttributeNames::torqueZ>();
 
-    [[maybe_unused]] auto *const __restrict typeptr = soa.template begin<ParticleT::AttributeNames::typeId>();
+    [[maybe_unused]] auto *const __restrict typeptr = soa.template begin<Particle_T::AttributeNames::typeId>();
 
     SoAFloatPrecision potentialEnergySum = 0.;
     SoAFloatPrecision virialSumX = 0.;

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJMultisiteFunctor.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJMultisiteFunctor.h
@@ -44,7 +44,7 @@ template <class ParticleT, bool applyShift = false, bool useMixing = false,
           bool countFLOPs = false, bool relevantForTuning = true>
 class LJMultisiteFunctor
     : public autopas::PairwiseFunctor<ParticleT, LJMultisiteFunctor<ParticleT, applyShift, useMixing, useNewton3,
-                                                                   calculateGlobals, relevantForTuning, countFLOPs>> {
+                                                                    calculateGlobals, relevantForTuning, countFLOPs>> {
   /**
    * Structure of the SoAs defined by the particle.
    */
@@ -114,7 +114,8 @@ class LJMultisiteFunctor
    */
   explicit LJMultisiteFunctor(SoAFloatPrecision cutoff, void * /*dummy*/)
       : autopas::PairwiseFunctor<ParticleT, LJMultisiteFunctor<ParticleT, applyShift, useMixing, useNewton3,
-                                                              calculateGlobals, relevantForTuning, countFLOPs>>(cutoff),
+                                                               calculateGlobals, relevantForTuning, countFLOPs>>(
+            cutoff),
         _cutoffSquared{cutoff * cutoff},
         _potentialEnergySum{0.},
         _virialSum{0., 0., 0.},

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJMultisiteFunctor.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJMultisiteFunctor.h
@@ -26,7 +26,7 @@ namespace mdLib {
 /**
  * A functor to handle Lennard-Jones interactions between two Multisite Molecules.
  *
- * @tparam Particle The type of particle.
+ * @tparam ParticleT The type of particle.
  * @tparam applyShift Flag for the LJ potential to have a truncated shift.
  * @tparam useMixing Flag for if the functor is to be used with multiple particle types. If set to false, _epsilon and
  * _sigma need to be set and the constructor with PPL can be omitted.
@@ -39,21 +39,21 @@ namespace mdLib {
  * @tparam countFLOPs counts FLOPs and hitrate. Currently not implemented as this functor is problematically bad and
  * will be replaced.
  */
-template <class Particle, bool applyShift = false, bool useMixing = false,
+template <class ParticleT, bool applyShift = false, bool useMixing = false,
           autopas::FunctorN3Modes useNewton3 = autopas::FunctorN3Modes::Both, bool calculateGlobals = false,
           bool countFLOPs = false, bool relevantForTuning = true>
 class LJMultisiteFunctor
-    : public autopas::PairwiseFunctor<Particle, LJMultisiteFunctor<Particle, applyShift, useMixing, useNewton3,
+    : public autopas::PairwiseFunctor<ParticleT, LJMultisiteFunctor<ParticleT, applyShift, useMixing, useNewton3,
                                                                    calculateGlobals, relevantForTuning, countFLOPs>> {
   /**
    * Structure of the SoAs defined by the particle.
    */
-  using SoAArraysType = typename Particle::SoAArraysType;
+  using SoAArraysType = typename ParticleT::SoAArraysType;
 
   /**
    * Precision of SoA entries
    */
-  using SoAFloatPrecision = typename Particle::ParticleSoAFloatPrecision;
+  using SoAFloatPrecision = typename ParticleT::ParticleSoAFloatPrecision;
 
   /**
    * cutoff^2
@@ -113,7 +113,7 @@ class LJMultisiteFunctor
    * @note param dummy is unused, only there to make the signature different from the public constructor.
    */
   explicit LJMultisiteFunctor(SoAFloatPrecision cutoff, void * /*dummy*/)
-      : autopas::PairwiseFunctor<Particle, LJMultisiteFunctor<Particle, applyShift, useMixing, useNewton3,
+      : autopas::PairwiseFunctor<ParticleT, LJMultisiteFunctor<ParticleT, applyShift, useMixing, useNewton3,
                                                               calculateGlobals, relevantForTuning, countFLOPs>>(cutoff),
         _cutoffSquared{cutoff * cutoff},
         _potentialEnergySum{0.},
@@ -175,7 +175,7 @@ class LJMultisiteFunctor
    * @param particleB Particle B
    * @param newton3 Flag for if newton3 is used.
    */
-  void AoSFunctor(Particle &particleA, Particle &particleB, bool newton3) final {
+  void AoSFunctor(ParticleT &particleA, ParticleT &particleB, bool newton3) final {
     using namespace autopas::utils::ArrayMath::literals;
     if (particleA.isDummy() or particleB.isDummy()) {
       return;
@@ -278,26 +278,26 @@ class LJMultisiteFunctor
   void SoAFunctorSingle(autopas::SoAView<SoAArraysType> soa, bool newton3) final {
     if (soa.size() == 0) return;
 
-    const auto *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
-    const auto *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
-    const auto *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
+    const auto *const __restrict xptr = soa.template begin<ParticleT::AttributeNames::posX>();
+    const auto *const __restrict yptr = soa.template begin<ParticleT::AttributeNames::posY>();
+    const auto *const __restrict zptr = soa.template begin<ParticleT::AttributeNames::posZ>();
 
-    const auto *const __restrict ownedStatePtr = soa.template begin<Particle::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr = soa.template begin<ParticleT::AttributeNames::ownershipState>();
 
-    const auto *const __restrict q0ptr = soa.template begin<Particle::AttributeNames::quaternion0>();
-    const auto *const __restrict q1ptr = soa.template begin<Particle::AttributeNames::quaternion1>();
-    const auto *const __restrict q2ptr = soa.template begin<Particle::AttributeNames::quaternion2>();
-    const auto *const __restrict q3ptr = soa.template begin<Particle::AttributeNames::quaternion3>();
+    const auto *const __restrict q0ptr = soa.template begin<ParticleT::AttributeNames::quaternion0>();
+    const auto *const __restrict q1ptr = soa.template begin<ParticleT::AttributeNames::quaternion1>();
+    const auto *const __restrict q2ptr = soa.template begin<ParticleT::AttributeNames::quaternion2>();
+    const auto *const __restrict q3ptr = soa.template begin<ParticleT::AttributeNames::quaternion3>();
 
-    SoAFloatPrecision *const __restrict fxptr = soa.template begin<Particle::AttributeNames::forceX>();
-    SoAFloatPrecision *const __restrict fyptr = soa.template begin<Particle::AttributeNames::forceY>();
-    SoAFloatPrecision *const __restrict fzptr = soa.template begin<Particle::AttributeNames::forceZ>();
+    SoAFloatPrecision *const __restrict fxptr = soa.template begin<ParticleT::AttributeNames::forceX>();
+    SoAFloatPrecision *const __restrict fyptr = soa.template begin<ParticleT::AttributeNames::forceY>();
+    SoAFloatPrecision *const __restrict fzptr = soa.template begin<ParticleT::AttributeNames::forceZ>();
 
-    SoAFloatPrecision *const __restrict txptr = soa.template begin<Particle::AttributeNames::torqueX>();
-    SoAFloatPrecision *const __restrict typtr = soa.template begin<Particle::AttributeNames::torqueY>();
-    SoAFloatPrecision *const __restrict tzptr = soa.template begin<Particle::AttributeNames::torqueZ>();
+    SoAFloatPrecision *const __restrict txptr = soa.template begin<ParticleT::AttributeNames::torqueX>();
+    SoAFloatPrecision *const __restrict typtr = soa.template begin<ParticleT::AttributeNames::torqueY>();
+    SoAFloatPrecision *const __restrict tzptr = soa.template begin<ParticleT::AttributeNames::torqueZ>();
 
-    [[maybe_unused]] auto *const __restrict typeptr = soa.template begin<Particle::AttributeNames::typeId>();
+    [[maybe_unused]] auto *const __restrict typeptr = soa.template begin<ParticleT::AttributeNames::typeId>();
 
     SoAFloatPrecision potentialEnergySum = 0.;
     SoAFloatPrecision virialSumX = 0.;
@@ -639,39 +639,39 @@ class LJMultisiteFunctor
    * @copydoc autopas::Functor::getNeededAttr()
    */
   constexpr static auto getNeededAttr() {
-    return std::array<typename Particle::AttributeNames, 16>{
-        Particle::AttributeNames::id,          Particle::AttributeNames::posX,
-        Particle::AttributeNames::posY,        Particle::AttributeNames::posZ,
-        Particle::AttributeNames::forceX,      Particle::AttributeNames::forceY,
-        Particle::AttributeNames::forceZ,      Particle::AttributeNames::quaternion0,
-        Particle::AttributeNames::quaternion1, Particle::AttributeNames::quaternion2,
-        Particle::AttributeNames::quaternion3, Particle::AttributeNames::torqueX,
-        Particle::AttributeNames::torqueY,     Particle::AttributeNames::torqueZ,
-        Particle::AttributeNames::typeId,      Particle::AttributeNames::ownershipState};
+    return std::array<typename ParticleT::AttributeNames, 16>{
+        ParticleT::AttributeNames::id,          ParticleT::AttributeNames::posX,
+        ParticleT::AttributeNames::posY,        ParticleT::AttributeNames::posZ,
+        ParticleT::AttributeNames::forceX,      ParticleT::AttributeNames::forceY,
+        ParticleT::AttributeNames::forceZ,      ParticleT::AttributeNames::quaternion0,
+        ParticleT::AttributeNames::quaternion1, ParticleT::AttributeNames::quaternion2,
+        ParticleT::AttributeNames::quaternion3, ParticleT::AttributeNames::torqueX,
+        ParticleT::AttributeNames::torqueY,     ParticleT::AttributeNames::torqueZ,
+        ParticleT::AttributeNames::typeId,      ParticleT::AttributeNames::ownershipState};
   }
 
   /**
    * @copydoc autopas::Functor::getNeededAttr(std::false_type)
    */
   constexpr static auto getNeededAttr(std::false_type) {
-    return std::array<typename Particle::AttributeNames, 16>{
-        Particle::AttributeNames::id,          Particle::AttributeNames::posX,
-        Particle::AttributeNames::posY,        Particle::AttributeNames::posZ,
-        Particle::AttributeNames::forceX,      Particle::AttributeNames::forceY,
-        Particle::AttributeNames::forceZ,      Particle::AttributeNames::quaternion0,
-        Particle::AttributeNames::quaternion1, Particle::AttributeNames::quaternion2,
-        Particle::AttributeNames::quaternion3, Particle::AttributeNames::torqueX,
-        Particle::AttributeNames::torqueY,     Particle::AttributeNames::torqueZ,
-        Particle::AttributeNames::typeId,      Particle::AttributeNames::ownershipState};
+    return std::array<typename ParticleT::AttributeNames, 16>{
+        ParticleT::AttributeNames::id,          ParticleT::AttributeNames::posX,
+        ParticleT::AttributeNames::posY,        ParticleT::AttributeNames::posZ,
+        ParticleT::AttributeNames::forceX,      ParticleT::AttributeNames::forceY,
+        ParticleT::AttributeNames::forceZ,      ParticleT::AttributeNames::quaternion0,
+        ParticleT::AttributeNames::quaternion1, ParticleT::AttributeNames::quaternion2,
+        ParticleT::AttributeNames::quaternion3, ParticleT::AttributeNames::torqueX,
+        ParticleT::AttributeNames::torqueY,     ParticleT::AttributeNames::torqueZ,
+        ParticleT::AttributeNames::typeId,      ParticleT::AttributeNames::ownershipState};
   }
 
   /**
    * @copydoc autopas::Functor::getComputedAttr()
    */
   constexpr static auto getComputedAttr() {
-    return std::array<typename Particle::AttributeNames, 6>{
-        Particle::AttributeNames::forceX,  Particle::AttributeNames::forceY,  Particle::AttributeNames::forceZ,
-        Particle::AttributeNames::torqueX, Particle::AttributeNames::torqueY, Particle::AttributeNames::torqueZ};
+    return std::array<typename ParticleT::AttributeNames, 6>{
+        ParticleT::AttributeNames::forceX,  ParticleT::AttributeNames::forceY,  ParticleT::AttributeNames::forceZ,
+        ParticleT::AttributeNames::torqueX, ParticleT::AttributeNames::torqueY, ParticleT::AttributeNames::torqueZ};
   }
 
   /**
@@ -793,41 +793,41 @@ class LJMultisiteFunctor
   void SoAFunctorPairImpl(autopas::SoAView<SoAArraysType> soaA, autopas::SoAView<SoAArraysType> soaB) {
     if (soaA.size() == 0 || soaB.size() == 0) return;
 
-    const auto *const __restrict xAptr = soaA.template begin<Particle::AttributeNames::posX>();
-    const auto *const __restrict yAptr = soaA.template begin<Particle::AttributeNames::posY>();
-    const auto *const __restrict zAptr = soaA.template begin<Particle::AttributeNames::posZ>();
-    const auto *const __restrict xBptr = soaB.template begin<Particle::AttributeNames::posX>();
-    const auto *const __restrict yBptr = soaB.template begin<Particle::AttributeNames::posY>();
-    const auto *const __restrict zBptr = soaB.template begin<Particle::AttributeNames::posZ>();
+    const auto *const __restrict xAptr = soaA.template begin<ParticleT::AttributeNames::posX>();
+    const auto *const __restrict yAptr = soaA.template begin<ParticleT::AttributeNames::posY>();
+    const auto *const __restrict zAptr = soaA.template begin<ParticleT::AttributeNames::posZ>();
+    const auto *const __restrict xBptr = soaB.template begin<ParticleT::AttributeNames::posX>();
+    const auto *const __restrict yBptr = soaB.template begin<ParticleT::AttributeNames::posY>();
+    const auto *const __restrict zBptr = soaB.template begin<ParticleT::AttributeNames::posZ>();
 
-    const auto *const __restrict ownedStatePtrA = soaA.template begin<Particle::AttributeNames::ownershipState>();
-    const auto *const __restrict ownedStatePtrB = soaB.template begin<Particle::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtrA = soaA.template begin<ParticleT::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtrB = soaB.template begin<ParticleT::AttributeNames::ownershipState>();
 
-    const auto *const __restrict q0Aptr = soaA.template begin<Particle::AttributeNames::quaternion0>();
-    const auto *const __restrict q1Aptr = soaA.template begin<Particle::AttributeNames::quaternion1>();
-    const auto *const __restrict q2Aptr = soaA.template begin<Particle::AttributeNames::quaternion2>();
-    const auto *const __restrict q3Aptr = soaA.template begin<Particle::AttributeNames::quaternion3>();
-    const auto *const __restrict q0Bptr = soaB.template begin<Particle::AttributeNames::quaternion0>();
-    const auto *const __restrict q1Bptr = soaB.template begin<Particle::AttributeNames::quaternion1>();
-    const auto *const __restrict q2Bptr = soaB.template begin<Particle::AttributeNames::quaternion2>();
-    const auto *const __restrict q3Bptr = soaB.template begin<Particle::AttributeNames::quaternion3>();
+    const auto *const __restrict q0Aptr = soaA.template begin<ParticleT::AttributeNames::quaternion0>();
+    const auto *const __restrict q1Aptr = soaA.template begin<ParticleT::AttributeNames::quaternion1>();
+    const auto *const __restrict q2Aptr = soaA.template begin<ParticleT::AttributeNames::quaternion2>();
+    const auto *const __restrict q3Aptr = soaA.template begin<ParticleT::AttributeNames::quaternion3>();
+    const auto *const __restrict q0Bptr = soaB.template begin<ParticleT::AttributeNames::quaternion0>();
+    const auto *const __restrict q1Bptr = soaB.template begin<ParticleT::AttributeNames::quaternion1>();
+    const auto *const __restrict q2Bptr = soaB.template begin<ParticleT::AttributeNames::quaternion2>();
+    const auto *const __restrict q3Bptr = soaB.template begin<ParticleT::AttributeNames::quaternion3>();
 
-    SoAFloatPrecision *const __restrict fxAptr = soaA.template begin<Particle::AttributeNames::forceX>();
-    SoAFloatPrecision *const __restrict fyAptr = soaA.template begin<Particle::AttributeNames::forceY>();
-    SoAFloatPrecision *const __restrict fzAptr = soaA.template begin<Particle::AttributeNames::forceZ>();
-    SoAFloatPrecision *const __restrict fxBptr = soaB.template begin<Particle::AttributeNames::forceX>();
-    SoAFloatPrecision *const __restrict fyBptr = soaB.template begin<Particle::AttributeNames::forceY>();
-    SoAFloatPrecision *const __restrict fzBptr = soaB.template begin<Particle::AttributeNames::forceZ>();
+    SoAFloatPrecision *const __restrict fxAptr = soaA.template begin<ParticleT::AttributeNames::forceX>();
+    SoAFloatPrecision *const __restrict fyAptr = soaA.template begin<ParticleT::AttributeNames::forceY>();
+    SoAFloatPrecision *const __restrict fzAptr = soaA.template begin<ParticleT::AttributeNames::forceZ>();
+    SoAFloatPrecision *const __restrict fxBptr = soaB.template begin<ParticleT::AttributeNames::forceX>();
+    SoAFloatPrecision *const __restrict fyBptr = soaB.template begin<ParticleT::AttributeNames::forceY>();
+    SoAFloatPrecision *const __restrict fzBptr = soaB.template begin<ParticleT::AttributeNames::forceZ>();
 
-    SoAFloatPrecision *const __restrict txAptr = soaA.template begin<Particle::AttributeNames::torqueX>();
-    SoAFloatPrecision *const __restrict tyAptr = soaA.template begin<Particle::AttributeNames::torqueY>();
-    SoAFloatPrecision *const __restrict tzAptr = soaA.template begin<Particle::AttributeNames::torqueZ>();
-    SoAFloatPrecision *const __restrict txBptr = soaB.template begin<Particle::AttributeNames::torqueX>();
-    SoAFloatPrecision *const __restrict tyBptr = soaB.template begin<Particle::AttributeNames::torqueY>();
-    SoAFloatPrecision *const __restrict tzBptr = soaB.template begin<Particle::AttributeNames::torqueZ>();
+    SoAFloatPrecision *const __restrict txAptr = soaA.template begin<ParticleT::AttributeNames::torqueX>();
+    SoAFloatPrecision *const __restrict tyAptr = soaA.template begin<ParticleT::AttributeNames::torqueY>();
+    SoAFloatPrecision *const __restrict tzAptr = soaA.template begin<ParticleT::AttributeNames::torqueZ>();
+    SoAFloatPrecision *const __restrict txBptr = soaB.template begin<ParticleT::AttributeNames::torqueX>();
+    SoAFloatPrecision *const __restrict tyBptr = soaB.template begin<ParticleT::AttributeNames::torqueY>();
+    SoAFloatPrecision *const __restrict tzBptr = soaB.template begin<ParticleT::AttributeNames::torqueZ>();
 
-    [[maybe_unused]] auto *const __restrict typeptrA = soaA.template begin<Particle::AttributeNames::typeId>();
-    [[maybe_unused]] auto *const __restrict typeptrB = soaB.template begin<Particle::AttributeNames::typeId>();
+    [[maybe_unused]] auto *const __restrict typeptrA = soaA.template begin<ParticleT::AttributeNames::typeId>();
+    [[maybe_unused]] auto *const __restrict typeptrB = soaB.template begin<ParticleT::AttributeNames::typeId>();
 
     SoAFloatPrecision potentialEnergySum = 0.;
     SoAFloatPrecision virialSumX = 0.;
@@ -1139,7 +1139,7 @@ class LJMultisiteFunctor
   template <bool newton3>
   void SoAFunctorVerletImpl(autopas::SoAView<SoAArraysType> soa, const size_t indexPrime,
                             const std::vector<size_t, autopas::AlignedAllocator<size_t>> &neighborList) {
-    const auto *const __restrict ownedStatePtr = soa.template begin<Particle::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr = soa.template begin<ParticleT::AttributeNames::ownershipState>();
 
     // Skip if primary particle is dummy
     const auto ownedStatePrime = ownedStatePtr[indexPrime];
@@ -1147,24 +1147,24 @@ class LJMultisiteFunctor
       return;
     }
 
-    const auto *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
-    const auto *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
-    const auto *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
+    const auto *const __restrict xptr = soa.template begin<ParticleT::AttributeNames::posX>();
+    const auto *const __restrict yptr = soa.template begin<ParticleT::AttributeNames::posY>();
+    const auto *const __restrict zptr = soa.template begin<ParticleT::AttributeNames::posZ>();
 
-    const auto *const __restrict q0ptr = soa.template begin<Particle::AttributeNames::quaternion0>();
-    const auto *const __restrict q1ptr = soa.template begin<Particle::AttributeNames::quaternion1>();
-    const auto *const __restrict q2ptr = soa.template begin<Particle::AttributeNames::quaternion2>();
-    const auto *const __restrict q3ptr = soa.template begin<Particle::AttributeNames::quaternion3>();
+    const auto *const __restrict q0ptr = soa.template begin<ParticleT::AttributeNames::quaternion0>();
+    const auto *const __restrict q1ptr = soa.template begin<ParticleT::AttributeNames::quaternion1>();
+    const auto *const __restrict q2ptr = soa.template begin<ParticleT::AttributeNames::quaternion2>();
+    const auto *const __restrict q3ptr = soa.template begin<ParticleT::AttributeNames::quaternion3>();
 
-    SoAFloatPrecision *const __restrict fxptr = soa.template begin<Particle::AttributeNames::forceX>();
-    SoAFloatPrecision *const __restrict fyptr = soa.template begin<Particle::AttributeNames::forceY>();
-    SoAFloatPrecision *const __restrict fzptr = soa.template begin<Particle::AttributeNames::forceZ>();
+    SoAFloatPrecision *const __restrict fxptr = soa.template begin<ParticleT::AttributeNames::forceX>();
+    SoAFloatPrecision *const __restrict fyptr = soa.template begin<ParticleT::AttributeNames::forceY>();
+    SoAFloatPrecision *const __restrict fzptr = soa.template begin<ParticleT::AttributeNames::forceZ>();
 
-    SoAFloatPrecision *const __restrict txptr = soa.template begin<Particle::AttributeNames::torqueX>();
-    SoAFloatPrecision *const __restrict typtr = soa.template begin<Particle::AttributeNames::torqueY>();
-    SoAFloatPrecision *const __restrict tzptr = soa.template begin<Particle::AttributeNames::torqueZ>();
+    SoAFloatPrecision *const __restrict txptr = soa.template begin<ParticleT::AttributeNames::torqueX>();
+    SoAFloatPrecision *const __restrict typtr = soa.template begin<ParticleT::AttributeNames::torqueY>();
+    SoAFloatPrecision *const __restrict tzptr = soa.template begin<ParticleT::AttributeNames::torqueZ>();
 
-    [[maybe_unused]] auto *const __restrict typeptr = soa.template begin<Particle::AttributeNames::typeId>();
+    [[maybe_unused]] auto *const __restrict typeptr = soa.template begin<ParticleT::AttributeNames::typeId>();
 
     SoAFloatPrecision potentialEnergySum = 0.;
     SoAFloatPrecision virialSumX = 0.;

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJ.cpp
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJ.cpp
@@ -9,7 +9,7 @@
 namespace mdLib {
 MoleculeLJ::MoleculeLJ(const std::array<double, 3> &pos, const std::array<double, 3> &v, unsigned long moleculeId,
                        unsigned long typeId)
-    : autopas::Particle(pos, v, moleculeId), _typeId(typeId) {}
+    : autopas::ParticleBaseFP64(pos, v, moleculeId), _typeId(typeId) {}
 
 const std::array<double, 3> &MoleculeLJ::getOldF() const { return _oldF; }
 void MoleculeLJ::setOldF(const std::array<double, 3> &oldForce) { _oldF = oldForce; }

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJ.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJ.h
@@ -9,7 +9,7 @@
 
 #include <vector>
 
-#include "autopas/particles/Particle.h"
+#include "autopas/particles/ParticleDefinitions.h"
 #include "autopas/utils/ExceptionHandler.h"
 
 namespace mdLib {
@@ -17,7 +17,7 @@ namespace mdLib {
 /**
  * Molecule class for the LJFunctor.
  */
-class MoleculeLJ : public autopas::Particle {
+class MoleculeLJ : public autopas::ParticleBaseFP64 {
  public:
   MoleculeLJ() = default;
 

--- a/applicationLibrary/molecularDynamics/tests/singleSiteTests/LJFunctorAVXTest.cpp
+++ b/applicationLibrary/molecularDynamics/tests/singleSiteTests/LJFunctorAVXTest.cpp
@@ -9,7 +9,7 @@
 #include "LJFunctorAVXTest.h"
 
 #include "autopas/cells/FullParticleCell.h"
-#include "autopas/particles/Particle.h"
+#include "autopas/particles/ParticleDefinitions.h"
 #include "autopasTools/generators/UniformGenerator.h"
 #include "molecularDynamicsLibrary/LJFunctor.h"
 #include "molecularDynamicsLibrary/LJFunctorAVX.h"
@@ -19,22 +19,22 @@ bool LJFunctorAVXTest::SoAParticlesEqual(autopas::SoA<SoAType> &soa1, autopas::S
   EXPECT_GT(soa1.size(), 0);
   EXPECT_EQ(soa1.size(), soa2.size());
 
-  unsigned long *const __restrict idptr1 = soa1.template begin<Particle::AttributeNames::id>();
-  unsigned long *const __restrict idptr2 = soa2.template begin<Particle::AttributeNames::id>();
+  unsigned long *const __restrict idptr1 = soa1.template begin<Molecule::AttributeNames::id>();
+  unsigned long *const __restrict idptr2 = soa2.template begin<Molecule::AttributeNames::id>();
 
-  double *const __restrict xptr1 = soa1.template begin<Particle::AttributeNames::posX>();
-  double *const __restrict yptr1 = soa1.template begin<Particle::AttributeNames::posY>();
-  double *const __restrict zptr1 = soa1.template begin<Particle::AttributeNames::posZ>();
-  double *const __restrict xptr2 = soa2.template begin<Particle::AttributeNames::posX>();
-  double *const __restrict yptr2 = soa2.template begin<Particle::AttributeNames::posY>();
-  double *const __restrict zptr2 = soa2.template begin<Particle::AttributeNames::posZ>();
+  double *const __restrict xptr1 = soa1.template begin<Molecule::AttributeNames::posX>();
+  double *const __restrict yptr1 = soa1.template begin<Molecule::AttributeNames::posY>();
+  double *const __restrict zptr1 = soa1.template begin<Molecule::AttributeNames::posZ>();
+  double *const __restrict xptr2 = soa2.template begin<Molecule::AttributeNames::posX>();
+  double *const __restrict yptr2 = soa2.template begin<Molecule::AttributeNames::posY>();
+  double *const __restrict zptr2 = soa2.template begin<Molecule::AttributeNames::posZ>();
 
-  double *const __restrict fxptr1 = soa1.template begin<Particle::AttributeNames::forceX>();
-  double *const __restrict fyptr1 = soa1.template begin<Particle::AttributeNames::forceY>();
-  double *const __restrict fzptr1 = soa1.template begin<Particle::AttributeNames::forceZ>();
-  double *const __restrict fxptr2 = soa2.template begin<Particle::AttributeNames::forceX>();
-  double *const __restrict fyptr2 = soa2.template begin<Particle::AttributeNames::forceY>();
-  double *const __restrict fzptr2 = soa2.template begin<Particle::AttributeNames::forceZ>();
+  double *const __restrict fxptr1 = soa1.template begin<Molecule::AttributeNames::forceX>();
+  double *const __restrict fyptr1 = soa1.template begin<Molecule::AttributeNames::forceY>();
+  double *const __restrict fzptr1 = soa1.template begin<Molecule::AttributeNames::forceZ>();
+  double *const __restrict fxptr2 = soa2.template begin<Molecule::AttributeNames::forceX>();
+  double *const __restrict fyptr2 = soa2.template begin<Molecule::AttributeNames::forceY>();
+  double *const __restrict fzptr2 = soa2.template begin<Molecule::AttributeNames::forceZ>();
 
   for (size_t i = 0; i < soa1.size(); ++i) {
     EXPECT_EQ(idptr1[i], idptr2[i]);
@@ -52,7 +52,7 @@ bool LJFunctorAVXTest::SoAParticlesEqual(autopas::SoA<SoAType> &soa1, autopas::S
   // clang-format on
 }
 
-bool LJFunctorAVXTest::particleEqual(Particle &p1, Particle &p2) {
+bool LJFunctorAVXTest::particleEqual(Molecule &p1, Molecule &p2) {
   EXPECT_EQ(p1.getID(), p2.getID());
 
   double tolerance = 2e-8;

--- a/applicationLibrary/molecularDynamics/tests/singleSiteTests/LJFunctorAVXTest.h
+++ b/applicationLibrary/molecularDynamics/tests/singleSiteTests/LJFunctorAVXTest.h
@@ -95,7 +95,7 @@ class LJFunctorAVXTest : public AutoPasTestBase, public ::testing::WithParamInte
    * @param p2
    * @return
    */
-  bool particleEqual(Particle &p1, Particle &p2);
+  bool particleEqual(Molecule &p1, Molecule &p2);
 
   constexpr static double _cutoff{6.};
   constexpr static double _skin{2.};

--- a/applicationLibrary/molecularDynamics/tests/singleSiteTests/LJFunctorSVETest.cpp
+++ b/applicationLibrary/molecularDynamics/tests/singleSiteTests/LJFunctorSVETest.cpp
@@ -9,7 +9,7 @@
 #include "LJFunctorSVETest.h"
 
 #include "autopas/cells/FullParticleCell.h"
-#include "autopas/particles/Particle.h"
+#include "autopas/particles/ParticleDefinitions.h"
 #include "autopasTools/generators/UniformGenerator.h"
 #include "molecularDynamicsLibrary/LJFunctor.h"
 #include "molecularDynamicsLibrary/LJFunctorSVE.h"

--- a/applicationLibrary/molecularDynamics/tests/singleSiteTests/LJFunctorSVETest.cpp
+++ b/applicationLibrary/molecularDynamics/tests/singleSiteTests/LJFunctorSVETest.cpp
@@ -19,22 +19,22 @@ bool LJFunctorSVETest::SoAParticlesEqual(autopas::SoA<SoAType> &soa1, autopas::S
   EXPECT_GT(soa1.size(), 0);
   EXPECT_EQ(soa1.size(), soa2.size());
 
-  unsigned long *const __restrict idptr1 = soa1.template begin<Particle::AttributeNames::id>();
-  unsigned long *const __restrict idptr2 = soa2.template begin<Particle::AttributeNames::id>();
+  unsigned long *const __restrict idptr1 = soa1.template begin<Molecule::AttributeNames::id>();
+  unsigned long *const __restrict idptr2 = soa2.template begin<Molecule::AttributeNames::id>();
 
-  double *const __restrict xptr1 = soa1.template begin<Particle::AttributeNames::posX>();
-  double *const __restrict yptr1 = soa1.template begin<Particle::AttributeNames::posY>();
-  double *const __restrict zptr1 = soa1.template begin<Particle::AttributeNames::posZ>();
-  double *const __restrict xptr2 = soa2.template begin<Particle::AttributeNames::posX>();
-  double *const __restrict yptr2 = soa2.template begin<Particle::AttributeNames::posY>();
-  double *const __restrict zptr2 = soa2.template begin<Particle::AttributeNames::posZ>();
+  double *const __restrict xptr1 = soa1.template begin<Molecule::AttributeNames::posX>();
+  double *const __restrict yptr1 = soa1.template begin<Molecule::AttributeNames::posY>();
+  double *const __restrict zptr1 = soa1.template begin<Molecule::AttributeNames::posZ>();
+  double *const __restrict xptr2 = soa2.template begin<Molecule::AttributeNames::posX>();
+  double *const __restrict yptr2 = soa2.template begin<Molecule::AttributeNames::posY>();
+  double *const __restrict zptr2 = soa2.template begin<Molecule::AttributeNames::posZ>();
 
-  double *const __restrict fxptr1 = soa1.template begin<Particle::AttributeNames::forceX>();
-  double *const __restrict fyptr1 = soa1.template begin<Particle::AttributeNames::forceY>();
-  double *const __restrict fzptr1 = soa1.template begin<Particle::AttributeNames::forceZ>();
-  double *const __restrict fxptr2 = soa2.template begin<Particle::AttributeNames::forceX>();
-  double *const __restrict fyptr2 = soa2.template begin<Particle::AttributeNames::forceY>();
-  double *const __restrict fzptr2 = soa2.template begin<Particle::AttributeNames::forceZ>();
+  double *const __restrict fxptr1 = soa1.template begin<Molecule::AttributeNames::forceX>();
+  double *const __restrict fyptr1 = soa1.template begin<Molecule::AttributeNames::forceY>();
+  double *const __restrict fzptr1 = soa1.template begin<Molecule::AttributeNames::forceZ>();
+  double *const __restrict fxptr2 = soa2.template begin<Molecule::AttributeNames::forceX>();
+  double *const __restrict fyptr2 = soa2.template begin<Molecule::AttributeNames::forceY>();
+  double *const __restrict fzptr2 = soa2.template begin<Molecule::AttributeNames::forceZ>();
 
   for (size_t i = 0; i < soa1.size(); ++i) {
     EXPECT_EQ(idptr1[i], idptr2[i]);
@@ -52,7 +52,7 @@ bool LJFunctorSVETest::SoAParticlesEqual(autopas::SoA<SoAType> &soa1, autopas::S
   // clang-format on
 }
 
-bool LJFunctorSVETest::particleEqual(Particle &p1, Particle &p2) {
+bool LJFunctorSVETest::particleEqual(Molecule &p1, Molecule &p2) {
   EXPECT_EQ(p1.getID(), p2.getID());
 
   double tolerance = 1e-8;

--- a/applicationLibrary/molecularDynamics/tests/singleSiteTests/LJFunctorSVETest.h
+++ b/applicationLibrary/molecularDynamics/tests/singleSiteTests/LJFunctorSVETest.h
@@ -87,7 +87,7 @@ class LJFunctorSVETest : public AutoPasTestBase, public ::testing::WithParamInte
    * @param p2
    * @return
    */
-  bool particleEqual(Particle &p1, Particle &p2);
+  bool particleEqual(Molecule &p1, Molecule &p2);
 
   constexpr static double _cutoff{6.};
   constexpr static double _skin{2.};

--- a/applicationLibrary/sph/SPHLibrary/SPHCalcDensityFunctor.h
+++ b/applicationLibrary/sph/SPHLibrary/SPHCalcDensityFunctor.h
@@ -14,15 +14,15 @@ namespace sphLib {
 /**
  * Class that defines the density functor.
  * It is used to calculate the density based on the given SPH kernel.
- * @tparam ParticleT
+ * @tparam Particle_T
  */
-template <class ParticleT>
-class SPHCalcDensityFunctor : public autopas::PairwiseFunctor<ParticleT, SPHCalcDensityFunctor<ParticleT>> {
+template <class Particle_T>
+class SPHCalcDensityFunctor : public autopas::PairwiseFunctor<Particle_T, SPHCalcDensityFunctor<Particle_T>> {
  public:
   /// soa arrays type
-  using SoAArraysType = typename ParticleT::SoAArraysType;
+  using SoAArraysType = typename Particle_T::SoAArraysType;
 
-  SPHCalcDensityFunctor() : autopas::PairwiseFunctor<ParticleT, SPHCalcDensityFunctor<ParticleT>>(0.){};
+  SPHCalcDensityFunctor() : autopas::PairwiseFunctor<Particle_T, SPHCalcDensityFunctor<Particle_T>>(0.){};
 
   virtual std::string getName() override { return "SPHDensityFunctor"; }
 
@@ -40,7 +40,7 @@ class SPHCalcDensityFunctor : public autopas::PairwiseFunctor<ParticleT, SPHCalc
    * @param j second particle of the interaction
    * @param newton3 defines whether or whether not to use newton 3
    */
-  inline void AoSFunctor(ParticleT &i, ParticleT &j, bool newton3 = true) override {
+  inline void AoSFunctor(Particle_T &i, Particle_T &j, bool newton3 = true) override {
     using namespace autopas::utils::ArrayMath::literals;
 
     if (i.isDummy() or j.isDummy()) {
@@ -78,15 +78,15 @@ class SPHCalcDensityFunctor : public autopas::PairwiseFunctor<ParticleT, SPHCalc
   void SoAFunctorSingle(autopas::SoAView<SoAArraysType> soa, bool newton3) override {
     if (soa.size() == 0) return;
 
-    double *const __restrict xptr = soa.template begin<ParticleT::AttributeNames::posX>();
-    double *const __restrict yptr = soa.template begin<ParticleT::AttributeNames::posY>();
-    double *const __restrict zptr = soa.template begin<ParticleT::AttributeNames::posZ>();
+    double *const __restrict xptr = soa.template begin<Particle_T::AttributeNames::posX>();
+    double *const __restrict yptr = soa.template begin<Particle_T::AttributeNames::posY>();
+    double *const __restrict zptr = soa.template begin<Particle_T::AttributeNames::posZ>();
 
-    double *const __restrict densityptr = soa.template begin<ParticleT::AttributeNames::density>();
-    double *const __restrict smthptr = soa.template begin<ParticleT::AttributeNames::smth>();
-    double *const __restrict massptr = soa.template begin<ParticleT::AttributeNames::mass>();
+    double *const __restrict densityptr = soa.template begin<Particle_T::AttributeNames::density>();
+    double *const __restrict smthptr = soa.template begin<Particle_T::AttributeNames::smth>();
+    double *const __restrict massptr = soa.template begin<Particle_T::AttributeNames::mass>();
 
-    const auto *const __restrict ownedStatePtr = soa.template begin<ParticleT::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr = soa.template begin<Particle_T::AttributeNames::ownershipState>();
 
     size_t numParticles = soa.size();
     for (unsigned int i = 0; i < numParticles; ++i) {
@@ -133,24 +133,24 @@ class SPHCalcDensityFunctor : public autopas::PairwiseFunctor<ParticleT, SPHCalc
                       bool newton3) override {
     if (soa1.size() == 0 || soa2.size() == 0) return;
 
-    double *const __restrict xptr1 = soa1.template begin<ParticleT::AttributeNames::posX>();
-    double *const __restrict yptr1 = soa1.template begin<ParticleT::AttributeNames::posY>();
-    double *const __restrict zptr1 = soa1.template begin<ParticleT::AttributeNames::posZ>();
+    double *const __restrict xptr1 = soa1.template begin<Particle_T::AttributeNames::posX>();
+    double *const __restrict yptr1 = soa1.template begin<Particle_T::AttributeNames::posY>();
+    double *const __restrict zptr1 = soa1.template begin<Particle_T::AttributeNames::posZ>();
 
-    double *const __restrict densityptr1 = soa1.template begin<ParticleT::AttributeNames::density>();
-    double *const __restrict smthptr1 = soa1.template begin<ParticleT::AttributeNames::smth>();
-    double *const __restrict massptr1 = soa1.template begin<ParticleT::AttributeNames::mass>();
+    double *const __restrict densityptr1 = soa1.template begin<Particle_T::AttributeNames::density>();
+    double *const __restrict smthptr1 = soa1.template begin<Particle_T::AttributeNames::smth>();
+    double *const __restrict massptr1 = soa1.template begin<Particle_T::AttributeNames::mass>();
 
-    double *const __restrict xptr2 = soa2.template begin<ParticleT::AttributeNames::posX>();
-    double *const __restrict yptr2 = soa2.template begin<ParticleT::AttributeNames::posY>();
-    double *const __restrict zptr2 = soa2.template begin<ParticleT::AttributeNames::posZ>();
+    double *const __restrict xptr2 = soa2.template begin<Particle_T::AttributeNames::posX>();
+    double *const __restrict yptr2 = soa2.template begin<Particle_T::AttributeNames::posY>();
+    double *const __restrict zptr2 = soa2.template begin<Particle_T::AttributeNames::posZ>();
 
-    double *const __restrict densityptr2 = soa2.template begin<ParticleT::AttributeNames::density>();
-    double *const __restrict smthptr2 = soa2.template begin<ParticleT::AttributeNames::smth>();
-    double *const __restrict massptr2 = soa2.template begin<ParticleT::AttributeNames::mass>();
+    double *const __restrict densityptr2 = soa2.template begin<Particle_T::AttributeNames::density>();
+    double *const __restrict smthptr2 = soa2.template begin<Particle_T::AttributeNames::smth>();
+    double *const __restrict massptr2 = soa2.template begin<Particle_T::AttributeNames::mass>();
 
-    const auto *const __restrict ownedStatePtr1 = soa1.template begin<ParticleT::AttributeNames::ownershipState>();
-    const auto *const __restrict ownedStatePtr2 = soa2.template begin<ParticleT::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr1 = soa1.template begin<Particle_T::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr2 = soa2.template begin<Particle_T::AttributeNames::ownershipState>();
 
     size_t numParticlesi = soa1.size();
     for (unsigned int i = 0; i < numParticlesi; ++i) {
@@ -202,20 +202,20 @@ class SPHCalcDensityFunctor : public autopas::PairwiseFunctor<ParticleT, SPHCalc
                         bool newton3) override {
     if (soa.size() == 0) return;
 
-    const auto *const __restrict ownedStatePtr = soa.template begin<ParticleT::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr = soa.template begin<Particle_T::AttributeNames::ownershipState>();
 
     // checks whether particle i is owned.
     if (ownedStatePtr[indexFirst] == autopas::OwnershipState::dummy) {
       return;
     }
 
-    double *const __restrict xptr = soa.template begin<ParticleT::AttributeNames::posX>();
-    double *const __restrict yptr = soa.template begin<ParticleT::AttributeNames::posY>();
-    double *const __restrict zptr = soa.template begin<ParticleT::AttributeNames::posZ>();
+    double *const __restrict xptr = soa.template begin<Particle_T::AttributeNames::posX>();
+    double *const __restrict yptr = soa.template begin<Particle_T::AttributeNames::posY>();
+    double *const __restrict zptr = soa.template begin<Particle_T::AttributeNames::posZ>();
 
-    double *const __restrict densityptr = soa.template begin<ParticleT::AttributeNames::density>();
-    double *const __restrict smthptr = soa.template begin<ParticleT::AttributeNames::smth>();
-    double *const __restrict massptr = soa.template begin<ParticleT::AttributeNames::mass>();
+    double *const __restrict densityptr = soa.template begin<Particle_T::AttributeNames::density>();
+    double *const __restrict smthptr = soa.template begin<Particle_T::AttributeNames::smth>();
+    double *const __restrict massptr = soa.template begin<Particle_T::AttributeNames::mass>();
 
     double densacc = 0;
     const auto &currentList = neighborList;
@@ -254,26 +254,27 @@ class SPHCalcDensityFunctor : public autopas::PairwiseFunctor<ParticleT, SPHCalc
    * @copydoc autopas::Functor::getNeededAttr()
    */
   constexpr static auto getNeededAttr() {
-    return std::array<typename ParticleT::AttributeNames, 7>{
-        ParticleT::AttributeNames::mass,          ParticleT::AttributeNames::posX, ParticleT::AttributeNames::posY,
-        ParticleT::AttributeNames::posZ,          ParticleT::AttributeNames::smth, ParticleT::AttributeNames::density,
-        ParticleT::AttributeNames::ownershipState};
+    return std::array<typename Particle_T::AttributeNames, 7>{
+        Particle_T::AttributeNames::mass,          Particle_T::AttributeNames::posX,
+        Particle_T::AttributeNames::posY,          Particle_T::AttributeNames::posZ,
+        Particle_T::AttributeNames::smth,          Particle_T::AttributeNames::density,
+        Particle_T::AttributeNames::ownershipState};
   }
 
   /**
    * @copydoc autopas::Functor::getNeededAttr(std::false_type)
    */
   constexpr static auto getNeededAttr(std::false_type) {
-    return std::array<typename ParticleT::AttributeNames, 6>{
-        ParticleT::AttributeNames::mass, ParticleT::AttributeNames::posX, ParticleT::AttributeNames::posY,
-        ParticleT::AttributeNames::posZ, ParticleT::AttributeNames::smth, ParticleT::AttributeNames::ownershipState};
+    return std::array<typename Particle_T::AttributeNames, 6>{
+        Particle_T::AttributeNames::mass, Particle_T::AttributeNames::posX, Particle_T::AttributeNames::posY,
+        Particle_T::AttributeNames::posZ, Particle_T::AttributeNames::smth, Particle_T::AttributeNames::ownershipState};
   }
 
   /**
    * @copydoc autopas::Functor::getComputedAttr()
    */
   constexpr static auto getComputedAttr() {
-    return std::array<typename ParticleT::AttributeNames, 1>{ParticleT::AttributeNames::density};
+    return std::array<typename Particle_T::AttributeNames, 1>{Particle_T::AttributeNames::density};
   }
 };
 }  // namespace sphLib

--- a/applicationLibrary/sph/SPHLibrary/SPHCalcDensityFunctor.h
+++ b/applicationLibrary/sph/SPHLibrary/SPHCalcDensityFunctor.h
@@ -14,16 +14,15 @@ namespace sphLib {
 /**
  * Class that defines the density functor.
  * It is used to calculate the density based on the given SPH kernel.
- * @tparam Particle
- * @tparam ParticleCell
+ * @tparam ParticleT
  */
-template <class Particle>
-class SPHCalcDensityFunctor : public autopas::PairwiseFunctor<Particle, SPHCalcDensityFunctor<Particle>> {
+template <class ParticleT>
+class SPHCalcDensityFunctor : public autopas::PairwiseFunctor<ParticleT, SPHCalcDensityFunctor<ParticleT>> {
  public:
   /// soa arrays type
-  using SoAArraysType = typename Particle::SoAArraysType;
+  using SoAArraysType = typename ParticleT::SoAArraysType;
 
-  SPHCalcDensityFunctor() : autopas::PairwiseFunctor<Particle, SPHCalcDensityFunctor<Particle>>(0.){};
+  SPHCalcDensityFunctor() : autopas::PairwiseFunctor<ParticleT, SPHCalcDensityFunctor<ParticleT>>(0.){};
 
   virtual std::string getName() override { return "SPHDensityFunctor"; }
 
@@ -41,7 +40,7 @@ class SPHCalcDensityFunctor : public autopas::PairwiseFunctor<Particle, SPHCalcD
    * @param j second particle of the interaction
    * @param newton3 defines whether or whether not to use newton 3
    */
-  inline void AoSFunctor(Particle &i, Particle &j, bool newton3 = true) override {
+  inline void AoSFunctor(ParticleT &i, ParticleT &j, bool newton3 = true) override {
     using namespace autopas::utils::ArrayMath::literals;
 
     if (i.isDummy() or j.isDummy()) {
@@ -79,15 +78,15 @@ class SPHCalcDensityFunctor : public autopas::PairwiseFunctor<Particle, SPHCalcD
   void SoAFunctorSingle(autopas::SoAView<SoAArraysType> soa, bool newton3) override {
     if (soa.size() == 0) return;
 
-    double *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
+    double *const __restrict xptr = soa.template begin<ParticleT::AttributeNames::posX>();
+    double *const __restrict yptr = soa.template begin<ParticleT::AttributeNames::posY>();
+    double *const __restrict zptr = soa.template begin<ParticleT::AttributeNames::posZ>();
 
-    double *const __restrict densityptr = soa.template begin<Particle::AttributeNames::density>();
-    double *const __restrict smthptr = soa.template begin<Particle::AttributeNames::smth>();
-    double *const __restrict massptr = soa.template begin<Particle::AttributeNames::mass>();
+    double *const __restrict densityptr = soa.template begin<ParticleT::AttributeNames::density>();
+    double *const __restrict smthptr = soa.template begin<ParticleT::AttributeNames::smth>();
+    double *const __restrict massptr = soa.template begin<ParticleT::AttributeNames::mass>();
 
-    const auto *const __restrict ownedStatePtr = soa.template begin<Particle::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr = soa.template begin<ParticleT::AttributeNames::ownershipState>();
 
     size_t numParticles = soa.size();
     for (unsigned int i = 0; i < numParticles; ++i) {
@@ -134,24 +133,24 @@ class SPHCalcDensityFunctor : public autopas::PairwiseFunctor<Particle, SPHCalcD
                       bool newton3) override {
     if (soa1.size() == 0 || soa2.size() == 0) return;
 
-    double *const __restrict xptr1 = soa1.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict yptr1 = soa1.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict zptr1 = soa1.template begin<Particle::AttributeNames::posZ>();
+    double *const __restrict xptr1 = soa1.template begin<ParticleT::AttributeNames::posX>();
+    double *const __restrict yptr1 = soa1.template begin<ParticleT::AttributeNames::posY>();
+    double *const __restrict zptr1 = soa1.template begin<ParticleT::AttributeNames::posZ>();
 
-    double *const __restrict densityptr1 = soa1.template begin<Particle::AttributeNames::density>();
-    double *const __restrict smthptr1 = soa1.template begin<Particle::AttributeNames::smth>();
-    double *const __restrict massptr1 = soa1.template begin<Particle::AttributeNames::mass>();
+    double *const __restrict densityptr1 = soa1.template begin<ParticleT::AttributeNames::density>();
+    double *const __restrict smthptr1 = soa1.template begin<ParticleT::AttributeNames::smth>();
+    double *const __restrict massptr1 = soa1.template begin<ParticleT::AttributeNames::mass>();
 
-    double *const __restrict xptr2 = soa2.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict yptr2 = soa2.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict zptr2 = soa2.template begin<Particle::AttributeNames::posZ>();
+    double *const __restrict xptr2 = soa2.template begin<ParticleT::AttributeNames::posX>();
+    double *const __restrict yptr2 = soa2.template begin<ParticleT::AttributeNames::posY>();
+    double *const __restrict zptr2 = soa2.template begin<ParticleT::AttributeNames::posZ>();
 
-    double *const __restrict densityptr2 = soa2.template begin<Particle::AttributeNames::density>();
-    double *const __restrict smthptr2 = soa2.template begin<Particle::AttributeNames::smth>();
-    double *const __restrict massptr2 = soa2.template begin<Particle::AttributeNames::mass>();
+    double *const __restrict densityptr2 = soa2.template begin<ParticleT::AttributeNames::density>();
+    double *const __restrict smthptr2 = soa2.template begin<ParticleT::AttributeNames::smth>();
+    double *const __restrict massptr2 = soa2.template begin<ParticleT::AttributeNames::mass>();
 
-    const auto *const __restrict ownedStatePtr1 = soa1.template begin<Particle::AttributeNames::ownershipState>();
-    const auto *const __restrict ownedStatePtr2 = soa2.template begin<Particle::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr1 = soa1.template begin<ParticleT::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr2 = soa2.template begin<ParticleT::AttributeNames::ownershipState>();
 
     size_t numParticlesi = soa1.size();
     for (unsigned int i = 0; i < numParticlesi; ++i) {
@@ -203,20 +202,20 @@ class SPHCalcDensityFunctor : public autopas::PairwiseFunctor<Particle, SPHCalcD
                         bool newton3) override {
     if (soa.size() == 0) return;
 
-    const auto *const __restrict ownedStatePtr = soa.template begin<Particle::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr = soa.template begin<ParticleT::AttributeNames::ownershipState>();
 
     // checks whether particle i is owned.
     if (ownedStatePtr[indexFirst] == autopas::OwnershipState::dummy) {
       return;
     }
 
-    double *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
+    double *const __restrict xptr = soa.template begin<ParticleT::AttributeNames::posX>();
+    double *const __restrict yptr = soa.template begin<ParticleT::AttributeNames::posY>();
+    double *const __restrict zptr = soa.template begin<ParticleT::AttributeNames::posZ>();
 
-    double *const __restrict densityptr = soa.template begin<Particle::AttributeNames::density>();
-    double *const __restrict smthptr = soa.template begin<Particle::AttributeNames::smth>();
-    double *const __restrict massptr = soa.template begin<Particle::AttributeNames::mass>();
+    double *const __restrict densityptr = soa.template begin<ParticleT::AttributeNames::density>();
+    double *const __restrict smthptr = soa.template begin<ParticleT::AttributeNames::smth>();
+    double *const __restrict massptr = soa.template begin<ParticleT::AttributeNames::mass>();
 
     double densacc = 0;
     const auto &currentList = neighborList;
@@ -255,26 +254,26 @@ class SPHCalcDensityFunctor : public autopas::PairwiseFunctor<Particle, SPHCalcD
    * @copydoc autopas::Functor::getNeededAttr()
    */
   constexpr static auto getNeededAttr() {
-    return std::array<typename Particle::AttributeNames, 7>{
-        Particle::AttributeNames::mass,          Particle::AttributeNames::posX, Particle::AttributeNames::posY,
-        Particle::AttributeNames::posZ,          Particle::AttributeNames::smth, Particle::AttributeNames::density,
-        Particle::AttributeNames::ownershipState};
+    return std::array<typename ParticleT::AttributeNames, 7>{
+        ParticleT::AttributeNames::mass,          ParticleT::AttributeNames::posX, ParticleT::AttributeNames::posY,
+        ParticleT::AttributeNames::posZ,          ParticleT::AttributeNames::smth, ParticleT::AttributeNames::density,
+        ParticleT::AttributeNames::ownershipState};
   }
 
   /**
    * @copydoc autopas::Functor::getNeededAttr(std::false_type)
    */
   constexpr static auto getNeededAttr(std::false_type) {
-    return std::array<typename Particle::AttributeNames, 6>{
-        Particle::AttributeNames::mass, Particle::AttributeNames::posX, Particle::AttributeNames::posY,
-        Particle::AttributeNames::posZ, Particle::AttributeNames::smth, Particle::AttributeNames::ownershipState};
+    return std::array<typename ParticleT::AttributeNames, 6>{
+        ParticleT::AttributeNames::mass, ParticleT::AttributeNames::posX, ParticleT::AttributeNames::posY,
+        ParticleT::AttributeNames::posZ, ParticleT::AttributeNames::smth, ParticleT::AttributeNames::ownershipState};
   }
 
   /**
    * @copydoc autopas::Functor::getComputedAttr()
    */
   constexpr static auto getComputedAttr() {
-    return std::array<typename Particle::AttributeNames, 1>{Particle::AttributeNames::density};
+    return std::array<typename ParticleT::AttributeNames, 1>{ParticleT::AttributeNames::density};
   }
 };
 }  // namespace sphLib

--- a/applicationLibrary/sph/SPHLibrary/SPHCalcHydroForceFunctor.h
+++ b/applicationLibrary/sph/SPHLibrary/SPHCalcHydroForceFunctor.h
@@ -13,18 +13,17 @@ namespace sphLib {
 /**
  * Class that defines the hydrodynamic force functor.
  * It is used to calculate the force based on the given SPH kernels.
- * @tparam Particle
- * @tparam ParticleCell
+ * @tparam ParticleT
  */
-template <class Particle>
-class SPHCalcHydroForceFunctor : public autopas::PairwiseFunctor<Particle, SPHCalcHydroForceFunctor<Particle>> {
+template <class ParticleT>
+class SPHCalcHydroForceFunctor : public autopas::PairwiseFunctor<ParticleT, SPHCalcHydroForceFunctor<ParticleT>> {
  public:
   /// soa arrays type
-  using SoAArraysType = typename Particle::SoAArraysType;
+  using SoAArraysType = typename ParticleT::SoAArraysType;
 
   SPHCalcHydroForceFunctor()
       // the actual cutoff used is dynamic. 0 is used to pass the sanity check.
-      : autopas::PairwiseFunctor<Particle, SPHCalcHydroForceFunctor<Particle>>(0.){};
+      : autopas::PairwiseFunctor<ParticleT, SPHCalcHydroForceFunctor<ParticleT>>(0.){};
 
   virtual std::string getName() override { return "SPHHydroForceFunctor"; }
 
@@ -43,7 +42,7 @@ class SPHCalcHydroForceFunctor : public autopas::PairwiseFunctor<Particle, SPHCa
    * @param j second particle of the interaction
    * @param newton3 defines whether or whether not to use newton 3
    */
-  void AoSFunctor(Particle &i, Particle &j, bool newton3 = true) override {
+  void AoSFunctor(ParticleT &i, ParticleT &j, bool newton3 = true) override {
     using namespace autopas::utils::ArrayMath::literals;
 
     if (i.isDummy() or j.isDummy()) {
@@ -112,25 +111,25 @@ class SPHCalcHydroForceFunctor : public autopas::PairwiseFunctor<Particle, SPHCa
     using namespace autopas::utils::ArrayMath::literals;
     if (soa.size() == 0) return;
 
-    double *const __restrict massptr = soa.template begin<Particle::AttributeNames::mass>();
-    double *const __restrict densityptr = soa.template begin<Particle::AttributeNames::density>();
-    double *const __restrict smthptr = soa.template begin<Particle::AttributeNames::smth>();
-    double *const __restrict soundSpeedptr = soa.template begin<Particle::AttributeNames::soundSpeed>();
-    double *const __restrict pressureptr = soa.template begin<Particle::AttributeNames::pressure>();
-    double *const __restrict vsigmaxptr = soa.template begin<Particle::AttributeNames::vsigmax>();
-    double *const __restrict engDotptr = soa.template begin<Particle::AttributeNames::engDot>();
+    double *const __restrict massptr = soa.template begin<ParticleT::AttributeNames::mass>();
+    double *const __restrict densityptr = soa.template begin<ParticleT::AttributeNames::density>();
+    double *const __restrict smthptr = soa.template begin<ParticleT::AttributeNames::smth>();
+    double *const __restrict soundSpeedptr = soa.template begin<ParticleT::AttributeNames::soundSpeed>();
+    double *const __restrict pressureptr = soa.template begin<ParticleT::AttributeNames::pressure>();
+    double *const __restrict vsigmaxptr = soa.template begin<ParticleT::AttributeNames::vsigmax>();
+    double *const __restrict engDotptr = soa.template begin<ParticleT::AttributeNames::engDot>();
 
-    double *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
-    double *const __restrict velXptr = soa.template begin<Particle::AttributeNames::velX>();
-    double *const __restrict velYptr = soa.template begin<Particle::AttributeNames::velY>();
-    double *const __restrict velZptr = soa.template begin<Particle::AttributeNames::velZ>();
-    double *const __restrict accXptr = soa.template begin<Particle::AttributeNames::accX>();
-    double *const __restrict accYptr = soa.template begin<Particle::AttributeNames::accY>();
-    double *const __restrict accZptr = soa.template begin<Particle::AttributeNames::accZ>();
+    double *const __restrict xptr = soa.template begin<ParticleT::AttributeNames::posX>();
+    double *const __restrict yptr = soa.template begin<ParticleT::AttributeNames::posY>();
+    double *const __restrict zptr = soa.template begin<ParticleT::AttributeNames::posZ>();
+    double *const __restrict velXptr = soa.template begin<ParticleT::AttributeNames::velX>();
+    double *const __restrict velYptr = soa.template begin<ParticleT::AttributeNames::velY>();
+    double *const __restrict velZptr = soa.template begin<ParticleT::AttributeNames::velZ>();
+    double *const __restrict accXptr = soa.template begin<ParticleT::AttributeNames::accX>();
+    double *const __restrict accYptr = soa.template begin<ParticleT::AttributeNames::accY>();
+    double *const __restrict accZptr = soa.template begin<ParticleT::AttributeNames::accZ>();
 
-    const auto *const __restrict ownedStatePtr = soa.template begin<Particle::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr = soa.template begin<ParticleT::AttributeNames::ownershipState>();
 
     for (unsigned int indexFirst = 0; indexFirst < soa.size(); ++indexFirst) {
       // checks whether particle i is owned.
@@ -232,44 +231,44 @@ class SPHCalcHydroForceFunctor : public autopas::PairwiseFunctor<Particle, SPHCa
     using namespace autopas::utils::ArrayMath::literals;
     if (soa1.size() == 0 || soa2.size() == 0) return;
 
-    double *const __restrict massptr1 = soa1.template begin<Particle::AttributeNames::mass>();
-    double *const __restrict densityptr1 = soa1.template begin<Particle::AttributeNames::density>();
-    double *const __restrict smthptr1 = soa1.template begin<Particle::AttributeNames::smth>();
-    double *const __restrict soundSpeedptr1 = soa1.template begin<Particle::AttributeNames::soundSpeed>();
-    double *const __restrict pressureptr1 = soa1.template begin<Particle::AttributeNames::pressure>();
-    double *const __restrict vsigmaxptr1 = soa1.template begin<Particle::AttributeNames::vsigmax>();
-    double *const __restrict engDotptr1 = soa1.template begin<Particle::AttributeNames::engDot>();
+    double *const __restrict massptr1 = soa1.template begin<ParticleT::AttributeNames::mass>();
+    double *const __restrict densityptr1 = soa1.template begin<ParticleT::AttributeNames::density>();
+    double *const __restrict smthptr1 = soa1.template begin<ParticleT::AttributeNames::smth>();
+    double *const __restrict soundSpeedptr1 = soa1.template begin<ParticleT::AttributeNames::soundSpeed>();
+    double *const __restrict pressureptr1 = soa1.template begin<ParticleT::AttributeNames::pressure>();
+    double *const __restrict vsigmaxptr1 = soa1.template begin<ParticleT::AttributeNames::vsigmax>();
+    double *const __restrict engDotptr1 = soa1.template begin<ParticleT::AttributeNames::engDot>();
 
-    double *const __restrict xptr1 = soa1.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict yptr1 = soa1.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict zptr1 = soa1.template begin<Particle::AttributeNames::posZ>();
-    double *const __restrict velXptr1 = soa1.template begin<Particle::AttributeNames::velX>();
-    double *const __restrict velYptr1 = soa1.template begin<Particle::AttributeNames::velY>();
-    double *const __restrict velZptr1 = soa1.template begin<Particle::AttributeNames::velZ>();
-    double *const __restrict accXptr1 = soa1.template begin<Particle::AttributeNames::accX>();
-    double *const __restrict accYptr1 = soa1.template begin<Particle::AttributeNames::accY>();
-    double *const __restrict accZptr1 = soa1.template begin<Particle::AttributeNames::accZ>();
+    double *const __restrict xptr1 = soa1.template begin<ParticleT::AttributeNames::posX>();
+    double *const __restrict yptr1 = soa1.template begin<ParticleT::AttributeNames::posY>();
+    double *const __restrict zptr1 = soa1.template begin<ParticleT::AttributeNames::posZ>();
+    double *const __restrict velXptr1 = soa1.template begin<ParticleT::AttributeNames::velX>();
+    double *const __restrict velYptr1 = soa1.template begin<ParticleT::AttributeNames::velY>();
+    double *const __restrict velZptr1 = soa1.template begin<ParticleT::AttributeNames::velZ>();
+    double *const __restrict accXptr1 = soa1.template begin<ParticleT::AttributeNames::accX>();
+    double *const __restrict accYptr1 = soa1.template begin<ParticleT::AttributeNames::accY>();
+    double *const __restrict accZptr1 = soa1.template begin<ParticleT::AttributeNames::accZ>();
 
-    double *const __restrict massptr2 = soa2.template begin<Particle::AttributeNames::mass>();
-    double *const __restrict densityptr2 = soa2.template begin<Particle::AttributeNames::density>();
-    double *const __restrict smthptr2 = soa2.template begin<Particle::AttributeNames::smth>();
-    double *const __restrict soundSpeedptr2 = soa2.template begin<Particle::AttributeNames::soundSpeed>();
-    double *const __restrict pressureptr2 = soa2.template begin<Particle::AttributeNames::pressure>();
-    double *const __restrict vsigmaxptr2 = soa2.template begin<Particle::AttributeNames::vsigmax>();
-    double *const __restrict engDotptr2 = soa2.template begin<Particle::AttributeNames::engDot>();
+    double *const __restrict massptr2 = soa2.template begin<ParticleT::AttributeNames::mass>();
+    double *const __restrict densityptr2 = soa2.template begin<ParticleT::AttributeNames::density>();
+    double *const __restrict smthptr2 = soa2.template begin<ParticleT::AttributeNames::smth>();
+    double *const __restrict soundSpeedptr2 = soa2.template begin<ParticleT::AttributeNames::soundSpeed>();
+    double *const __restrict pressureptr2 = soa2.template begin<ParticleT::AttributeNames::pressure>();
+    double *const __restrict vsigmaxptr2 = soa2.template begin<ParticleT::AttributeNames::vsigmax>();
+    double *const __restrict engDotptr2 = soa2.template begin<ParticleT::AttributeNames::engDot>();
 
-    double *const __restrict xptr2 = soa2.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict yptr2 = soa2.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict zptr2 = soa2.template begin<Particle::AttributeNames::posZ>();
-    double *const __restrict velXptr2 = soa2.template begin<Particle::AttributeNames::velX>();
-    double *const __restrict velYptr2 = soa2.template begin<Particle::AttributeNames::velY>();
-    double *const __restrict velZptr2 = soa2.template begin<Particle::AttributeNames::velZ>();
-    double *const __restrict accXptr2 = soa2.template begin<Particle::AttributeNames::accX>();
-    double *const __restrict accYptr2 = soa2.template begin<Particle::AttributeNames::accY>();
-    double *const __restrict accZptr2 = soa2.template begin<Particle::AttributeNames::accZ>();
+    double *const __restrict xptr2 = soa2.template begin<ParticleT::AttributeNames::posX>();
+    double *const __restrict yptr2 = soa2.template begin<ParticleT::AttributeNames::posY>();
+    double *const __restrict zptr2 = soa2.template begin<ParticleT::AttributeNames::posZ>();
+    double *const __restrict velXptr2 = soa2.template begin<ParticleT::AttributeNames::velX>();
+    double *const __restrict velYptr2 = soa2.template begin<ParticleT::AttributeNames::velY>();
+    double *const __restrict velZptr2 = soa2.template begin<ParticleT::AttributeNames::velZ>();
+    double *const __restrict accXptr2 = soa2.template begin<ParticleT::AttributeNames::accX>();
+    double *const __restrict accYptr2 = soa2.template begin<ParticleT::AttributeNames::accY>();
+    double *const __restrict accZptr2 = soa2.template begin<ParticleT::AttributeNames::accZ>();
 
-    const auto *const __restrict ownedStatePtr1 = soa1.template begin<Particle::AttributeNames::ownershipState>();
-    const auto *const __restrict ownedStatePtr2 = soa2.template begin<Particle::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr1 = soa1.template begin<ParticleT::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr2 = soa2.template begin<ParticleT::AttributeNames::ownershipState>();
 
     for (unsigned int indexFirst = 0; indexFirst < soa1.size(); ++indexFirst) {
       // checks whether particle i is owned.
@@ -376,30 +375,30 @@ class SPHCalcHydroForceFunctor : public autopas::PairwiseFunctor<Particle, SPHCa
     using namespace autopas::utils::ArrayMath::literals;
     if (soa.size() == 0) return;
 
-    const auto *const __restrict ownedStatePtr = soa.template begin<Particle::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr = soa.template begin<ParticleT::AttributeNames::ownershipState>();
 
     // checks whether particle i is owned.
     if (ownedStatePtr[indexFirst] == autopas::OwnershipState::dummy) {
       return;
     }
 
-    double *const __restrict massptr = soa.template begin<Particle::AttributeNames::mass>();
-    double *const __restrict densityptr = soa.template begin<Particle::AttributeNames::density>();
-    double *const __restrict smthptr = soa.template begin<Particle::AttributeNames::smth>();
-    double *const __restrict soundSpeedptr = soa.template begin<Particle::AttributeNames::soundSpeed>();
-    double *const __restrict pressureptr = soa.template begin<Particle::AttributeNames::pressure>();
-    double *const __restrict vsigmaxptr = soa.template begin<Particle::AttributeNames::vsigmax>();
-    double *const __restrict engDotptr = soa.template begin<Particle::AttributeNames::engDot>();
+    double *const __restrict massptr = soa.template begin<ParticleT::AttributeNames::mass>();
+    double *const __restrict densityptr = soa.template begin<ParticleT::AttributeNames::density>();
+    double *const __restrict smthptr = soa.template begin<ParticleT::AttributeNames::smth>();
+    double *const __restrict soundSpeedptr = soa.template begin<ParticleT::AttributeNames::soundSpeed>();
+    double *const __restrict pressureptr = soa.template begin<ParticleT::AttributeNames::pressure>();
+    double *const __restrict vsigmaxptr = soa.template begin<ParticleT::AttributeNames::vsigmax>();
+    double *const __restrict engDotptr = soa.template begin<ParticleT::AttributeNames::engDot>();
 
-    double *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
-    double *const __restrict velXptr = soa.template begin<Particle::AttributeNames::velX>();
-    double *const __restrict velYptr = soa.template begin<Particle::AttributeNames::velY>();
-    double *const __restrict velZptr = soa.template begin<Particle::AttributeNames::velZ>();
-    double *const __restrict accXptr = soa.template begin<Particle::AttributeNames::accX>();
-    double *const __restrict accYptr = soa.template begin<Particle::AttributeNames::accY>();
-    double *const __restrict accZptr = soa.template begin<Particle::AttributeNames::accZ>();
+    double *const __restrict xptr = soa.template begin<ParticleT::AttributeNames::posX>();
+    double *const __restrict yptr = soa.template begin<ParticleT::AttributeNames::posY>();
+    double *const __restrict zptr = soa.template begin<ParticleT::AttributeNames::posZ>();
+    double *const __restrict velXptr = soa.template begin<ParticleT::AttributeNames::velX>();
+    double *const __restrict velYptr = soa.template begin<ParticleT::AttributeNames::velY>();
+    double *const __restrict velZptr = soa.template begin<ParticleT::AttributeNames::velZ>();
+    double *const __restrict accXptr = soa.template begin<ParticleT::AttributeNames::accX>();
+    double *const __restrict accYptr = soa.template begin<ParticleT::AttributeNames::accY>();
+    double *const __restrict accZptr = soa.template begin<ParticleT::AttributeNames::accZ>();
 
     double localvsigmax = 0.;
     double localengdotsum = 0.;
@@ -499,38 +498,39 @@ class SPHCalcHydroForceFunctor : public autopas::PairwiseFunctor<Particle, SPHCa
    * @copydoc autopas::Functor::getNeededAttr()
    */
   constexpr static auto getNeededAttr() {
-    return std::array<typename Particle::AttributeNames, 17>{
-        Particle::AttributeNames::mass,          Particle::AttributeNames::density,
-        Particle::AttributeNames::smth,          Particle::AttributeNames::soundSpeed,
-        Particle::AttributeNames::pressure,      Particle::AttributeNames::vsigmax,
-        Particle::AttributeNames::engDot,        Particle::AttributeNames::posX,
-        Particle::AttributeNames::posY,          Particle::AttributeNames::posZ,
-        Particle::AttributeNames::velX,          Particle::AttributeNames::velY,
-        Particle::AttributeNames::velZ,          Particle::AttributeNames::accX,
-        Particle::AttributeNames::accY,          Particle::AttributeNames::accZ,
-        Particle::AttributeNames::ownershipState};
+    return std::array<typename ParticleT::AttributeNames, 17>{
+        ParticleT::AttributeNames::mass,          ParticleT::AttributeNames::density,
+        ParticleT::AttributeNames::smth,          ParticleT::AttributeNames::soundSpeed,
+        ParticleT::AttributeNames::pressure,      ParticleT::AttributeNames::vsigmax,
+        ParticleT::AttributeNames::engDot,        ParticleT::AttributeNames::posX,
+        ParticleT::AttributeNames::posY,          ParticleT::AttributeNames::posZ,
+        ParticleT::AttributeNames::velX,          ParticleT::AttributeNames::velY,
+        ParticleT::AttributeNames::velZ,          ParticleT::AttributeNames::accX,
+        ParticleT::AttributeNames::accY,          ParticleT::AttributeNames::accZ,
+        ParticleT::AttributeNames::ownershipState};
   }
 
   /**
    * @copydoc autopas::Functor::getNeededAttr(std::false_type)
    */
   constexpr static auto getNeededAttr(std::false_type) {
-    return std::array<typename Particle::AttributeNames, 12>{
-        Particle::AttributeNames::mass,     Particle::AttributeNames::density,
-        Particle::AttributeNames::smth,     Particle::AttributeNames::soundSpeed,
-        Particle::AttributeNames::pressure, Particle::AttributeNames::posX,
-        Particle::AttributeNames::posY,     Particle::AttributeNames::posZ,
-        Particle::AttributeNames::velX,     Particle::AttributeNames::velY,
-        Particle::AttributeNames::velZ,     Particle::AttributeNames::ownershipState};
+    return std::array<typename ParticleT::AttributeNames, 12>{
+        ParticleT::AttributeNames::mass,     ParticleT::AttributeNames::density,
+        ParticleT::AttributeNames::smth,     ParticleT::AttributeNames::soundSpeed,
+        ParticleT::AttributeNames::pressure, ParticleT::AttributeNames::posX,
+        ParticleT::AttributeNames::posY,     ParticleT::AttributeNames::posZ,
+        ParticleT::AttributeNames::velX,     ParticleT::AttributeNames::velY,
+        ParticleT::AttributeNames::velZ,     ParticleT::AttributeNames::ownershipState};
   }
 
   /**
    * @copydoc autopas::Functor::getComputedAttr()
    */
   constexpr static auto getComputedAttr() {
-    return std::array<typename Particle::AttributeNames, 6>{
-        Particle::AttributeNames::vsigmax, Particle::AttributeNames::engDot, Particle::AttributeNames::accX,
-        Particle::AttributeNames::accY,    Particle::AttributeNames::accZ,   Particle::AttributeNames::ownershipState};
+    return std::array<typename ParticleT::AttributeNames, 6>{
+        ParticleT::AttributeNames::vsigmax, ParticleT::AttributeNames::engDot,
+        ParticleT::AttributeNames::accX,    ParticleT::AttributeNames::accY,
+        ParticleT::AttributeNames::accZ,    ParticleT::AttributeNames::ownershipState};
   }
 };
 

--- a/applicationLibrary/sph/SPHLibrary/SPHCalcHydroForceFunctor.h
+++ b/applicationLibrary/sph/SPHLibrary/SPHCalcHydroForceFunctor.h
@@ -13,17 +13,17 @@ namespace sphLib {
 /**
  * Class that defines the hydrodynamic force functor.
  * It is used to calculate the force based on the given SPH kernels.
- * @tparam ParticleT
+ * @tparam Particle_T
  */
-template <class ParticleT>
-class SPHCalcHydroForceFunctor : public autopas::PairwiseFunctor<ParticleT, SPHCalcHydroForceFunctor<ParticleT>> {
+template <class Particle_T>
+class SPHCalcHydroForceFunctor : public autopas::PairwiseFunctor<Particle_T, SPHCalcHydroForceFunctor<Particle_T>> {
  public:
   /// soa arrays type
-  using SoAArraysType = typename ParticleT::SoAArraysType;
+  using SoAArraysType = typename Particle_T::SoAArraysType;
 
   SPHCalcHydroForceFunctor()
       // the actual cutoff used is dynamic. 0 is used to pass the sanity check.
-      : autopas::PairwiseFunctor<ParticleT, SPHCalcHydroForceFunctor<ParticleT>>(0.){};
+      : autopas::PairwiseFunctor<Particle_T, SPHCalcHydroForceFunctor<Particle_T>>(0.){};
 
   virtual std::string getName() override { return "SPHHydroForceFunctor"; }
 
@@ -42,7 +42,7 @@ class SPHCalcHydroForceFunctor : public autopas::PairwiseFunctor<ParticleT, SPHC
    * @param j second particle of the interaction
    * @param newton3 defines whether or whether not to use newton 3
    */
-  void AoSFunctor(ParticleT &i, ParticleT &j, bool newton3 = true) override {
+  void AoSFunctor(Particle_T &i, Particle_T &j, bool newton3 = true) override {
     using namespace autopas::utils::ArrayMath::literals;
 
     if (i.isDummy() or j.isDummy()) {
@@ -111,25 +111,25 @@ class SPHCalcHydroForceFunctor : public autopas::PairwiseFunctor<ParticleT, SPHC
     using namespace autopas::utils::ArrayMath::literals;
     if (soa.size() == 0) return;
 
-    double *const __restrict massptr = soa.template begin<ParticleT::AttributeNames::mass>();
-    double *const __restrict densityptr = soa.template begin<ParticleT::AttributeNames::density>();
-    double *const __restrict smthptr = soa.template begin<ParticleT::AttributeNames::smth>();
-    double *const __restrict soundSpeedptr = soa.template begin<ParticleT::AttributeNames::soundSpeed>();
-    double *const __restrict pressureptr = soa.template begin<ParticleT::AttributeNames::pressure>();
-    double *const __restrict vsigmaxptr = soa.template begin<ParticleT::AttributeNames::vsigmax>();
-    double *const __restrict engDotptr = soa.template begin<ParticleT::AttributeNames::engDot>();
+    double *const __restrict massptr = soa.template begin<Particle_T::AttributeNames::mass>();
+    double *const __restrict densityptr = soa.template begin<Particle_T::AttributeNames::density>();
+    double *const __restrict smthptr = soa.template begin<Particle_T::AttributeNames::smth>();
+    double *const __restrict soundSpeedptr = soa.template begin<Particle_T::AttributeNames::soundSpeed>();
+    double *const __restrict pressureptr = soa.template begin<Particle_T::AttributeNames::pressure>();
+    double *const __restrict vsigmaxptr = soa.template begin<Particle_T::AttributeNames::vsigmax>();
+    double *const __restrict engDotptr = soa.template begin<Particle_T::AttributeNames::engDot>();
 
-    double *const __restrict xptr = soa.template begin<ParticleT::AttributeNames::posX>();
-    double *const __restrict yptr = soa.template begin<ParticleT::AttributeNames::posY>();
-    double *const __restrict zptr = soa.template begin<ParticleT::AttributeNames::posZ>();
-    double *const __restrict velXptr = soa.template begin<ParticleT::AttributeNames::velX>();
-    double *const __restrict velYptr = soa.template begin<ParticleT::AttributeNames::velY>();
-    double *const __restrict velZptr = soa.template begin<ParticleT::AttributeNames::velZ>();
-    double *const __restrict accXptr = soa.template begin<ParticleT::AttributeNames::accX>();
-    double *const __restrict accYptr = soa.template begin<ParticleT::AttributeNames::accY>();
-    double *const __restrict accZptr = soa.template begin<ParticleT::AttributeNames::accZ>();
+    double *const __restrict xptr = soa.template begin<Particle_T::AttributeNames::posX>();
+    double *const __restrict yptr = soa.template begin<Particle_T::AttributeNames::posY>();
+    double *const __restrict zptr = soa.template begin<Particle_T::AttributeNames::posZ>();
+    double *const __restrict velXptr = soa.template begin<Particle_T::AttributeNames::velX>();
+    double *const __restrict velYptr = soa.template begin<Particle_T::AttributeNames::velY>();
+    double *const __restrict velZptr = soa.template begin<Particle_T::AttributeNames::velZ>();
+    double *const __restrict accXptr = soa.template begin<Particle_T::AttributeNames::accX>();
+    double *const __restrict accYptr = soa.template begin<Particle_T::AttributeNames::accY>();
+    double *const __restrict accZptr = soa.template begin<Particle_T::AttributeNames::accZ>();
 
-    const auto *const __restrict ownedStatePtr = soa.template begin<ParticleT::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr = soa.template begin<Particle_T::AttributeNames::ownershipState>();
 
     for (unsigned int indexFirst = 0; indexFirst < soa.size(); ++indexFirst) {
       // checks whether particle i is owned.
@@ -231,44 +231,44 @@ class SPHCalcHydroForceFunctor : public autopas::PairwiseFunctor<ParticleT, SPHC
     using namespace autopas::utils::ArrayMath::literals;
     if (soa1.size() == 0 || soa2.size() == 0) return;
 
-    double *const __restrict massptr1 = soa1.template begin<ParticleT::AttributeNames::mass>();
-    double *const __restrict densityptr1 = soa1.template begin<ParticleT::AttributeNames::density>();
-    double *const __restrict smthptr1 = soa1.template begin<ParticleT::AttributeNames::smth>();
-    double *const __restrict soundSpeedptr1 = soa1.template begin<ParticleT::AttributeNames::soundSpeed>();
-    double *const __restrict pressureptr1 = soa1.template begin<ParticleT::AttributeNames::pressure>();
-    double *const __restrict vsigmaxptr1 = soa1.template begin<ParticleT::AttributeNames::vsigmax>();
-    double *const __restrict engDotptr1 = soa1.template begin<ParticleT::AttributeNames::engDot>();
+    double *const __restrict massptr1 = soa1.template begin<Particle_T::AttributeNames::mass>();
+    double *const __restrict densityptr1 = soa1.template begin<Particle_T::AttributeNames::density>();
+    double *const __restrict smthptr1 = soa1.template begin<Particle_T::AttributeNames::smth>();
+    double *const __restrict soundSpeedptr1 = soa1.template begin<Particle_T::AttributeNames::soundSpeed>();
+    double *const __restrict pressureptr1 = soa1.template begin<Particle_T::AttributeNames::pressure>();
+    double *const __restrict vsigmaxptr1 = soa1.template begin<Particle_T::AttributeNames::vsigmax>();
+    double *const __restrict engDotptr1 = soa1.template begin<Particle_T::AttributeNames::engDot>();
 
-    double *const __restrict xptr1 = soa1.template begin<ParticleT::AttributeNames::posX>();
-    double *const __restrict yptr1 = soa1.template begin<ParticleT::AttributeNames::posY>();
-    double *const __restrict zptr1 = soa1.template begin<ParticleT::AttributeNames::posZ>();
-    double *const __restrict velXptr1 = soa1.template begin<ParticleT::AttributeNames::velX>();
-    double *const __restrict velYptr1 = soa1.template begin<ParticleT::AttributeNames::velY>();
-    double *const __restrict velZptr1 = soa1.template begin<ParticleT::AttributeNames::velZ>();
-    double *const __restrict accXptr1 = soa1.template begin<ParticleT::AttributeNames::accX>();
-    double *const __restrict accYptr1 = soa1.template begin<ParticleT::AttributeNames::accY>();
-    double *const __restrict accZptr1 = soa1.template begin<ParticleT::AttributeNames::accZ>();
+    double *const __restrict xptr1 = soa1.template begin<Particle_T::AttributeNames::posX>();
+    double *const __restrict yptr1 = soa1.template begin<Particle_T::AttributeNames::posY>();
+    double *const __restrict zptr1 = soa1.template begin<Particle_T::AttributeNames::posZ>();
+    double *const __restrict velXptr1 = soa1.template begin<Particle_T::AttributeNames::velX>();
+    double *const __restrict velYptr1 = soa1.template begin<Particle_T::AttributeNames::velY>();
+    double *const __restrict velZptr1 = soa1.template begin<Particle_T::AttributeNames::velZ>();
+    double *const __restrict accXptr1 = soa1.template begin<Particle_T::AttributeNames::accX>();
+    double *const __restrict accYptr1 = soa1.template begin<Particle_T::AttributeNames::accY>();
+    double *const __restrict accZptr1 = soa1.template begin<Particle_T::AttributeNames::accZ>();
 
-    double *const __restrict massptr2 = soa2.template begin<ParticleT::AttributeNames::mass>();
-    double *const __restrict densityptr2 = soa2.template begin<ParticleT::AttributeNames::density>();
-    double *const __restrict smthptr2 = soa2.template begin<ParticleT::AttributeNames::smth>();
-    double *const __restrict soundSpeedptr2 = soa2.template begin<ParticleT::AttributeNames::soundSpeed>();
-    double *const __restrict pressureptr2 = soa2.template begin<ParticleT::AttributeNames::pressure>();
-    double *const __restrict vsigmaxptr2 = soa2.template begin<ParticleT::AttributeNames::vsigmax>();
-    double *const __restrict engDotptr2 = soa2.template begin<ParticleT::AttributeNames::engDot>();
+    double *const __restrict massptr2 = soa2.template begin<Particle_T::AttributeNames::mass>();
+    double *const __restrict densityptr2 = soa2.template begin<Particle_T::AttributeNames::density>();
+    double *const __restrict smthptr2 = soa2.template begin<Particle_T::AttributeNames::smth>();
+    double *const __restrict soundSpeedptr2 = soa2.template begin<Particle_T::AttributeNames::soundSpeed>();
+    double *const __restrict pressureptr2 = soa2.template begin<Particle_T::AttributeNames::pressure>();
+    double *const __restrict vsigmaxptr2 = soa2.template begin<Particle_T::AttributeNames::vsigmax>();
+    double *const __restrict engDotptr2 = soa2.template begin<Particle_T::AttributeNames::engDot>();
 
-    double *const __restrict xptr2 = soa2.template begin<ParticleT::AttributeNames::posX>();
-    double *const __restrict yptr2 = soa2.template begin<ParticleT::AttributeNames::posY>();
-    double *const __restrict zptr2 = soa2.template begin<ParticleT::AttributeNames::posZ>();
-    double *const __restrict velXptr2 = soa2.template begin<ParticleT::AttributeNames::velX>();
-    double *const __restrict velYptr2 = soa2.template begin<ParticleT::AttributeNames::velY>();
-    double *const __restrict velZptr2 = soa2.template begin<ParticleT::AttributeNames::velZ>();
-    double *const __restrict accXptr2 = soa2.template begin<ParticleT::AttributeNames::accX>();
-    double *const __restrict accYptr2 = soa2.template begin<ParticleT::AttributeNames::accY>();
-    double *const __restrict accZptr2 = soa2.template begin<ParticleT::AttributeNames::accZ>();
+    double *const __restrict xptr2 = soa2.template begin<Particle_T::AttributeNames::posX>();
+    double *const __restrict yptr2 = soa2.template begin<Particle_T::AttributeNames::posY>();
+    double *const __restrict zptr2 = soa2.template begin<Particle_T::AttributeNames::posZ>();
+    double *const __restrict velXptr2 = soa2.template begin<Particle_T::AttributeNames::velX>();
+    double *const __restrict velYptr2 = soa2.template begin<Particle_T::AttributeNames::velY>();
+    double *const __restrict velZptr2 = soa2.template begin<Particle_T::AttributeNames::velZ>();
+    double *const __restrict accXptr2 = soa2.template begin<Particle_T::AttributeNames::accX>();
+    double *const __restrict accYptr2 = soa2.template begin<Particle_T::AttributeNames::accY>();
+    double *const __restrict accZptr2 = soa2.template begin<Particle_T::AttributeNames::accZ>();
 
-    const auto *const __restrict ownedStatePtr1 = soa1.template begin<ParticleT::AttributeNames::ownershipState>();
-    const auto *const __restrict ownedStatePtr2 = soa2.template begin<ParticleT::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr1 = soa1.template begin<Particle_T::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr2 = soa2.template begin<Particle_T::AttributeNames::ownershipState>();
 
     for (unsigned int indexFirst = 0; indexFirst < soa1.size(); ++indexFirst) {
       // checks whether particle i is owned.
@@ -375,30 +375,30 @@ class SPHCalcHydroForceFunctor : public autopas::PairwiseFunctor<ParticleT, SPHC
     using namespace autopas::utils::ArrayMath::literals;
     if (soa.size() == 0) return;
 
-    const auto *const __restrict ownedStatePtr = soa.template begin<ParticleT::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr = soa.template begin<Particle_T::AttributeNames::ownershipState>();
 
     // checks whether particle i is owned.
     if (ownedStatePtr[indexFirst] == autopas::OwnershipState::dummy) {
       return;
     }
 
-    double *const __restrict massptr = soa.template begin<ParticleT::AttributeNames::mass>();
-    double *const __restrict densityptr = soa.template begin<ParticleT::AttributeNames::density>();
-    double *const __restrict smthptr = soa.template begin<ParticleT::AttributeNames::smth>();
-    double *const __restrict soundSpeedptr = soa.template begin<ParticleT::AttributeNames::soundSpeed>();
-    double *const __restrict pressureptr = soa.template begin<ParticleT::AttributeNames::pressure>();
-    double *const __restrict vsigmaxptr = soa.template begin<ParticleT::AttributeNames::vsigmax>();
-    double *const __restrict engDotptr = soa.template begin<ParticleT::AttributeNames::engDot>();
+    double *const __restrict massptr = soa.template begin<Particle_T::AttributeNames::mass>();
+    double *const __restrict densityptr = soa.template begin<Particle_T::AttributeNames::density>();
+    double *const __restrict smthptr = soa.template begin<Particle_T::AttributeNames::smth>();
+    double *const __restrict soundSpeedptr = soa.template begin<Particle_T::AttributeNames::soundSpeed>();
+    double *const __restrict pressureptr = soa.template begin<Particle_T::AttributeNames::pressure>();
+    double *const __restrict vsigmaxptr = soa.template begin<Particle_T::AttributeNames::vsigmax>();
+    double *const __restrict engDotptr = soa.template begin<Particle_T::AttributeNames::engDot>();
 
-    double *const __restrict xptr = soa.template begin<ParticleT::AttributeNames::posX>();
-    double *const __restrict yptr = soa.template begin<ParticleT::AttributeNames::posY>();
-    double *const __restrict zptr = soa.template begin<ParticleT::AttributeNames::posZ>();
-    double *const __restrict velXptr = soa.template begin<ParticleT::AttributeNames::velX>();
-    double *const __restrict velYptr = soa.template begin<ParticleT::AttributeNames::velY>();
-    double *const __restrict velZptr = soa.template begin<ParticleT::AttributeNames::velZ>();
-    double *const __restrict accXptr = soa.template begin<ParticleT::AttributeNames::accX>();
-    double *const __restrict accYptr = soa.template begin<ParticleT::AttributeNames::accY>();
-    double *const __restrict accZptr = soa.template begin<ParticleT::AttributeNames::accZ>();
+    double *const __restrict xptr = soa.template begin<Particle_T::AttributeNames::posX>();
+    double *const __restrict yptr = soa.template begin<Particle_T::AttributeNames::posY>();
+    double *const __restrict zptr = soa.template begin<Particle_T::AttributeNames::posZ>();
+    double *const __restrict velXptr = soa.template begin<Particle_T::AttributeNames::velX>();
+    double *const __restrict velYptr = soa.template begin<Particle_T::AttributeNames::velY>();
+    double *const __restrict velZptr = soa.template begin<Particle_T::AttributeNames::velZ>();
+    double *const __restrict accXptr = soa.template begin<Particle_T::AttributeNames::accX>();
+    double *const __restrict accYptr = soa.template begin<Particle_T::AttributeNames::accY>();
+    double *const __restrict accZptr = soa.template begin<Particle_T::AttributeNames::accZ>();
 
     double localvsigmax = 0.;
     double localengdotsum = 0.;
@@ -498,39 +498,39 @@ class SPHCalcHydroForceFunctor : public autopas::PairwiseFunctor<ParticleT, SPHC
    * @copydoc autopas::Functor::getNeededAttr()
    */
   constexpr static auto getNeededAttr() {
-    return std::array<typename ParticleT::AttributeNames, 17>{
-        ParticleT::AttributeNames::mass,          ParticleT::AttributeNames::density,
-        ParticleT::AttributeNames::smth,          ParticleT::AttributeNames::soundSpeed,
-        ParticleT::AttributeNames::pressure,      ParticleT::AttributeNames::vsigmax,
-        ParticleT::AttributeNames::engDot,        ParticleT::AttributeNames::posX,
-        ParticleT::AttributeNames::posY,          ParticleT::AttributeNames::posZ,
-        ParticleT::AttributeNames::velX,          ParticleT::AttributeNames::velY,
-        ParticleT::AttributeNames::velZ,          ParticleT::AttributeNames::accX,
-        ParticleT::AttributeNames::accY,          ParticleT::AttributeNames::accZ,
-        ParticleT::AttributeNames::ownershipState};
+    return std::array<typename Particle_T::AttributeNames, 17>{
+        Particle_T::AttributeNames::mass,          Particle_T::AttributeNames::density,
+        Particle_T::AttributeNames::smth,          Particle_T::AttributeNames::soundSpeed,
+        Particle_T::AttributeNames::pressure,      Particle_T::AttributeNames::vsigmax,
+        Particle_T::AttributeNames::engDot,        Particle_T::AttributeNames::posX,
+        Particle_T::AttributeNames::posY,          Particle_T::AttributeNames::posZ,
+        Particle_T::AttributeNames::velX,          Particle_T::AttributeNames::velY,
+        Particle_T::AttributeNames::velZ,          Particle_T::AttributeNames::accX,
+        Particle_T::AttributeNames::accY,          Particle_T::AttributeNames::accZ,
+        Particle_T::AttributeNames::ownershipState};
   }
 
   /**
    * @copydoc autopas::Functor::getNeededAttr(std::false_type)
    */
   constexpr static auto getNeededAttr(std::false_type) {
-    return std::array<typename ParticleT::AttributeNames, 12>{
-        ParticleT::AttributeNames::mass,     ParticleT::AttributeNames::density,
-        ParticleT::AttributeNames::smth,     ParticleT::AttributeNames::soundSpeed,
-        ParticleT::AttributeNames::pressure, ParticleT::AttributeNames::posX,
-        ParticleT::AttributeNames::posY,     ParticleT::AttributeNames::posZ,
-        ParticleT::AttributeNames::velX,     ParticleT::AttributeNames::velY,
-        ParticleT::AttributeNames::velZ,     ParticleT::AttributeNames::ownershipState};
+    return std::array<typename Particle_T::AttributeNames, 12>{
+        Particle_T::AttributeNames::mass,     Particle_T::AttributeNames::density,
+        Particle_T::AttributeNames::smth,     Particle_T::AttributeNames::soundSpeed,
+        Particle_T::AttributeNames::pressure, Particle_T::AttributeNames::posX,
+        Particle_T::AttributeNames::posY,     Particle_T::AttributeNames::posZ,
+        Particle_T::AttributeNames::velX,     Particle_T::AttributeNames::velY,
+        Particle_T::AttributeNames::velZ,     Particle_T::AttributeNames::ownershipState};
   }
 
   /**
    * @copydoc autopas::Functor::getComputedAttr()
    */
   constexpr static auto getComputedAttr() {
-    return std::array<typename ParticleT::AttributeNames, 6>{
-        ParticleT::AttributeNames::vsigmax, ParticleT::AttributeNames::engDot,
-        ParticleT::AttributeNames::accX,    ParticleT::AttributeNames::accY,
-        ParticleT::AttributeNames::accZ,    ParticleT::AttributeNames::ownershipState};
+    return std::array<typename Particle_T::AttributeNames, 6>{
+        Particle_T::AttributeNames::vsigmax, Particle_T::AttributeNames::engDot,
+        Particle_T::AttributeNames::accX,    Particle_T::AttributeNames::accY,
+        Particle_T::AttributeNames::accZ,    Particle_T::AttributeNames::ownershipState};
   }
 };
 

--- a/applicationLibrary/sph/SPHLibrary/SPHParticle.h
+++ b/applicationLibrary/sph/SPHLibrary/SPHParticle.h
@@ -9,20 +9,20 @@
 #include <cstring>
 #include <vector>
 
-#include "autopas/particles/Particle.h"
+#include "autopas/particles/ParticleDefinitions.h"
 
 namespace sphLib {
 /**
  * Basic SPHParticle class.
  */
-class SPHParticle : public autopas::Particle {
+class SPHParticle : public autopas::ParticleBaseFP64 {
  public:
   /**
    * Default constructor of SPHParticle.
    * Will initialize all values to some basic defaults.
    */
   SPHParticle()
-      : autopas::Particle(),
+      : autopas::ParticleBaseFP64(),
         _density(0.),
         _pressure(0.),
         _mass(0.),
@@ -43,7 +43,7 @@ class SPHParticle : public autopas::Particle {
    * @param id id of the particle. This id should be unique
    */
   SPHParticle(const std::array<double, 3> &r, const std::array<double, 3> &v, unsigned long id)
-      : autopas::Particle(r, v, id),
+      : autopas::ParticleBaseFP64(r, v, id),
         _density(0.),
         _pressure(0.),
         _mass(0.),
@@ -69,7 +69,7 @@ class SPHParticle : public autopas::Particle {
    */
   SPHParticle(const std::array<double, 3> &r, const std::array<double, 3> &v, unsigned long id, double mass,
               double smth, double snds)
-      : autopas::Particle(r, v, id),
+      : autopas::ParticleBaseFP64(r, v, id),
         _density(0.),
         _pressure(0.),
         _mass(mass),

--- a/src/autopas/AutoPasDecl.h
+++ b/src/autopas/AutoPasDecl.h
@@ -33,46 +33,41 @@ namespace autopas {
 
 // Forward declare Handler so that including this header does not include the whole library with all
 // containers and traversals.
-template <class Particle>
+template <class ParticleT>
 class LogicHandler;
 
 /**
  * The AutoPas class is intended to be the main point of Interaction for the user.
  * It acts as an interface from where all features of the library can be triggered and configured.
- * @tparam Particle Class for particles
+ * @tparam ParticleT Class for particles
  * @tparam ParticleCell Class for the particle cells
  */
-template <class Particle>
+template <class ParticleT>
 class AutoPas {
  public:
-  /**
-   * Particle type to be accessible after initialization.
-   */
-  using Particle_t = Particle;
-
   /**
    * Define the iterator type for ease of use. Also for external use.
    * Helps to, e.g., wrap the AutoPas iterators
    */
-  using IteratorT = autopas::ContainerIterator<Particle, true, false>;
+  using IteratorT = autopas::ContainerIterator<ParticleT, true, false>;
 
   /**
    * Define the const iterator type for ease of use. Also for external use.
    * Helps to, e.g., wrap the AutoPas iterators
    */
-  using ConstIteratorT = autopas::ContainerIterator<Particle, false, false>;
+  using ConstIteratorT = autopas::ContainerIterator<ParticleT, false, false>;
 
   /**
    * Define the region iterator type for ease of use. Also for external use.
    * Helps to, e.g., wrap the AutoPas iterators
    */
-  using RegionIteratorT = autopas::ContainerIterator<Particle, true, true>;
+  using RegionIteratorT = autopas::ContainerIterator<ParticleT, true, true>;
 
   /**
    * Define the const region iterator type for ease of use. Also for external use.
    * Helps to, e.g., wrap the AutoPas iterators
    */
-  using RegionConstIteratorT = autopas::ContainerIterator<Particle, false, true>;
+  using RegionConstIteratorT = autopas::ContainerIterator<ParticleT, false, true>;
 
   /**
    * Constructor for the autopas class.
@@ -105,7 +100,7 @@ class AutoPas {
    * @param boxMax
    * @return Vector of particles that are outside the box after the resize.
    */
-  std::vector<Particle> resizeBox(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax);
+  std::vector<ParticleT> resizeBox(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax);
 
   /**
    * Force the internal tuner to enter a new tuning phase upon the next call to computeInteractions().
@@ -129,7 +124,7 @@ class AutoPas {
    * and returned.
    * @return A vector of invalid particles that do no longer belong in the current container.
    */
-  [[nodiscard]] std::vector<Particle> updateContainer();
+  [[nodiscard]] std::vector<ParticleT> updateContainer();
 
   /**
    * Reserve memory for a given number of particles in the container and logic layers.
@@ -161,7 +156,7 @@ class AutoPas {
    * boxMin and boxMax) of the container.
    * @note This function is NOT thread-safe if the container is Octree.
    */
-  void addParticle(const Particle &p);
+  void addParticle(const ParticleT &p);
 
   /**
    * Adds all particles from the collection to the container.
@@ -178,7 +173,7 @@ class AutoPas {
    * @note This function uses reserve().
    * @note This function uses addParticle().
    * @tparam Collection Collection type that contains the particles (e.g. std::vector). Needs to support `.size()`.
-   * @tparam F Function type of predicate. Should be of the form: (const Particle &) -> bool.
+   * @tparam F Function type of predicate. Should be of the form: (const ParticleT &) -> bool.
    * @param particles Particles that are potentially added.
    * @param predicate Condition that determines if an individual particle should be added.
    */
@@ -192,7 +187,7 @@ class AutoPas {
    * and boxMax) of the container.
    * @note This function is NOT thread-safe if the container is Octree.
    */
-  void addHaloParticle(const Particle &haloParticle);
+  void addHaloParticle(const ParticleT &haloParticle);
 
   /**
    * Adds all halo particles from the collection to the container.
@@ -209,7 +204,7 @@ class AutoPas {
    * @note This function uses reserve().
    * @note This function uses addHaloParticle().
    * @tparam Collection Collection type that contains the particles (e.g. std::vector). Needs to support `.size()`.
-   * @tparam F Function type of predicate. Should be of the form: (const Particle &) -> bool.
+   * @tparam F Function type of predicate. Should be of the form: (const ParticleT &) -> bool.
    * @param particles Particles that are potentially added.
    * @param predicate Condition that determines if an individual particle should be added.
    */
@@ -251,7 +246,7 @@ class AutoPas {
    *
    * @return True iff the reference still points to a valid particle.
    */
-  bool deleteParticle(Particle &particle);
+  bool deleteParticle(ParticleT &particle);
 
   /**
    * Function to iterate over all inter-particle interactions in the container
@@ -279,7 +274,7 @@ class AutoPas {
 
   /**
    * execute code on all particles in parallel as defined by a lambda function
-   * @tparam Lambda (Particle &p) -> void
+   * @tparam Lambda (ParticleT &p) -> void
    * @param forEachLambda code to be executed on all particles
    * @param behavior @see IteratorBehavior default: @see IteratorBehavior::ownerOrHalo
    * @note not actually parallel until kokkos integration
@@ -302,7 +297,7 @@ class AutoPas {
 
   /**
    * Execute code on all particles as defined by a lambda function.
-   * @tparam Lambda (Particle &p) -> void
+   * @tparam Lambda (ParticleT &p) -> void
    * @param forEachLambda code to be executed on all particles
    * @param behavior @see IteratorBehavior default: @see IteratorBehavior::ownerOrHalo
    */
@@ -322,7 +317,7 @@ class AutoPas {
 
   /**
    * Reduce properties of particles in parallel as defined by a lambda function.
-   * @tparam Lambda (Particle p, A &initialValue) -> void
+   * @tparam Lambda (ParticleT p, A &initialValue) -> void
    * @tparam reference to result of type A
    * @param reduceLambda code to reduce properties of particles
    * @param result reference to result of type A
@@ -347,7 +342,7 @@ class AutoPas {
 
   /**
    * Reduce properties of particles as defined by a lambda function.
-   * @tparam Lambda (Particle p, A &initialValue) -> void
+   * @tparam Lambda (ParticleT p, A &initialValue) -> void
    * @tparam reference to result of type A
    * @param reduceLambda code to reduce properties of particles
    * @param result reference to result of type A
@@ -408,7 +403,7 @@ class AutoPas {
 
   /**
    * Execute code on all particles in a certain region in parallel as defined by a lambda function.
-   * @tparam Lambda (Particle &p) -> void
+   * @tparam Lambda (ParticleT &p) -> void
    * @param forEachLambda code to be executed on all particles
    * @param lowerCorner lower corner of bounding box
    * @param higherCorner higher corner of bounding box
@@ -441,7 +436,7 @@ class AutoPas {
 
   /**
    * Execute code on all particles in a certain region as defined by a lambda function.
-   * @tparam Lambda (Particle &p) -> void
+   * @tparam Lambda (ParticleT &p) -> void
    * @param forEachLambda code to be executed on all particles
    * @param lowerCorner lower corner of bounding box
    * @param higherCorner higher corner of bounding box
@@ -471,7 +466,7 @@ class AutoPas {
 
   /**
    * Execute code on all particles in a certain region in parallel as defined by a lambda function.
-   * @tparam Lambda (Particle &p, A &result) -> void
+   * @tparam Lambda (ParticleT &p, A &result) -> void
    * @tparam A type of reduction value
    * @param reduceLambda code to be executed on all particles
    * @param result reference to starting and final value of reduction
@@ -506,7 +501,7 @@ class AutoPas {
 
   /**
    * Execute code on all particles in a certain region as defined by a lambda function.
-   * @tparam Lambda (Particle &p, A &result) -> void
+   * @tparam Lambda (ParticleT &p, A &result) -> void
    * @tparam A type of reduction value
    * @param reduceLambda code to be executed on all particles
    * @param result reference to starting and final value of reduction
@@ -1100,9 +1095,9 @@ class AutoPas {
   size_t getSortingThreshold() const { return _sortingThreshold; }
 
  private:
-  autopas::ParticleContainerInterface<Particle> &getContainer();
+  autopas::ParticleContainerInterface<ParticleT> &getContainer();
 
-  const autopas::ParticleContainerInterface<Particle> &getContainer() const;
+  const autopas::ParticleContainerInterface<ParticleT> &getContainer() const;
   /**
    * Information needed for TuningStrategyFactory::generateTuningStrategy().
    */
@@ -1172,7 +1167,7 @@ class AutoPas {
   /**
    * LogicHandler of autopas.
    */
-  std::unique_ptr<autopas::LogicHandler<Particle>> _logicHandler;
+  std::unique_ptr<autopas::LogicHandler<ParticleT>> _logicHandler;
 
   /**
    * All AutoTuners used in this instance of AutoPas.

--- a/src/autopas/AutoPasDecl.h
+++ b/src/autopas/AutoPasDecl.h
@@ -33,46 +33,46 @@ namespace autopas {
 
 // Forward declare Handler so that including this header does not include the whole library with all
 // containers and traversals.
-template <class ParticleT>
+template <class Particle_T>
 class LogicHandler;
 
 /**
  * The AutoPas class is intended to be the main point of Interaction for the user.
  * It acts as an interface from where all features of the library can be triggered and configured.
- * @tparam ParticleT Class for particles
+ * @tparam Particle_T Class for particles
  * @tparam ParticleCell Class for the particle cells
  */
-template <class ParticleT>
+template <class Particle_T>
 class AutoPas {
  public:
   /**
    * Particle type to be accessible after initialization.
    */
-  using ParticleType = ParticleT;
+  using ParticleType = Particle_T;
 
   /**
    * Define the iterator type for ease of use. Also for external use.
    * Helps to, e.g., wrap the AutoPas iterators
    */
-  using IteratorT = autopas::ContainerIterator<ParticleT, true, false>;
+  using IteratorT = autopas::ContainerIterator<Particle_T, true, false>;
 
   /**
    * Define the const iterator type for ease of use. Also for external use.
    * Helps to, e.g., wrap the AutoPas iterators
    */
-  using ConstIteratorT = autopas::ContainerIterator<ParticleT, false, false>;
+  using ConstIteratorT = autopas::ContainerIterator<Particle_T, false, false>;
 
   /**
    * Define the region iterator type for ease of use. Also for external use.
    * Helps to, e.g., wrap the AutoPas iterators
    */
-  using RegionIteratorT = autopas::ContainerIterator<ParticleT, true, true>;
+  using RegionIteratorT = autopas::ContainerIterator<Particle_T, true, true>;
 
   /**
    * Define the const region iterator type for ease of use. Also for external use.
    * Helps to, e.g., wrap the AutoPas iterators
    */
-  using RegionConstIteratorT = autopas::ContainerIterator<ParticleT, false, true>;
+  using RegionConstIteratorT = autopas::ContainerIterator<Particle_T, false, true>;
 
   /**
    * Constructor for the autopas class.
@@ -105,7 +105,7 @@ class AutoPas {
    * @param boxMax
    * @return Vector of particles that are outside the box after the resize.
    */
-  std::vector<ParticleT> resizeBox(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax);
+  std::vector<Particle_T> resizeBox(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax);
 
   /**
    * Force the internal tuner to enter a new tuning phase upon the next call to computeInteractions().
@@ -129,7 +129,7 @@ class AutoPas {
    * and returned.
    * @return A vector of invalid particles that do no longer belong in the current container.
    */
-  [[nodiscard]] std::vector<ParticleT> updateContainer();
+  [[nodiscard]] std::vector<Particle_T> updateContainer();
 
   /**
    * Reserve memory for a given number of particles in the container and logic layers.
@@ -161,7 +161,7 @@ class AutoPas {
    * boxMin and boxMax) of the container.
    * @note This function is NOT thread-safe if the container is Octree.
    */
-  void addParticle(const ParticleT &p);
+  void addParticle(const Particle_T &p);
 
   /**
    * Adds all particles from the collection to the container.
@@ -178,7 +178,7 @@ class AutoPas {
    * @note This function uses reserve().
    * @note This function uses addParticle().
    * @tparam Collection Collection type that contains the particles (e.g. std::vector). Needs to support `.size()`.
-   * @tparam F Function type of predicate. Should be of the form: (const ParticleT &) -> bool.
+   * @tparam F Function type of predicate. Should be of the form: (const Particle_T &) -> bool.
    * @param particles Particles that are potentially added.
    * @param predicate Condition that determines if an individual particle should be added.
    */
@@ -192,7 +192,7 @@ class AutoPas {
    * and boxMax) of the container.
    * @note This function is NOT thread-safe if the container is Octree.
    */
-  void addHaloParticle(const ParticleT &haloParticle);
+  void addHaloParticle(const Particle_T &haloParticle);
 
   /**
    * Adds all halo particles from the collection to the container.
@@ -209,7 +209,7 @@ class AutoPas {
    * @note This function uses reserve().
    * @note This function uses addHaloParticle().
    * @tparam Collection Collection type that contains the particles (e.g. std::vector). Needs to support `.size()`.
-   * @tparam F Function type of predicate. Should be of the form: (const ParticleT &) -> bool.
+   * @tparam F Function type of predicate. Should be of the form: (const Particle_T &) -> bool.
    * @param particles Particles that are potentially added.
    * @param predicate Condition that determines if an individual particle should be added.
    */
@@ -251,7 +251,7 @@ class AutoPas {
    *
    * @return True iff the reference still points to a valid particle.
    */
-  bool deleteParticle(ParticleT &particle);
+  bool deleteParticle(Particle_T &particle);
 
   /**
    * Function to iterate over all inter-particle interactions in the container
@@ -279,7 +279,7 @@ class AutoPas {
 
   /**
    * execute code on all particles in parallel as defined by a lambda function
-   * @tparam Lambda (ParticleT &p) -> void
+   * @tparam Lambda (Particle_T &p) -> void
    * @param forEachLambda code to be executed on all particles
    * @param behavior @see IteratorBehavior default: @see IteratorBehavior::ownerOrHalo
    * @note not actually parallel until kokkos integration
@@ -302,7 +302,7 @@ class AutoPas {
 
   /**
    * Execute code on all particles as defined by a lambda function.
-   * @tparam Lambda (ParticleT &p) -> void
+   * @tparam Lambda (Particle_T &p) -> void
    * @param forEachLambda code to be executed on all particles
    * @param behavior @see IteratorBehavior default: @see IteratorBehavior::ownerOrHalo
    */
@@ -322,7 +322,7 @@ class AutoPas {
 
   /**
    * Reduce properties of particles in parallel as defined by a lambda function.
-   * @tparam Lambda (ParticleT p, A &initialValue) -> void
+   * @tparam Lambda (Particle_T p, A &initialValue) -> void
    * @tparam reference to result of type A
    * @param reduceLambda code to reduce properties of particles
    * @param result reference to result of type A
@@ -347,7 +347,7 @@ class AutoPas {
 
   /**
    * Reduce properties of particles as defined by a lambda function.
-   * @tparam Lambda (ParticleT p, A &initialValue) -> void
+   * @tparam Lambda (Particle_T p, A &initialValue) -> void
    * @tparam reference to result of type A
    * @param reduceLambda code to reduce properties of particles
    * @param result reference to result of type A
@@ -408,7 +408,7 @@ class AutoPas {
 
   /**
    * Execute code on all particles in a certain region in parallel as defined by a lambda function.
-   * @tparam Lambda (ParticleT &p) -> void
+   * @tparam Lambda (Particle_T &p) -> void
    * @param forEachLambda code to be executed on all particles
    * @param lowerCorner lower corner of bounding box
    * @param higherCorner higher corner of bounding box
@@ -441,7 +441,7 @@ class AutoPas {
 
   /**
    * Execute code on all particles in a certain region as defined by a lambda function.
-   * @tparam Lambda (ParticleT &p) -> void
+   * @tparam Lambda (Particle_T &p) -> void
    * @param forEachLambda code to be executed on all particles
    * @param lowerCorner lower corner of bounding box
    * @param higherCorner higher corner of bounding box
@@ -471,7 +471,7 @@ class AutoPas {
 
   /**
    * Execute code on all particles in a certain region in parallel as defined by a lambda function.
-   * @tparam Lambda (ParticleT &p, A &result) -> void
+   * @tparam Lambda (Particle_T &p, A &result) -> void
    * @tparam A type of reduction value
    * @param reduceLambda code to be executed on all particles
    * @param result reference to starting and final value of reduction
@@ -506,7 +506,7 @@ class AutoPas {
 
   /**
    * Execute code on all particles in a certain region as defined by a lambda function.
-   * @tparam Lambda (ParticleT &p, A &result) -> void
+   * @tparam Lambda (Particle_T &p, A &result) -> void
    * @tparam A type of reduction value
    * @param reduceLambda code to be executed on all particles
    * @param result reference to starting and final value of reduction
@@ -1107,9 +1107,9 @@ class AutoPas {
   size_t getSortingThreshold() const { return _sortingThreshold; }
 
  private:
-  autopas::ParticleContainerInterface<ParticleT> &getContainer();
+  autopas::ParticleContainerInterface<Particle_T> &getContainer();
 
-  const autopas::ParticleContainerInterface<ParticleT> &getContainer() const;
+  const autopas::ParticleContainerInterface<Particle_T> &getContainer() const;
   /**
    * Information needed for TuningStrategyFactory::generateTuningStrategy().
    */
@@ -1179,7 +1179,7 @@ class AutoPas {
   /**
    * LogicHandler of autopas.
    */
-  std::unique_ptr<autopas::LogicHandler<ParticleT>> _logicHandler;
+  std::unique_ptr<autopas::LogicHandler<Particle_T>> _logicHandler;
 
   /**
    * All AutoTuners used in this instance of AutoPas.

--- a/src/autopas/AutoPasDecl.h
+++ b/src/autopas/AutoPasDecl.h
@@ -46,6 +46,11 @@ template <class ParticleT>
 class AutoPas {
  public:
   /**
+   * Particle type to be accessible after initialization.
+   */
+  using ParticleType = ParticleT;
+
+  /**
    * Define the iterator type for ease of use. Also for external use.
    * Helps to, e.g., wrap the AutoPas iterators
    */

--- a/src/autopas/AutoPasImpl.h
+++ b/src/autopas/AutoPasImpl.h
@@ -178,7 +178,7 @@ void AutoPas<ParticleT>::reserve(size_t numParticles, size_t numHaloParticles) {
 template <class ParticleT>
 template <class F>
 void AutoPas<ParticleT>::addParticlesAux(size_t numParticlesToAdd, size_t numHalosToAdd, size_t collectionSize,
-                                        F loopBody) {
+                                         F loopBody) {
   reserve(getNumberOfParticles(IteratorBehavior::owned) + numParticlesToAdd,
           getNumberOfParticles(IteratorBehavior::halo) + numHalosToAdd);
   AUTOPAS_OPENMP(parallel for schedule(static, std::max(1ul, collectionSize / omp_get_max_threads())))
@@ -227,7 +227,7 @@ std::vector<ParticleT> AutoPas<ParticleT>::updateContainer() {
 
 template <class ParticleT>
 std::vector<ParticleT> AutoPas<ParticleT>::resizeBox(const std::array<double, 3> &boxMin,
-                                                   const std::array<double, 3> &boxMax) {
+                                                     const std::array<double, 3> &boxMax) {
   if (_allowedCellSizeFactors->isInterval()) {
     AutoPasLog(WARN,
                "The allowed Cell Size Factors are a continuous interval but internally only those values that "

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -487,8 +487,8 @@ class LogicHandler {
    * @copydoc AutoPas::getRegionIterator()
    */
   autopas::ContainerIterator<ParticleT, true, true> getRegionIterator(const std::array<double, 3> &lowerCorner,
-                                                                     const std::array<double, 3> &higherCorner,
-                                                                     IteratorBehavior behavior) {
+                                                                      const std::array<double, 3> &higherCorner,
+                                                                      IteratorBehavior behavior) {
     // sanity check: Most of our stuff depends on `inBox` which does not handle lowerCorner > higherCorner well.
     for (size_t d = 0; d < 3; ++d) {
       if (lowerCorner[d] > higherCorner[d]) {
@@ -509,8 +509,8 @@ class LogicHandler {
    * @copydoc AutoPas::getRegionIterator()
    */
   autopas::ContainerIterator<ParticleT, false, true> getRegionIterator(const std::array<double, 3> &lowerCorner,
-                                                                      const std::array<double, 3> &higherCorner,
-                                                                      IteratorBehavior behavior) const {
+                                                                       const std::array<double, 3> &higherCorner,
+                                                                       IteratorBehavior behavior) const {
     // sanity check: Most of our stuff depends on `inBox` which does not handle lowerCorner > higherCorner well.
     for (size_t d = 0; d < 3; ++d) {
       if (lowerCorner[d] > higherCorner[d]) {
@@ -1175,7 +1175,7 @@ void LogicHandler<ParticleT>::resetNeighborListsInvalidDoDynamicRebuild() {
 
 template <typename ParticleT>
 void LogicHandler<ParticleT>::setParticleBuffers(const std::vector<FullParticleCell<ParticleT>> &particleBuffers,
-                                                const std::vector<FullParticleCell<ParticleT>> &haloParticleBuffers) {
+                                                 const std::vector<FullParticleCell<ParticleT>> &haloParticleBuffers) {
   auto exchangeBuffer = [](const auto &newBuffers, auto &oldBuffers, auto &particleCounter) {
     // sanity check
     if (oldBuffers.size() < newBuffers.size()) {
@@ -1483,8 +1483,8 @@ void LogicHandler<ParticleT>::remainderHelperBufferContainerAoS(
 template <class ParticleT>
 template <bool newton3, class PairwiseFunctor>
 void LogicHandler<ParticleT>::remainderHelperBufferBuffer(PairwiseFunctor *f,
-                                                         std::vector<FullParticleCell<ParticleT>> &particleBuffers,
-                                                         bool useSoA) {
+                                                          std::vector<FullParticleCell<ParticleT>> &particleBuffers,
+                                                          bool useSoA) {
   if (useSoA) {
     remainderHelperBufferBufferSoA<newton3>(f, particleBuffers);
   } else {
@@ -1494,8 +1494,8 @@ void LogicHandler<ParticleT>::remainderHelperBufferBuffer(PairwiseFunctor *f,
 
 template <class ParticleT>
 template <bool newton3, class PairwiseFunctor>
-void LogicHandler<ParticleT>::remainderHelperBufferBufferAoS(PairwiseFunctor *f,
-                                                            std::vector<FullParticleCell<ParticleT>> &particleBuffers) {
+void LogicHandler<ParticleT>::remainderHelperBufferBufferAoS(
+    PairwiseFunctor *f, std::vector<FullParticleCell<ParticleT>> &particleBuffers) {
   // For all interactions between different buffers we turn newton3 always off,
   // which ensures that only one thread at a time is writing to a buffer.
   // This saves expensive locks.
@@ -1539,8 +1539,8 @@ void LogicHandler<ParticleT>::remainderHelperBufferBufferAoS(PairwiseFunctor *f,
 
 template <class ParticleT>
 template <bool newton3, class PairwiseFunctor>
-void LogicHandler<ParticleT>::remainderHelperBufferBufferSoA(PairwiseFunctor *f,
-                                                            std::vector<FullParticleCell<ParticleT>> &particleBuffers) {
+void LogicHandler<ParticleT>::remainderHelperBufferBufferSoA(
+    PairwiseFunctor *f, std::vector<FullParticleCell<ParticleT>> &particleBuffers) {
   // we can not use collapse here without locks, otherwise races would occur.
   AUTOPAS_OPENMP(parallel for)
   for (size_t i = 0; i < particleBuffers.size(); ++i) {
@@ -1662,8 +1662,8 @@ void LogicHandler<ParticleT>::computeRemainderInteractions3B(
 
 template <class ParticleT>
 size_t LogicHandler<ParticleT>::collectBufferParticles(std::vector<ParticleT *> &bufferParticles,
-                                                      std::vector<FullParticleCell<ParticleT>> &particleBuffers,
-                                                      std::vector<FullParticleCell<ParticleT>> &haloParticleBuffers) {
+                                                       std::vector<FullParticleCell<ParticleT>> &particleBuffers,
+                                                       std::vector<FullParticleCell<ParticleT>> &haloParticleBuffers) {
   // Reserve the needed amount
   auto cellToVec = [](auto &cell) -> std::vector<ParticleT> & { return cell._particles; };
 
@@ -1697,8 +1697,8 @@ size_t LogicHandler<ParticleT>::collectBufferParticles(std::vector<ParticleT *> 
 template <class ParticleT>
 template <class TriwiseFunctor>
 void LogicHandler<ParticleT>::remainderHelper3bBufferBufferBufferAoS(const std::vector<ParticleT *> &bufferParticles,
-                                                                    const size_t numOwnedBufferParticles,
-                                                                    TriwiseFunctor *f) {
+                                                                     const size_t numOwnedBufferParticles,
+                                                                     TriwiseFunctor *f) {
   AUTOPAS_OPENMP(parallel for)
   for (auto i = 0; i < numOwnedBufferParticles; ++i) {
     ParticleT &p1 = *bufferParticles[i];
@@ -1720,8 +1720,8 @@ void LogicHandler<ParticleT>::remainderHelper3bBufferBufferBufferAoS(const std::
 template <class ParticleT>
 template <class ContainerType, class TriwiseFunctor>
 void LogicHandler<ParticleT>::remainderHelper3bBufferBufferContainerAoS(const std::vector<ParticleT *> &bufferParticles,
-                                                                       const size_t numOwnedBufferParticles,
-                                                                       ContainerType &container, TriwiseFunctor *f) {
+                                                                        const size_t numOwnedBufferParticles,
+                                                                        ContainerType &container, TriwiseFunctor *f) {
   using autopas::utils::ArrayUtils::static_cast_copy_array;
   using namespace autopas::utils::ArrayMath::literals;
 
@@ -1892,7 +1892,7 @@ std::tuple<Configuration, std::unique_ptr<TraversalInterface>, bool> LogicHandle
 template <typename ParticleT>
 template <class Functor>
 bool LogicHandler<ParticleT>::computeInteractionsPipeline(Functor *functor,
-                                                         const InteractionTypeOption &interactionType) {
+                                                          const InteractionTypeOption &interactionType) {
   if (not _interactionTypes.count(interactionType)) {
     autopas::utils::ExceptionHandler::exception(
         "LogicHandler::computeInteractionsPipeline(): AutPas was not initialized for the Functor's interactions type: "

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -43,7 +43,7 @@ namespace autopas {
  * This is mainly done by incorporating a global container rebuild frequency, which defines when containers and their
  * neighbor lists will be rebuilt.
  */
-template <typename ParticleT>
+template <typename Particle_T>
 class LogicHandler {
  public:
   /**
@@ -96,17 +96,17 @@ class LogicHandler {
    * Returns a non-const reference to the currently selected particle container.
    * @return Non-const reference to the container.
    */
-  autopas::ParticleContainerInterface<ParticleT> &getContainer() { return _containerSelector.getCurrentContainer(); }
+  autopas::ParticleContainerInterface<Particle_T> &getContainer() { return _containerSelector.getCurrentContainer(); }
 
   /**
    * Collects leaving particles from buffer and potentially inserts owned particles to the container.
    * @param insertOwnedParticlesToContainer Decides whether to insert owned particles to the container.
    * @return Leaving particles.
    */
-  [[nodiscard]] std::vector<ParticleT> collectLeavingParticlesFromBuffer(bool insertOwnedParticlesToContainer) {
+  [[nodiscard]] std::vector<Particle_T> collectLeavingParticlesFromBuffer(bool insertOwnedParticlesToContainer) {
     const auto &boxMin = _containerSelector.getCurrentContainer().getBoxMin();
     const auto &boxMax = _containerSelector.getCurrentContainer().getBoxMax();
-    std::vector<ParticleT> leavingBufferParticles{};
+    std::vector<Particle_T> leavingBufferParticles{};
     for (auto &cell : _particleBuffer) {
       auto &buffer = cell._particles;
       if (insertOwnedParticlesToContainer) {
@@ -156,7 +156,7 @@ class LogicHandler {
   /**
    * @copydoc AutoPas::updateContainer()
    */
-  [[nodiscard]] std::vector<ParticleT> updateContainer() {
+  [[nodiscard]] std::vector<Particle_T> updateContainer() {
 #ifdef AUTOPAS_ENABLE_DYNAMIC_CONTAINERS
     this->checkNeighborListsInvalidDoDynamicRebuild();
 #endif
@@ -203,7 +203,7 @@ class LogicHandler {
    * @param boxMax
    * @return Vector of particles that are outside the box after the resize.
    */
-  std::vector<ParticleT> resizeBox(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax) {
+  std::vector<Particle_T> resizeBox(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax) {
     using namespace autopas::utils::ArrayMath::literals;
     const auto &oldMin = _containerSelector.getCurrentContainer().getBoxMin();
     const auto &oldMax = _containerSelector.getCurrentContainer().getBoxMax();
@@ -241,7 +241,7 @@ class LogicHandler {
     }
 
     // check all particles
-    std::vector<ParticleT> particlesNowOutside;
+    std::vector<Particle_T> particlesNowOutside;
     for (auto pIter = _containerSelector.getCurrentContainer().begin(); pIter.isValid(); ++pIter) {
       // make sure only owned ones are present
       if (not pIter->isOwned()) {
@@ -306,7 +306,7 @@ class LogicHandler {
   /**
    * @copydoc AutoPas::addParticle()
    */
-  void addParticle(const ParticleT &p) {
+  void addParticle(const Particle_T &p) {
     // first check that the particle actually belongs in the container
     const auto &boxMin = _containerSelector.getCurrentContainer().getBoxMin();
     const auto &boxMax = _containerSelector.getCurrentContainer().getBoxMax();
@@ -318,7 +318,7 @@ class LogicHandler {
           "{}",
           boxMin, boxMax, p.toString());
     }
-    ParticleT particleCopy = p;
+    Particle_T particleCopy = p;
     particleCopy.setOwnershipState(OwnershipState::owned);
     if (not _neighborListsAreValid.load(std::memory_order_relaxed)) {
       // Container has to (about to) be invalid to be able to add Particles!
@@ -333,11 +333,11 @@ class LogicHandler {
   /**
    * @copydoc AutoPas::addHaloParticle()
    */
-  void addHaloParticle(const ParticleT &haloParticle) {
+  void addHaloParticle(const Particle_T &haloParticle) {
     auto &container = _containerSelector.getCurrentContainer();
     const auto &boxMin = container.getBoxMin();
     const auto &boxMax = container.getBoxMax();
-    ParticleT haloParticleCopy = haloParticle;
+    Particle_T haloParticleCopy = haloParticle;
     if (utils::inBox(haloParticleCopy.getR(), boxMin, boxMax)) {
       autopas::utils::ExceptionHandler::exception(
           "LogicHandler: Trying to add a halo particle that is not outside the box of the container.\n"
@@ -380,7 +380,7 @@ class LogicHandler {
    * invalid memory.
    * @return Tuple: <True iff the particle was found and deleted, True iff the reference is valid>
    */
-  std::tuple<bool, bool> deleteParticleFromBuffers(ParticleT &particle) {
+  std::tuple<bool, bool> deleteParticleFromBuffers(Particle_T &particle) {
     // find the buffer the particle belongs to
     auto &bufferCollection = particle.isOwned() ? _particleBuffer : _haloParticleBuffer;
     for (auto &cell : bufferCollection) {
@@ -402,7 +402,7 @@ class LogicHandler {
    * This function should always be called if individual particles are deleted.
    * @param particle reference to particles that should be deleted
    */
-  void decreaseParticleCounter(ParticleT &particle) {
+  void decreaseParticleCounter(Particle_T &particle) {
     if (particle.isOwned()) {
       _numParticlesOwned.fetch_sub(1, std::memory_order_relaxed);
     } else {
@@ -469,26 +469,27 @@ class LogicHandler {
   /**
    * @copydoc AutoPas::begin()
    */
-  autopas::ContainerIterator<ParticleT, true, false> begin(IteratorBehavior behavior) {
-    auto additionalVectors = gatherAdditionalVectors<ContainerIterator<ParticleT, true, false>>(behavior);
+  autopas::ContainerIterator<Particle_T, true, false> begin(IteratorBehavior behavior) {
+    auto additionalVectors = gatherAdditionalVectors<ContainerIterator<Particle_T, true, false>>(behavior);
     return _containerSelector.getCurrentContainer().begin(behavior, &additionalVectors);
   }
 
   /**
    * @copydoc AutoPas::begin()
    */
-  autopas::ContainerIterator<ParticleT, false, false> begin(IteratorBehavior behavior) const {
+  autopas::ContainerIterator<Particle_T, false, false> begin(IteratorBehavior behavior) const {
     auto additionalVectors =
-        const_cast<LogicHandler *>(this)->gatherAdditionalVectors<ContainerIterator<ParticleT, false, false>>(behavior);
+        const_cast<LogicHandler *>(this)->gatherAdditionalVectors<ContainerIterator<Particle_T, false, false>>(
+            behavior);
     return _containerSelector.getCurrentContainer().begin(behavior, &additionalVectors);
   }
 
   /**
    * @copydoc AutoPas::getRegionIterator()
    */
-  autopas::ContainerIterator<ParticleT, true, true> getRegionIterator(const std::array<double, 3> &lowerCorner,
-                                                                      const std::array<double, 3> &higherCorner,
-                                                                      IteratorBehavior behavior) {
+  autopas::ContainerIterator<Particle_T, true, true> getRegionIterator(const std::array<double, 3> &lowerCorner,
+                                                                       const std::array<double, 3> &higherCorner,
+                                                                       IteratorBehavior behavior) {
     // sanity check: Most of our stuff depends on `inBox` which does not handle lowerCorner > higherCorner well.
     for (size_t d = 0; d < 3; ++d) {
       if (lowerCorner[d] > higherCorner[d]) {
@@ -500,7 +501,7 @@ class LogicHandler {
       }
     }
 
-    auto additionalVectors = gatherAdditionalVectors<ContainerIterator<ParticleT, true, true>>(behavior);
+    auto additionalVectors = gatherAdditionalVectors<ContainerIterator<Particle_T, true, true>>(behavior);
     return _containerSelector.getCurrentContainer().getRegionIterator(lowerCorner, higherCorner, behavior,
                                                                       &additionalVectors);
   }
@@ -508,9 +509,9 @@ class LogicHandler {
   /**
    * @copydoc AutoPas::getRegionIterator()
    */
-  autopas::ContainerIterator<ParticleT, false, true> getRegionIterator(const std::array<double, 3> &lowerCorner,
-                                                                       const std::array<double, 3> &higherCorner,
-                                                                       IteratorBehavior behavior) const {
+  autopas::ContainerIterator<Particle_T, false, true> getRegionIterator(const std::array<double, 3> &lowerCorner,
+                                                                        const std::array<double, 3> &higherCorner,
+                                                                        IteratorBehavior behavior) const {
     // sanity check: Most of our stuff depends on `inBox` which does not handle lowerCorner > higherCorner well.
     for (size_t d = 0; d < 3; ++d) {
       if (lowerCorner[d] > higherCorner[d]) {
@@ -523,7 +524,7 @@ class LogicHandler {
     }
 
     auto additionalVectors =
-        const_cast<LogicHandler *>(this)->gatherAdditionalVectors<ContainerIterator<ParticleT, false, true>>(behavior);
+        const_cast<LogicHandler *>(this)->gatherAdditionalVectors<ContainerIterator<Particle_T, false, true>>(behavior);
     return std::as_const(_containerSelector)
         .getCurrentContainer()
         .getRegionIterator(lowerCorner, higherCorner, behavior, &additionalVectors);
@@ -582,8 +583,8 @@ class LogicHandler {
    * @param particleBuffers
    * @param haloParticleBuffers
    */
-  void setParticleBuffers(const std::vector<FullParticleCell<ParticleT>> &particleBuffers,
-                          const std::vector<FullParticleCell<ParticleT>> &haloParticleBuffers);
+  void setParticleBuffers(const std::vector<FullParticleCell<Particle_T>> &particleBuffers,
+                          const std::vector<FullParticleCell<Particle_T>> &haloParticleBuffers);
 
   /**
    * Getter for the particle buffers.
@@ -592,7 +593,7 @@ class LogicHandler {
    *
    * @return tuple of const references to the internal buffers.
    */
-  std::tuple<const std::vector<FullParticleCell<ParticleT>> &, const std::vector<FullParticleCell<ParticleT>> &>
+  std::tuple<const std::vector<FullParticleCell<Particle_T>> &, const std::vector<FullParticleCell<Particle_T>> &>
   getParticleBuffers() const;
 
   /**
@@ -787,8 +788,8 @@ class LogicHandler {
    */
   template <bool newton3, class ContainerType, class PairwiseFunctor>
   void computeRemainderInteractions2B(PairwiseFunctor *f, ContainerType &container,
-                                      std::vector<FullParticleCell<ParticleT>> &particleBuffers,
-                                      std::vector<FullParticleCell<ParticleT>> &haloParticleBuffers, bool useSoA);
+                                      std::vector<FullParticleCell<Particle_T>> &particleBuffers,
+                                      std::vector<FullParticleCell<Particle_T>> &haloParticleBuffers, bool useSoA);
 
   /**
    * Helper Method for computeRemainderInteractions2B.
@@ -805,8 +806,8 @@ class LogicHandler {
    */
   template <bool newton3, class ContainerType, class PairwiseFunctor>
   void remainderHelperBufferContainerAoS(PairwiseFunctor *f, ContainerType &container,
-                                         std::vector<FullParticleCell<ParticleT>> &particleBuffers,
-                                         std::vector<FullParticleCell<ParticleT>> &haloParticleBuffers);
+                                         std::vector<FullParticleCell<Particle_T>> &particleBuffers,
+                                         std::vector<FullParticleCell<Particle_T>> &haloParticleBuffers);
 
   /**
    * Helper Method for computeRemainderInteractions2B.
@@ -818,7 +819,7 @@ class LogicHandler {
    * @param useSoA Use SoA based interactions instead of AoS.
    */
   template <bool newton3, class PairwiseFunctor>
-  void remainderHelperBufferBuffer(PairwiseFunctor *f, std::vector<FullParticleCell<ParticleT>> &particleBuffers,
+  void remainderHelperBufferBuffer(PairwiseFunctor *f, std::vector<FullParticleCell<Particle_T>> &particleBuffers,
                                    bool useSoA);
 
   /**
@@ -829,7 +830,7 @@ class LogicHandler {
    * @param particleBuffers
    */
   template <bool newton3, class PairwiseFunctor>
-  void remainderHelperBufferBufferAoS(PairwiseFunctor *f, std::vector<FullParticleCell<ParticleT>> &particleBuffers);
+  void remainderHelperBufferBufferAoS(PairwiseFunctor *f, std::vector<FullParticleCell<Particle_T>> &particleBuffers);
 
   /**
    * SoA implementation for remainderHelperBufferBuffer().
@@ -839,7 +840,7 @@ class LogicHandler {
    * @param particleBuffers
    */
   template <bool newton3, class PairwiseFunctor>
-  void remainderHelperBufferBufferSoA(PairwiseFunctor *f, std::vector<FullParticleCell<ParticleT>> &particleBuffers);
+  void remainderHelperBufferBufferSoA(PairwiseFunctor *f, std::vector<FullParticleCell<Particle_T>> &particleBuffers);
 
   /**
    * Helper Method for computeRemainderInteractions2B.
@@ -855,8 +856,8 @@ class LogicHandler {
    * @param useSoA Use SoA based interactions instead of AoS.
    */
   template <class PairwiseFunctor>
-  void remainderHelperBufferHaloBuffer(PairwiseFunctor *f, std::vector<FullParticleCell<ParticleT>> &particleBuffers,
-                                       std::vector<FullParticleCell<ParticleT>> &haloParticleBuffers, bool useSoA);
+  void remainderHelperBufferHaloBuffer(PairwiseFunctor *f, std::vector<FullParticleCell<Particle_T>> &particleBuffers,
+                                       std::vector<FullParticleCell<Particle_T>> &haloParticleBuffers, bool useSoA);
 
   /**
    * AoS implementation for remainderHelperBufferHaloBuffer()
@@ -866,8 +867,9 @@ class LogicHandler {
    * @param haloParticleBuffers
    */
   template <class PairwiseFunctor>
-  void remainderHelperBufferHaloBufferAoS(PairwiseFunctor *f, std::vector<FullParticleCell<ParticleT>> &particleBuffers,
-                                          std::vector<FullParticleCell<ParticleT>> &haloParticleBuffers);
+  void remainderHelperBufferHaloBufferAoS(PairwiseFunctor *f,
+                                          std::vector<FullParticleCell<Particle_T>> &particleBuffers,
+                                          std::vector<FullParticleCell<Particle_T>> &haloParticleBuffers);
 
   /**
    * SoA implementation for remainderHelperBufferHaloBuffer()
@@ -877,8 +879,9 @@ class LogicHandler {
    * @param haloParticleBuffers
    */
   template <class PairwiseFunctor>
-  void remainderHelperBufferHaloBufferSoA(PairwiseFunctor *f, std::vector<FullParticleCell<ParticleT>> &particleBuffers,
-                                          std::vector<FullParticleCell<ParticleT>> &haloParticleBuffers);
+  void remainderHelperBufferHaloBufferSoA(PairwiseFunctor *f,
+                                          std::vector<FullParticleCell<Particle_T>> &particleBuffers,
+                                          std::vector<FullParticleCell<Particle_T>> &haloParticleBuffers);
 
   /**
    * Performs the interactions ParticleContainer::computeInteractions() did not cover.
@@ -902,8 +905,8 @@ class LogicHandler {
    */
   template <bool newton3, class ContainerType, class TriwiseFunctor>
   void computeRemainderInteractions3B(TriwiseFunctor *f, ContainerType &container,
-                                      std::vector<FullParticleCell<ParticleT>> &particleBuffers,
-                                      std::vector<FullParticleCell<ParticleT>> &haloParticleBuffers);
+                                      std::vector<FullParticleCell<Particle_T>> &particleBuffers,
+                                      std::vector<FullParticleCell<Particle_T>> &haloParticleBuffers);
 
   /**
    * Helper Method for computeRemainderInteractions3B. This method collects pointers to all owned halo particle buffers.
@@ -915,9 +918,9 @@ class LogicHandler {
    * @return Number of owned buffer particles. The bufferParticles vector is two-way split, with the first half being
    * owned buffer particles and the second half being halo buffer particles.
    */
-  size_t collectBufferParticles(std::vector<ParticleT *> &bufferParticles,
-                                std::vector<FullParticleCell<ParticleT>> &particleBuffers,
-                                std::vector<FullParticleCell<ParticleT>> &haloParticleBuffers);
+  size_t collectBufferParticles(std::vector<Particle_T *> &bufferParticles,
+                                std::vector<FullParticleCell<Particle_T>> &particleBuffers,
+                                std::vector<FullParticleCell<Particle_T>> &haloParticleBuffers);
 
   /**
    * Helper Method for computeRemainderInteractions3B. This method calculates all interactions between all triplets
@@ -929,7 +932,7 @@ class LogicHandler {
    * @param f
    */
   template <class TriwiseFunctor>
-  void remainderHelper3bBufferBufferBufferAoS(const std::vector<ParticleT *> &bufferParticles,
+  void remainderHelper3bBufferBufferBufferAoS(const std::vector<Particle_T *> &bufferParticles,
                                               size_t numOwnedBufferParticles, TriwiseFunctor *f);
 
   /**
@@ -944,7 +947,7 @@ class LogicHandler {
    * @param f
    */
   template <class ContainerType, class TriwiseFunctor>
-  void remainderHelper3bBufferBufferContainerAoS(const std::vector<ParticleT *> &bufferParticles,
+  void remainderHelper3bBufferBufferContainerAoS(const std::vector<Particle_T *> &bufferParticles,
                                                  size_t numOwnedBufferParticles, ContainerType &container,
                                                  TriwiseFunctor *f);
 
@@ -961,7 +964,7 @@ class LogicHandler {
    * @param f
    */
   template <bool newton3, class ContainerType, class TriwiseFunctor>
-  void remainderHelper3bBufferContainerContainerAoS(const std::vector<ParticleT *> &bufferParticles,
+  void remainderHelper3bBufferContainerContainerAoS(const std::vector<Particle_T *> &bufferParticles,
                                                     size_t numOwnedBufferParticles, ContainerType &container,
                                                     TriwiseFunctor *f);
 
@@ -1047,17 +1050,17 @@ class LogicHandler {
   /**
    * Buffer to store particles that should not yet be added to the container. There is one buffer per thread.
    */
-  std::vector<FullParticleCell<ParticleT>> _particleBuffer;
+  std::vector<FullParticleCell<Particle_T>> _particleBuffer;
 
   /**
    * Buffer to store halo particles that should not yet be added to the container. There is one buffer per thread.
    */
-  std::vector<FullParticleCell<ParticleT>> _haloParticleBuffer;
+  std::vector<FullParticleCell<Particle_T>> _haloParticleBuffer;
 
   /**
    * Object holding the actual particle container with the ability to switch container types.
    */
-  ContainerSelector<ParticleT> _containerSelector;
+  ContainerSelector<Particle_T> _containerSelector;
 
   /**
    * Locks for regions in the domain. Used for buffer <-> container interaction.
@@ -1098,8 +1101,8 @@ class LogicHandler {
   FLOPLogger _flopLogger;
 };
 
-template <typename ParticleT>
-void LogicHandler<ParticleT>::updateRebuildPositions() {
+template <typename Particle_T>
+void LogicHandler<Particle_T>::updateRebuildPositions() {
 #ifdef AUTOPAS_ENABLE_DYNAMIC_CONTAINERS
   // The owned particles in buffer are ignored because they do not rely on the structure of the particle containers,
   // e.g. neighbour list, and these are iterated over using the region iterator. Movement of particles in buffer doesn't
@@ -1111,8 +1114,8 @@ void LogicHandler<ParticleT>::updateRebuildPositions() {
 #endif
 }
 
-template <typename ParticleT>
-void LogicHandler<ParticleT>::checkMinimalSize() const {
+template <typename Particle_T>
+void LogicHandler<Particle_T>::checkMinimalSize() const {
   const auto &container = _containerSelector.getCurrentContainer();
   // check boxSize at least cutoff + skin
   for (unsigned int dim = 0; dim < 3; ++dim) {
@@ -1125,13 +1128,13 @@ void LogicHandler<ParticleT>::checkMinimalSize() const {
   }
 }
 
-template <typename ParticleT>
-bool LogicHandler<ParticleT>::getNeighborListsInvalidDoDynamicRebuild() {
+template <typename Particle_T>
+bool LogicHandler<Particle_T>::getNeighborListsInvalidDoDynamicRebuild() {
   return _neighborListInvalidDoDynamicRebuild;
 }
 
-template <typename ParticleT>
-bool LogicHandler<ParticleT>::neighborListsAreValid() {
+template <typename Particle_T>
+bool LogicHandler<Particle_T>::neighborListsAreValid() {
   // Implement rebuild indicator as function, so it is only evaluated when needed.
   const auto needRebuild = [&](const InteractionTypeOption &interactionOption) {
     return _interactionTypes.count(interactionOption) != 0 and
@@ -1149,8 +1152,8 @@ bool LogicHandler<ParticleT>::neighborListsAreValid() {
   return _neighborListsAreValid.load(std::memory_order_relaxed);
 }
 
-template <typename ParticleT>
-void LogicHandler<ParticleT>::checkNeighborListsInvalidDoDynamicRebuild() {
+template <typename Particle_T>
+void LogicHandler<Particle_T>::checkNeighborListsInvalidDoDynamicRebuild() {
 #ifdef AUTOPAS_ENABLE_DYNAMIC_CONTAINERS
   const auto skin = getContainer().getVerletSkin();
   // (skin/2)^2
@@ -1168,14 +1171,15 @@ void LogicHandler<ParticleT>::checkNeighborListsInvalidDoDynamicRebuild() {
 #endif
 }
 
-template <typename ParticleT>
-void LogicHandler<ParticleT>::resetNeighborListsInvalidDoDynamicRebuild() {
+template <typename Particle_T>
+void LogicHandler<Particle_T>::resetNeighborListsInvalidDoDynamicRebuild() {
   _neighborListInvalidDoDynamicRebuild = false;
 }
 
-template <typename ParticleT>
-void LogicHandler<ParticleT>::setParticleBuffers(const std::vector<FullParticleCell<ParticleT>> &particleBuffers,
-                                                 const std::vector<FullParticleCell<ParticleT>> &haloParticleBuffers) {
+template <typename Particle_T>
+void LogicHandler<Particle_T>::setParticleBuffers(
+    const std::vector<FullParticleCell<Particle_T>> &particleBuffers,
+    const std::vector<FullParticleCell<Particle_T>> &haloParticleBuffers) {
   auto exchangeBuffer = [](const auto &newBuffers, auto &oldBuffers, auto &particleCounter) {
     // sanity check
     if (oldBuffers.size() < newBuffers.size()) {
@@ -1207,15 +1211,15 @@ void LogicHandler<ParticleT>::setParticleBuffers(const std::vector<FullParticleC
   exchangeBuffer(haloParticleBuffers, _haloParticleBuffer, _numParticlesHalo);
 }
 
-template <typename ParticleT>
-std::tuple<const std::vector<FullParticleCell<ParticleT>> &, const std::vector<FullParticleCell<ParticleT>> &>
-LogicHandler<ParticleT>::getParticleBuffers() const {
+template <typename Particle_T>
+std::tuple<const std::vector<FullParticleCell<Particle_T>> &, const std::vector<FullParticleCell<Particle_T>> &>
+LogicHandler<Particle_T>::getParticleBuffers() const {
   return {_particleBuffer, _haloParticleBuffer};
 }
 
-template <typename ParticleT>
+template <typename Particle_T>
 template <class Functor>
-IterationMeasurements LogicHandler<ParticleT>::computeInteractions(Functor &functor, TraversalInterface &traversal) {
+IterationMeasurements LogicHandler<Particle_T>::computeInteractions(Functor &functor, TraversalInterface &traversal) {
   // Helper to derive the Functor type at compile time
   constexpr auto interactionType = [] {
     if (utils::isPairwiseFunctor<Functor>()) {
@@ -1295,9 +1299,9 @@ IterationMeasurements LogicHandler<ParticleT>::computeInteractions(Functor &func
           energyMeasurementsPossible ? energyTotal : nanL};
 }
 
-template <typename ParticleT>
+template <typename Particle_T>
 template <class Functor>
-void LogicHandler<ParticleT>::computeRemainderInteractions(Functor &functor, bool newton3, bool useSoA) {
+void LogicHandler<Particle_T>::computeRemainderInteractions(Functor &functor, bool newton3, bool useSoA) {
   auto &container = _containerSelector.getCurrentContainer();
 
   withStaticContainerType(container, [&](auto &actualContainerType) {
@@ -1319,11 +1323,11 @@ void LogicHandler<ParticleT>::computeRemainderInteractions(Functor &functor, boo
   });
 }
 
-template <class ParticleT>
+template <class Particle_T>
 template <bool newton3, class ContainerType, class PairwiseFunctor>
-void LogicHandler<ParticleT>::computeRemainderInteractions2B(
-    PairwiseFunctor *f, ContainerType &container, std::vector<FullParticleCell<ParticleT>> &particleBuffers,
-    std::vector<FullParticleCell<ParticleT>> &haloParticleBuffers, bool useSoA) {
+void LogicHandler<Particle_T>::computeRemainderInteractions2B(
+    PairwiseFunctor *f, ContainerType &container, std::vector<FullParticleCell<Particle_T>> &particleBuffers,
+    std::vector<FullParticleCell<Particle_T>> &haloParticleBuffers, bool useSoA) {
   // Sanity check. If this is violated feel free to add some logic here that adapts the number of locks.
   if (_bufferLocks.size() < particleBuffers.size()) {
     utils::ExceptionHandler::exception("Not enough locks for non-halo buffers! Num Locks: {}, Buffers: {}",
@@ -1333,7 +1337,7 @@ void LogicHandler<ParticleT>::computeRemainderInteractions2B(
   // Balance buffers. This makes processing them with static scheduling quite efficient.
   // Also, if particles were not inserted in parallel, this enables us to process them in parallel now.
   // Cost is at max O(2N) worst O(N) per buffer collection and negligible compared to interacting them.
-  auto cellToVec = [](auto &cell) -> std::vector<ParticleT> & { return cell._particles; };
+  auto cellToVec = [](auto &cell) -> std::vector<Particle_T> & { return cell._particles; };
   utils::ArrayUtils::balanceVectors(particleBuffers, cellToVec);
   utils::ArrayUtils::balanceVectors(haloParticleBuffers, cellToVec);
 
@@ -1404,11 +1408,11 @@ void LogicHandler<ParticleT>::computeRemainderInteractions2B(
   // Note: haloParticleBuffer with itself is NOT needed, as interactions between halo particles are unneeded!
 }
 
-template <class ParticleT>
+template <class Particle_T>
 template <bool newton3, class ContainerType, class PairwiseFunctor>
-void LogicHandler<ParticleT>::remainderHelperBufferContainerAoS(
-    PairwiseFunctor *f, ContainerType &container, std::vector<FullParticleCell<ParticleT>> &particleBuffers,
-    std::vector<FullParticleCell<ParticleT>> &haloParticleBuffers) {
+void LogicHandler<Particle_T>::remainderHelperBufferContainerAoS(
+    PairwiseFunctor *f, ContainerType &container, std::vector<FullParticleCell<Particle_T>> &particleBuffers,
+    std::vector<FullParticleCell<Particle_T>> &haloParticleBuffers) {
   using autopas::utils::ArrayUtils::static_cast_copy_array;
   using namespace autopas::utils::ArrayMath::literals;
 
@@ -1480,11 +1484,11 @@ void LogicHandler<ParticleT>::remainderHelperBufferContainerAoS(
   }
 }
 
-template <class ParticleT>
+template <class Particle_T>
 template <bool newton3, class PairwiseFunctor>
-void LogicHandler<ParticleT>::remainderHelperBufferBuffer(PairwiseFunctor *f,
-                                                          std::vector<FullParticleCell<ParticleT>> &particleBuffers,
-                                                          bool useSoA) {
+void LogicHandler<Particle_T>::remainderHelperBufferBuffer(PairwiseFunctor *f,
+                                                           std::vector<FullParticleCell<Particle_T>> &particleBuffers,
+                                                           bool useSoA) {
   if (useSoA) {
     remainderHelperBufferBufferSoA<newton3>(f, particleBuffers);
   } else {
@@ -1492,10 +1496,10 @@ void LogicHandler<ParticleT>::remainderHelperBufferBuffer(PairwiseFunctor *f,
   }
 }
 
-template <class ParticleT>
+template <class Particle_T>
 template <bool newton3, class PairwiseFunctor>
-void LogicHandler<ParticleT>::remainderHelperBufferBufferAoS(
-    PairwiseFunctor *f, std::vector<FullParticleCell<ParticleT>> &particleBuffers) {
+void LogicHandler<Particle_T>::remainderHelperBufferBufferAoS(
+    PairwiseFunctor *f, std::vector<FullParticleCell<Particle_T>> &particleBuffers) {
   // For all interactions between different buffers we turn newton3 always off,
   // which ensures that only one thread at a time is writing to a buffer.
   // This saves expensive locks.
@@ -1537,10 +1541,10 @@ void LogicHandler<ParticleT>::remainderHelperBufferBufferAoS(
   }
 }
 
-template <class ParticleT>
+template <class Particle_T>
 template <bool newton3, class PairwiseFunctor>
-void LogicHandler<ParticleT>::remainderHelperBufferBufferSoA(
-    PairwiseFunctor *f, std::vector<FullParticleCell<ParticleT>> &particleBuffers) {
+void LogicHandler<Particle_T>::remainderHelperBufferBufferSoA(
+    PairwiseFunctor *f, std::vector<FullParticleCell<Particle_T>> &particleBuffers) {
   // we can not use collapse here without locks, otherwise races would occur.
   AUTOPAS_OPENMP(parallel for)
   for (size_t i = 0; i < particleBuffers.size(); ++i) {
@@ -1561,11 +1565,11 @@ void LogicHandler<ParticleT>::remainderHelperBufferBufferSoA(
   }
 }
 
-template <class ParticleT>
+template <class Particle_T>
 template <class PairwiseFunctor>
-void LogicHandler<ParticleT>::remainderHelperBufferHaloBuffer(
-    PairwiseFunctor *f, std::vector<FullParticleCell<ParticleT>> &particleBuffers,
-    std::vector<FullParticleCell<ParticleT>> &haloParticleBuffers, bool useSoA) {
+void LogicHandler<Particle_T>::remainderHelperBufferHaloBuffer(
+    PairwiseFunctor *f, std::vector<FullParticleCell<Particle_T>> &particleBuffers,
+    std::vector<FullParticleCell<Particle_T>> &haloParticleBuffers, bool useSoA) {
   if (useSoA) {
     remainderHelperBufferHaloBufferSoA<PairwiseFunctor>(f, particleBuffers, haloParticleBuffers);
   } else {
@@ -1573,11 +1577,11 @@ void LogicHandler<ParticleT>::remainderHelperBufferHaloBuffer(
   }
 }
 
-template <class ParticleT>
+template <class Particle_T>
 template <class PairwiseFunctor>
-void LogicHandler<ParticleT>::remainderHelperBufferHaloBufferAoS(
-    PairwiseFunctor *f, std::vector<FullParticleCell<ParticleT>> &particleBuffers,
-    std::vector<FullParticleCell<ParticleT>> &haloParticleBuffers) {
+void LogicHandler<Particle_T>::remainderHelperBufferHaloBufferAoS(
+    PairwiseFunctor *f, std::vector<FullParticleCell<Particle_T>> &particleBuffers,
+    std::vector<FullParticleCell<Particle_T>> &haloParticleBuffers) {
   // Here, phase / color based parallelism turned out to be more efficient than tasks
   AUTOPAS_OPENMP(parallel)
   for (int interactionOffset = 0; interactionOffset < haloParticleBuffers.size(); ++interactionOffset) {
@@ -1595,11 +1599,11 @@ void LogicHandler<ParticleT>::remainderHelperBufferHaloBufferAoS(
   }
 }
 
-template <class ParticleT>
+template <class Particle_T>
 template <class PairwiseFunctor>
-void LogicHandler<ParticleT>::remainderHelperBufferHaloBufferSoA(
-    PairwiseFunctor *f, std::vector<FullParticleCell<ParticleT>> &particleBuffers,
-    std::vector<FullParticleCell<ParticleT>> &haloParticleBuffers) {
+void LogicHandler<Particle_T>::remainderHelperBufferHaloBufferSoA(
+    PairwiseFunctor *f, std::vector<FullParticleCell<Particle_T>> &particleBuffers,
+    std::vector<FullParticleCell<Particle_T>> &haloParticleBuffers) {
   // Here, phase / color based parallelism turned out to be more efficient than tasks
   AUTOPAS_OPENMP(parallel)
   for (int interactionOffset = 0; interactionOffset < haloParticleBuffers.size(); ++interactionOffset) {
@@ -1613,13 +1617,13 @@ void LogicHandler<ParticleT>::remainderHelperBufferHaloBufferSoA(
   }
 }
 
-template <class ParticleT>
+template <class Particle_T>
 template <bool newton3, class ContainerType, class TriwiseFunctor>
-void LogicHandler<ParticleT>::computeRemainderInteractions3B(
-    TriwiseFunctor *f, ContainerType &container, std::vector<FullParticleCell<ParticleT>> &particleBuffers,
-    std::vector<FullParticleCell<ParticleT>> &haloParticleBuffers) {
+void LogicHandler<Particle_T>::computeRemainderInteractions3B(
+    TriwiseFunctor *f, ContainerType &container, std::vector<FullParticleCell<Particle_T>> &particleBuffers,
+    std::vector<FullParticleCell<Particle_T>> &haloParticleBuffers) {
   // Vector to collect pointers to all buffer particles
-  std::vector<ParticleT *> bufferParticles;
+  std::vector<Particle_T *> bufferParticles;
   const auto numOwnedBufferParticles = collectBufferParticles(bufferParticles, particleBuffers, haloParticleBuffers);
 
   // The following part performs the main remainder traversal.
@@ -1660,12 +1664,12 @@ void LogicHandler<ParticleT>::computeRemainderInteractions3B(
   AutoPasLog(TRACE, "Timer Buffer <-> Container <-> Container : {}", timerBufferContainerContainer.getTotalTime());
 }
 
-template <class ParticleT>
-size_t LogicHandler<ParticleT>::collectBufferParticles(std::vector<ParticleT *> &bufferParticles,
-                                                       std::vector<FullParticleCell<ParticleT>> &particleBuffers,
-                                                       std::vector<FullParticleCell<ParticleT>> &haloParticleBuffers) {
+template <class Particle_T>
+size_t LogicHandler<Particle_T>::collectBufferParticles(
+    std::vector<Particle_T *> &bufferParticles, std::vector<FullParticleCell<Particle_T>> &particleBuffers,
+    std::vector<FullParticleCell<Particle_T>> &haloParticleBuffers) {
   // Reserve the needed amount
-  auto cellToVec = [](auto &cell) -> std::vector<ParticleT> & { return cell._particles; };
+  auto cellToVec = [](auto &cell) -> std::vector<Particle_T> & { return cell._particles; };
 
   const size_t numOwnedBufferParticles =
       std::transform_reduce(particleBuffers.begin(), particleBuffers.end(), 0, std::plus<>(),
@@ -1694,22 +1698,22 @@ size_t LogicHandler<ParticleT>::collectBufferParticles(std::vector<ParticleT *> 
   return numOwnedBufferParticles;
 }
 
-template <class ParticleT>
+template <class Particle_T>
 template <class TriwiseFunctor>
-void LogicHandler<ParticleT>::remainderHelper3bBufferBufferBufferAoS(const std::vector<ParticleT *> &bufferParticles,
-                                                                     const size_t numOwnedBufferParticles,
-                                                                     TriwiseFunctor *f) {
+void LogicHandler<Particle_T>::remainderHelper3bBufferBufferBufferAoS(const std::vector<Particle_T *> &bufferParticles,
+                                                                      const size_t numOwnedBufferParticles,
+                                                                      TriwiseFunctor *f) {
   AUTOPAS_OPENMP(parallel for)
   for (auto i = 0; i < numOwnedBufferParticles; ++i) {
-    ParticleT &p1 = *bufferParticles[i];
+    Particle_T &p1 = *bufferParticles[i];
 
     for (auto j = 0; j < bufferParticles.size(); ++j) {
       if (i == j) continue;
-      ParticleT &p2 = *bufferParticles[j];
+      Particle_T &p2 = *bufferParticles[j];
 
       for (auto k = j + 1; k < bufferParticles.size(); ++k) {
         if (k == i) continue;
-        ParticleT &p3 = *bufferParticles[k];
+        Particle_T &p3 = *bufferParticles[k];
 
         f->AoSFunctor(p1, p2, p3, false);
       }
@@ -1717,11 +1721,11 @@ void LogicHandler<ParticleT>::remainderHelper3bBufferBufferBufferAoS(const std::
   }
 }
 
-template <class ParticleT>
+template <class Particle_T>
 template <class ContainerType, class TriwiseFunctor>
-void LogicHandler<ParticleT>::remainderHelper3bBufferBufferContainerAoS(const std::vector<ParticleT *> &bufferParticles,
-                                                                        const size_t numOwnedBufferParticles,
-                                                                        ContainerType &container, TriwiseFunctor *f) {
+void LogicHandler<Particle_T>::remainderHelper3bBufferBufferContainerAoS(
+    const std::vector<Particle_T *> &bufferParticles, const size_t numOwnedBufferParticles, ContainerType &container,
+    TriwiseFunctor *f) {
   using autopas::utils::ArrayUtils::static_cast_copy_array;
   using namespace autopas::utils::ArrayMath::literals;
 
@@ -1731,14 +1735,14 @@ void LogicHandler<ParticleT>::remainderHelper3bBufferBufferContainerAoS(const st
 
   AUTOPAS_OPENMP(parallel for)
   for (auto i = 0; i < bufferParticles.size(); ++i) {
-    ParticleT &p1 = *bufferParticles[i];
+    Particle_T &p1 = *bufferParticles[i];
     const auto pos = p1.getR();
     const auto min = pos - cutoff;
     const auto max = pos + cutoff;
 
     for (auto j = 0; j < bufferParticles.size(); ++j) {
       if (j == i) continue;
-      ParticleT &p2 = *bufferParticles[j];
+      Particle_T &p2 = *bufferParticles[j];
 
       container.forEachInRegion(
           [&](auto &p3) {
@@ -1754,10 +1758,10 @@ void LogicHandler<ParticleT>::remainderHelper3bBufferBufferContainerAoS(const st
   }
 }
 
-template <class ParticleT>
+template <class Particle_T>
 template <bool newton3, class ContainerType, class TriwiseFunctor>
-void LogicHandler<ParticleT>::remainderHelper3bBufferContainerContainerAoS(
-    const std::vector<ParticleT *> &bufferParticles, const size_t numOwnedBufferParticles, ContainerType &container,
+void LogicHandler<Particle_T>::remainderHelper3bBufferContainerContainerAoS(
+    const std::vector<Particle_T *> &bufferParticles, const size_t numOwnedBufferParticles, ContainerType &container,
     TriwiseFunctor *f) {
   // Todo: parallelize without race conditions - https://github.com/AutoPas/AutoPas/issues/904
   using autopas::utils::ArrayUtils::static_cast_copy_array;
@@ -1766,7 +1770,7 @@ void LogicHandler<ParticleT>::remainderHelper3bBufferContainerContainerAoS(
   const double cutoff = container.getCutoff();
 
   for (auto i = 0; i < bufferParticles.size(); ++i) {
-    ParticleT &p1 = *bufferParticles[i];
+    Particle_T &p1 = *bufferParticles[i];
     const auto pos = p1.getR();
     const auto boxmin = pos - cutoff;
     const auto boxmax = pos + cutoff;
@@ -1774,13 +1778,13 @@ void LogicHandler<ParticleT>::remainderHelper3bBufferContainerContainerAoS(
     auto p2Iter = container.getRegionIterator(
         boxmin, boxmax, IteratorBehavior::ownedOrHalo | IteratorBehavior::forceSequential, nullptr);
     for (; p2Iter.isValid(); ++p2Iter) {
-      ParticleT &p2 = *p2Iter;
+      Particle_T &p2 = *p2Iter;
 
       auto p3Iter = p2Iter;
       ++p3Iter;
 
       for (; p3Iter.isValid(); ++p3Iter) {
-        ParticleT &p3 = *p3Iter;
+        Particle_T &p3 = *p3Iter;
 
         if constexpr (newton3) {
           f->AoSFunctor(p1, p2, p3, true);
@@ -1800,9 +1804,9 @@ void LogicHandler<ParticleT>::remainderHelper3bBufferContainerContainerAoS(
   }
 }
 
-template <typename ParticleT>
+template <typename Particle_T>
 template <class Functor>
-std::tuple<Configuration, std::unique_ptr<TraversalInterface>, bool> LogicHandler<ParticleT>::selectConfiguration(
+std::tuple<Configuration, std::unique_ptr<TraversalInterface>, bool> LogicHandler<Particle_T>::selectConfiguration(
     Functor &functor, const InteractionTypeOption &interactionType) {
   bool stillTuning = false;
   Configuration configuration{};
@@ -1825,7 +1829,7 @@ std::tuple<Configuration, std::unique_ptr<TraversalInterface>, bool> LogicHandle
                                 _neighborListRebuildFrequency, _verletClusterSize, configuration.loadEstimator));
     }
     const auto &container = _containerSelector.getCurrentContainer();
-    traversalPtrOpt = autopas::utils::withStaticCellType<ParticleT>(
+    traversalPtrOpt = autopas::utils::withStaticCellType<Particle_T>(
         container.getParticleCellTypeEnum(), [&](const auto &particleCellDummy) -> decltype(traversalPtrOpt) {
           // Can't make this unique_ptr const otherwise we can't move it later.
           auto traversalPtr =
@@ -1889,10 +1893,10 @@ std::tuple<Configuration, std::unique_ptr<TraversalInterface>, bool> LogicHandle
   return {configuration, std::move(traversalPtrOpt.value()), stillTuning};
 }
 
-template <typename ParticleT>
+template <typename Particle_T>
 template <class Functor>
-bool LogicHandler<ParticleT>::computeInteractionsPipeline(Functor *functor,
-                                                          const InteractionTypeOption &interactionType) {
+bool LogicHandler<Particle_T>::computeInteractionsPipeline(Functor *functor,
+                                                           const InteractionTypeOption &interactionType) {
   if (not _interactionTypes.count(interactionType)) {
     autopas::utils::ExceptionHandler::exception(
         "LogicHandler::computeInteractionsPipeline(): AutPas was not initialized for the Functor's interactions type: "
@@ -1967,10 +1971,11 @@ bool LogicHandler<ParticleT>::computeInteractionsPipeline(Functor *functor,
   return stillTuning;
 }
 
-template <typename ParticleT>
+template <typename Particle_T>
 template <class Functor>
-std::tuple<std::optional<std::unique_ptr<TraversalInterface>>, bool> LogicHandler<ParticleT>::isConfigurationApplicable(
-    const Configuration &conf, Functor &functor, const InteractionTypeOption &interactionType) {
+std::tuple<std::optional<std::unique_ptr<TraversalInterface>>, bool>
+LogicHandler<Particle_T>::isConfigurationApplicable(const Configuration &conf, Functor &functor,
+                                                    const InteractionTypeOption &interactionType) {
   // Check if the container supports the traversal
   const auto allContainerTraversals =
       compatibleTraversals::allCompatibleTraversals(conf.container, conf.interactionType);
@@ -1995,7 +2000,7 @@ std::tuple<std::optional<std::unique_ptr<TraversalInterface>>, bool> LogicHandle
   const auto &container = _containerSelector.getCurrentContainer();
   const auto traversalInfo = container.getTraversalSelectorInfo();
 
-  auto traversalPtrOpt = autopas::utils::withStaticCellType<ParticleT>(
+  auto traversalPtrOpt = autopas::utils::withStaticCellType<Particle_T>(
       container.getParticleCellTypeEnum(),
       [&](const auto &particleCellDummy) -> std::optional<std::unique_ptr<TraversalInterface>> {
         // Can't make this unique_ptr const otherwise we can't move it later.

--- a/src/autopas/baseFunctors/Functor.h
+++ b/src/autopas/baseFunctors/Functor.h
@@ -33,16 +33,16 @@ enum class FunctorN3Modes {
  * non-newton3 version. Instead you can specify, which version you use by
  * overriding allowsNonNewton3 resp. allowsNewton3
  *
- * @tparam Particle the type of Particle
+ * @tparam ParticleT the type of Particle
  * @tparam CRTP_T the actual type of the functor
  */
-template <class Particle, class CRTP_T>
+template <class ParticleT, class CRTP_T>
 class Functor {
  public:
   /**
    * Structure of the SoAs defined by the particle.
    */
-  using SoAArraysType = typename Particle::SoAArraysType;
+  using SoAArraysType = typename ParticleT::SoAArraysType;
 
   /**
    * Make the Implementation type template publicly available.
@@ -74,8 +74,8 @@ class Functor {
    * @return Attributes needed for computation.
    * @todo C++20: make this function virtual
    */
-  constexpr static std::array<typename Particle::AttributeNames, 0> getNeededAttr() {
-    return std::array<typename Particle::AttributeNames, 0>{};
+  constexpr static std::array<typename ParticleT::AttributeNames, 0> getNeededAttr() {
+    return std::array<typename ParticleT::AttributeNames, 0>{};
   }
 
   /**
@@ -83,7 +83,7 @@ class Functor {
    * @return Attributes needed for computation.
    * @todo C++20: make this function virtual
    */
-  constexpr static std::array<typename Particle::AttributeNames, 0> getNeededAttr(std::false_type) {
+  constexpr static std::array<typename ParticleT::AttributeNames, 0> getNeededAttr(std::false_type) {
     return Functor_T::getNeededAttr();
   }
 
@@ -92,8 +92,8 @@ class Functor {
    * @return Attributes computed by this functor.
    * @todo C++20: make this function virtual
    */
-  constexpr static std::array<typename Particle::AttributeNames, 0> getComputedAttr() {
-    return std::array<typename Particle::AttributeNames, 0>{};
+  constexpr static std::array<typename ParticleT::AttributeNames, 0> getComputedAttr() {
+    return std::array<typename ParticleT::AttributeNames, 0>{};
   }
 
   /**

--- a/src/autopas/baseFunctors/Functor.h
+++ b/src/autopas/baseFunctors/Functor.h
@@ -33,16 +33,16 @@ enum class FunctorN3Modes {
  * non-newton3 version. Instead you can specify, which version you use by
  * overriding allowsNonNewton3 resp. allowsNewton3
  *
- * @tparam ParticleT the type of Particle
+ * @tparam Particle_T the type of Particle
  * @tparam CRTP_T the actual type of the functor
  */
-template <class ParticleT, class CRTP_T>
+template <class Particle_T, class CRTP_T>
 class Functor {
  public:
   /**
    * Structure of the SoAs defined by the particle.
    */
-  using SoAArraysType = typename ParticleT::SoAArraysType;
+  using SoAArraysType = typename Particle_T::SoAArraysType;
 
   /**
    * Make the Implementation type template publicly available.
@@ -74,8 +74,8 @@ class Functor {
    * @return Attributes needed for computation.
    * @todo C++20: make this function virtual
    */
-  constexpr static std::array<typename ParticleT::AttributeNames, 0> getNeededAttr() {
-    return std::array<typename ParticleT::AttributeNames, 0>{};
+  constexpr static std::array<typename Particle_T::AttributeNames, 0> getNeededAttr() {
+    return std::array<typename Particle_T::AttributeNames, 0>{};
   }
 
   /**
@@ -83,7 +83,7 @@ class Functor {
    * @return Attributes needed for computation.
    * @todo C++20: make this function virtual
    */
-  constexpr static std::array<typename ParticleT::AttributeNames, 0> getNeededAttr(std::false_type) {
+  constexpr static std::array<typename Particle_T::AttributeNames, 0> getNeededAttr(std::false_type) {
     return Functor_T::getNeededAttr();
   }
 
@@ -92,8 +92,8 @@ class Functor {
    * @return Attributes computed by this functor.
    * @todo C++20: make this function virtual
    */
-  constexpr static std::array<typename ParticleT::AttributeNames, 0> getComputedAttr() {
-    return std::array<typename ParticleT::AttributeNames, 0>{};
+  constexpr static std::array<typename Particle_T::AttributeNames, 0> getComputedAttr() {
+    return std::array<typename Particle_T::AttributeNames, 0>{};
   }
 
   /**

--- a/src/autopas/baseFunctors/PairwiseFunctor.h
+++ b/src/autopas/baseFunctors/PairwiseFunctor.h
@@ -24,22 +24,22 @@ class VerletListHelpers;
  * particles.
  * @copydoc autopas::Functor
  *
- * @tparam Particle the type of Particle
+ * @tparam ParticleT the type of Particle
  * @tparam CRTP_T the actual type of the functor
  */
-template <class Particle, class CRTP_T>
-class PairwiseFunctor : public Functor<Particle, CRTP_T> {
+template <class ParticleT, class CRTP_T>
+class PairwiseFunctor : public Functor<ParticleT, CRTP_T> {
  public:
   /**
    * Structure of the SoAs defined by the particle.
    */
-  using SoAArraysType = typename Particle::SoAArraysType;
+  using SoAArraysType = typename ParticleT::SoAArraysType;
 
   /**
    * Constructor
    * @param cutoff
    */
-  explicit PairwiseFunctor(double cutoff) : Functor<Particle, CRTP_T>(cutoff){};
+  explicit PairwiseFunctor(double cutoff) : Functor<ParticleT, CRTP_T>(cutoff){};
 
   virtual ~PairwiseFunctor() = default;
 
@@ -53,7 +53,7 @@ class PairwiseFunctor : public Functor<Particle, CRTP_T> {
    * @param j Particle j
    * @param newton3 defines whether or whether not to use newton 3
    */
-  virtual void AoSFunctor(Particle &i, Particle &j, bool newton3) {
+  virtual void AoSFunctor(ParticleT &i, ParticleT &j, bool newton3) {
     utils::ExceptionHandler::exception("{}::AoSFunctor: not implemented", this->getName());
   }
 

--- a/src/autopas/baseFunctors/PairwiseFunctor.h
+++ b/src/autopas/baseFunctors/PairwiseFunctor.h
@@ -24,22 +24,22 @@ class VerletListHelpers;
  * particles.
  * @copydoc autopas::Functor
  *
- * @tparam ParticleT the type of Particle
+ * @tparam Particle_T the type of Particle
  * @tparam CRTP_T the actual type of the functor
  */
-template <class ParticleT, class CRTP_T>
-class PairwiseFunctor : public Functor<ParticleT, CRTP_T> {
+template <class Particle_T, class CRTP_T>
+class PairwiseFunctor : public Functor<Particle_T, CRTP_T> {
  public:
   /**
    * Structure of the SoAs defined by the particle.
    */
-  using SoAArraysType = typename ParticleT::SoAArraysType;
+  using SoAArraysType = typename Particle_T::SoAArraysType;
 
   /**
    * Constructor
    * @param cutoff
    */
-  explicit PairwiseFunctor(double cutoff) : Functor<ParticleT, CRTP_T>(cutoff){};
+  explicit PairwiseFunctor(double cutoff) : Functor<Particle_T, CRTP_T>(cutoff){};
 
   virtual ~PairwiseFunctor() = default;
 
@@ -53,7 +53,7 @@ class PairwiseFunctor : public Functor<ParticleT, CRTP_T> {
    * @param j Particle j
    * @param newton3 defines whether or whether not to use newton 3
    */
-  virtual void AoSFunctor(ParticleT &i, ParticleT &j, bool newton3) {
+  virtual void AoSFunctor(Particle_T &i, Particle_T &j, bool newton3) {
     utils::ExceptionHandler::exception("{}::AoSFunctor: not implemented", this->getName());
   }
 

--- a/src/autopas/baseFunctors/TriwiseFunctor.h
+++ b/src/autopas/baseFunctors/TriwiseFunctor.h
@@ -21,22 +21,22 @@ namespace autopas {
  * particles.
  * @copydoc autopas::Functor
  *
- * @tparam Particle the type of Particle
+ * @tparam ParticleT the type of Particle
  * @tparam CRTP_T the actual type of the functor
  */
-template <class Particle, class CRTP_T>
-class TriwiseFunctor : public Functor<Particle, CRTP_T> {
+template <class ParticleT, class CRTP_T>
+class TriwiseFunctor : public Functor<ParticleT, CRTP_T> {
  public:
   /**
    * Structure of the SoAs defined by the particle.
    */
-  using SoAArraysType = typename Particle::SoAArraysType;
+  using SoAArraysType = typename ParticleT::SoAArraysType;
 
   /**
    * Constructor
    * @param cutoff
    */
-  explicit TriwiseFunctor(double cutoff) : Functor<Particle, CRTP_T>(cutoff){};
+  explicit TriwiseFunctor(double cutoff) : Functor<ParticleT, CRTP_T>(cutoff){};
 
   virtual ~TriwiseFunctor() = default;
 
@@ -51,7 +51,7 @@ class TriwiseFunctor : public Functor<Particle, CRTP_T> {
    * @param k Particle k
    * @param newton3 defines whether or whether not to use newton 3
    */
-  virtual void AoSFunctor(Particle &i, Particle &j, Particle &k, bool newton3) {
+  virtual void AoSFunctor(ParticleT &i, ParticleT &j, ParticleT &k, bool newton3) {
     utils::ExceptionHandler::exception("{}::AoSFunctor: not implemented", this->getName());
   }
 

--- a/src/autopas/baseFunctors/TriwiseFunctor.h
+++ b/src/autopas/baseFunctors/TriwiseFunctor.h
@@ -21,22 +21,22 @@ namespace autopas {
  * particles.
  * @copydoc autopas::Functor
  *
- * @tparam ParticleT the type of Particle
+ * @tparam Particle_T the type of Particle
  * @tparam CRTP_T the actual type of the functor
  */
-template <class ParticleT, class CRTP_T>
-class TriwiseFunctor : public Functor<ParticleT, CRTP_T> {
+template <class Particle_T, class CRTP_T>
+class TriwiseFunctor : public Functor<Particle_T, CRTP_T> {
  public:
   /**
    * Structure of the SoAs defined by the particle.
    */
-  using SoAArraysType = typename ParticleT::SoAArraysType;
+  using SoAArraysType = typename Particle_T::SoAArraysType;
 
   /**
    * Constructor
    * @param cutoff
    */
-  explicit TriwiseFunctor(double cutoff) : Functor<ParticleT, CRTP_T>(cutoff){};
+  explicit TriwiseFunctor(double cutoff) : Functor<Particle_T, CRTP_T>(cutoff){};
 
   virtual ~TriwiseFunctor() = default;
 
@@ -51,7 +51,7 @@ class TriwiseFunctor : public Functor<ParticleT, CRTP_T> {
    * @param k Particle k
    * @param newton3 defines whether or whether not to use newton 3
    */
-  virtual void AoSFunctor(ParticleT &i, ParticleT &j, ParticleT &k, bool newton3) {
+  virtual void AoSFunctor(Particle_T &i, Particle_T &j, Particle_T &k, bool newton3) {
     utils::ExceptionHandler::exception("{}::AoSFunctor: not implemented", this->getName());
   }
 

--- a/src/autopas/cells/FullParticleCell.h
+++ b/src/autopas/cells/FullParticleCell.h
@@ -20,20 +20,20 @@ namespace autopas {
 
 /**
  * This class handles the storage of particles in their full form.
- * @tparam Particle
+ * @tparam ParticleT
  */
-template <class Particle>
-class FullParticleCell : public ParticleCell<Particle> {
+template <class ParticleT>
+class FullParticleCell : public ParticleCell<ParticleT> {
  public:
   /**
    * The structure of the SoAs is defined by the particle.
    */
-  using SoAArraysType = typename Particle::SoAArraysType;
+  using SoAArraysType = typename ParticleT::SoAArraysType;
 
   /**
    * Type that holds or refers to the actual particles.
    */
-  using StorageType = std::vector<Particle>;
+  using StorageType = std::vector<ParticleT>;
 
   /**
    * Constructs a new FullParticleCell.
@@ -48,7 +48,7 @@ class FullParticleCell : public ParticleCell<Particle> {
    */
   explicit FullParticleCell(const std::array<double, 3> &cellLength) : _cellLength(cellLength) {}
 
-  void addParticle(const Particle &p) override {
+  void addParticle(const ParticleT &p) override {
     std::lock_guard<AutoPasLock> guard(this->_cellLock);
 
     // sanity check that ensures that only particles of the cells OwnershipState can be added. Note: if a cell is a
@@ -98,7 +98,7 @@ class FullParticleCell : public ParticleCell<Particle> {
 
   /**
    * Executes code for every particle in this cell as defined by lambda function.
-   * @tparam Lambda (Particle &p) -> void
+   * @tparam Lambda (ParticleT &p) -> void
    * @param forEachLambda code to be executed on particles
    */
   template <typename Lambda>
@@ -109,7 +109,7 @@ class FullParticleCell : public ParticleCell<Particle> {
 
   /**
    * Executes code for every particle in this cell as defined by lambda function.
-   * @tparam Lambda (Particle &p) -> void
+   * @tparam Lambda (ParticleT &p) -> void
    * @param forEachLambda code to be executed on particles
    * @param behavior ownerships of particles that should be in-/excluded
    */
@@ -121,7 +121,7 @@ class FullParticleCell : public ParticleCell<Particle> {
 
   /**
    * Executes code for every particle in this cell as defined by lambda function.
-   * @tparam Lambda (Particle &p) -> void
+   * @tparam Lambda (ParticleT &p) -> void
    * @param forEachLambda code to be executed on particles
    * @param lowerCorner lower corner of bounding box
    * @param higherCorner higher corner of bounding box
@@ -135,7 +135,7 @@ class FullParticleCell : public ParticleCell<Particle> {
 
   /**
    * Reduce properties of particles as defined by a lambda function.
-   * @tparam Lambda (Particle p, A initialValue) -> void
+   * @tparam Lambda (ParticleT p, A initialValue) -> void
    * @tparam A type of particle attribute to be reduced
    * @param reduceLambda code to reduce properties of particles
    * @param result reference to result of type A
@@ -148,7 +148,7 @@ class FullParticleCell : public ParticleCell<Particle> {
 
   /**
    * Reduce properties of particles as defined by a lambda function.
-   * @tparam Lambda (Particle p, A initialValue) -> void
+   * @tparam Lambda (ParticleT p, A initialValue) -> void
    * @tparam A type of particle attribute to be reduced
    * @param reduceLambda code to reduce properties of particles
    * @param result reference to result of type A
@@ -162,7 +162,7 @@ class FullParticleCell : public ParticleCell<Particle> {
 
   /**
    * Reduce properties of particles as defined by a lambda function.
-   * @tparam Lambda (Particle p, A initialValue) -> void
+   * @tparam Lambda (ParticleT p, A initialValue) -> void
    * @tparam A type of particle attribute to be reduced
    * @param reduceLambda code to reduce properties of particles
    * @param result reference to result of type A
@@ -195,21 +195,21 @@ class FullParticleCell : public ParticleCell<Particle> {
    * @param n Position of an element in the container
    * @return Reference to the element
    */
-  Particle &operator[](size_t n) { return _particles[n]; }
+  ParticleT &operator[](size_t n) { return _particles[n]; }
 
   /**
    * Returns a const reference to the element at position n in the cell.
    * @param n Position of an element in the container
    * @return Reference to the element
    */
-  const Particle &operator[](size_t n) const { return _particles[n]; }
+  const ParticleT &operator[](size_t n) const { return _particles[n]; }
 
   /**
    * Returns the particle at position index. Needed by SingleCellIterator.
    * @param index the position of the particle to return.
    * @return the particle at position index.
    */
-  Particle &at(size_t index) { return _particles.at(index); }
+  ParticleT &at(size_t index) { return _particles.at(index); }
 
   CellType getParticleCellTypeAsEnum() override { return CellType::FullParticleCell; }
 
@@ -218,7 +218,7 @@ class FullParticleCell : public ParticleCell<Particle> {
    * @param index the position of the particle to return.
    * @return the particle at position index.
    */
-  const Particle &at(size_t index) const { return _particles.at(index); }
+  const ParticleT &at(size_t index) const { return _particles.at(index); }
 
   [[nodiscard]] bool isEmpty() const override { return size() == 0; }
 
@@ -251,7 +251,7 @@ class FullParticleCell : public ParticleCell<Particle> {
    * @param n New container size
    * @param toInsert Particle to insert. This is needed to allow for non-default-constructible particles.
    */
-  void resize(size_t n, const Particle &toInsert) { _particles.resize(n, toInsert); }
+  void resize(size_t n, const ParticleT &toInsert) { _particles.resize(n, toInsert); }
 
   /**
    * Sort the particles in the cell by a dimension.
@@ -259,7 +259,7 @@ class FullParticleCell : public ParticleCell<Particle> {
    */
   void sortByDim(const size_t dim) {
     std::sort(_particles.begin(), _particles.end(),
-              [dim](const Particle &a, const Particle &b) -> bool { return a.getR()[dim] < b.getR()[dim]; });
+              [dim](const ParticleT &a, const ParticleT &b) -> bool { return a.getR()[dim] < b.getR()[dim]; });
   }
 
   /**
@@ -285,7 +285,7 @@ class FullParticleCell : public ParticleCell<Particle> {
   void forEachImpl(Lambda forEachLambda, const std::array<double, 3> &lowerCorner,
                    const std::array<double, 3> &higherCorner,
                    IteratorBehavior behavior = autopas::IteratorBehavior::ownedOrHaloOrDummy) {
-    for (Particle &p : _particles) {
+    for (ParticleT &p : _particles) {
       if ((not ownershipCheck) or behavior.contains(p)) {
         if ((not regionCheck) or utils::inBox(p.getR(), lowerCorner, higherCorner)) {
           forEachLambda(p);
@@ -298,7 +298,7 @@ class FullParticleCell : public ParticleCell<Particle> {
   void reduceImpl(Lambda reduceLambda, A &result, const std::array<double, 3> &lowerCorner,
                   const std::array<double, 3> &higherCorner,
                   IteratorBehavior behavior = autopas::IteratorBehavior::ownedOrHaloOrDummy) {
-    for (Particle &p : _particles) {
+    for (ParticleT &p : _particles) {
       if ((not ownershipCheck) or behavior.contains(p)) {
         if ((not regionCheck) or utils::inBox(p.getR(), lowerCorner, higherCorner)) {
           reduceLambda(p, result);

--- a/src/autopas/cells/FullParticleCell.h
+++ b/src/autopas/cells/FullParticleCell.h
@@ -20,20 +20,20 @@ namespace autopas {
 
 /**
  * This class handles the storage of particles in their full form.
- * @tparam ParticleT
+ * @tparam Particle_T
  */
-template <class ParticleT>
-class FullParticleCell : public ParticleCell<ParticleT> {
+template <class Particle_T>
+class FullParticleCell : public ParticleCell<Particle_T> {
  public:
   /**
    * The structure of the SoAs is defined by the particle.
    */
-  using SoAArraysType = typename ParticleT::SoAArraysType;
+  using SoAArraysType = typename Particle_T::SoAArraysType;
 
   /**
    * Type that holds or refers to the actual particles.
    */
-  using StorageType = std::vector<ParticleT>;
+  using StorageType = std::vector<Particle_T>;
 
   /**
    * Constructs a new FullParticleCell.
@@ -48,7 +48,7 @@ class FullParticleCell : public ParticleCell<ParticleT> {
    */
   explicit FullParticleCell(const std::array<double, 3> &cellLength) : _cellLength(cellLength) {}
 
-  void addParticle(const ParticleT &p) override {
+  void addParticle(const Particle_T &p) override {
     std::lock_guard<AutoPasLock> guard(this->_cellLock);
 
     // sanity check that ensures that only particles of the cells OwnershipState can be added. Note: if a cell is a
@@ -98,7 +98,7 @@ class FullParticleCell : public ParticleCell<ParticleT> {
 
   /**
    * Executes code for every particle in this cell as defined by lambda function.
-   * @tparam Lambda (ParticleT &p) -> void
+   * @tparam Lambda (Particle_T &p) -> void
    * @param forEachLambda code to be executed on particles
    */
   template <typename Lambda>
@@ -109,7 +109,7 @@ class FullParticleCell : public ParticleCell<ParticleT> {
 
   /**
    * Executes code for every particle in this cell as defined by lambda function.
-   * @tparam Lambda (ParticleT &p) -> void
+   * @tparam Lambda (Particle_T &p) -> void
    * @param forEachLambda code to be executed on particles
    * @param behavior ownerships of particles that should be in-/excluded
    */
@@ -121,7 +121,7 @@ class FullParticleCell : public ParticleCell<ParticleT> {
 
   /**
    * Executes code for every particle in this cell as defined by lambda function.
-   * @tparam Lambda (ParticleT &p) -> void
+   * @tparam Lambda (Particle_T &p) -> void
    * @param forEachLambda code to be executed on particles
    * @param lowerCorner lower corner of bounding box
    * @param higherCorner higher corner of bounding box
@@ -135,7 +135,7 @@ class FullParticleCell : public ParticleCell<ParticleT> {
 
   /**
    * Reduce properties of particles as defined by a lambda function.
-   * @tparam Lambda (ParticleT p, A initialValue) -> void
+   * @tparam Lambda (Particle_T p, A initialValue) -> void
    * @tparam A type of particle attribute to be reduced
    * @param reduceLambda code to reduce properties of particles
    * @param result reference to result of type A
@@ -148,7 +148,7 @@ class FullParticleCell : public ParticleCell<ParticleT> {
 
   /**
    * Reduce properties of particles as defined by a lambda function.
-   * @tparam Lambda (ParticleT p, A initialValue) -> void
+   * @tparam Lambda (Particle_T p, A initialValue) -> void
    * @tparam A type of particle attribute to be reduced
    * @param reduceLambda code to reduce properties of particles
    * @param result reference to result of type A
@@ -162,7 +162,7 @@ class FullParticleCell : public ParticleCell<ParticleT> {
 
   /**
    * Reduce properties of particles as defined by a lambda function.
-   * @tparam Lambda (ParticleT p, A initialValue) -> void
+   * @tparam Lambda (Particle_T p, A initialValue) -> void
    * @tparam A type of particle attribute to be reduced
    * @param reduceLambda code to reduce properties of particles
    * @param result reference to result of type A
@@ -195,21 +195,21 @@ class FullParticleCell : public ParticleCell<ParticleT> {
    * @param n Position of an element in the container
    * @return Reference to the element
    */
-  ParticleT &operator[](size_t n) { return _particles[n]; }
+  Particle_T &operator[](size_t n) { return _particles[n]; }
 
   /**
    * Returns a const reference to the element at position n in the cell.
    * @param n Position of an element in the container
    * @return Reference to the element
    */
-  const ParticleT &operator[](size_t n) const { return _particles[n]; }
+  const Particle_T &operator[](size_t n) const { return _particles[n]; }
 
   /**
    * Returns the particle at position index. Needed by SingleCellIterator.
    * @param index the position of the particle to return.
    * @return the particle at position index.
    */
-  ParticleT &at(size_t index) { return _particles.at(index); }
+  Particle_T &at(size_t index) { return _particles.at(index); }
 
   CellType getParticleCellTypeAsEnum() override { return CellType::FullParticleCell; }
 
@@ -218,7 +218,7 @@ class FullParticleCell : public ParticleCell<ParticleT> {
    * @param index the position of the particle to return.
    * @return the particle at position index.
    */
-  const ParticleT &at(size_t index) const { return _particles.at(index); }
+  const Particle_T &at(size_t index) const { return _particles.at(index); }
 
   [[nodiscard]] bool isEmpty() const override { return size() == 0; }
 
@@ -251,7 +251,7 @@ class FullParticleCell : public ParticleCell<ParticleT> {
    * @param n New container size
    * @param toInsert Particle to insert. This is needed to allow for non-default-constructible particles.
    */
-  void resize(size_t n, const ParticleT &toInsert) { _particles.resize(n, toInsert); }
+  void resize(size_t n, const Particle_T &toInsert) { _particles.resize(n, toInsert); }
 
   /**
    * Sort the particles in the cell by a dimension.
@@ -259,7 +259,7 @@ class FullParticleCell : public ParticleCell<ParticleT> {
    */
   void sortByDim(const size_t dim) {
     std::sort(_particles.begin(), _particles.end(),
-              [dim](const ParticleT &a, const ParticleT &b) -> bool { return a.getR()[dim] < b.getR()[dim]; });
+              [dim](const Particle_T &a, const Particle_T &b) -> bool { return a.getR()[dim] < b.getR()[dim]; });
   }
 
   /**
@@ -285,7 +285,7 @@ class FullParticleCell : public ParticleCell<ParticleT> {
   void forEachImpl(Lambda forEachLambda, const std::array<double, 3> &lowerCorner,
                    const std::array<double, 3> &higherCorner,
                    IteratorBehavior behavior = autopas::IteratorBehavior::ownedOrHaloOrDummy) {
-    for (ParticleT &p : _particles) {
+    for (Particle_T &p : _particles) {
       if ((not ownershipCheck) or behavior.contains(p)) {
         if ((not regionCheck) or utils::inBox(p.getR(), lowerCorner, higherCorner)) {
           forEachLambda(p);
@@ -298,7 +298,7 @@ class FullParticleCell : public ParticleCell<ParticleT> {
   void reduceImpl(Lambda reduceLambda, A &result, const std::array<double, 3> &lowerCorner,
                   const std::array<double, 3> &higherCorner,
                   IteratorBehavior behavior = autopas::IteratorBehavior::ownedOrHaloOrDummy) {
-    for (ParticleT &p : _particles) {
+    for (Particle_T &p : _particles) {
       if ((not ownershipCheck) or behavior.contains(p)) {
         if ((not regionCheck) or utils::inBox(p.getR(), lowerCorner, higherCorner)) {
           reduceLambda(p, result);

--- a/src/autopas/cells/ParticleCell.h
+++ b/src/autopas/cells/ParticleCell.h
@@ -43,17 +43,17 @@ enum class CellType {
  * Class for Cells of Particles.
  * The class handles to storage particles and provides an interface to add the
  * particles
- * @tparam Particle the type of particles to be stored in the cells
+ * @tparam ParticleT the type of particles to be stored in the cells
  * @tparam Iterator the type of the iterator iterate through the particles in
  * this cell
  */
-template <class Particle>
+template <class ParticleT>
 class ParticleCell {
  public:
   /**
-   * The particle type for this cell.
+   * The particle type for this cell. Used to refer to the ParticleT typename for an instantiation of ParticleCell.
    */
-  using ParticleType = Particle;
+  using ParticleType = ParticleT;
 
   /**
    * Default destructor.
@@ -81,7 +81,7 @@ class ParticleCell {
    * Adds a Particle to the cell.
    * @param p the particle to be added
    */
-  virtual void addParticle(const Particle &p) = 0;
+  virtual void addParticle(const ParticleT &p) = 0;
 
   /**
    * Get the number of all particles stored in this cell (owned, halo and dummy).

--- a/src/autopas/cells/ParticleCell.h
+++ b/src/autopas/cells/ParticleCell.h
@@ -43,17 +43,17 @@ enum class CellType {
  * Class for Cells of Particles.
  * The class handles to storage particles and provides an interface to add the
  * particles
- * @tparam ParticleT the type of particles to be stored in the cells
+ * @tparam Particle_T the type of particles to be stored in the cells
  * @tparam Iterator the type of the iterator iterate through the particles in
  * this cell
  */
-template <class ParticleT>
+template <class Particle_T>
 class ParticleCell {
  public:
   /**
-   * The particle type for this cell. Used to refer to the ParticleT typename for an instantiation of ParticleCell.
+   * The particle type for this cell. Used to refer to the Particle_T typename for an instantiation of ParticleCell.
    */
-  using ParticleType = ParticleT;
+  using ParticleType = Particle_T;
 
   /**
    * Default destructor.
@@ -81,7 +81,7 @@ class ParticleCell {
    * Adds a Particle to the cell.
    * @param p the particle to be added
    */
-  virtual void addParticle(const ParticleT &p) = 0;
+  virtual void addParticle(const Particle_T &p) = 0;
 
   /**
    * Get the number of all particles stored in this cell (owned, halo and dummy).

--- a/src/autopas/cells/ReferenceParticleCell.h
+++ b/src/autopas/cells/ReferenceParticleCell.h
@@ -18,19 +18,19 @@ namespace autopas {
 
 /**
  * This class handles the storage of particles in their full form.
- * @tparam ParticleT
+ * @tparam Particle_T
  */
-template <class ParticleT>
-class ReferenceParticleCell : public ParticleCell<ParticleT> {
+template <class Particle_T>
+class ReferenceParticleCell : public ParticleCell<Particle_T> {
  public:
   /**
    * The structure of the SoAs is defined by the particle.
    */
-  using SoAArraysType = typename ParticleT::SoAArraysType;
+  using SoAArraysType = typename Particle_T::SoAArraysType;
   /**
    * Type that holds or refers to the actual particles.
    */
-  using StorageType = std::vector<ParticleT *>;
+  using StorageType = std::vector<Particle_T *>;
 
   /**
    * Constructs a new ReferenceParticleCell.
@@ -45,14 +45,14 @@ class ReferenceParticleCell : public ParticleCell<ParticleT> {
    */
   explicit ReferenceParticleCell(const std::array<double, 3> &cellLength) : _cellLength(cellLength) {}
 
-  void addParticle(const ParticleT &p) override {
+  void addParticle(const Particle_T &p) override {
     autopas::utils::ExceptionHandler::exception("Should use addParticleReference instead");
   }
 
   /**
    * @copydoc ParticleCell::addParticle()
    */
-  void addParticleReference(ParticleT *p) {
+  void addParticleReference(Particle_T *p) {
     // sanity check that ensures that only particles of the cells OwnershipState can be added. Note: is a cell is a
     // dummy-cell, only dummies can be added, otherwise dummies can always be added
     if ((not toInt64(p->getOwnershipState() & this->_ownershipState)) and
@@ -95,7 +95,7 @@ class ReferenceParticleCell : public ParticleCell<ParticleT> {
 
   /**
    * Executes code for every particle in this cell as defined by lambda function.
-   * @tparam Lambda (ParticleT &p) -> void
+   * @tparam Lambda (Particle_T &p) -> void
    * @param forEachLambda code to be executed on particles
    * @param behavior ownerships of particles that should be in-/excluded
    */
@@ -107,7 +107,7 @@ class ReferenceParticleCell : public ParticleCell<ParticleT> {
 
   /**
    * Executes code for every particle in this cell as defined by lambda function.
-   * @tparam Lambda (ParticleT &p) -> void
+   * @tparam Lambda (Particle_T &p) -> void
    * @param forEachLambda code to be executed on particles
    * @param lowerCorner lower corner of bounding box
    * @param higherCorner higher corner of bounding box
@@ -120,7 +120,7 @@ class ReferenceParticleCell : public ParticleCell<ParticleT> {
   }
   /**
    * Reduce properties of particles as defined by a lambda function.
-   * @tparam Lambda (ParticleT p, A initialValue) -> void
+   * @tparam Lambda (Particle_T p, A initialValue) -> void
    * @tparam A type of particle attribute to be reduced
    * @param reduceLambda code to reduce properties of particles
    * @param result reference to result of type A
@@ -134,7 +134,7 @@ class ReferenceParticleCell : public ParticleCell<ParticleT> {
 
   /**
    * Reduce properties of particles as defined by a lambda function.
-   * @tparam Lambda (ParticleT p, A initialValue) -> void
+   * @tparam Lambda (Particle_T p, A initialValue) -> void
    * @tparam A type of particle attribute to be reduced
    * @param reduceLambda code to reduce properties of particles
    * @param result reference to result of type A
@@ -172,7 +172,7 @@ class ReferenceParticleCell : public ParticleCell<ParticleT> {
    * @param n Position of an element in the container
    * @return Reference to the element
    */
-  ParticleT &operator[](size_t n) { return *(_particles[n]); }
+  Particle_T &operator[](size_t n) { return *(_particles[n]); }
 
   /**
    * @copydoc ParticleCell::getParticleCellTypeAsEnum()
@@ -184,21 +184,21 @@ class ReferenceParticleCell : public ParticleCell<ParticleT> {
    * @param n Position of an element in the container
    * @return Reference to the element
    */
-  const ParticleT &operator[](size_t n) const { return *(_particles[n]); }
+  const Particle_T &operator[](size_t n) const { return *(_particles[n]); }
 
   /**
    * Returns the particle at position index. Needed by SingleCellIterator.
    * @param index the position of the particle to return.
    * @return the particle at position index.
    */
-  [[nodiscard]] ParticleT &at(size_t index) { return *(_particles.at(index)); }
+  [[nodiscard]] Particle_T &at(size_t index) { return *(_particles.at(index)); }
 
   /**
    * Returns the const particle at position index. Needed by SingleCellIterator.
    * @param index the position of the particle to return.
    * @return the particle at position index.
    */
-  [[nodiscard]] const ParticleT &at(size_t index) const { return *(_particles.at(index)); }
+  [[nodiscard]] const Particle_T &at(size_t index) const { return *(_particles.at(index)); }
 
   [[nodiscard]] bool isEmpty() const override { return size() == 0; }
 
@@ -233,7 +233,7 @@ class ReferenceParticleCell : public ParticleCell<ParticleT> {
    * @param n New container size
    * @param toInsert Particle to insert. This is needed to allow for non-default-constructible particles.
    */
-  void resize(size_t n, const ParticleT &toInsert) { _particles.resize(n, std::unique_ptr<ParticleT>(toInsert)); }
+  void resize(size_t n, const Particle_T &toInsert) { _particles.resize(n, std::unique_ptr<Particle_T>(toInsert)); }
 
   /**
    * Sort the particles in the cell by a dimension.
@@ -267,7 +267,7 @@ class ReferenceParticleCell : public ParticleCell<ParticleT> {
   void forEachImpl(Lambda forEachLambda, const std::array<double, 3> &lowerCorner,
                    const std::array<double, 3> &higherCorner,
                    IteratorBehavior behavior = autopas::IteratorBehavior::ownedOrHaloOrDummy) {
-    for (ParticleT *p : _particles) {
+    for (Particle_T *p : _particles) {
       if (behavior.contains(*p)) {
         if ((not regionCheck) or utils::inBox(p->getR(), lowerCorner, higherCorner)) {
           forEachLambda(*p);
@@ -280,7 +280,7 @@ class ReferenceParticleCell : public ParticleCell<ParticleT> {
   void reduceImpl(Lambda reduceLambda, A &result, const std::array<double, 3> &lowerCorner,
                   const std::array<double, 3> &higherCorner,
                   IteratorBehavior behavior = autopas::IteratorBehavior::ownedOrHaloOrDummy) {
-    for (ParticleT *p : _particles) {
+    for (Particle_T *p : _particles) {
       if ((not ownershipCheck) or behavior.contains(*p)) {
         if ((not regionCheck) or utils::inBox(p->getR(), lowerCorner, higherCorner)) {
           reduceLambda(*p, result);

--- a/src/autopas/cells/ReferenceParticleCell.h
+++ b/src/autopas/cells/ReferenceParticleCell.h
@@ -18,19 +18,19 @@ namespace autopas {
 
 /**
  * This class handles the storage of particles in their full form.
- * @tparam Particle
+ * @tparam ParticleT
  */
-template <class Particle>
-class ReferenceParticleCell : public ParticleCell<Particle> {
+template <class ParticleT>
+class ReferenceParticleCell : public ParticleCell<ParticleT> {
  public:
   /**
    * The structure of the SoAs is defined by the particle.
    */
-  using SoAArraysType = typename Particle::SoAArraysType;
+  using SoAArraysType = typename ParticleT::SoAArraysType;
   /**
    * Type that holds or refers to the actual particles.
    */
-  using StorageType = std::vector<Particle *>;
+  using StorageType = std::vector<ParticleT *>;
 
   /**
    * Constructs a new ReferenceParticleCell.
@@ -45,14 +45,14 @@ class ReferenceParticleCell : public ParticleCell<Particle> {
    */
   explicit ReferenceParticleCell(const std::array<double, 3> &cellLength) : _cellLength(cellLength) {}
 
-  void addParticle(const Particle &p) override {
+  void addParticle(const ParticleT &p) override {
     autopas::utils::ExceptionHandler::exception("Should use addParticleReference instead");
   }
 
   /**
    * @copydoc ParticleCell::addParticle()
    */
-  void addParticleReference(Particle *p) {
+  void addParticleReference(ParticleT *p) {
     // sanity check that ensures that only particles of the cells OwnershipState can be added. Note: is a cell is a
     // dummy-cell, only dummies can be added, otherwise dummies can always be added
     if ((not toInt64(p->getOwnershipState() & this->_ownershipState)) and
@@ -95,7 +95,7 @@ class ReferenceParticleCell : public ParticleCell<Particle> {
 
   /**
    * Executes code for every particle in this cell as defined by lambda function.
-   * @tparam Lambda (Particle &p) -> void
+   * @tparam Lambda (ParticleT &p) -> void
    * @param forEachLambda code to be executed on particles
    * @param behavior ownerships of particles that should be in-/excluded
    */
@@ -107,7 +107,7 @@ class ReferenceParticleCell : public ParticleCell<Particle> {
 
   /**
    * Executes code for every particle in this cell as defined by lambda function.
-   * @tparam Lambda (Particle &p) -> void
+   * @tparam Lambda (ParticleT &p) -> void
    * @param forEachLambda code to be executed on particles
    * @param lowerCorner lower corner of bounding box
    * @param higherCorner higher corner of bounding box
@@ -120,7 +120,7 @@ class ReferenceParticleCell : public ParticleCell<Particle> {
   }
   /**
    * Reduce properties of particles as defined by a lambda function.
-   * @tparam Lambda (Particle p, A initialValue) -> void
+   * @tparam Lambda (ParticleT p, A initialValue) -> void
    * @tparam A type of particle attribute to be reduced
    * @param reduceLambda code to reduce properties of particles
    * @param result reference to result of type A
@@ -134,7 +134,7 @@ class ReferenceParticleCell : public ParticleCell<Particle> {
 
   /**
    * Reduce properties of particles as defined by a lambda function.
-   * @tparam Lambda (Particle p, A initialValue) -> void
+   * @tparam Lambda (ParticleT p, A initialValue) -> void
    * @tparam A type of particle attribute to be reduced
    * @param reduceLambda code to reduce properties of particles
    * @param result reference to result of type A
@@ -172,7 +172,7 @@ class ReferenceParticleCell : public ParticleCell<Particle> {
    * @param n Position of an element in the container
    * @return Reference to the element
    */
-  Particle &operator[](size_t n) { return *(_particles[n]); }
+  ParticleT &operator[](size_t n) { return *(_particles[n]); }
 
   /**
    * @copydoc ParticleCell::getParticleCellTypeAsEnum()
@@ -184,21 +184,21 @@ class ReferenceParticleCell : public ParticleCell<Particle> {
    * @param n Position of an element in the container
    * @return Reference to the element
    */
-  const Particle &operator[](size_t n) const { return *(_particles[n]); }
+  const ParticleT &operator[](size_t n) const { return *(_particles[n]); }
 
   /**
    * Returns the particle at position index. Needed by SingleCellIterator.
    * @param index the position of the particle to return.
    * @return the particle at position index.
    */
-  [[nodiscard]] Particle &at(size_t index) { return *(_particles.at(index)); }
+  [[nodiscard]] ParticleT &at(size_t index) { return *(_particles.at(index)); }
 
   /**
    * Returns the const particle at position index. Needed by SingleCellIterator.
    * @param index the position of the particle to return.
    * @return the particle at position index.
    */
-  [[nodiscard]] const Particle &at(size_t index) const { return *(_particles.at(index)); }
+  [[nodiscard]] const ParticleT &at(size_t index) const { return *(_particles.at(index)); }
 
   [[nodiscard]] bool isEmpty() const override { return size() == 0; }
 
@@ -233,7 +233,7 @@ class ReferenceParticleCell : public ParticleCell<Particle> {
    * @param n New container size
    * @param toInsert Particle to insert. This is needed to allow for non-default-constructible particles.
    */
-  void resize(size_t n, const Particle &toInsert) { _particles.resize(n, std::unique_ptr<Particle>(toInsert)); }
+  void resize(size_t n, const ParticleT &toInsert) { _particles.resize(n, std::unique_ptr<ParticleT>(toInsert)); }
 
   /**
    * Sort the particles in the cell by a dimension.
@@ -267,7 +267,7 @@ class ReferenceParticleCell : public ParticleCell<Particle> {
   void forEachImpl(Lambda forEachLambda, const std::array<double, 3> &lowerCorner,
                    const std::array<double, 3> &higherCorner,
                    IteratorBehavior behavior = autopas::IteratorBehavior::ownedOrHaloOrDummy) {
-    for (Particle *p : _particles) {
+    for (ParticleT *p : _particles) {
       if (behavior.contains(*p)) {
         if ((not regionCheck) or utils::inBox(p->getR(), lowerCorner, higherCorner)) {
           forEachLambda(*p);
@@ -280,7 +280,7 @@ class ReferenceParticleCell : public ParticleCell<Particle> {
   void reduceImpl(Lambda reduceLambda, A &result, const std::array<double, 3> &lowerCorner,
                   const std::array<double, 3> &higherCorner,
                   IteratorBehavior behavior = autopas::IteratorBehavior::ownedOrHaloOrDummy) {
-    for (Particle *p : _particles) {
+    for (ParticleT *p : _particles) {
       if ((not ownershipCheck) or behavior.contains(*p)) {
         if ((not regionCheck) or utils::inBox(p->getR(), lowerCorner, higherCorner)) {
           reduceLambda(*p, result);

--- a/src/autopas/containers/CellBasedParticleContainer.h
+++ b/src/autopas/containers/CellBasedParticleContainer.h
@@ -23,7 +23,7 @@ namespace autopas {
  */
 template <class ParticleCell>
 class CellBasedParticleContainer : public ParticleContainerInterface<typename ParticleCell::ParticleType> {
-  using Particle = typename ParticleCell::ParticleType;
+  using ParticleType = typename ParticleCell::ParticleType;
 
  public:
   /**
@@ -36,7 +36,7 @@ class CellBasedParticleContainer : public ParticleContainerInterface<typename Pa
    */
   CellBasedParticleContainer(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax,
                              const double cutoff, double skin, unsigned int rebuildFrequency)
-      : ParticleContainerInterface<Particle>(skin),
+      : ParticleContainerInterface<ParticleType>(skin),
         _cells(),
         _boxMin(boxMin),
         _boxMax(boxMax),

--- a/src/autopas/containers/LoadEstimators.h
+++ b/src/autopas/containers/LoadEstimators.h
@@ -52,9 +52,9 @@ unsigned long squaredParticlesPerCell(const std::vector<ParticleCell> &cells,
  * @param cellIndex the index of the current cell being processed
  * @return estimated load for current cell
  */
-template <class ParticleT>
+template <class Particle_T>
 unsigned long neighborListLengthImpl(
-    const typename autopas::VerletListsCellsHelpers::AllCellsNeighborListsType<ParticleT> &neighborLists,
+    const typename autopas::VerletListsCellsHelpers::AllCellsNeighborListsType<Particle_T> &neighborLists,
     unsigned long cellIndex) {
   unsigned long cellLoad = 0;
   for (auto &list : neighborLists[cellIndex]) {
@@ -71,9 +71,9 @@ unsigned long neighborListLengthImpl(
  * @param cellIndex the index of the current cell being processed
  * @return estimated load for current cell
  */
-template <class ParticleT>
+template <class Particle_T>
 unsigned long neighborListLengthImpl(
-    const typename autopas::VerletListsCellsHelpers::PairwiseNeighborListsType<ParticleT> &neighborLists,
+    const typename autopas::VerletListsCellsHelpers::PairwiseNeighborListsType<Particle_T> &neighborLists,
     unsigned long cellIndex) {
   unsigned long cellLoad = 0;
   for (auto &list : neighborLists[cellIndex]) {
@@ -94,7 +94,7 @@ unsigned long neighborListLengthImpl(
  * @param upperCorner upper boundary indices for region
  * @return estimated load for given region
  */
-template <class ParticleT, class NeighborList>
+template <class Particle_T, class NeighborList>
 unsigned long neighborListLength(NeighborList &neighborLists, const std::array<unsigned long, 3> &cellsPerDimension,
                                  const std::array<unsigned long, 3> &lowerCorner,
                                  const std::array<unsigned long, 3> &upperCorner) {
@@ -104,7 +104,7 @@ unsigned long neighborListLength(NeighborList &neighborLists, const std::array<u
     for (unsigned long y = lowerCorner[1]; y <= upperCorner[1]; y++) {
       for (unsigned long z = lowerCorner[2]; z <= upperCorner[2]; z++) {
         auto cellIndex = autopas::utils::ThreeDimensionalMapping::threeToOneD(x, y, z, cellsPerDimension);
-        sum += neighborListLengthImpl<ParticleT>(internalList, cellIndex);
+        sum += neighborListLengthImpl<Particle_T>(internalList, cellIndex);
       }
     }
   }

--- a/src/autopas/containers/LoadEstimators.h
+++ b/src/autopas/containers/LoadEstimators.h
@@ -52,9 +52,9 @@ unsigned long squaredParticlesPerCell(const std::vector<ParticleCell> &cells,
  * @param cellIndex the index of the current cell being processed
  * @return estimated load for current cell
  */
-template <class Particle>
+template <class ParticleT>
 unsigned long neighborListLengthImpl(
-    const typename autopas::VerletListsCellsHelpers::AllCellsNeighborListsType<Particle> &neighborLists,
+    const typename autopas::VerletListsCellsHelpers::AllCellsNeighborListsType<ParticleT> &neighborLists,
     unsigned long cellIndex) {
   unsigned long cellLoad = 0;
   for (auto &list : neighborLists[cellIndex]) {
@@ -71,9 +71,9 @@ unsigned long neighborListLengthImpl(
  * @param cellIndex the index of the current cell being processed
  * @return estimated load for current cell
  */
-template <class Particle>
+template <class ParticleT>
 unsigned long neighborListLengthImpl(
-    const typename autopas::VerletListsCellsHelpers::PairwiseNeighborListsType<Particle> &neighborLists,
+    const typename autopas::VerletListsCellsHelpers::PairwiseNeighborListsType<ParticleT> &neighborLists,
     unsigned long cellIndex) {
   unsigned long cellLoad = 0;
   for (auto &list : neighborLists[cellIndex]) {
@@ -94,7 +94,7 @@ unsigned long neighborListLengthImpl(
  * @param upperCorner upper boundary indices for region
  * @return estimated load for given region
  */
-template <class Particle, class NeighborList>
+template <class ParticleT, class NeighborList>
 unsigned long neighborListLength(NeighborList &neighborLists, const std::array<unsigned long, 3> &cellsPerDimension,
                                  const std::array<unsigned long, 3> &lowerCorner,
                                  const std::array<unsigned long, 3> &upperCorner) {
@@ -104,7 +104,7 @@ unsigned long neighborListLength(NeighborList &neighborLists, const std::array<u
     for (unsigned long y = lowerCorner[1]; y <= upperCorner[1]; y++) {
       for (unsigned long z = lowerCorner[2]; z <= upperCorner[2]; z++) {
         auto cellIndex = autopas::utils::ThreeDimensionalMapping::threeToOneD(x, y, z, cellsPerDimension);
-        sum += neighborListLengthImpl<Particle>(internalList, cellIndex);
+        sum += neighborListLengthImpl<ParticleT>(internalList, cellIndex);
       }
     }
   }

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -23,7 +23,7 @@
 namespace autopas {
 
 // forward declaration
-template <class ParticleT, bool modifiable, bool regionIter>
+template <class Particle_T, bool modifiable, bool regionIter>
 class ContainerIterator;
 
 /**
@@ -31,15 +31,15 @@ class ContainerIterator;
  * It defines method interfaces for addition and deletion of particles, accessing general container
  * properties and creating iterators.
  *
- * @tparam ParticleT Class for particle.
+ * @tparam Particle_T Class for particle.
  */
-template <class ParticleT>
+template <class Particle_T>
 class ParticleContainerInterface {
  public:
   /**
    *  Type of the Particle.
    */
-  using ParticleType = ParticleT;
+  using ParticleType = Particle_T;
 
   /**
    * Get the ParticleCell type as an Enum
@@ -93,7 +93,7 @@ class ParticleContainerInterface {
    * @param p The particle to be added.
    */
   template <bool checkInBox = true>
-  void addParticle(const ParticleT &p) {
+  void addParticle(const Particle_T &p) {
     if constexpr (checkInBox) {
       if (utils::notInBox(p.getR(), this->getBoxMin(), this->getBoxMax())) {
         utils::ExceptionHandler::exception(
@@ -114,7 +114,7 @@ class ParticleContainerInterface {
    * @param p The particle to be added. This particle is already checked to be inside of the bounding box.
    * @note Only call this function if the position of the particle is guaranteed to be inside of the bounding box!
    */
-  virtual void addParticleImpl(const ParticleT &p) = 0;
+  virtual void addParticleImpl(const Particle_T &p) = 0;
 
  public:
   /**
@@ -124,7 +124,7 @@ class ParticleContainerInterface {
    * already been performed.
    */
   template <bool checkInBox = true>
-  void addHaloParticle(const ParticleT &haloParticle) {
+  void addHaloParticle(const Particle_T &haloParticle) {
     if constexpr (checkInBox) {
       /// @todo do we want a check of the particle not being too far away in here as well?
       if (utils::inBox(haloParticle.getR(), this->getBoxMin(), this->getBoxMax())) {
@@ -146,7 +146,7 @@ class ParticleContainerInterface {
    * @param haloParticle Particle to be added. This particle is already checked to be outside of the bounding box.
    * @note Only call this function if the position of the particle is guaranteed to be outside of the bounding box!
    */
-  virtual void addHaloParticleImpl(const ParticleT &haloParticle) = 0;
+  virtual void addHaloParticleImpl(const Particle_T &haloParticle) = 0;
 
  public:
   /**
@@ -154,7 +154,7 @@ class ParticleContainerInterface {
    * @param haloParticle Particle to be updated.
    * @return Returns true if the particle was updated, false if no particle could be found.
    */
-  virtual bool updateHaloParticle(const ParticleT &haloParticle) = 0;
+  virtual bool updateHaloParticle(const Particle_T &haloParticle) = 0;
 
   /**
    * Rebuilds the neighbor lists for the next traversals.
@@ -344,15 +344,15 @@ class ParticleContainerInterface {
    * @param cellIndex Index of the cell the particle is located in.
    * @param particleIndex Particle index within the cell.
    * @param iteratorBehavior Which ownership states should be considered for the next particle.
-   * @return Pointer to the particle and its indices. tuple<ParticleT*, cellIndex, particleIndex>
+   * @return Pointer to the particle and its indices. tuple<Particle_T*, cellIndex, particleIndex>
    * If a index pair is given that does not exist but is also not beyond the last cell, the next fitting particle shall
    * be returned.
    * Example: If [4,2] does not exist, [5,1] shall be returned
    * (or whatever is the next particle that fulfills the iterator requirements).
    * If there is no next fitting particle {nullptr, 0, 0} is returned.
    */
-  virtual std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
-                                                                    IteratorBehavior iteratorBehavior) const = 0;
+  virtual std::tuple<const Particle_T *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
+                                                                     IteratorBehavior iteratorBehavior) const = 0;
 
   /**
    * @copydoc getParticle(size_t cellIndex, size_t particleIndex, IteratorBehavior iteratorBehavior) const
@@ -362,10 +362,10 @@ class ParticleContainerInterface {
    * @param boxMax end of region in which the next particle should be. The coordinates are expected to be within the
    * domain.
    */
-  virtual std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
-                                                                    IteratorBehavior iteratorBehavior,
-                                                                    const std::array<double, 3> &boxMin,
-                                                                    const std::array<double, 3> &boxMax) const = 0;
+  virtual std::tuple<const Particle_T *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
+                                                                     IteratorBehavior iteratorBehavior,
+                                                                     const std::array<double, 3> &boxMin,
+                                                                     const std::array<double, 3> &boxMax) const = 0;
 
   // clang-format off
   /**
@@ -374,16 +374,16 @@ class ParticleContainerInterface {
    * @note non-const region iter version
    */
   // clang-format on
-  std::tuple<ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
-                                                      IteratorBehavior iteratorBehavior,
-                                                      const std::array<double, 3> &boxMin,
-                                                      const std::array<double, 3> &boxMax) {
-    const ParticleT *ptr{};
+  std::tuple<Particle_T *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
+                                                       IteratorBehavior iteratorBehavior,
+                                                       const std::array<double, 3> &boxMin,
+                                                       const std::array<double, 3> &boxMax) {
+    const Particle_T *ptr{};
     size_t nextCellIndex{}, nextParticleIndex{};
     std::tie(ptr, nextCellIndex, nextParticleIndex) =
-        const_cast<const ParticleContainerInterface<ParticleT> *>(this)->getParticle(cellIndex, particleIndex,
-                                                                                     iteratorBehavior, boxMin, boxMax);
-    return {const_cast<ParticleT *>(ptr), nextCellIndex, nextParticleIndex};
+        const_cast<const ParticleContainerInterface<Particle_T> *>(this)->getParticle(cellIndex, particleIndex,
+                                                                                      iteratorBehavior, boxMin, boxMax);
+    return {const_cast<Particle_T *>(ptr), nextCellIndex, nextParticleIndex};
   }
 
   /**
@@ -391,14 +391,14 @@ class ParticleContainerInterface {
    *
    * @note non-const non-region iter version
    */
-  std::tuple<ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
-                                                      IteratorBehavior iteratorBehavior) {
-    const ParticleT *ptr{};
+  std::tuple<Particle_T *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
+                                                       IteratorBehavior iteratorBehavior) {
+    const Particle_T *ptr{};
     size_t nextCellIndex{}, nextParticleIndex{};
     std::tie(ptr, nextCellIndex, nextParticleIndex) =
-        const_cast<const ParticleContainerInterface<ParticleT> *>(this)->getParticle(cellIndex, particleIndex,
-                                                                                     iteratorBehavior);
-    return {const_cast<ParticleT *>(ptr), nextCellIndex, nextParticleIndex};
+        const_cast<const ParticleContainerInterface<Particle_T> *>(this)->getParticle(cellIndex, particleIndex,
+                                                                                      iteratorBehavior);
+    return {const_cast<Particle_T *>(ptr), nextCellIndex, nextParticleIndex};
   }
 
   /**
@@ -408,7 +408,7 @@ class ParticleContainerInterface {
    * @param particle Reference to the particle that is to be deleted.
    * @return True if the given pointer still points to a new particle.
    */
-  virtual bool deleteParticle(ParticleT &particle) = 0;
+  virtual bool deleteParticle(Particle_T &particle) = 0;
 
   /**
    * Deletes the particle at the given index positions as long as this does not compromise the validity of the

--- a/src/autopas/containers/ParticleContainerInterface.h
+++ b/src/autopas/containers/ParticleContainerInterface.h
@@ -352,7 +352,7 @@ class ParticleContainerInterface {
    * If there is no next fitting particle {nullptr, 0, 0} is returned.
    */
   virtual std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
-                                                                   IteratorBehavior iteratorBehavior) const = 0;
+                                                                    IteratorBehavior iteratorBehavior) const = 0;
 
   /**
    * @copydoc getParticle(size_t cellIndex, size_t particleIndex, IteratorBehavior iteratorBehavior) const
@@ -363,9 +363,9 @@ class ParticleContainerInterface {
    * domain.
    */
   virtual std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
-                                                                   IteratorBehavior iteratorBehavior,
-                                                                   const std::array<double, 3> &boxMin,
-                                                                   const std::array<double, 3> &boxMax) const = 0;
+                                                                    IteratorBehavior iteratorBehavior,
+                                                                    const std::array<double, 3> &boxMin,
+                                                                    const std::array<double, 3> &boxMax) const = 0;
 
   // clang-format off
   /**
@@ -375,14 +375,14 @@ class ParticleContainerInterface {
    */
   // clang-format on
   std::tuple<ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
-                                                     IteratorBehavior iteratorBehavior,
-                                                     const std::array<double, 3> &boxMin,
-                                                     const std::array<double, 3> &boxMax) {
+                                                      IteratorBehavior iteratorBehavior,
+                                                      const std::array<double, 3> &boxMin,
+                                                      const std::array<double, 3> &boxMax) {
     const ParticleT *ptr{};
     size_t nextCellIndex{}, nextParticleIndex{};
     std::tie(ptr, nextCellIndex, nextParticleIndex) =
         const_cast<const ParticleContainerInterface<ParticleT> *>(this)->getParticle(cellIndex, particleIndex,
-                                                                                    iteratorBehavior, boxMin, boxMax);
+                                                                                     iteratorBehavior, boxMin, boxMax);
     return {const_cast<ParticleT *>(ptr), nextCellIndex, nextParticleIndex};
   }
 
@@ -392,12 +392,12 @@ class ParticleContainerInterface {
    * @note non-const non-region iter version
    */
   std::tuple<ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
-                                                     IteratorBehavior iteratorBehavior) {
+                                                      IteratorBehavior iteratorBehavior) {
     const ParticleT *ptr{};
     size_t nextCellIndex{}, nextParticleIndex{};
     std::tie(ptr, nextCellIndex, nextParticleIndex) =
         const_cast<const ParticleContainerInterface<ParticleT> *>(this)->getParticle(cellIndex, particleIndex,
-                                                                                    iteratorBehavior);
+                                                                                     iteratorBehavior);
     return {const_cast<ParticleT *>(ptr), nextCellIndex, nextParticleIndex};
   }
 

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -40,15 +40,15 @@ namespace autopas {
  * The image above depicts the segmentation of the surrounding halo volume into six cells, one cell on every side,
  * where the halo cell centers always align with the owned cell center.
  *
- * @tparam Particle Particle type that is used with this container.
+ * @tparam ParticleT Particle type that is used with this container.
  */
-template <class Particle>
-class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> {
+template <class ParticleT>
+class DirectSum : public CellBasedParticleContainer<FullParticleCell<ParticleT>> {
  public:
   /**
    *  Type of the ParticleCell.
    */
-  using ParticleCell = FullParticleCell<Particle>;
+  using ParticleCell = FullParticleCell<ParticleT>;
 
   /**
    *  Type of the Particle.
@@ -298,13 +298,13 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
     }
   }
 
-  std::tuple<const Particle *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
+  std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
                                                            IteratorBehavior iteratorBehavior,
                                                            const std::array<double, 3> &boxMin,
                                                            const std::array<double, 3> &boxMax) const override {
     return getParticleImpl<true>(cellIndex, particleIndex, iteratorBehavior, boxMin, boxMax);
   }
-  std::tuple<const Particle *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
+  std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
                                                            IteratorBehavior iteratorBehavior) const override {
     // this is not a region iter hence we stretch the bounding box to the numeric max
     constexpr std::array<double, 3> boxMin{std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(),
@@ -315,7 +315,7 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
     return getParticleImpl<false>(cellIndex, particleIndex, iteratorBehavior, boxMin, boxMax);
   }
 
-  bool deleteParticle(Particle &particle) override {
+  bool deleteParticle(ParticleT &particle) override {
     // swap-delete helper function
     auto swapDelFromCell = [&](auto &particleCell) -> bool {
       auto &particleVec = particleCell._particles;
@@ -387,7 +387,7 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
    * @return tuple<ParticlePointer, CellIndex, ParticleIndex>
    */
   template <bool regionIter>
-  std::tuple<const Particle *, size_t, size_t> getParticleImpl(size_t cellIndex, size_t particleIndex,
+  std::tuple<const ParticleT *, size_t, size_t> getParticleImpl(size_t cellIndex, size_t particleIndex,
                                                                IteratorBehavior iteratorBehavior,
                                                                const std::array<double, 3> &boxMin,
                                                                const std::array<double, 3> &boxMax) const {
@@ -434,7 +434,7 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
     if (cellIndex >= this->_cells.size()) {
       return {nullptr, 0, 0};
     }
-    const Particle *retPtr = &this->_cells[cellIndex][particleIndex];
+    const ParticleT *retPtr = &this->_cells[cellIndex][particleIndex];
 
     return {retPtr, cellIndex, particleIndex};
   }

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -53,7 +53,7 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<ParticleT>>
   /**
    *  Type of the Particle.
    */
-  using ParticleType = typename CellBasedParticleContainer<ParticleCell>::ParticleType;
+  using ParticleType = ParticleT;
 
   /**
    * Constructor of the DirectSum class

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -299,13 +299,13 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<ParticleT>>
   }
 
   std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
-                                                           IteratorBehavior iteratorBehavior,
-                                                           const std::array<double, 3> &boxMin,
-                                                           const std::array<double, 3> &boxMax) const override {
+                                                            IteratorBehavior iteratorBehavior,
+                                                            const std::array<double, 3> &boxMin,
+                                                            const std::array<double, 3> &boxMax) const override {
     return getParticleImpl<true>(cellIndex, particleIndex, iteratorBehavior, boxMin, boxMax);
   }
   std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
-                                                           IteratorBehavior iteratorBehavior) const override {
+                                                            IteratorBehavior iteratorBehavior) const override {
     // this is not a region iter hence we stretch the bounding box to the numeric max
     constexpr std::array<double, 3> boxMin{std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(),
                                            std::numeric_limits<double>::lowest()};
@@ -388,9 +388,9 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<ParticleT>>
    */
   template <bool regionIter>
   std::tuple<const ParticleT *, size_t, size_t> getParticleImpl(size_t cellIndex, size_t particleIndex,
-                                                               IteratorBehavior iteratorBehavior,
-                                                               const std::array<double, 3> &boxMin,
-                                                               const std::array<double, 3> &boxMax) const {
+                                                                IteratorBehavior iteratorBehavior,
+                                                                const std::array<double, 3> &boxMin,
+                                                                const std::array<double, 3> &boxMax) const {
     // first and last relevant cell index
     const auto [startCellIndex, endCellIndex] = [&]() -> std::tuple<size_t, size_t> {
       // shortcuts to limit the iterator to only part of the domain.

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -40,20 +40,20 @@ namespace autopas {
  * The image above depicts the segmentation of the surrounding halo volume into six cells, one cell on every side,
  * where the halo cell centers always align with the owned cell center.
  *
- * @tparam ParticleT Particle type that is used with this container.
+ * @tparam Particle_T Particle type that is used with this container.
  */
-template <class ParticleT>
-class DirectSum : public CellBasedParticleContainer<FullParticleCell<ParticleT>> {
+template <class Particle_T>
+class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle_T>> {
  public:
   /**
    *  Type of the ParticleCell.
    */
-  using ParticleCell = FullParticleCell<ParticleT>;
+  using ParticleCell = FullParticleCell<Particle_T>;
 
   /**
    *  Type of the Particle.
    */
-  using ParticleType = ParticleT;
+  using ParticleType = Particle_T;
 
   /**
    * Constructor of the DirectSum class
@@ -298,14 +298,14 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<ParticleT>>
     }
   }
 
-  std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
-                                                            IteratorBehavior iteratorBehavior,
-                                                            const std::array<double, 3> &boxMin,
-                                                            const std::array<double, 3> &boxMax) const override {
+  std::tuple<const Particle_T *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
+                                                             IteratorBehavior iteratorBehavior,
+                                                             const std::array<double, 3> &boxMin,
+                                                             const std::array<double, 3> &boxMax) const override {
     return getParticleImpl<true>(cellIndex, particleIndex, iteratorBehavior, boxMin, boxMax);
   }
-  std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
-                                                            IteratorBehavior iteratorBehavior) const override {
+  std::tuple<const Particle_T *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
+                                                             IteratorBehavior iteratorBehavior) const override {
     // this is not a region iter hence we stretch the bounding box to the numeric max
     constexpr std::array<double, 3> boxMin{std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(),
                                            std::numeric_limits<double>::lowest()};
@@ -315,7 +315,7 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<ParticleT>>
     return getParticleImpl<false>(cellIndex, particleIndex, iteratorBehavior, boxMin, boxMax);
   }
 
-  bool deleteParticle(ParticleT &particle) override {
+  bool deleteParticle(Particle_T &particle) override {
     // swap-delete helper function
     auto swapDelFromCell = [&](auto &particleCell) -> bool {
       auto &particleVec = particleCell._particles;
@@ -387,10 +387,10 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<ParticleT>>
    * @return tuple<ParticlePointer, CellIndex, ParticleIndex>
    */
   template <bool regionIter>
-  std::tuple<const ParticleT *, size_t, size_t> getParticleImpl(size_t cellIndex, size_t particleIndex,
-                                                                IteratorBehavior iteratorBehavior,
-                                                                const std::array<double, 3> &boxMin,
-                                                                const std::array<double, 3> &boxMax) const {
+  std::tuple<const Particle_T *, size_t, size_t> getParticleImpl(size_t cellIndex, size_t particleIndex,
+                                                                 IteratorBehavior iteratorBehavior,
+                                                                 const std::array<double, 3> &boxMin,
+                                                                 const std::array<double, 3> &boxMax) const {
     // first and last relevant cell index
     const auto [startCellIndex, endCellIndex] = [&]() -> std::tuple<size_t, size_t> {
       // shortcuts to limit the iterator to only part of the domain.
@@ -434,7 +434,7 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<ParticleT>>
     if (cellIndex >= this->_cells.size()) {
       return {nullptr, 0, 0};
     }
-    const ParticleT *retPtr = &this->_cells[cellIndex][particleIndex];
+    const Particle_T *retPtr = &this->_cells[cellIndex][particleIndex];
 
     return {retPtr, cellIndex, particleIndex};
   }

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -34,15 +34,15 @@ namespace autopas {
  * These cells dimensions are at least as large as the given cutoff radius,
  * therefore short-range interactions only need to be calculated between
  * particles in neighboring cells.
- * @tparam Particle type of the Particle
+ * @tparam ParticleT type of the Particle
  */
-template <class Particle>
-class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>> {
+template <class ParticleT>
+class LinkedCells : public CellBasedParticleContainer<FullParticleCell<ParticleT>> {
  public:
   /**
    *  Type of the ParticleCell.
    */
-  using ParticleCell = FullParticleCell<Particle>;
+  using ParticleCell = FullParticleCell<ParticleT>;
 
   /**
    *  Type of the Particle.
@@ -196,13 +196,13 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
                                  this->getCellBlock().getCellLength(), 0);
   }
 
-  std::tuple<const Particle *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
+  std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
                                                            IteratorBehavior iteratorBehavior,
                                                            const std::array<double, 3> &boxMin,
                                                            const std::array<double, 3> &boxMax) const override {
     return getParticleImpl<true>(cellIndex, particleIndex, iteratorBehavior, boxMin, boxMax);
   }
-  std::tuple<const Particle *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
+  std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
                                                            IteratorBehavior iteratorBehavior) const override {
     // this is not a region iter hence we stretch the bounding box to the numeric max
     constexpr std::array<double, 3> boxMin{std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(),
@@ -225,7 +225,7 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
    * @return tuple<ParticlePointer, CellIndex, ParticleIndex>
    */
   template <bool regionIter>
-  std::tuple<const Particle *, size_t, size_t> getParticleImpl(size_t cellIndex, size_t particleIndex,
+  std::tuple<const ParticleT *, size_t, size_t> getParticleImpl(size_t cellIndex, size_t particleIndex,
                                                                IteratorBehavior iteratorBehavior,
                                                                const std::array<double, 3> &boxMin,
                                                                const std::array<double, 3> &boxMax) const {
@@ -279,12 +279,12 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
     if (cellIndex > endCellIndex) {
       return {nullptr, 0, 0};
     }
-    const Particle *retPtr = &this->_cells[cellIndex][particleIndex];
+    const ParticleT *retPtr = &this->_cells[cellIndex][particleIndex];
 
     return {retPtr, cellIndex, particleIndex};
   }
 
-  bool deleteParticle(Particle &particle) override {
+  bool deleteParticle(ParticleT &particle) override {
     // deduce into which vector the reference points
     auto &particleVec = _cellBlock.getContainingCell(particle.getR())._particles;
     const bool isRearParticle = &particle == &particleVec.back();
@@ -318,7 +318,7 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
 
   /**
    * Execute code on all particles in this container as defined by a lambda function.
-   * @tparam Lambda (Particle &p) -> void
+   * @tparam Lambda (ParticleT &p) -> void
    * @param forEachLambda code to be executed on all particles
    * @param behavior @see IteratorBehavior
    */
@@ -339,7 +339,7 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
 
   /**
    * Reduce properties of particles as defined by a lambda function.
-   * @tparam Lambda (Particle p, A initialValue) -> void
+   * @tparam Lambda (ParticleT p, A initialValue) -> void
    * @tparam A type of particle attribute to be reduced
    * @param reduceLambda code to reduce properties of particles
    * @param result reference to result of type A
@@ -375,7 +375,7 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
 
   /**
    * Execute code on all particles in this container in a certain region as defined by a lambda function.
-   * @tparam Lambda (Particle &p) -> void
+   * @tparam Lambda (ParticleT &p) -> void
    * @param forEachLambda code to be executed on all particles
    * @param lowerCorner lower corner of bounding box
    * @param higherCorner higher corner of bounding box
@@ -413,7 +413,7 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
 
   /**
    * Execute code on all particles in this container in a certain region as defined by a lambda function.
-   * @tparam Lambda (Particle &p, A &result) -> void
+   * @tparam Lambda (ParticleT &p, A &result) -> void
    * @tparam A type of reduction Value
    * @param reduceLambda code to be executed on all particles
    * @param result reference to starting and final value for reduction

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -197,13 +197,13 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<ParticleT
   }
 
   std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
-                                                           IteratorBehavior iteratorBehavior,
-                                                           const std::array<double, 3> &boxMin,
-                                                           const std::array<double, 3> &boxMax) const override {
+                                                            IteratorBehavior iteratorBehavior,
+                                                            const std::array<double, 3> &boxMin,
+                                                            const std::array<double, 3> &boxMax) const override {
     return getParticleImpl<true>(cellIndex, particleIndex, iteratorBehavior, boxMin, boxMax);
   }
   std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
-                                                           IteratorBehavior iteratorBehavior) const override {
+                                                            IteratorBehavior iteratorBehavior) const override {
     // this is not a region iter hence we stretch the bounding box to the numeric max
     constexpr std::array<double, 3> boxMin{std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(),
                                            std::numeric_limits<double>::lowest()};
@@ -226,9 +226,9 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<ParticleT
    */
   template <bool regionIter>
   std::tuple<const ParticleT *, size_t, size_t> getParticleImpl(size_t cellIndex, size_t particleIndex,
-                                                               IteratorBehavior iteratorBehavior,
-                                                               const std::array<double, 3> &boxMin,
-                                                               const std::array<double, 3> &boxMax) const {
+                                                                IteratorBehavior iteratorBehavior,
+                                                                const std::array<double, 3> &boxMin,
+                                                                const std::array<double, 3> &boxMax) const {
     using namespace autopas::utils::ArrayMath::literals;
 
     std::array<double, 3> boxMinWithSafetyMargin = boxMin;

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -34,15 +34,15 @@ namespace autopas {
  * These cells dimensions are at least as large as the given cutoff radius,
  * therefore short-range interactions only need to be calculated between
  * particles in neighboring cells.
- * @tparam ParticleT type of the Particle
+ * @tparam Particle_T type of the Particle
  */
-template <class ParticleT>
-class LinkedCells : public CellBasedParticleContainer<FullParticleCell<ParticleT>> {
+template <class Particle_T>
+class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle_T>> {
  public:
   /**
    *  Type of the ParticleCell.
    */
-  using ParticleCell = FullParticleCell<ParticleT>;
+  using ParticleCell = FullParticleCell<Particle_T>;
 
   /**
    *  Type of the Particle.
@@ -196,14 +196,14 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<ParticleT
                                  this->getCellBlock().getCellLength(), 0);
   }
 
-  std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
-                                                            IteratorBehavior iteratorBehavior,
-                                                            const std::array<double, 3> &boxMin,
-                                                            const std::array<double, 3> &boxMax) const override {
+  std::tuple<const Particle_T *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
+                                                             IteratorBehavior iteratorBehavior,
+                                                             const std::array<double, 3> &boxMin,
+                                                             const std::array<double, 3> &boxMax) const override {
     return getParticleImpl<true>(cellIndex, particleIndex, iteratorBehavior, boxMin, boxMax);
   }
-  std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
-                                                            IteratorBehavior iteratorBehavior) const override {
+  std::tuple<const Particle_T *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
+                                                             IteratorBehavior iteratorBehavior) const override {
     // this is not a region iter hence we stretch the bounding box to the numeric max
     constexpr std::array<double, 3> boxMin{std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(),
                                            std::numeric_limits<double>::lowest()};
@@ -225,10 +225,10 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<ParticleT
    * @return tuple<ParticlePointer, CellIndex, ParticleIndex>
    */
   template <bool regionIter>
-  std::tuple<const ParticleT *, size_t, size_t> getParticleImpl(size_t cellIndex, size_t particleIndex,
-                                                                IteratorBehavior iteratorBehavior,
-                                                                const std::array<double, 3> &boxMin,
-                                                                const std::array<double, 3> &boxMax) const {
+  std::tuple<const Particle_T *, size_t, size_t> getParticleImpl(size_t cellIndex, size_t particleIndex,
+                                                                 IteratorBehavior iteratorBehavior,
+                                                                 const std::array<double, 3> &boxMin,
+                                                                 const std::array<double, 3> &boxMax) const {
     using namespace autopas::utils::ArrayMath::literals;
 
     std::array<double, 3> boxMinWithSafetyMargin = boxMin;
@@ -279,12 +279,12 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<ParticleT
     if (cellIndex > endCellIndex) {
       return {nullptr, 0, 0};
     }
-    const ParticleT *retPtr = &this->_cells[cellIndex][particleIndex];
+    const Particle_T *retPtr = &this->_cells[cellIndex][particleIndex];
 
     return {retPtr, cellIndex, particleIndex};
   }
 
-  bool deleteParticle(ParticleT &particle) override {
+  bool deleteParticle(Particle_T &particle) override {
     // deduce into which vector the reference points
     auto &particleVec = _cellBlock.getContainingCell(particle.getR())._particles;
     const bool isRearParticle = &particle == &particleVec.back();
@@ -318,7 +318,7 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<ParticleT
 
   /**
    * Execute code on all particles in this container as defined by a lambda function.
-   * @tparam Lambda (ParticleT &p) -> void
+   * @tparam Lambda (Particle_T &p) -> void
    * @param forEachLambda code to be executed on all particles
    * @param behavior @see IteratorBehavior
    */
@@ -339,7 +339,7 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<ParticleT
 
   /**
    * Reduce properties of particles as defined by a lambda function.
-   * @tparam Lambda (ParticleT p, A initialValue) -> void
+   * @tparam Lambda (Particle_T p, A initialValue) -> void
    * @tparam A type of particle attribute to be reduced
    * @param reduceLambda code to reduce properties of particles
    * @param result reference to result of type A
@@ -375,7 +375,7 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<ParticleT
 
   /**
    * Execute code on all particles in this container in a certain region as defined by a lambda function.
-   * @tparam Lambda (ParticleT &p) -> void
+   * @tparam Lambda (Particle_T &p) -> void
    * @param forEachLambda code to be executed on all particles
    * @param lowerCorner lower corner of bounding box
    * @param higherCorner higher corner of bounding box
@@ -413,7 +413,7 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<ParticleT
 
   /**
    * Execute code on all particles in this container in a certain region as defined by a lambda function.
-   * @tparam Lambda (ParticleT &p, A &result) -> void
+   * @tparam Lambda (Particle_T &p, A &result) -> void
    * @tparam A type of reduction Value
    * @param reduceLambda code to be executed on all particles
    * @param result reference to starting and final value for reduction

--- a/src/autopas/containers/linkedCells/LinkedCellsReferences.h
+++ b/src/autopas/containers/linkedCells/LinkedCellsReferences.h
@@ -190,13 +190,13 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
   }
 
   std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
-                                                           IteratorBehavior iteratorBehavior,
-                                                           const std::array<double, 3> &boxMin,
-                                                           const std::array<double, 3> &boxMax) const override {
+                                                            IteratorBehavior iteratorBehavior,
+                                                            const std::array<double, 3> &boxMin,
+                                                            const std::array<double, 3> &boxMax) const override {
     return getParticleImpl<true>(cellIndex, particleIndex, iteratorBehavior, boxMin, boxMax);
   }
   std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
-                                                           IteratorBehavior iteratorBehavior) const override {
+                                                            IteratorBehavior iteratorBehavior) const override {
     // this is not a region iter hence we stretch the bounding box to the numeric max
     constexpr std::array<double, 3> boxMin{std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(),
                                            std::numeric_limits<double>::lowest()};
@@ -219,9 +219,9 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
    */
   template <bool regionIter>
   std::tuple<const ParticleT *, size_t, size_t> getParticleImpl(size_t cellIndex, size_t particleIndex,
-                                                               IteratorBehavior iteratorBehavior,
-                                                               const std::array<double, 3> &boxMin,
-                                                               const std::array<double, 3> &boxMax) const {
+                                                                IteratorBehavior iteratorBehavior,
+                                                                const std::array<double, 3> &boxMin,
+                                                                const std::array<double, 3> &boxMax) const {
     using namespace autopas::utils::ArrayMath::literals;
 
     std::array<double, 3> boxMinWithSafetyMargin = boxMin;

--- a/src/autopas/containers/linkedCells/LinkedCellsReferences.h
+++ b/src/autopas/containers/linkedCells/LinkedCellsReferences.h
@@ -35,17 +35,17 @@ namespace autopas {
  * particles in neighboring cells.
  * @tparam ParticleCell type of the ParticleCells that are used to store the particles
  */
-template <class Particle>
-class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticleCell<Particle>> {
+template <class ParticleT>
+class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticleCell<ParticleT>> {
  public:
   /**
    *  Type of the Particle.
    */
-  using ParticleType = Particle;
+  using ParticleType = ParticleT;
   /**
    *  Type of the ParticleCell.
    */
-  using ReferenceCell = ReferenceParticleCell<Particle>;
+  using ReferenceCell = ReferenceParticleCell<ParticleT>;
   /**
    * Constructor of the LinkedCells class
    * @param boxMin
@@ -189,13 +189,13 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
     traversal->endTraversal();
   }
 
-  std::tuple<const Particle *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
+  std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
                                                            IteratorBehavior iteratorBehavior,
                                                            const std::array<double, 3> &boxMin,
                                                            const std::array<double, 3> &boxMax) const override {
     return getParticleImpl<true>(cellIndex, particleIndex, iteratorBehavior, boxMin, boxMax);
   }
-  std::tuple<const Particle *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
+  std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
                                                            IteratorBehavior iteratorBehavior) const override {
     // this is not a region iter hence we stretch the bounding box to the numeric max
     constexpr std::array<double, 3> boxMin{std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(),
@@ -218,7 +218,7 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
    * @return tuple<ParticlePointer, CellIndex, ParticleIndex>
    */
   template <bool regionIter>
-  std::tuple<const Particle *, size_t, size_t> getParticleImpl(size_t cellIndex, size_t particleIndex,
+  std::tuple<const ParticleT *, size_t, size_t> getParticleImpl(size_t cellIndex, size_t particleIndex,
                                                                IteratorBehavior iteratorBehavior,
                                                                const std::array<double, 3> &boxMin,
                                                                const std::array<double, 3> &boxMax) const {
@@ -272,12 +272,12 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
     if (cellIndex > endCellIndex) {
       return {nullptr, 0, 0};
     }
-    const Particle *retPtr = &this->_cells[cellIndex][particleIndex];
+    const ParticleT *retPtr = &this->_cells[cellIndex][particleIndex];
 
     return {retPtr, cellIndex, particleIndex};
   }
 
-  bool deleteParticle(Particle &particle) override {
+  bool deleteParticle(ParticleT &particle) override {
     // This function doesn't actually delete anything as it would mess up the reference structure.
     internal::markParticleAsDeleted(particle);
     return false;

--- a/src/autopas/containers/linkedCells/LinkedCellsReferences.h
+++ b/src/autopas/containers/linkedCells/LinkedCellsReferences.h
@@ -35,17 +35,17 @@ namespace autopas {
  * particles in neighboring cells.
  * @tparam ParticleCell type of the ParticleCells that are used to store the particles
  */
-template <class ParticleT>
-class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticleCell<ParticleT>> {
+template <class Particle_T>
+class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticleCell<Particle_T>> {
  public:
   /**
    *  Type of the Particle.
    */
-  using ParticleType = ParticleT;
+  using ParticleType = Particle_T;
   /**
    *  Type of the ParticleCell.
    */
-  using ReferenceCell = ReferenceParticleCell<ParticleT>;
+  using ReferenceCell = ReferenceParticleCell<Particle_T>;
   /**
    * Constructor of the LinkedCells class
    * @param boxMin
@@ -189,14 +189,14 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
     traversal->endTraversal();
   }
 
-  std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
-                                                            IteratorBehavior iteratorBehavior,
-                                                            const std::array<double, 3> &boxMin,
-                                                            const std::array<double, 3> &boxMax) const override {
+  std::tuple<const Particle_T *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
+                                                             IteratorBehavior iteratorBehavior,
+                                                             const std::array<double, 3> &boxMin,
+                                                             const std::array<double, 3> &boxMax) const override {
     return getParticleImpl<true>(cellIndex, particleIndex, iteratorBehavior, boxMin, boxMax);
   }
-  std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
-                                                            IteratorBehavior iteratorBehavior) const override {
+  std::tuple<const Particle_T *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
+                                                             IteratorBehavior iteratorBehavior) const override {
     // this is not a region iter hence we stretch the bounding box to the numeric max
     constexpr std::array<double, 3> boxMin{std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(),
                                            std::numeric_limits<double>::lowest()};
@@ -218,10 +218,10 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
    * @return tuple<ParticlePointer, CellIndex, ParticleIndex>
    */
   template <bool regionIter>
-  std::tuple<const ParticleT *, size_t, size_t> getParticleImpl(size_t cellIndex, size_t particleIndex,
-                                                                IteratorBehavior iteratorBehavior,
-                                                                const std::array<double, 3> &boxMin,
-                                                                const std::array<double, 3> &boxMax) const {
+  std::tuple<const Particle_T *, size_t, size_t> getParticleImpl(size_t cellIndex, size_t particleIndex,
+                                                                 IteratorBehavior iteratorBehavior,
+                                                                 const std::array<double, 3> &boxMin,
+                                                                 const std::array<double, 3> &boxMax) const {
     using namespace autopas::utils::ArrayMath::literals;
 
     std::array<double, 3> boxMinWithSafetyMargin = boxMin;
@@ -272,12 +272,12 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
     if (cellIndex > endCellIndex) {
       return {nullptr, 0, 0};
     }
-    const ParticleT *retPtr = &this->_cells[cellIndex][particleIndex];
+    const Particle_T *retPtr = &this->_cells[cellIndex][particleIndex];
 
     return {retPtr, cellIndex, particleIndex};
   }
 
-  bool deleteParticle(ParticleT &particle) override {
+  bool deleteParticle(Particle_T &particle) override {
     // This function doesn't actually delete anything as it would mess up the reference structure.
     internal::markParticleAsDeleted(particle);
     return false;

--- a/src/autopas/containers/linkedCells/ParticleVector.h
+++ b/src/autopas/containers/linkedCells/ParticleVector.h
@@ -16,12 +16,12 @@
  * This class uses a std::vector to store particles and allows access to its references.
  * It also keeps track, which references are no longer valid, which happens
  * when operations like delete and resize are performed.
- * @tparam Type of the Particle that is being stored
+ * @tparam ParticleT of the Particle that is being stored
  */
-template <class Type>
+template <class ParticleT>
 class ParticleVector {
  public:
-  ParticleVector<Type>() = default;
+  ParticleVector<ParticleT>() = default;
 
   /**
    * Returns the dirty flag, indicating whether Particles exist in the vector that are not stored in a cell yet.
@@ -63,7 +63,7 @@ class ParticleVector {
    * Add a Particle to the data structure.
    * @param particle A reference to the particle to be stored
    */
-  void push_back(const Type &particle) {
+  void push_back(const ParticleT &particle) {
     _particleListLock.lock();
     _dirty = true;
     if (_particleListImp.capacity() == _particleListImp.size()) {
@@ -108,7 +108,7 @@ class ParticleVector {
    */
   template <typename Lambda>
   void forEach(Lambda forEachLambda) {
-    for (Type &p : _particleListImp) {
+    for (ParticleT &p : _particleListImp) {
       forEachLambda(p);
     }
   }
@@ -120,7 +120,7 @@ class ParticleVector {
    */
   template <typename Lambda, typename A>
   void reduce(Lambda reduceLambda, A &result) {
-    for (Type &p : _particleListImp) {
+    for (ParticleT &p : _particleListImp) {
       reduceLambda(p, result);
     }
   }
@@ -135,5 +135,5 @@ class ParticleVector {
    */
   size_t _dirtyIndex{0};
   autopas::AutoPasLock _particleListLock;
-  std::vector<Type> _particleListImp;
+  std::vector<ParticleT> _particleListImp;
 };

--- a/src/autopas/containers/linkedCells/ParticleVector.h
+++ b/src/autopas/containers/linkedCells/ParticleVector.h
@@ -16,12 +16,12 @@
  * This class uses a std::vector to store particles and allows access to its references.
  * It also keeps track, which references are no longer valid, which happens
  * when operations like delete and resize are performed.
- * @tparam ParticleT of the Particle that is being stored
+ * @tparam Particle_T of the Particle that is being stored
  */
-template <class ParticleT>
+template <class Particle_T>
 class ParticleVector {
  public:
-  ParticleVector<ParticleT>() = default;
+  ParticleVector<Particle_T>() = default;
 
   /**
    * Returns the dirty flag, indicating whether Particles exist in the vector that are not stored in a cell yet.
@@ -63,7 +63,7 @@ class ParticleVector {
    * Add a Particle to the data structure.
    * @param particle A reference to the particle to be stored
    */
-  void push_back(const ParticleT &particle) {
+  void push_back(const Particle_T &particle) {
     _particleListLock.lock();
     _dirty = true;
     if (_particleListImp.capacity() == _particleListImp.size()) {
@@ -108,7 +108,7 @@ class ParticleVector {
    */
   template <typename Lambda>
   void forEach(Lambda forEachLambda) {
-    for (ParticleT &p : _particleListImp) {
+    for (Particle_T &p : _particleListImp) {
       forEachLambda(p);
     }
   }
@@ -120,7 +120,7 @@ class ParticleVector {
    */
   template <typename Lambda, typename A>
   void reduce(Lambda reduceLambda, A &result) {
-    for (ParticleT &p : _particleListImp) {
+    for (Particle_T &p : _particleListImp) {
       reduceLambda(p, result);
     }
   }
@@ -135,5 +135,5 @@ class ParticleVector {
    */
   size_t _dirtyIndex{0};
   autopas::AutoPasLock _particleListLock;
-  std::vector<ParticleT> _particleListImp;
+  std::vector<Particle_T> _particleListImp;
 };

--- a/src/autopas/containers/octree/Octree.h
+++ b/src/autopas/containers/octree/Octree.h
@@ -189,13 +189,13 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<ParticleT>>,
   void rebuildNeighborLists(TraversalInterface *traversal) override {}
 
   std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
-                                                           IteratorBehavior iteratorBehavior,
-                                                           const std::array<double, 3> &boxMin,
-                                                           const std::array<double, 3> &boxMax) const override {
+                                                            IteratorBehavior iteratorBehavior,
+                                                            const std::array<double, 3> &boxMin,
+                                                            const std::array<double, 3> &boxMax) const override {
     return getParticleImpl<true>(cellIndex, particleIndex, iteratorBehavior, boxMin, boxMax);
   }
   std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
-                                                           IteratorBehavior iteratorBehavior) const override {
+                                                            IteratorBehavior iteratorBehavior) const override {
     // this is not a region iter hence we stretch the bounding box to the numeric max
     constexpr std::array<double, 3> boxMin{std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(),
                                            std::numeric_limits<double>::lowest()};
@@ -352,7 +352,8 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<ParticleT>>,
    */
   [[nodiscard]] ContainerIterator<ParticleT, false, false> begin(
       IteratorBehavior behavior,
-      typename ContainerIterator<ParticleT, false, false>::ParticleVecType *additionalVectors = nullptr) const override {
+      typename ContainerIterator<ParticleT, false, false>::ParticleVecType *additionalVectors =
+          nullptr) const override {
     return ContainerIterator<ParticleT, false, false>(*this, behavior, additionalVectors);
   }
 

--- a/src/autopas/containers/octree/Octree.h
+++ b/src/autopas/containers/octree/Octree.h
@@ -34,16 +34,16 @@ namespace autopas {
  *
  * @note Octree has a particular to interpret the index of the ContainerIterator. For details see getParticleImpl().
  *
- * @tparam Particle
+ * @tparam ParticleT
  */
-template <class Particle>
-class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
+template <class ParticleT>
+class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<ParticleT>>,
                public internal::CellBorderAndFlagManager {
  public:
   /**
    * The particle cell used in this CellBasedParticleContainer
    */
-  using ParticleCell = OctreeNodeWrapper<Particle>;
+  using ParticleCell = OctreeNodeWrapper<ParticleT>;
 
   /**
    * The particle type used in this container.
@@ -83,14 +83,14 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
 
     // Create the octree for the owned particles
     this->_cells.push_back(
-        OctreeNodeWrapper<Particle>(boxMin, boxMax, treeSplitThreshold, interactionLength, cellSizeFactor));
+        OctreeNodeWrapper<ParticleT>(boxMin, boxMax, treeSplitThreshold, interactionLength, cellSizeFactor));
 
     // Extend the halo region with cutoff + skin in all dimensions
     auto haloBoxMin = boxMin - interactionLength;
     auto haloBoxMax = boxMax + interactionLength;
     // Create the octree for the halo particles
     this->_cells.push_back(
-        OctreeNodeWrapper<Particle>(haloBoxMin, haloBoxMax, treeSplitThreshold, interactionLength, cellSizeFactor));
+        OctreeNodeWrapper<ParticleT>(haloBoxMin, haloBoxMax, treeSplitThreshold, interactionLength, cellSizeFactor));
 
     // set type of particles in the two cells
     this->_cells[CellTypes::OWNED].setPossibleParticleOwnerships(OwnershipState::owned);
@@ -99,7 +99,7 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
 
   [[nodiscard]] std::vector<ParticleType> updateContainer(bool keepNeighborListValid) override {
     // invalidParticles: all outside boxMin/Max
-    std::vector<Particle> invalidParticles{};
+    std::vector<ParticleT> invalidParticles{};
 
     if (keepNeighborListValid) {
       invalidParticles = LeavingParticleCollector::collectParticlesAndMarkNonOwnedAsDummy(*this);
@@ -111,9 +111,9 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
       //   The problem is captured by https://github.com/AutoPas/AutoPas/issues/622
 
       // 1. Copy all particles out of the container
-      std::vector<Particle *> particleRefs;
+      std::vector<ParticleT *> particleRefs;
       this->_cells[CellTypes::OWNED].collectAllParticles(particleRefs);
-      std::vector<Particle> particles{};
+      std::vector<ParticleT> particles{};
       particles.reserve(particleRefs.size());
 
       for (auto *p : particleRefs) {
@@ -188,13 +188,13 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
 
   void rebuildNeighborLists(TraversalInterface *traversal) override {}
 
-  std::tuple<const Particle *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
+  std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
                                                            IteratorBehavior iteratorBehavior,
                                                            const std::array<double, 3> &boxMin,
                                                            const std::array<double, 3> &boxMax) const override {
     return getParticleImpl<true>(cellIndex, particleIndex, iteratorBehavior, boxMin, boxMax);
   }
-  std::tuple<const Particle *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
+  std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
                                                            IteratorBehavior iteratorBehavior) const override {
     // this is not a region iter hence we stretch the bounding box to the numeric max
     constexpr std::array<double, 3> boxMin{std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(),
@@ -253,7 +253,7 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
     }
 
     std::vector<size_t> currentCellIndex{};
-    OctreeLeafNode<Particle> *currentCellPtr = nullptr;
+    OctreeLeafNode<ParticleT> *currentCellPtr = nullptr;
 
     std::tie(currentCellIndex, currentCellPtr) = getLeafCellByIndex(cellIndex);
     // check the data behind the indices
@@ -271,7 +271,7 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
       return {nullptr, 0, 0};
     }
     // parse cellIndex and get referenced cell and particle
-    const Particle *retPtr = &((*currentCellPtr)[particleIndex]);
+    const ParticleT *retPtr = &((*currentCellPtr)[particleIndex]);
 
     // if no err value was set, convert cell index from vec to integer
     if (currentCellIndex.empty()) {
@@ -297,27 +297,27 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
    * @param cellIndex Index in the tree as integer
    * @return tuple<index as vector, pointer to cell>
    */
-  std::tuple<std::vector<size_t>, OctreeLeafNode<Particle> *> getLeafCellByIndex(size_t cellIndex) const {
+  std::tuple<std::vector<size_t>, OctreeLeafNode<ParticleT> *> getLeafCellByIndex(size_t cellIndex) const {
     // parse cellIndex and get referenced cell and particle
     std::vector<size_t> currentCellIndex;
     // constant heuristic for the tree depth
     currentCellIndex.reserve(10);
     currentCellIndex.push_back(cellIndex % 10);
     cellIndex /= 10;
-    OctreeNodeInterface<Particle> *currentCell = this->_cells[currentCellIndex.back()].getRaw();
+    OctreeNodeInterface<ParticleT> *currentCell = this->_cells[currentCellIndex.back()].getRaw();
     // don't restrict loop via cellIndex because it might have "hidden" leading 0
     while (currentCell->hasChildren()) {
       currentCellIndex.push_back(cellIndex % 10);
       cellIndex /= 10;
       currentCell = currentCell->getChild(currentCellIndex.back());
     }
-    return {currentCellIndex, dynamic_cast<OctreeLeafNode<Particle> *>(currentCell)};
+    return {currentCellIndex, dynamic_cast<OctreeLeafNode<ParticleT> *>(currentCell)};
   }
 
   /**
    * @copydoc ParticleContainerInterface::deleteParticle()
    */
-  bool deleteParticle(Particle &particle) override {
+  bool deleteParticle(ParticleT &particle) override {
     if (particle.isOwned()) {
       return this->_cells[CellTypes::OWNED].deleteParticle(particle);
     } else if (particle.isHalo()) {
@@ -341,37 +341,37 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
   /**
    * @copydoc ParticleContainerInterface::begin()
    */
-  [[nodiscard]] ContainerIterator<Particle, true, false> begin(
+  [[nodiscard]] ContainerIterator<ParticleT, true, false> begin(
       IteratorBehavior behavior,
-      typename ContainerIterator<Particle, true, false>::ParticleVecType *additionalVectors = nullptr) override {
-    return ContainerIterator<Particle, true, false>(*this, behavior, additionalVectors);
+      typename ContainerIterator<ParticleT, true, false>::ParticleVecType *additionalVectors = nullptr) override {
+    return ContainerIterator<ParticleT, true, false>(*this, behavior, additionalVectors);
   }
 
   /**
    * @copydoc ParticleContainerInterface::begin()
    */
-  [[nodiscard]] ContainerIterator<Particle, false, false> begin(
+  [[nodiscard]] ContainerIterator<ParticleT, false, false> begin(
       IteratorBehavior behavior,
-      typename ContainerIterator<Particle, false, false>::ParticleVecType *additionalVectors = nullptr) const override {
-    return ContainerIterator<Particle, false, false>(*this, behavior, additionalVectors);
+      typename ContainerIterator<ParticleT, false, false>::ParticleVecType *additionalVectors = nullptr) const override {
+    return ContainerIterator<ParticleT, false, false>(*this, behavior, additionalVectors);
   }
 
   /**
    * @copydoc ParticleContainerInterface::getRegionIterator()
    */
-  [[nodiscard]] ContainerIterator<Particle, true, true> getRegionIterator(
+  [[nodiscard]] ContainerIterator<ParticleT, true, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner, IteratorBehavior behavior,
-      typename ContainerIterator<Particle, true, true>::ParticleVecType *additionalVectors = nullptr) override {
-    return ContainerIterator<Particle, true, true>(*this, behavior, additionalVectors, lowerCorner, higherCorner);
+      typename ContainerIterator<ParticleT, true, true>::ParticleVecType *additionalVectors = nullptr) override {
+    return ContainerIterator<ParticleT, true, true>(*this, behavior, additionalVectors, lowerCorner, higherCorner);
   }
 
   /**
    * @copydoc ParticleContainerInterface::getRegionIterator()
    */
-  [[nodiscard]] ContainerIterator<Particle, false, true> getRegionIterator(
+  [[nodiscard]] ContainerIterator<ParticleT, false, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner, IteratorBehavior behavior,
-      typename ContainerIterator<Particle, false, true>::ParticleVecType *additionalVectors = nullptr) const override {
-    return ContainerIterator<Particle, false, true>(*this, behavior, additionalVectors, lowerCorner, higherCorner);
+      typename ContainerIterator<ParticleT, false, true>::ParticleVecType *additionalVectors = nullptr) const override {
+    return ContainerIterator<ParticleT, false, true>(*this, behavior, additionalVectors, lowerCorner, higherCorner);
   }
 
   /**
@@ -420,7 +420,7 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
 
   /**
    * Execute code on all particles in this container as defined by a lambda function.
-   * @tparam Lambda (Particle &p) -> void
+   * @tparam Lambda (ParticleT &p) -> void
    * @param forEachLambda code to be executed on all particles
    * @param behavior @see IteratorBehavior
    */
@@ -434,7 +434,7 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
 
   /**
    * Reduce properties of particles as defined by a lambda function.
-   * @tparam Lambda (Particle p, A initialValue) -> void
+   * @tparam Lambda (ParticleT p, A initialValue) -> void
    * @tparam A type of particle attribute to be reduced
    * @param reduceLambda code to reduce properties of particles
    * @param result reference to result of type A
@@ -492,8 +492,8 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
    * @return tuple<nextLeafCell, nextParticleIndex>
    */
   template <bool regionIter>
-  std::tuple<OctreeLeafNode<Particle> *, size_t> advanceIteratorIndices(
-      std::vector<size_t> &currentCellIndex, OctreeNodeInterface<Particle> *const currentCellPtr, size_t particleIndex,
+  std::tuple<OctreeLeafNode<ParticleT> *, size_t> advanceIteratorIndices(
+      std::vector<size_t> &currentCellIndex, OctreeNodeInterface<ParticleT> *const currentCellPtr, size_t particleIndex,
       IteratorBehavior iteratorBehavior, const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax,
       const std::array<double, 3> &boxMinWithSafetyMargin, const std::array<double, 3> &boxMaxWithSafetyMargin) const {
     // TODO: parallelize at the higher tree levels. Choose tree level to parallelize via log_8(numThreads)
@@ -502,11 +502,11 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
     //            ? 0
     //            : static_cast<size_t>(std::ceil(std::log(static_cast<double>(autopas_get_num_threads())) /
     //            std::log(8.)));
-    OctreeNodeInterface<Particle> *currentCellInterfacePtr = currentCellPtr;
-    OctreeLeafNode<Particle> *currentLeafCellPtr = nullptr;
+    OctreeNodeInterface<ParticleT> *currentCellInterfacePtr = currentCellPtr;
+    OctreeLeafNode<ParticleT> *currentLeafCellPtr = nullptr;
 
     // helper function:
-    auto cellIsRelevant = [&](const OctreeNodeInterface<Particle> *const cellPtr) {
+    auto cellIsRelevant = [&](const OctreeNodeInterface<ParticleT> *const cellPtr) {
       bool isRelevant = cellPtr->size() > 0;
       if constexpr (regionIter) {
         isRelevant = utils::boxesOverlap(cellPtr->getBoxMin(), cellPtr->getBoxMax(), boxMinWithSafetyMargin,
@@ -587,7 +587,7 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
       }
 
       // at this point we should point to a leaf. All other cases should have hit a return earlier.
-      currentLeafCellPtr = dynamic_cast<OctreeLeafNode<Particle> *>(currentCellInterfacePtr);
+      currentLeafCellPtr = dynamic_cast<OctreeLeafNode<ParticleT> *>(currentCellInterfacePtr);
       // sanity check
       if (currentLeafCellPtr == nullptr) {
         utils::ExceptionHandler::exception("Expected a leaf node but didn't get one!");
@@ -601,7 +601,7 @@ class Octree : public CellBasedParticleContainer<OctreeNodeWrapper<Particle>>,
   /**
    * A logger that can be called to log the octree data structure.
    */
-  OctreeLogger<Particle> logger;
+  OctreeLogger<ParticleT> logger;
 
   double skin;
 };

--- a/src/autopas/containers/octree/OctreeInnerNode.h
+++ b/src/autopas/containers/octree/OctreeInnerNode.h
@@ -70,7 +70,7 @@ class OctreeInnerNode : public OctreeNodeInterface<ParticleT> {
 
       // Assign new leaves as the children.
       _children[i] = std::make_unique<OctreeLeafNode<ParticleT>>(newBoxMin, newBoxMax, this, treeSplitThreshold,
-                                                                interactionLength, cellSizeFactor);
+                                                                 interactionLength, cellSizeFactor);
     }
   }
 
@@ -80,7 +80,7 @@ class OctreeInnerNode : public OctreeNodeInterface<ParticleT> {
    */
   OctreeInnerNode(const OctreeInnerNode<ParticleT> &other)
       : OctreeNodeInterface<ParticleT>(other._boxMin, other._boxMax, other._parent, other._treeSplitThreshold,
-                                      other._interactionLength, other._cellSizeFactor) {
+                                       other._interactionLength, other._cellSizeFactor) {
     for (auto i = 0; i < other._children.size(); ++i) {
       auto *otherChild = other._children[i].get();
       if (otherChild->hasChildren()) {
@@ -218,7 +218,7 @@ class OctreeInnerNode : public OctreeNodeInterface<ParticleT> {
   }
 
   std::set<OctreeLeafNode<ParticleT> *> getLeavesInRange(const std::array<double, 3> &min,
-                                                        const std::array<double, 3> &max) override {
+                                                         const std::array<double, 3> &max) override {
     std::set<OctreeLeafNode<ParticleT> *> result;
     for (auto &child : _children) {
       double vol = child->getEnclosedVolumeWith(min, max);

--- a/src/autopas/containers/octree/OctreeInnerNode.h
+++ b/src/autopas/containers/octree/OctreeInnerNode.h
@@ -17,10 +17,10 @@ namespace autopas {
  * Inner nodes of the octree data structure. An inner node always points to eight children, which can either be leaves
  * or inner nodes as well.
  *
- * @tparam ParticleT
+ * @tparam Particle_T
  */
-template <class ParticleT>
-class OctreeInnerNode : public OctreeNodeInterface<ParticleT> {
+template <class Particle_T>
+class OctreeInnerNode : public OctreeNodeInterface<Particle_T> {
  public:
   /**
    * Create an octree inner node that points to eight leaves.
@@ -32,9 +32,9 @@ class OctreeInnerNode : public OctreeNodeInterface<ParticleT> {
    * @param cellSizeFactor The cell size factor
    */
   OctreeInnerNode(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax,
-                  OctreeNodeInterface<ParticleT> *parent, int unsigned treeSplitThreshold, double interactionLength,
+                  OctreeNodeInterface<Particle_T> *parent, int unsigned treeSplitThreshold, double interactionLength,
                   double cellSizeFactor)
-      : OctreeNodeInterface<ParticleT>(boxMin, boxMax, parent, treeSplitThreshold, interactionLength, cellSizeFactor) {
+      : OctreeNodeInterface<Particle_T>(boxMin, boxMax, parent, treeSplitThreshold, interactionLength, cellSizeFactor) {
     using namespace autopas::utils;
     using namespace autopas::utils::ArrayMath::literals;
 
@@ -69,8 +69,8 @@ class OctreeInnerNode : public OctreeNodeInterface<ParticleT> {
       }
 
       // Assign new leaves as the children.
-      _children[i] = std::make_unique<OctreeLeafNode<ParticleT>>(newBoxMin, newBoxMax, this, treeSplitThreshold,
-                                                                 interactionLength, cellSizeFactor);
+      _children[i] = std::make_unique<OctreeLeafNode<Particle_T>>(newBoxMin, newBoxMax, this, treeSplitThreshold,
+                                                                  interactionLength, cellSizeFactor);
     }
   }
 
@@ -78,15 +78,16 @@ class OctreeInnerNode : public OctreeNodeInterface<ParticleT> {
    * Copy all children from the other octree into this octree. (Create a new, copied subtree)
    * @param other The other octree (to copy from)
    */
-  OctreeInnerNode(const OctreeInnerNode<ParticleT> &other)
-      : OctreeNodeInterface<ParticleT>(other._boxMin, other._boxMax, other._parent, other._treeSplitThreshold,
-                                       other._interactionLength, other._cellSizeFactor) {
+  OctreeInnerNode(const OctreeInnerNode<Particle_T> &other)
+      : OctreeNodeInterface<Particle_T>(other._boxMin, other._boxMax, other._parent, other._treeSplitThreshold,
+                                        other._interactionLength, other._cellSizeFactor) {
     for (auto i = 0; i < other._children.size(); ++i) {
       auto *otherChild = other._children[i].get();
       if (otherChild->hasChildren()) {
-        _children[i] = std::make_unique<OctreeInnerNode<ParticleT>>((OctreeInnerNode<ParticleT> &)*other._children[i]);
+        _children[i] =
+            std::make_unique<OctreeInnerNode<Particle_T>>((OctreeInnerNode<Particle_T> &)*other._children[i]);
       } else {
-        _children[i] = std::make_unique<OctreeLeafNode<ParticleT>>((OctreeLeafNode<ParticleT> &)*other._children[i]);
+        _children[i] = std::make_unique<OctreeLeafNode<Particle_T>>((OctreeLeafNode<Particle_T> &)*other._children[i]);
       }
     }
   }
@@ -94,7 +95,7 @@ class OctreeInnerNode : public OctreeNodeInterface<ParticleT> {
   /**
    * @copydoc OctreeNodeInterface::insert()
    */
-  std::unique_ptr<OctreeNodeInterface<ParticleT>> insert(const ParticleT &p) override {
+  std::unique_ptr<OctreeNodeInterface<Particle_T>> insert(const Particle_T &p) override {
     // Find a child to insert the particle into.
     for (auto &child : _children) {
       if (child->isInside(p.getR())) {
@@ -107,7 +108,7 @@ class OctreeInnerNode : public OctreeNodeInterface<ParticleT> {
     return nullptr;
   }
 
-  bool deleteParticle(ParticleT &particle) override {
+  bool deleteParticle(Particle_T &particle) override {
     for (auto &child : _children) {
       if (child->isInside(particle.getR())) {
         return child->deleteParticle(particle);
@@ -126,7 +127,7 @@ class OctreeInnerNode : public OctreeNodeInterface<ParticleT> {
   /**
    * @copydoc OctreeNodeInterface::collectAllParticles()
    */
-  void collectAllParticles(std::vector<ParticleT *> &ps) const override {
+  void collectAllParticles(std::vector<Particle_T *> &ps) const override {
     // An inner node does not contain particles, traverse down to the children.
     for (auto &child : _children) {
       child->collectAllParticles(ps);
@@ -145,12 +146,12 @@ class OctreeInnerNode : public OctreeNodeInterface<ParticleT> {
   /**
    * @copydoc OctreeNodeInterface::clearChildren()
    */
-  void clearChildren(std::unique_ptr<OctreeNodeInterface<ParticleT>> &ref) override {
+  void clearChildren(std::unique_ptr<OctreeNodeInterface<Particle_T>> &ref) override {
     for (auto &child : _children) {
       child->clearChildren(child);
     }
 
-    std::unique_ptr<OctreeLeafNode<ParticleT>> newLeaf = std::make_unique<OctreeLeafNode<ParticleT>>(
+    std::unique_ptr<OctreeLeafNode<Particle_T>> newLeaf = std::make_unique<OctreeLeafNode<Particle_T>>(
         this->getBoxMin(), this->getBoxMax(), this->_parent, this->_treeSplitThreshold, this->_interactionLength,
         this->_cellSizeFactor);
     ref = std::move(newLeaf);
@@ -186,11 +187,11 @@ class OctreeInnerNode : public OctreeNodeInterface<ParticleT> {
   /**
    * @copydoc OctreeNodeInterface::getChild()
    */
-  OctreeNodeInterface<ParticleT> *getChild(int index) override { return _children[index].get(); }
+  OctreeNodeInterface<Particle_T> *getChild(int index) override { return _children[index].get(); }
 
-  std::vector<OctreeLeafNode<ParticleT> *> getLeavesFromDirections(
+  std::vector<OctreeLeafNode<Particle_T> *> getLeavesFromDirections(
       const std::vector<octree::Vertex> &directions) override {
-    std::vector<OctreeLeafNode<ParticleT> *> result;
+    std::vector<OctreeLeafNode<Particle_T> *> result;
     // Only take the children that are allowed (i.e. those which are in the given directions list)
     for (auto d : directions) {
       int childIndex = vertexToIndex(d);
@@ -205,21 +206,21 @@ class OctreeInnerNode : public OctreeNodeInterface<ParticleT> {
     return result;
   }
 
-  OctreeNodeInterface<ParticleT> *SON(octree::Octant octant) override {
+  OctreeNodeInterface<Particle_T> *SON(octree::Octant octant) override {
     // convert the Octant to a flat child index
     auto flat = vertexToIndex(octant);
     return _children[flat].get();
   }
 
-  void appendAllLeaves(std::vector<OctreeLeafNode<ParticleT> *> &leaves) const override {
+  void appendAllLeaves(std::vector<OctreeLeafNode<Particle_T> *> &leaves) const override {
     for (auto &child : _children) {
       child->appendAllLeaves(leaves);
     }
   }
 
-  std::set<OctreeLeafNode<ParticleT> *> getLeavesInRange(const std::array<double, 3> &min,
-                                                         const std::array<double, 3> &max) override {
-    std::set<OctreeLeafNode<ParticleT> *> result;
+  std::set<OctreeLeafNode<Particle_T> *> getLeavesInRange(const std::array<double, 3> &min,
+                                                          const std::array<double, 3> &max) override {
+    std::set<OctreeLeafNode<Particle_T> *> result;
     for (auto &child : _children) {
       double vol = child->getEnclosedVolumeWith(min, max);
       // Prevent iteration of the subtree if it is unnecessary
@@ -299,6 +300,6 @@ class OctreeInnerNode : public OctreeNodeInterface<ParticleT> {
   /**
    * Each inner node of an octree can contain exactly 8 children.
    */
-  std::array<std::unique_ptr<OctreeNodeInterface<ParticleT>>, 8> _children;
+  std::array<std::unique_ptr<OctreeNodeInterface<Particle_T>>, 8> _children;
 };
 }  // namespace autopas

--- a/src/autopas/containers/octree/OctreeLeafNode.h
+++ b/src/autopas/containers/octree/OctreeLeafNode.h
@@ -47,7 +47,7 @@ class OctreeLeafNode : public OctreeNodeInterface<ParticleT>, public FullParticl
    */
   OctreeLeafNode(OctreeLeafNode<ParticleT> const &other)
       : OctreeNodeInterface<ParticleT>(other._boxMin, other._boxMax, other._parent, other._treeSplitThreshold,
-                                      other._interactionLength),
+                                       other._interactionLength),
         FullParticleCell<ParticleT>(utils::ArrayMath::sub(other._boxMax, other._boxMin)),
         _id(other.getID()) {
     this->_particles.reserve(other._particles.size());
@@ -180,7 +180,7 @@ class OctreeLeafNode : public OctreeNodeInterface<ParticleT>, public FullParticl
   }
 
   std::set<OctreeLeafNode<ParticleT> *> getLeavesInRange(const std::array<double, 3> &min,
-                                                        const std::array<double, 3> &max) override {
+                                                         const std::array<double, 3> &max) override {
     if (this->getEnclosedVolumeWith(min, max) > 0.0) {
       return {this};
     } else {

--- a/src/autopas/containers/octree/OctreeNodeInterface.h
+++ b/src/autopas/containers/octree/OctreeNodeInterface.h
@@ -18,17 +18,17 @@ namespace autopas {
 /**
  * This forward declaration is required since the `OctreeNodeInterface` provides a method to gather all
  * `OctreeLeafNode`s.
- * @tparam Particle
+ * @tparam ParticleT
  */
-template <typename Particle>
+template <typename ParticleT>
 class OctreeLeafNode;
 
 /**
  * The base class that provides the necessary function definitions that can be applied to an octree.
  *
- * @tparam Particle
+ * @tparam ParticleT
  */
-template <class Particle>
+template <class ParticleT>
 class OctreeNodeInterface {
  public:
   /**
@@ -41,7 +41,7 @@ class OctreeNodeInterface {
    * @param cellSizeFactor The cell size factor
    */
   OctreeNodeInterface(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax,
-                      OctreeNodeInterface<Particle> *parent, const int unsigned treeSplitThreshold,
+                      OctreeNodeInterface<ParticleT> *parent, const int unsigned treeSplitThreshold,
                       const double interactionLength, const double cellSizeFactor)
       : _boxMin(boxMin),
         _boxMax(boxMax),
@@ -54,25 +54,25 @@ class OctreeNodeInterface {
   virtual ~OctreeNodeInterface() = default;
 
   /** Default copy constructor */
-  OctreeNodeInterface(const OctreeNodeInterface<Particle> &) = default;
+  OctreeNodeInterface(const OctreeNodeInterface<ParticleT> &) = default;
 
   /**
    * Insert a particle into the octree.
    * @param p The particle to insert
    * @return A std::unique_ptr to a newly created subtree or nullptr if the subtree did not change
    */
-  virtual std::unique_ptr<OctreeNodeInterface<Particle>> insert(const Particle &p) = 0;
+  virtual std::unique_ptr<OctreeNodeInterface<ParticleT>> insert(const ParticleT &p) = 0;
 
   /**
    * @copydoc OctreeNodeWrapper::deleteParticle()
    */
-  virtual bool deleteParticle(Particle &particle) = 0;
+  virtual bool deleteParticle(ParticleT &particle) = 0;
 
   /**
    * Put all particles that are below this node into the vector.
    * @param ps A reference to the vector that should contain the particles after the operation
    */
-  virtual void collectAllParticles(std::vector<Particle *> &ps) const = 0;
+  virtual void collectAllParticles(std::vector<ParticleT *> &ps) const = 0;
 
   /**
    * Put the min/max corner coordinates of every leaf into the vector.
@@ -85,13 +85,13 @@ class OctreeNodeInterface {
    * Put all leaves below this subtree into a given list.
    * @param leaves A reference to the vector that should contain pointers to the leaves
    */
-  virtual void appendAllLeaves(std::vector<OctreeLeafNode<Particle> *> &leaves) const = 0;
+  virtual void appendAllLeaves(std::vector<OctreeLeafNode<ParticleT> *> &leaves) const = 0;
 
   /**
    * Delete the entire tree below this node.
    * @param ref A reference that contains this node
    */
-  virtual void clearChildren(std::unique_ptr<OctreeNodeInterface<Particle>> &ref) = 0;
+  virtual void clearChildren(std::unique_ptr<OctreeNodeInterface<ParticleT>> &ref) = 0;
 
   /**
    * @copydoc CellBasedParticleContainer::size()
@@ -109,7 +109,7 @@ class OctreeNodeInterface {
    * @param O The octant
    * @return A pointer to a child node
    */
-  virtual OctreeNodeInterface<Particle> *SON(octree::Octant O) = 0;
+  virtual OctreeNodeInterface<ParticleT> *SON(octree::Octant O) = 0;
 
   /**
    * Check if the node is a leaf or an inner node. Use this over dynamic_cast to distinguish node types.
@@ -124,7 +124,7 @@ class OctreeNodeInterface {
    * @param index The index of the child. Must be between 0 and 7 inclusive.
    * @return A pointer to the child.
    */
-  virtual OctreeNodeInterface<Particle> *getChild(int index) = 0;
+  virtual OctreeNodeInterface<ParticleT> *getChild(int index) = 0;
 
   /**
    * Find all leaves below this subtree that are in the given range.
@@ -132,7 +132,7 @@ class OctreeNodeInterface {
    * @param max The maximum coordinate in 3D space of the query area
    * @return A set of all leaf nodes that are in the query region
    */
-  virtual std::set<OctreeLeafNode<Particle> *> getLeavesInRange(const std::array<double, 3> &min,
+  virtual std::set<OctreeLeafNode<ParticleT> *> getLeavesInRange(const std::array<double, 3> &min,
                                                                 const std::array<double, 3> &max) = 0;
 
   /**
@@ -167,7 +167,7 @@ class OctreeNodeInterface {
    * @param other The octree node to check against.
    * @return true iff the enclosed volume is greater than zero, false if the enclosed volume is equal to zero.
    */
-  bool enclosesVolumeWithOtherOnAxis(const int axis, const OctreeNodeInterface<Particle> *other) {
+  bool enclosesVolumeWithOtherOnAxis(const int axis, const OctreeNodeInterface<ParticleT> *other) {
     return volumeExistsOnAxis(axis, this->getBoxMin(), this->getBoxMax(), other->getBoxMin(), other->getBoxMax());
   }
 
@@ -228,8 +228,8 @@ class OctreeNodeInterface {
    * @param I The face in which direction the search should find a node
    * @return An octree node
    */
-  OctreeNodeInterface<Particle> *EQ_FACE_NEIGHBOR(const octree::Face I) {
-    OctreeNodeInterface<Particle> *param, *P = this;
+  OctreeNodeInterface<ParticleT> *EQ_FACE_NEIGHBOR(const octree::Face I) {
+    OctreeNodeInterface<ParticleT> *param, *P = this;
     if (ADJ(I, SONTYPE(P))) {
       param = FATHER(P)->EQ_FACE_NEIGHBOR(I);
     } else {
@@ -244,8 +244,8 @@ class OctreeNodeInterface {
    * @param I The edge in which direction the search should find a node
    * @return An octree node
    */
-  OctreeNodeInterface<Particle> *EQ_EDGE_NEIGHBOR(const octree::Edge I) {
-    OctreeNodeInterface<Particle> *param, *P = this;
+  OctreeNodeInterface<ParticleT> *EQ_EDGE_NEIGHBOR(const octree::Edge I) {
+    OctreeNodeInterface<ParticleT> *param, *P = this;
     if (ADJ(I, SONTYPE(P))) {
       param = FATHER(P)->EQ_EDGE_NEIGHBOR(I);
     } else if (COMMON_FACE(I, SONTYPE(P)) != octree::O) {
@@ -262,8 +262,8 @@ class OctreeNodeInterface {
    * @param I The face in which direction the search should find a node
    * @return An octree node
    */
-  OctreeNodeInterface<Particle> *EQ_VERTEX_NEIGHBOR(const octree::Vertex I) {
-    OctreeNodeInterface<Particle> *param, *P = this;
+  OctreeNodeInterface<ParticleT> *EQ_VERTEX_NEIGHBOR(const octree::Vertex I) {
+    OctreeNodeInterface<ParticleT> *param, *P = this;
     if (ADJ(I, SONTYPE(P))) {
       param = FATHER(P)->EQ_VERTEX_NEIGHBOR(I);
     } else if (COMMON_EDGE(I, SONTYPE(P)) != octree::OO) {
@@ -282,7 +282,7 @@ class OctreeNodeInterface {
    * @param I The face in which direction the search should find a node
    * @return An octree node
    */
-  OctreeNodeInterface<Particle> *GTEQ_FACE_NEIGHBOR(octree::Face I);
+  OctreeNodeInterface<ParticleT> *GTEQ_FACE_NEIGHBOR(octree::Face I);
 
   /**
    * Find a node (via the pointer structure) that is of greater than or equal to the size of the current node's bounding
@@ -290,7 +290,7 @@ class OctreeNodeInterface {
    * @param I The edge in which direction the search should find a node
    * @return An octree node
    */
-  OctreeNodeInterface<Particle> *GTEQ_EDGE_NEIGHBOR(octree::Edge I);
+  OctreeNodeInterface<ParticleT> *GTEQ_EDGE_NEIGHBOR(octree::Edge I);
 
   /**
    * Find a node (via the pointer structure) that is of greater than or equal to the size of the current node's bounding
@@ -298,14 +298,14 @@ class OctreeNodeInterface {
    * @param I The vertex in which direction the search should find a node
    * @return An octree node
    */
-  OctreeNodeInterface<Particle> *GTEQ_VERTEX_NEIGHBOR(octree::Vertex I);
+  OctreeNodeInterface<ParticleT> *GTEQ_VERTEX_NEIGHBOR(octree::Vertex I);
 
   /**
    * Find all leaf nodes along a list of given directions.
    * @param directions A list of allowed directions for traversal.
    * @return A list of leaf nodes
    */
-  virtual std::vector<OctreeLeafNode<Particle> *> getLeavesFromDirections(
+  virtual std::vector<OctreeLeafNode<ParticleT> *> getLeavesFromDirections(
       const std::vector<octree::Vertex> &directions) = 0;
 
   /**
@@ -313,7 +313,7 @@ class OctreeNodeInterface {
    * @param direction The "original" direction. The leaves will be found along the opposite direction.
    * @return A list of leaf nodes
    */
-  std::vector<OctreeLeafNode<Particle> *> getNeighborLeaves(const octree::Any direction) {
+  std::vector<OctreeLeafNode<ParticleT> *> getNeighborLeaves(const octree::Any direction) {
     auto opposite = octree::getOppositeDirection(direction);
     auto directions = octree::getAllowedDirections(opposite);
     auto neighborLeaves = getLeavesFromDirections(directions);
@@ -324,12 +324,12 @@ class OctreeNodeInterface {
    * Get the neighbor leaves in all directions
    * @return A set of (unique) neighboring leaves
    */
-  std::set<OctreeLeafNode<Particle> *> getNeighborLeaves() {
-    std::set<OctreeLeafNode<Particle> *> result;
+  std::set<OctreeLeafNode<ParticleT> *> getNeighborLeaves() {
+    std::set<OctreeLeafNode<ParticleT> *> result;
 
     // Get all face neighbors
     for (auto face : octree::Tables::faces) {
-      OctreeNodeInterface<Particle> *neighbor = GTEQ_FACE_NEIGHBOR(face);
+      OctreeNodeInterface<ParticleT> *neighbor = GTEQ_FACE_NEIGHBOR(face);
       if (neighbor) {
         auto leaves = neighbor->getNeighborLeaves(face);
         result.insert(leaves.begin(), leaves.end());
@@ -338,7 +338,7 @@ class OctreeNodeInterface {
 
     // Get all edge neighbors
     for (auto edge : octree::Tables::edges) {
-      OctreeNodeInterface<Particle> *neighbor = GTEQ_EDGE_NEIGHBOR(edge);
+      OctreeNodeInterface<ParticleT> *neighbor = GTEQ_EDGE_NEIGHBOR(edge);
       if (neighbor) {
         auto leaves = neighbor->getNeighborLeaves(edge);
         result.insert(leaves.begin(), leaves.end());
@@ -347,7 +347,7 @@ class OctreeNodeInterface {
 
     // Get all face neighbors
     for (auto vertex : octree::Tables::vertices) {
-      OctreeNodeInterface<Particle> *neighbor = GTEQ_VERTEX_NEIGHBOR(vertex);
+      OctreeNodeInterface<ParticleT> *neighbor = GTEQ_VERTEX_NEIGHBOR(vertex);
       if (neighbor) {
         auto leaves = neighbor->getNeighborLeaves(vertex);
         result.insert(leaves.begin(), leaves.end());
@@ -373,7 +373,7 @@ class OctreeNodeInterface {
    * Get the parent node of this node.
    * @return A pointer to the parent, can be nullptr.
    */
-  OctreeNodeInterface<Particle> *getParent() const { return _parent; }
+  OctreeNodeInterface<ParticleT> *getParent() const { return _parent; }
 
  protected:
   /**
@@ -385,7 +385,7 @@ class OctreeNodeInterface {
   /**
    * A pointer to the parent node. Can be nullptr (iff this is the root node).
    */
-  OctreeNodeInterface<Particle> *_parent;
+  OctreeNodeInterface<ParticleT> *_parent;
 
   /**
    * The min coordinate of the enclosed volume.
@@ -415,12 +415,12 @@ class OctreeNodeInterface {
 
 /**
  * Check if a node is an inner node.
- * @tparam Particle The particle type used in this container
+ * @tparam ParticleT The particle type used in this container
  * @param node A pointer to a node
  * @return true if the node has children, false otherwise.
  */
-template <class Particle>
-inline bool GRAY(OctreeNodeInterface<Particle> *node) {
+template <class ParticleT>
+inline bool GRAY(OctreeNodeInterface<ParticleT> *node) {
   // According to Samet: "All non-leaf nodes are said to be GRAY"
   return node->hasChildren();
 }
@@ -428,25 +428,25 @@ inline bool GRAY(OctreeNodeInterface<Particle> *node) {
 /**
  * Get the parent node of an arbitrary octree node.
  *
- * @tparam Particle
+ * @tparam ParticleT
  * @param node
  * @return The parent of the given node if the node is not the root node, otherwise nullptr.
  */
-template <class Particle>
-inline OctreeNodeInterface<Particle> *FATHER(const OctreeNodeInterface<Particle> *node) {
+template <class ParticleT>
+inline OctreeNodeInterface<ParticleT> *FATHER(const OctreeNodeInterface<ParticleT> *node) {
   return node->getParent();
 }
 
 /**
  * Get the octant in which a given node can be found in the parent.
  *
- * @tparam Particle
+ * @tparam ParticleT
  * @param node The node to check
  * @return The octant in which the node is in the parent, OOO if the node either does not have a parent or could not be
  * found in the parent.
  */
-template <class Particle>
-static octree::Octant SONTYPE(const OctreeNodeInterface<Particle> *node) {
+template <class ParticleT>
+static octree::Octant SONTYPE(const OctreeNodeInterface<ParticleT> *node) {
   octree::Octant result = octree::OOO;
   if (FATHER(node)) {
     for (octree::Vertex test : octree::Tables::vertices) {
@@ -462,17 +462,17 @@ static octree::Octant SONTYPE(const OctreeNodeInterface<Particle> *node) {
   return result;
 }
 
-template <class Particle>
-OctreeNodeInterface<Particle> *OctreeNodeInterface<Particle>::GTEQ_FACE_NEIGHBOR(const octree::Face I) {
+template <class ParticleT>
+OctreeNodeInterface<ParticleT> *OctreeNodeInterface<ParticleT>::GTEQ_FACE_NEIGHBOR(const octree::Face I) {
   // Check precondition
   if (not isFace(I)) {
     throw std::runtime_error("[OctreeNodeInterface::GTEQ_FACE_NEIGHBOR()] Received invalid face.");
   }
 
-  auto null = [](OctreeNodeInterface<Particle> *T) { return T == nullptr; };
+  auto null = [](OctreeNodeInterface<ParticleT> *T) { return T == nullptr; };
 
   // Find a common ancestor
-  OctreeNodeInterface<Particle> *Q, *P = this;
+  OctreeNodeInterface<ParticleT> *Q, *P = this;
   if ((not null(FATHER(P))) and ADJ(I, SONTYPE(P))) {
     Q = FATHER(P)->GTEQ_FACE_NEIGHBOR(I);
   } else {
@@ -487,17 +487,17 @@ OctreeNodeInterface<Particle> *OctreeNodeInterface<Particle>::GTEQ_FACE_NEIGHBOR
   }
 }
 
-template <class Particle>
-OctreeNodeInterface<Particle> *OctreeNodeInterface<Particle>::GTEQ_EDGE_NEIGHBOR(const octree::Edge I) {
+template <class ParticleT>
+OctreeNodeInterface<ParticleT> *OctreeNodeInterface<ParticleT>::GTEQ_EDGE_NEIGHBOR(const octree::Edge I) {
   // Check precondition
   if (not isEdge(I)) {
     throw std::runtime_error("[OctreeNodeInterface::GTEQ_EDGE_NEIGHBOR()] Received invalid edge.");
   }
 
-  auto null = [](OctreeNodeInterface<Particle> *T) { return T == nullptr; };
+  auto null = [](OctreeNodeInterface<ParticleT> *T) { return T == nullptr; };
 
   // Find a common ancestor
-  OctreeNodeInterface<Particle> *Q, *P = this;
+  OctreeNodeInterface<ParticleT> *Q, *P = this;
   if (null(FATHER(P))) {
     Q = nullptr;
   } else if (ADJ(I, SONTYPE(P))) {
@@ -516,15 +516,15 @@ OctreeNodeInterface<Particle> *OctreeNodeInterface<Particle>::GTEQ_EDGE_NEIGHBOR
   }
 }
 
-template <class Particle>
-OctreeNodeInterface<Particle> *OctreeNodeInterface<Particle>::GTEQ_VERTEX_NEIGHBOR(const octree::Vertex I) {
+template <class ParticleT>
+OctreeNodeInterface<ParticleT> *OctreeNodeInterface<ParticleT>::GTEQ_VERTEX_NEIGHBOR(const octree::Vertex I) {
   // Check precondition
   if (not isVertex(I)) {
     throw std::runtime_error("[OctreeNodeInterface::GTEQ_VERTEX_NEIGHBOR()] Received invalid vertex.");
   }
 
   // Find a common ancestor
-  OctreeNodeInterface<Particle> *Q, *P = this;
+  OctreeNodeInterface<ParticleT> *Q, *P = this;
   if (not FATHER(P)) {
     Q = nullptr;
   } else if (ADJ(I, SONTYPE(P))) {

--- a/src/autopas/containers/octree/OctreeNodeInterface.h
+++ b/src/autopas/containers/octree/OctreeNodeInterface.h
@@ -133,7 +133,7 @@ class OctreeNodeInterface {
    * @return A set of all leaf nodes that are in the query region
    */
   virtual std::set<OctreeLeafNode<ParticleT> *> getLeavesInRange(const std::array<double, 3> &min,
-                                                                const std::array<double, 3> &max) = 0;
+                                                                 const std::array<double, 3> &max) = 0;
 
   /**
    * Check if a 3d point is inside the node's axis aligned bounding box. (Set by the boxMin and boxMax fields.)

--- a/src/autopas/containers/octree/OctreeNodeInterface.h
+++ b/src/autopas/containers/octree/OctreeNodeInterface.h
@@ -18,17 +18,17 @@ namespace autopas {
 /**
  * This forward declaration is required since the `OctreeNodeInterface` provides a method to gather all
  * `OctreeLeafNode`s.
- * @tparam ParticleT
+ * @tparam Particle_T
  */
-template <typename ParticleT>
+template <typename Particle_T>
 class OctreeLeafNode;
 
 /**
  * The base class that provides the necessary function definitions that can be applied to an octree.
  *
- * @tparam ParticleT
+ * @tparam Particle_T
  */
-template <class ParticleT>
+template <class Particle_T>
 class OctreeNodeInterface {
  public:
   /**
@@ -41,7 +41,7 @@ class OctreeNodeInterface {
    * @param cellSizeFactor The cell size factor
    */
   OctreeNodeInterface(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax,
-                      OctreeNodeInterface<ParticleT> *parent, const int unsigned treeSplitThreshold,
+                      OctreeNodeInterface<Particle_T> *parent, const int unsigned treeSplitThreshold,
                       const double interactionLength, const double cellSizeFactor)
       : _boxMin(boxMin),
         _boxMax(boxMax),
@@ -54,25 +54,25 @@ class OctreeNodeInterface {
   virtual ~OctreeNodeInterface() = default;
 
   /** Default copy constructor */
-  OctreeNodeInterface(const OctreeNodeInterface<ParticleT> &) = default;
+  OctreeNodeInterface(const OctreeNodeInterface<Particle_T> &) = default;
 
   /**
    * Insert a particle into the octree.
    * @param p The particle to insert
    * @return A std::unique_ptr to a newly created subtree or nullptr if the subtree did not change
    */
-  virtual std::unique_ptr<OctreeNodeInterface<ParticleT>> insert(const ParticleT &p) = 0;
+  virtual std::unique_ptr<OctreeNodeInterface<Particle_T>> insert(const Particle_T &p) = 0;
 
   /**
    * @copydoc OctreeNodeWrapper::deleteParticle()
    */
-  virtual bool deleteParticle(ParticleT &particle) = 0;
+  virtual bool deleteParticle(Particle_T &particle) = 0;
 
   /**
    * Put all particles that are below this node into the vector.
    * @param ps A reference to the vector that should contain the particles after the operation
    */
-  virtual void collectAllParticles(std::vector<ParticleT *> &ps) const = 0;
+  virtual void collectAllParticles(std::vector<Particle_T *> &ps) const = 0;
 
   /**
    * Put the min/max corner coordinates of every leaf into the vector.
@@ -85,13 +85,13 @@ class OctreeNodeInterface {
    * Put all leaves below this subtree into a given list.
    * @param leaves A reference to the vector that should contain pointers to the leaves
    */
-  virtual void appendAllLeaves(std::vector<OctreeLeafNode<ParticleT> *> &leaves) const = 0;
+  virtual void appendAllLeaves(std::vector<OctreeLeafNode<Particle_T> *> &leaves) const = 0;
 
   /**
    * Delete the entire tree below this node.
    * @param ref A reference that contains this node
    */
-  virtual void clearChildren(std::unique_ptr<OctreeNodeInterface<ParticleT>> &ref) = 0;
+  virtual void clearChildren(std::unique_ptr<OctreeNodeInterface<Particle_T>> &ref) = 0;
 
   /**
    * @copydoc CellBasedParticleContainer::size()
@@ -109,7 +109,7 @@ class OctreeNodeInterface {
    * @param O The octant
    * @return A pointer to a child node
    */
-  virtual OctreeNodeInterface<ParticleT> *SON(octree::Octant O) = 0;
+  virtual OctreeNodeInterface<Particle_T> *SON(octree::Octant O) = 0;
 
   /**
    * Check if the node is a leaf or an inner node. Use this over dynamic_cast to distinguish node types.
@@ -124,7 +124,7 @@ class OctreeNodeInterface {
    * @param index The index of the child. Must be between 0 and 7 inclusive.
    * @return A pointer to the child.
    */
-  virtual OctreeNodeInterface<ParticleT> *getChild(int index) = 0;
+  virtual OctreeNodeInterface<Particle_T> *getChild(int index) = 0;
 
   /**
    * Find all leaves below this subtree that are in the given range.
@@ -132,8 +132,8 @@ class OctreeNodeInterface {
    * @param max The maximum coordinate in 3D space of the query area
    * @return A set of all leaf nodes that are in the query region
    */
-  virtual std::set<OctreeLeafNode<ParticleT> *> getLeavesInRange(const std::array<double, 3> &min,
-                                                                 const std::array<double, 3> &max) = 0;
+  virtual std::set<OctreeLeafNode<Particle_T> *> getLeavesInRange(const std::array<double, 3> &min,
+                                                                  const std::array<double, 3> &max) = 0;
 
   /**
    * Check if a 3d point is inside the node's axis aligned bounding box. (Set by the boxMin and boxMax fields.)
@@ -167,7 +167,7 @@ class OctreeNodeInterface {
    * @param other The octree node to check against.
    * @return true iff the enclosed volume is greater than zero, false if the enclosed volume is equal to zero.
    */
-  bool enclosesVolumeWithOtherOnAxis(const int axis, const OctreeNodeInterface<ParticleT> *other) {
+  bool enclosesVolumeWithOtherOnAxis(const int axis, const OctreeNodeInterface<Particle_T> *other) {
     return volumeExistsOnAxis(axis, this->getBoxMin(), this->getBoxMax(), other->getBoxMin(), other->getBoxMax());
   }
 
@@ -228,8 +228,8 @@ class OctreeNodeInterface {
    * @param I The face in which direction the search should find a node
    * @return An octree node
    */
-  OctreeNodeInterface<ParticleT> *EQ_FACE_NEIGHBOR(const octree::Face I) {
-    OctreeNodeInterface<ParticleT> *param, *P = this;
+  OctreeNodeInterface<Particle_T> *EQ_FACE_NEIGHBOR(const octree::Face I) {
+    OctreeNodeInterface<Particle_T> *param, *P = this;
     if (ADJ(I, SONTYPE(P))) {
       param = FATHER(P)->EQ_FACE_NEIGHBOR(I);
     } else {
@@ -244,8 +244,8 @@ class OctreeNodeInterface {
    * @param I The edge in which direction the search should find a node
    * @return An octree node
    */
-  OctreeNodeInterface<ParticleT> *EQ_EDGE_NEIGHBOR(const octree::Edge I) {
-    OctreeNodeInterface<ParticleT> *param, *P = this;
+  OctreeNodeInterface<Particle_T> *EQ_EDGE_NEIGHBOR(const octree::Edge I) {
+    OctreeNodeInterface<Particle_T> *param, *P = this;
     if (ADJ(I, SONTYPE(P))) {
       param = FATHER(P)->EQ_EDGE_NEIGHBOR(I);
     } else if (COMMON_FACE(I, SONTYPE(P)) != octree::O) {
@@ -262,8 +262,8 @@ class OctreeNodeInterface {
    * @param I The face in which direction the search should find a node
    * @return An octree node
    */
-  OctreeNodeInterface<ParticleT> *EQ_VERTEX_NEIGHBOR(const octree::Vertex I) {
-    OctreeNodeInterface<ParticleT> *param, *P = this;
+  OctreeNodeInterface<Particle_T> *EQ_VERTEX_NEIGHBOR(const octree::Vertex I) {
+    OctreeNodeInterface<Particle_T> *param, *P = this;
     if (ADJ(I, SONTYPE(P))) {
       param = FATHER(P)->EQ_VERTEX_NEIGHBOR(I);
     } else if (COMMON_EDGE(I, SONTYPE(P)) != octree::OO) {
@@ -282,7 +282,7 @@ class OctreeNodeInterface {
    * @param I The face in which direction the search should find a node
    * @return An octree node
    */
-  OctreeNodeInterface<ParticleT> *GTEQ_FACE_NEIGHBOR(octree::Face I);
+  OctreeNodeInterface<Particle_T> *GTEQ_FACE_NEIGHBOR(octree::Face I);
 
   /**
    * Find a node (via the pointer structure) that is of greater than or equal to the size of the current node's bounding
@@ -290,7 +290,7 @@ class OctreeNodeInterface {
    * @param I The edge in which direction the search should find a node
    * @return An octree node
    */
-  OctreeNodeInterface<ParticleT> *GTEQ_EDGE_NEIGHBOR(octree::Edge I);
+  OctreeNodeInterface<Particle_T> *GTEQ_EDGE_NEIGHBOR(octree::Edge I);
 
   /**
    * Find a node (via the pointer structure) that is of greater than or equal to the size of the current node's bounding
@@ -298,14 +298,14 @@ class OctreeNodeInterface {
    * @param I The vertex in which direction the search should find a node
    * @return An octree node
    */
-  OctreeNodeInterface<ParticleT> *GTEQ_VERTEX_NEIGHBOR(octree::Vertex I);
+  OctreeNodeInterface<Particle_T> *GTEQ_VERTEX_NEIGHBOR(octree::Vertex I);
 
   /**
    * Find all leaf nodes along a list of given directions.
    * @param directions A list of allowed directions for traversal.
    * @return A list of leaf nodes
    */
-  virtual std::vector<OctreeLeafNode<ParticleT> *> getLeavesFromDirections(
+  virtual std::vector<OctreeLeafNode<Particle_T> *> getLeavesFromDirections(
       const std::vector<octree::Vertex> &directions) = 0;
 
   /**
@@ -313,7 +313,7 @@ class OctreeNodeInterface {
    * @param direction The "original" direction. The leaves will be found along the opposite direction.
    * @return A list of leaf nodes
    */
-  std::vector<OctreeLeafNode<ParticleT> *> getNeighborLeaves(const octree::Any direction) {
+  std::vector<OctreeLeafNode<Particle_T> *> getNeighborLeaves(const octree::Any direction) {
     auto opposite = octree::getOppositeDirection(direction);
     auto directions = octree::getAllowedDirections(opposite);
     auto neighborLeaves = getLeavesFromDirections(directions);
@@ -324,12 +324,12 @@ class OctreeNodeInterface {
    * Get the neighbor leaves in all directions
    * @return A set of (unique) neighboring leaves
    */
-  std::set<OctreeLeafNode<ParticleT> *> getNeighborLeaves() {
-    std::set<OctreeLeafNode<ParticleT> *> result;
+  std::set<OctreeLeafNode<Particle_T> *> getNeighborLeaves() {
+    std::set<OctreeLeafNode<Particle_T> *> result;
 
     // Get all face neighbors
     for (auto face : octree::Tables::faces) {
-      OctreeNodeInterface<ParticleT> *neighbor = GTEQ_FACE_NEIGHBOR(face);
+      OctreeNodeInterface<Particle_T> *neighbor = GTEQ_FACE_NEIGHBOR(face);
       if (neighbor) {
         auto leaves = neighbor->getNeighborLeaves(face);
         result.insert(leaves.begin(), leaves.end());
@@ -338,7 +338,7 @@ class OctreeNodeInterface {
 
     // Get all edge neighbors
     for (auto edge : octree::Tables::edges) {
-      OctreeNodeInterface<ParticleT> *neighbor = GTEQ_EDGE_NEIGHBOR(edge);
+      OctreeNodeInterface<Particle_T> *neighbor = GTEQ_EDGE_NEIGHBOR(edge);
       if (neighbor) {
         auto leaves = neighbor->getNeighborLeaves(edge);
         result.insert(leaves.begin(), leaves.end());
@@ -347,7 +347,7 @@ class OctreeNodeInterface {
 
     // Get all face neighbors
     for (auto vertex : octree::Tables::vertices) {
-      OctreeNodeInterface<ParticleT> *neighbor = GTEQ_VERTEX_NEIGHBOR(vertex);
+      OctreeNodeInterface<Particle_T> *neighbor = GTEQ_VERTEX_NEIGHBOR(vertex);
       if (neighbor) {
         auto leaves = neighbor->getNeighborLeaves(vertex);
         result.insert(leaves.begin(), leaves.end());
@@ -373,7 +373,7 @@ class OctreeNodeInterface {
    * Get the parent node of this node.
    * @return A pointer to the parent, can be nullptr.
    */
-  OctreeNodeInterface<ParticleT> *getParent() const { return _parent; }
+  OctreeNodeInterface<Particle_T> *getParent() const { return _parent; }
 
  protected:
   /**
@@ -385,7 +385,7 @@ class OctreeNodeInterface {
   /**
    * A pointer to the parent node. Can be nullptr (iff this is the root node).
    */
-  OctreeNodeInterface<ParticleT> *_parent;
+  OctreeNodeInterface<Particle_T> *_parent;
 
   /**
    * The min coordinate of the enclosed volume.
@@ -415,12 +415,12 @@ class OctreeNodeInterface {
 
 /**
  * Check if a node is an inner node.
- * @tparam ParticleT The particle type used in this container
+ * @tparam Particle_T The particle type used in this container
  * @param node A pointer to a node
  * @return true if the node has children, false otherwise.
  */
-template <class ParticleT>
-inline bool GRAY(OctreeNodeInterface<ParticleT> *node) {
+template <class Particle_T>
+inline bool GRAY(OctreeNodeInterface<Particle_T> *node) {
   // According to Samet: "All non-leaf nodes are said to be GRAY"
   return node->hasChildren();
 }
@@ -428,25 +428,25 @@ inline bool GRAY(OctreeNodeInterface<ParticleT> *node) {
 /**
  * Get the parent node of an arbitrary octree node.
  *
- * @tparam ParticleT
+ * @tparam Particle_T
  * @param node
  * @return The parent of the given node if the node is not the root node, otherwise nullptr.
  */
-template <class ParticleT>
-inline OctreeNodeInterface<ParticleT> *FATHER(const OctreeNodeInterface<ParticleT> *node) {
+template <class Particle_T>
+inline OctreeNodeInterface<Particle_T> *FATHER(const OctreeNodeInterface<Particle_T> *node) {
   return node->getParent();
 }
 
 /**
  * Get the octant in which a given node can be found in the parent.
  *
- * @tparam ParticleT
+ * @tparam Particle_T
  * @param node The node to check
  * @return The octant in which the node is in the parent, OOO if the node either does not have a parent or could not be
  * found in the parent.
  */
-template <class ParticleT>
-static octree::Octant SONTYPE(const OctreeNodeInterface<ParticleT> *node) {
+template <class Particle_T>
+static octree::Octant SONTYPE(const OctreeNodeInterface<Particle_T> *node) {
   octree::Octant result = octree::OOO;
   if (FATHER(node)) {
     for (octree::Vertex test : octree::Tables::vertices) {
@@ -462,17 +462,17 @@ static octree::Octant SONTYPE(const OctreeNodeInterface<ParticleT> *node) {
   return result;
 }
 
-template <class ParticleT>
-OctreeNodeInterface<ParticleT> *OctreeNodeInterface<ParticleT>::GTEQ_FACE_NEIGHBOR(const octree::Face I) {
+template <class Particle_T>
+OctreeNodeInterface<Particle_T> *OctreeNodeInterface<Particle_T>::GTEQ_FACE_NEIGHBOR(const octree::Face I) {
   // Check precondition
   if (not isFace(I)) {
     throw std::runtime_error("[OctreeNodeInterface::GTEQ_FACE_NEIGHBOR()] Received invalid face.");
   }
 
-  auto null = [](OctreeNodeInterface<ParticleT> *T) { return T == nullptr; };
+  auto null = [](OctreeNodeInterface<Particle_T> *T) { return T == nullptr; };
 
   // Find a common ancestor
-  OctreeNodeInterface<ParticleT> *Q, *P = this;
+  OctreeNodeInterface<Particle_T> *Q, *P = this;
   if ((not null(FATHER(P))) and ADJ(I, SONTYPE(P))) {
     Q = FATHER(P)->GTEQ_FACE_NEIGHBOR(I);
   } else {
@@ -487,17 +487,17 @@ OctreeNodeInterface<ParticleT> *OctreeNodeInterface<ParticleT>::GTEQ_FACE_NEIGHB
   }
 }
 
-template <class ParticleT>
-OctreeNodeInterface<ParticleT> *OctreeNodeInterface<ParticleT>::GTEQ_EDGE_NEIGHBOR(const octree::Edge I) {
+template <class Particle_T>
+OctreeNodeInterface<Particle_T> *OctreeNodeInterface<Particle_T>::GTEQ_EDGE_NEIGHBOR(const octree::Edge I) {
   // Check precondition
   if (not isEdge(I)) {
     throw std::runtime_error("[OctreeNodeInterface::GTEQ_EDGE_NEIGHBOR()] Received invalid edge.");
   }
 
-  auto null = [](OctreeNodeInterface<ParticleT> *T) { return T == nullptr; };
+  auto null = [](OctreeNodeInterface<Particle_T> *T) { return T == nullptr; };
 
   // Find a common ancestor
-  OctreeNodeInterface<ParticleT> *Q, *P = this;
+  OctreeNodeInterface<Particle_T> *Q, *P = this;
   if (null(FATHER(P))) {
     Q = nullptr;
   } else if (ADJ(I, SONTYPE(P))) {
@@ -516,15 +516,15 @@ OctreeNodeInterface<ParticleT> *OctreeNodeInterface<ParticleT>::GTEQ_EDGE_NEIGHB
   }
 }
 
-template <class ParticleT>
-OctreeNodeInterface<ParticleT> *OctreeNodeInterface<ParticleT>::GTEQ_VERTEX_NEIGHBOR(const octree::Vertex I) {
+template <class Particle_T>
+OctreeNodeInterface<Particle_T> *OctreeNodeInterface<Particle_T>::GTEQ_VERTEX_NEIGHBOR(const octree::Vertex I) {
   // Check precondition
   if (not isVertex(I)) {
     throw std::runtime_error("[OctreeNodeInterface::GTEQ_VERTEX_NEIGHBOR()] Received invalid vertex.");
   }
 
   // Find a common ancestor
-  OctreeNodeInterface<ParticleT> *Q, *P = this;
+  OctreeNodeInterface<Particle_T> *Q, *P = this;
   if (not FATHER(P)) {
     Q = nullptr;
   } else if (ADJ(I, SONTYPE(P))) {

--- a/src/autopas/containers/octree/OctreeNodeWrapper.h
+++ b/src/autopas/containers/octree/OctreeNodeWrapper.h
@@ -26,20 +26,20 @@ namespace autopas {
  *
  * This class includes some proxy methods: `appendAllParticles()`, `appendAllLeaves()` and some more. Those methods only
  * invoke similar functions on the pointer to an octree. This indirection could be removed by implementing the
- * `OctreeNodeInterface<ParticleT>`. However, if this class inherited directly from `OctreeNodeInterface<ParticleT>`, it
- * would have to implement the _entire interface_ provided by `OctreeNodeInterface<ParticleT>`. This does not increase
- * the code quality, since one would have to implement other interface methods (like `insert()`) that should not be
- * exposed to the outside. Having proxy calls inside this class keeps the interface clean.
+ * `OctreeNodeInterface<Particle_T>`. However, if this class inherited directly from `OctreeNodeInterface<Particle_T>`,
+ * it would have to implement the _entire interface_ provided by `OctreeNodeInterface<Particle_T>`. This does not
+ * increase the code quality, since one would have to implement other interface methods (like `insert()`) that should
+ * not be exposed to the outside. Having proxy calls inside this class keeps the interface clean.
  *
- * @tparam ParticleT The particle class that should be used in the octree cell.
+ * @tparam Particle_T The particle class that should be used in the octree cell.
  */
-template <typename ParticleT>
-class OctreeNodeWrapper : public ParticleCell<ParticleT> {
+template <typename Particle_T>
+class OctreeNodeWrapper : public ParticleCell<Particle_T> {
  public:
   /**
    * The contained particle cell.
    */
-  using ParticleCell = OctreeNodeWrapper<ParticleT>;
+  using ParticleCell = OctreeNodeWrapper<Particle_T>;
   /**
    * The contained particle type.
    */
@@ -47,7 +47,7 @@ class OctreeNodeWrapper : public ParticleCell<ParticleT> {
   /**
    * Type that holds or refers to the actual particles.
    */
-  using StorageType = std::vector<ParticleT *>;
+  using StorageType = std::vector<Particle_T *>;
 
   /**
    * Constructs a new, empty octree and stores the root.
@@ -61,8 +61,8 @@ class OctreeNodeWrapper : public ParticleCell<ParticleT> {
   OctreeNodeWrapper(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax,
                     int unsigned const treeSplitThreshold, double const interactionLength,
                     double const cellSizeFactor) {
-    _pointer = std::make_unique<OctreeLeafNode<ParticleT>>(boxMin, boxMax, nullptr, treeSplitThreshold,
-                                                           interactionLength, cellSizeFactor);
+    _pointer = std::make_unique<OctreeLeafNode<Particle_T>>(boxMin, boxMax, nullptr, treeSplitThreshold,
+                                                            interactionLength, cellSizeFactor);
   }
 
   /**
@@ -78,13 +78,13 @@ class OctreeNodeWrapper : public ParticleCell<ParticleT> {
    * Append all leaves in the octree to a list.
    * @param leaves The list to which the leaves should be appended to
    */
-  void appendAllLeaves(std::vector<OctreeLeafNode<ParticleT> *> &leaves) { _pointer->appendAllLeaves(leaves); }
+  void appendAllLeaves(std::vector<OctreeLeafNode<Particle_T> *> &leaves) { _pointer->appendAllLeaves(leaves); }
 
   /**
    * Adds a Particle to the cell.
    * @param p the particle to be added
    */
-  void addParticle(const ParticleT &p) override {
+  void addParticle(const Particle_T &p) override {
     std::lock_guard<AutoPasLock> lock(_lock);
 
     auto ret = _pointer->insert(p);
@@ -179,7 +179,7 @@ class OctreeNodeWrapper : public ParticleCell<ParticleT> {
    * @param particle
    * @return True if the given pointer still points to a new, valid particle.
    */
-  bool deleteParticle(ParticleT &particle) {
+  bool deleteParticle(Particle_T &particle) {
     --_enclosedParticleCount;
 
     return _pointer->deleteParticle(particle);
@@ -216,7 +216,7 @@ class OctreeNodeWrapper : public ParticleCell<ParticleT> {
    * @param index The index of the particle
    * @return A ref to a particle
    */
-  ParticleT &at(size_t index) {
+  Particle_T &at(size_t index) {
     std::lock_guard<AutoPasLock> lock(_lock);
     return _ps.at(index);
   }
@@ -227,7 +227,7 @@ class OctreeNodeWrapper : public ParticleCell<ParticleT> {
    * @param index The index of the particle
    * @return A const ref to a particle
    */
-  const ParticleT &at(size_t index) const {
+  const Particle_T &at(size_t index) const {
     std::lock_guard<AutoPasLock> lock(_lock);
     return _ps.at(index);
   }
@@ -238,7 +238,7 @@ class OctreeNodeWrapper : public ParticleCell<ParticleT> {
    * @param index The index of the particle
    * @return A ref to a particle
    */
-  ParticleT &operator[](size_t index) {
+  Particle_T &operator[](size_t index) {
     std::lock_guard<AutoPasLock> lock(_lock);
     return *_ps[index];
   }
@@ -249,7 +249,7 @@ class OctreeNodeWrapper : public ParticleCell<ParticleT> {
    * @param index The index of the particle
    * @return A ref to a particle
    */
-  const ParticleT &operator[](size_t index) const {
+  const Particle_T &operator[](size_t index) const {
     std::lock_guard<AutoPasLock> lock(_lock);
     return *_ps[index];
   }
@@ -260,8 +260,8 @@ class OctreeNodeWrapper : public ParticleCell<ParticleT> {
    * @param max The maximum coordinate in 3D space of the query area
    * @return A set of all leaf nodes that are in the query region
    */
-  std::set<OctreeLeafNode<ParticleT> *> getLeavesInRange(const std::array<double, 3> &min,
-                                                         const std::array<double, 3> &max) {
+  std::set<OctreeLeafNode<Particle_T> *> getLeavesInRange(const std::array<double, 3> &min,
+                                                          const std::array<double, 3> &max) {
     return _pointer->getLeavesInRange(min, max);
   }
 
@@ -270,7 +270,7 @@ class OctreeNodeWrapper : public ParticleCell<ParticleT> {
    * @note This should only be used for debugging and insight into the internal structure fo the octree.
    * @return A raw C pointer to the enclosed node
    */
-  OctreeNodeInterface<ParticleT> *getRaw() const { return _pointer.get(); }
+  OctreeNodeInterface<Particle_T> *getRaw() const { return _pointer.get(); }
 
   /**
    * Apply the forEach lambda to each particle.
@@ -338,7 +338,7 @@ class OctreeNodeWrapper : public ParticleCell<ParticleT> {
   /**
    * A pointer to the root node of the enclosed octree.
    */
-  std::unique_ptr<OctreeNodeInterface<ParticleT>> _pointer;
+  std::unique_ptr<OctreeNodeInterface<Particle_T>> _pointer;
 
   /**
    * A vector containing all particles when iterating. This serves as a cache such that the octree does not need to

--- a/src/autopas/containers/octree/OctreeNodeWrapper.h
+++ b/src/autopas/containers/octree/OctreeNodeWrapper.h
@@ -26,20 +26,20 @@ namespace autopas {
  *
  * This class includes some proxy methods: `appendAllParticles()`, `appendAllLeaves()` and some more. Those methods only
  * invoke similar functions on the pointer to an octree. This indirection could be removed by implementing the
- * `OctreeNodeInterface<Particle>`. However, if this class inherited directly from `OctreeNodeInterface<Particle>`, it
- * would have to implement the _entire interface_ provided by `OctreeNodeInterface<Particle>`. This does not increase
+ * `OctreeNodeInterface<ParticleT>`. However, if this class inherited directly from `OctreeNodeInterface<ParticleT>`, it
+ * would have to implement the _entire interface_ provided by `OctreeNodeInterface<ParticleT>`. This does not increase
  * the code quality, since one would have to implement other interface methods (like `insert()`) that should not be
  * exposed to the outside. Having proxy calls inside this class keeps the interface clean.
  *
- * @tparam Particle The particle class that should be used in the octree cell.
+ * @tparam ParticleT The particle class that should be used in the octree cell.
  */
-template <typename Particle>
-class OctreeNodeWrapper : public ParticleCell<Particle> {
+template <typename ParticleT>
+class OctreeNodeWrapper : public ParticleCell<ParticleT> {
  public:
   /**
    * The contained particle cell.
    */
-  using ParticleCell = OctreeNodeWrapper<Particle>;
+  using ParticleCell = OctreeNodeWrapper<ParticleT>;
   /**
    * The contained particle type.
    */
@@ -47,7 +47,7 @@ class OctreeNodeWrapper : public ParticleCell<Particle> {
   /**
    * Type that holds or refers to the actual particles.
    */
-  using StorageType = std::vector<Particle *>;
+  using StorageType = std::vector<ParticleT *>;
 
   /**
    * Constructs a new, empty octree and stores the root.
@@ -61,7 +61,7 @@ class OctreeNodeWrapper : public ParticleCell<Particle> {
   OctreeNodeWrapper(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax,
                     int unsigned const treeSplitThreshold, double const interactionLength,
                     double const cellSizeFactor) {
-    _pointer = std::make_unique<OctreeLeafNode<Particle>>(boxMin, boxMax, nullptr, treeSplitThreshold,
+    _pointer = std::make_unique<OctreeLeafNode<ParticleT>>(boxMin, boxMax, nullptr, treeSplitThreshold,
                                                           interactionLength, cellSizeFactor);
   }
 
@@ -78,13 +78,13 @@ class OctreeNodeWrapper : public ParticleCell<Particle> {
    * Append all leaves in the octree to a list.
    * @param leaves The list to which the leaves should be appended to
    */
-  void appendAllLeaves(std::vector<OctreeLeafNode<Particle> *> &leaves) { _pointer->appendAllLeaves(leaves); }
+  void appendAllLeaves(std::vector<OctreeLeafNode<ParticleT> *> &leaves) { _pointer->appendAllLeaves(leaves); }
 
   /**
    * Adds a Particle to the cell.
    * @param p the particle to be added
    */
-  void addParticle(const Particle &p) override {
+  void addParticle(const ParticleT &p) override {
     std::lock_guard<AutoPasLock> lock(_lock);
 
     auto ret = _pointer->insert(p);
@@ -179,7 +179,7 @@ class OctreeNodeWrapper : public ParticleCell<Particle> {
    * @param particle
    * @return True if the given pointer still points to a new, valid particle.
    */
-  bool deleteParticle(Particle &particle) {
+  bool deleteParticle(ParticleT &particle) {
     --_enclosedParticleCount;
 
     return _pointer->deleteParticle(particle);
@@ -216,7 +216,7 @@ class OctreeNodeWrapper : public ParticleCell<Particle> {
    * @param index The index of the particle
    * @return A ref to a particle
    */
-  Particle &at(size_t index) {
+  ParticleT &at(size_t index) {
     std::lock_guard<AutoPasLock> lock(_lock);
     return _ps.at(index);
   }
@@ -227,7 +227,7 @@ class OctreeNodeWrapper : public ParticleCell<Particle> {
    * @param index The index of the particle
    * @return A const ref to a particle
    */
-  const Particle &at(size_t index) const {
+  const ParticleT &at(size_t index) const {
     std::lock_guard<AutoPasLock> lock(_lock);
     return _ps.at(index);
   }
@@ -238,7 +238,7 @@ class OctreeNodeWrapper : public ParticleCell<Particle> {
    * @param index The index of the particle
    * @return A ref to a particle
    */
-  Particle &operator[](size_t index) {
+  ParticleT &operator[](size_t index) {
     std::lock_guard<AutoPasLock> lock(_lock);
     return *_ps[index];
   }
@@ -249,7 +249,7 @@ class OctreeNodeWrapper : public ParticleCell<Particle> {
    * @param index The index of the particle
    * @return A ref to a particle
    */
-  const Particle &operator[](size_t index) const {
+  const ParticleT &operator[](size_t index) const {
     std::lock_guard<AutoPasLock> lock(_lock);
     return *_ps[index];
   }
@@ -260,7 +260,7 @@ class OctreeNodeWrapper : public ParticleCell<Particle> {
    * @param max The maximum coordinate in 3D space of the query area
    * @return A set of all leaf nodes that are in the query region
    */
-  std::set<OctreeLeafNode<Particle> *> getLeavesInRange(const std::array<double, 3> &min,
+  std::set<OctreeLeafNode<ParticleT> *> getLeavesInRange(const std::array<double, 3> &min,
                                                         const std::array<double, 3> &max) {
     return _pointer->getLeavesInRange(min, max);
   }
@@ -270,7 +270,7 @@ class OctreeNodeWrapper : public ParticleCell<Particle> {
    * @note This should only be used for debugging and insight into the internal structure fo the octree.
    * @return A raw C pointer to the enclosed node
    */
-  OctreeNodeInterface<Particle> *getRaw() const { return _pointer.get(); }
+  OctreeNodeInterface<ParticleT> *getRaw() const { return _pointer.get(); }
 
   /**
    * Apply the forEach lambda to each particle.
@@ -338,7 +338,7 @@ class OctreeNodeWrapper : public ParticleCell<Particle> {
   /**
    * A pointer to the root node of the enclosed octree.
    */
-  std::unique_ptr<OctreeNodeInterface<Particle>> _pointer;
+  std::unique_ptr<OctreeNodeInterface<ParticleT>> _pointer;
 
   /**
    * A vector containing all particles when iterating. This serves as a cache such that the octree does not need to

--- a/src/autopas/containers/octree/OctreeNodeWrapper.h
+++ b/src/autopas/containers/octree/OctreeNodeWrapper.h
@@ -62,7 +62,7 @@ class OctreeNodeWrapper : public ParticleCell<ParticleT> {
                     int unsigned const treeSplitThreshold, double const interactionLength,
                     double const cellSizeFactor) {
     _pointer = std::make_unique<OctreeLeafNode<ParticleT>>(boxMin, boxMax, nullptr, treeSplitThreshold,
-                                                          interactionLength, cellSizeFactor);
+                                                           interactionLength, cellSizeFactor);
   }
 
   /**
@@ -261,7 +261,7 @@ class OctreeNodeWrapper : public ParticleCell<ParticleT> {
    * @return A set of all leaf nodes that are in the query region
    */
   std::set<OctreeLeafNode<ParticleT> *> getLeavesInRange(const std::array<double, 3> &min,
-                                                        const std::array<double, 3> &max) {
+                                                         const std::array<double, 3> &max) {
     return _pointer->getLeavesInRange(min, max);
   }
 

--- a/src/autopas/containers/octree/OctreeStaticNodeSelector.h
+++ b/src/autopas/containers/octree/OctreeStaticNodeSelector.h
@@ -26,7 +26,8 @@ class OctreeInnerNode;
  * @return
  */
 template <typename ParticleT, typename FunctionType>
-decltype(auto) withStaticNodeType(const std::unique_ptr<OctreeNodeInterface<ParticleT>> &root, FunctionType &&function) {
+decltype(auto) withStaticNodeType(const std::unique_ptr<OctreeNodeInterface<ParticleT>> &root,
+                                  FunctionType &&function) {
   OctreeNodeInterface<ParticleT> *nodePtr = root.get();
   // TODO: These should be static casts because we already do the runtime check via hasChildren()
   if (nodePtr->hasChildren()) {

--- a/src/autopas/containers/octree/OctreeStaticNodeSelector.h
+++ b/src/autopas/containers/octree/OctreeStaticNodeSelector.h
@@ -13,26 +13,26 @@
 #include "autopas/containers/octree/OctreeNodeWrapper.h"
 
 namespace autopas {
-template <typename Particle>
+template <typename ParticleT>
 class OctreeInnerNode;
 
 /**
  * Will execute the passed function on the given root node.
  *
- * @tparam Particle
+ * @tparam ParticleT
  * @tparam FunctionType
  * @param root
  * @param function
  * @return
  */
-template <typename Particle, typename FunctionType>
-decltype(auto) withStaticNodeType(const std::unique_ptr<OctreeNodeInterface<Particle>> &root, FunctionType &&function) {
-  OctreeNodeInterface<Particle> *nodePtr = root.get();
+template <typename ParticleT, typename FunctionType>
+decltype(auto) withStaticNodeType(const std::unique_ptr<OctreeNodeInterface<ParticleT>> &root, FunctionType &&function) {
+  OctreeNodeInterface<ParticleT> *nodePtr = root.get();
   // TODO: These should be static casts because we already do the runtime check via hasChildren()
   if (nodePtr->hasChildren()) {
-    return function(dynamic_cast<OctreeInnerNode<Particle> *>(nodePtr));
+    return function(dynamic_cast<OctreeInnerNode<ParticleT> *>(nodePtr));
   } else {
-    return function(dynamic_cast<OctreeLeafNode<Particle> *>(nodePtr));
+    return function(dynamic_cast<OctreeLeafNode<ParticleT> *>(nodePtr));
   }
 }
 }  // namespace autopas

--- a/src/autopas/containers/octree/OctreeStaticNodeSelector.h
+++ b/src/autopas/containers/octree/OctreeStaticNodeSelector.h
@@ -13,27 +13,27 @@
 #include "autopas/containers/octree/OctreeNodeWrapper.h"
 
 namespace autopas {
-template <typename ParticleT>
+template <typename Particle_T>
 class OctreeInnerNode;
 
 /**
  * Will execute the passed function on the given root node.
  *
- * @tparam ParticleT
+ * @tparam Particle_T
  * @tparam FunctionType
  * @param root
  * @param function
  * @return
  */
-template <typename ParticleT, typename FunctionType>
-decltype(auto) withStaticNodeType(const std::unique_ptr<OctreeNodeInterface<ParticleT>> &root,
+template <typename Particle_T, typename FunctionType>
+decltype(auto) withStaticNodeType(const std::unique_ptr<OctreeNodeInterface<Particle_T>> &root,
                                   FunctionType &&function) {
-  OctreeNodeInterface<ParticleT> *nodePtr = root.get();
+  OctreeNodeInterface<Particle_T> *nodePtr = root.get();
   // TODO: These should be static casts because we already do the runtime check via hasChildren()
   if (nodePtr->hasChildren()) {
-    return function(dynamic_cast<OctreeInnerNode<ParticleT> *>(nodePtr));
+    return function(dynamic_cast<OctreeInnerNode<Particle_T> *>(nodePtr));
   } else {
-    return function(dynamic_cast<OctreeLeafNode<ParticleT> *>(nodePtr));
+    return function(dynamic_cast<OctreeLeafNode<Particle_T> *>(nodePtr));
   }
 }
 }  // namespace autopas

--- a/src/autopas/containers/octree/traversals/OTC01Traversal.h
+++ b/src/autopas/containers/octree/traversals/OTC01Traversal.h
@@ -76,7 +76,7 @@ class OTC01Traversal : public CellTraversal<OctreeLeafNode<ParticleT>>,
     auto *haloWrapper = this->getHalo();
 
     OctreeLogger<ParticleT>::octreeToJSON(this->getOwned()->getRaw(), this->getHalo()->getRaw(), this->_ownedLeaves,
-                                         this->_haloLeaves);
+                                          this->_haloLeaves);
 
     // Get neighboring cells for each leaf
     // #pragma omp parallel for

--- a/src/autopas/containers/octree/traversals/OTC01Traversal.h
+++ b/src/autopas/containers/octree/traversals/OTC01Traversal.h
@@ -22,17 +22,17 @@ namespace autopas {
 /**
  * This traversal is capable of iterating over particles stored in the Octree data structure.
  *
- * @tparam ParticleT
+ * @tparam Particle_T
  * @tparam PairwiseFunctor
  */
-template <class ParticleT, class PairwiseFunctor>
-class OTC01Traversal : public CellTraversal<OctreeLeafNode<ParticleT>>,
-                       public OTTraversalInterface<OctreeNodeWrapper<ParticleT>> {
+template <class Particle_T, class PairwiseFunctor>
+class OTC01Traversal : public CellTraversal<OctreeLeafNode<Particle_T>>,
+                       public OTTraversalInterface<OctreeNodeWrapper<Particle_T>> {
  public:
   /**
    * A shortcut to specify the type of the actual iterated cell
    */
-  using ParticleCell = OctreeLeafNode<ParticleT>;
+  using ParticleCell = OctreeLeafNode<Particle_T>;
 
   /**
    * Constructor for the Octree traversal.
@@ -45,7 +45,7 @@ class OTC01Traversal : public CellTraversal<OctreeLeafNode<ParticleT>>,
   explicit OTC01Traversal(PairwiseFunctor *pairwiseFunctor, double cutoff, double interactionLength,
                           DataLayoutOption dataLayout, bool useNewton3)
       : CellTraversal<ParticleCell>({2, 1, 1}),
-        OTTraversalInterface<OctreeNodeWrapper<ParticleT>>(interactionLength, dataLayout, useNewton3),
+        OTTraversalInterface<OctreeNodeWrapper<Particle_T>>(interactionLength, dataLayout, useNewton3),
         _cellFunctor(pairwiseFunctor, cutoff /*should use cutoff here, if not used to build verlet-lists*/, dataLayout,
                      useNewton3),
         _dataLayoutConverter(pairwiseFunctor, dataLayout) {}
@@ -75,20 +75,20 @@ class OTC01Traversal : public CellTraversal<OctreeLeafNode<ParticleT>>,
 
     auto *haloWrapper = this->getHalo();
 
-    OctreeLogger<ParticleT>::octreeToJSON(this->getOwned()->getRaw(), this->getHalo()->getRaw(), this->_ownedLeaves,
-                                          this->_haloLeaves);
+    OctreeLogger<Particle_T>::octreeToJSON(this->getOwned()->getRaw(), this->getHalo()->getRaw(), this->_ownedLeaves,
+                                           this->_haloLeaves);
 
     // Get neighboring cells for each leaf
     // #pragma omp parallel for
     for (int i = 0; i < this->_ownedLeaves.size(); ++i) {
-      OctreeLeafNode<ParticleT> *leaf = this->_ownedLeaves[i];
+      OctreeLeafNode<Particle_T> *leaf = this->_ownedLeaves[i];
 
       // Process cell itself
       _cellFunctor.processCell(*leaf);
 
       // Process connection to all neighbors in this octree
       auto uniqueNeighboringLeaves = leaf->getNeighborLeaves();
-      for (OctreeLeafNode<ParticleT> *neighborLeaf : uniqueNeighboringLeaves) {
+      for (OctreeLeafNode<Particle_T> *neighborLeaf : uniqueNeighboringLeaves) {
         _cellFunctor.processCellPair(*leaf, *neighborLeaf);
       }
 
@@ -97,7 +97,7 @@ class OTC01Traversal : public CellTraversal<OctreeLeafNode<ParticleT>>,
       auto max = leaf->getBoxMax() + this->_interactionLength;
       auto haloNeighbors = haloWrapper->getLeavesInRange(min, max);
 
-      for (OctreeLeafNode<ParticleT> *neighborLeaf : haloNeighbors) {
+      for (OctreeLeafNode<Particle_T> *neighborLeaf : haloNeighbors) {
         _cellFunctor.processCellPair(*leaf, *neighborLeaf);
       }
     }

--- a/src/autopas/containers/octree/traversals/OTC01Traversal.h
+++ b/src/autopas/containers/octree/traversals/OTC01Traversal.h
@@ -22,17 +22,17 @@ namespace autopas {
 /**
  * This traversal is capable of iterating over particles stored in the Octree data structure.
  *
- * @tparam Particle
+ * @tparam ParticleT
  * @tparam PairwiseFunctor
  */
-template <class Particle, class PairwiseFunctor>
-class OTC01Traversal : public CellTraversal<OctreeLeafNode<Particle>>,
-                       public OTTraversalInterface<OctreeNodeWrapper<Particle>> {
+template <class ParticleT, class PairwiseFunctor>
+class OTC01Traversal : public CellTraversal<OctreeLeafNode<ParticleT>>,
+                       public OTTraversalInterface<OctreeNodeWrapper<ParticleT>> {
  public:
   /**
    * A shortcut to specify the type of the actual iterated cell
    */
-  using ParticleCell = OctreeLeafNode<Particle>;
+  using ParticleCell = OctreeLeafNode<ParticleT>;
 
   /**
    * Constructor for the Octree traversal.
@@ -45,7 +45,7 @@ class OTC01Traversal : public CellTraversal<OctreeLeafNode<Particle>>,
   explicit OTC01Traversal(PairwiseFunctor *pairwiseFunctor, double cutoff, double interactionLength,
                           DataLayoutOption dataLayout, bool useNewton3)
       : CellTraversal<ParticleCell>({2, 1, 1}),
-        OTTraversalInterface<OctreeNodeWrapper<Particle>>(interactionLength, dataLayout, useNewton3),
+        OTTraversalInterface<OctreeNodeWrapper<ParticleT>>(interactionLength, dataLayout, useNewton3),
         _cellFunctor(pairwiseFunctor, cutoff /*should use cutoff here, if not used to build verlet-lists*/, dataLayout,
                      useNewton3),
         _dataLayoutConverter(pairwiseFunctor, dataLayout) {}
@@ -75,20 +75,20 @@ class OTC01Traversal : public CellTraversal<OctreeLeafNode<Particle>>,
 
     auto *haloWrapper = this->getHalo();
 
-    OctreeLogger<Particle>::octreeToJSON(this->getOwned()->getRaw(), this->getHalo()->getRaw(), this->_ownedLeaves,
+    OctreeLogger<ParticleT>::octreeToJSON(this->getOwned()->getRaw(), this->getHalo()->getRaw(), this->_ownedLeaves,
                                          this->_haloLeaves);
 
     // Get neighboring cells for each leaf
     // #pragma omp parallel for
     for (int i = 0; i < this->_ownedLeaves.size(); ++i) {
-      OctreeLeafNode<Particle> *leaf = this->_ownedLeaves[i];
+      OctreeLeafNode<ParticleT> *leaf = this->_ownedLeaves[i];
 
       // Process cell itself
       _cellFunctor.processCell(*leaf);
 
       // Process connection to all neighbors in this octree
       auto uniqueNeighboringLeaves = leaf->getNeighborLeaves();
-      for (OctreeLeafNode<Particle> *neighborLeaf : uniqueNeighboringLeaves) {
+      for (OctreeLeafNode<ParticleT> *neighborLeaf : uniqueNeighboringLeaves) {
         _cellFunctor.processCellPair(*leaf, *neighborLeaf);
       }
 
@@ -97,7 +97,7 @@ class OTC01Traversal : public CellTraversal<OctreeLeafNode<Particle>>,
       auto max = leaf->getBoxMax() + this->_interactionLength;
       auto haloNeighbors = haloWrapper->getLeavesInRange(min, max);
 
-      for (OctreeLeafNode<Particle> *neighborLeaf : haloNeighbors) {
+      for (OctreeLeafNode<ParticleT> *neighborLeaf : haloNeighbors) {
         _cellFunctor.processCellPair(*leaf, *neighborLeaf);
       }
     }

--- a/src/autopas/containers/octree/traversals/OTC18Traversal.h
+++ b/src/autopas/containers/octree/traversals/OTC18Traversal.h
@@ -22,17 +22,17 @@ namespace autopas {
  * This traversal is capable of iterating over particles stored in the Octree data structure. This traversal does not
  * use any parallelization or speed-increasing strategies and is therefore called naive.
  *
- * @tparam Particle
+ * @tparam ParticleT
  * @tparam PairwiseFunctor
  */
-template <class Particle, class PairwiseFunctor>
-class OTC18Traversal : public CellTraversal<OctreeLeafNode<Particle>>,
-                       public OTTraversalInterface<OctreeNodeWrapper<Particle>> {
+template <class ParticleT, class PairwiseFunctor>
+class OTC18Traversal : public CellTraversal<OctreeLeafNode<ParticleT>>,
+                       public OTTraversalInterface<OctreeNodeWrapper<ParticleT>> {
  public:
   /**
    * A shortcut to specify the type of the actual iterated cell
    */
-  using ParticleCell = OctreeLeafNode<Particle>;
+  using ParticleCell = OctreeLeafNode<ParticleT>;
 
   /**
    * Constructor for the Octree traversal.
@@ -47,7 +47,7 @@ class OTC18Traversal : public CellTraversal<OctreeLeafNode<Particle>>,
       // {2, 1, 1} says that there are only two cells in the container (owned and halo), no other cell. Both are along
       // the (imaginary) x-axis. This results in the cuboid specified by {2, 1, 1}.
       : CellTraversal<ParticleCell>({2, 1, 1}),
-        OTTraversalInterface<OctreeNodeWrapper<Particle>>(interactionLength, dataLayout, useNewton3),
+        OTTraversalInterface<OctreeNodeWrapper<ParticleT>>(interactionLength, dataLayout, useNewton3),
         _cellFunctor(pairwiseFunctor, cutoff /*should use cutoff here, if not used to build verlet-lists*/, dataLayout,
                      useNewton3),
         _dataLayoutConverter(pairwiseFunctor, dataLayout) {}
@@ -62,7 +62,7 @@ class OTC18Traversal : public CellTraversal<OctreeLeafNode<Particle>>,
    * @param leaves A list of leaves to assign the IDs to
    * @param startID The minimum ID
    */
-  static void assignIDs(std::vector<OctreeLeafNode<Particle> *> &leaves, int startID = 0) {
+  static void assignIDs(std::vector<OctreeLeafNode<ParticleT> *> &leaves, int startID = 0) {
     for (int i = 0; i < leaves.size(); ++i) {
       leaves[i]->setID(startID + i);
     }
@@ -94,13 +94,13 @@ class OTC18Traversal : public CellTraversal<OctreeLeafNode<Particle>>,
     auto *haloWrapper = this->getHalo();
 
     // Get neighboring cells for each leaf
-    for (OctreeLeafNode<Particle> *leaf : this->_ownedLeaves) {
+    for (OctreeLeafNode<ParticleT> *leaf : this->_ownedLeaves) {
       // Process cell itself
       _cellFunctor.processCell(*leaf);
 
       // Process connection to all neighbors
       auto uniqueNeighboringLeaves = leaf->getNeighborLeaves();
-      for (OctreeLeafNode<Particle> *neighborLeaf : uniqueNeighboringLeaves) {
+      for (OctreeLeafNode<ParticleT> *neighborLeaf : uniqueNeighboringLeaves) {
         if (leaf->getID() < neighborLeaf->getID()) {
           // Execute the cell functor
           _cellFunctor.processCellPair(*leaf, *neighborLeaf);
@@ -112,7 +112,7 @@ class OTC18Traversal : public CellTraversal<OctreeLeafNode<Particle>>,
       auto max = leaf->getBoxMax() + this->_interactionLength;
       auto haloNeighbors = haloWrapper->getLeavesInRange(min, max);
 
-      for (OctreeLeafNode<Particle> *neighborLeaf : haloNeighbors) {
+      for (OctreeLeafNode<ParticleT> *neighborLeaf : haloNeighbors) {
         if (leaf->getID() < neighborLeaf->getID()) {
           _cellFunctor.processCellPair(*leaf, *neighborLeaf);
         }

--- a/src/autopas/containers/octree/traversals/OTC18Traversal.h
+++ b/src/autopas/containers/octree/traversals/OTC18Traversal.h
@@ -22,17 +22,17 @@ namespace autopas {
  * This traversal is capable of iterating over particles stored in the Octree data structure. This traversal does not
  * use any parallelization or speed-increasing strategies and is therefore called naive.
  *
- * @tparam ParticleT
+ * @tparam Particle_T
  * @tparam PairwiseFunctor
  */
-template <class ParticleT, class PairwiseFunctor>
-class OTC18Traversal : public CellTraversal<OctreeLeafNode<ParticleT>>,
-                       public OTTraversalInterface<OctreeNodeWrapper<ParticleT>> {
+template <class Particle_T, class PairwiseFunctor>
+class OTC18Traversal : public CellTraversal<OctreeLeafNode<Particle_T>>,
+                       public OTTraversalInterface<OctreeNodeWrapper<Particle_T>> {
  public:
   /**
    * A shortcut to specify the type of the actual iterated cell
    */
-  using ParticleCell = OctreeLeafNode<ParticleT>;
+  using ParticleCell = OctreeLeafNode<Particle_T>;
 
   /**
    * Constructor for the Octree traversal.
@@ -47,7 +47,7 @@ class OTC18Traversal : public CellTraversal<OctreeLeafNode<ParticleT>>,
       // {2, 1, 1} says that there are only two cells in the container (owned and halo), no other cell. Both are along
       // the (imaginary) x-axis. This results in the cuboid specified by {2, 1, 1}.
       : CellTraversal<ParticleCell>({2, 1, 1}),
-        OTTraversalInterface<OctreeNodeWrapper<ParticleT>>(interactionLength, dataLayout, useNewton3),
+        OTTraversalInterface<OctreeNodeWrapper<Particle_T>>(interactionLength, dataLayout, useNewton3),
         _cellFunctor(pairwiseFunctor, cutoff /*should use cutoff here, if not used to build verlet-lists*/, dataLayout,
                      useNewton3),
         _dataLayoutConverter(pairwiseFunctor, dataLayout) {}
@@ -62,7 +62,7 @@ class OTC18Traversal : public CellTraversal<OctreeLeafNode<ParticleT>>,
    * @param leaves A list of leaves to assign the IDs to
    * @param startID The minimum ID
    */
-  static void assignIDs(std::vector<OctreeLeafNode<ParticleT> *> &leaves, int startID = 0) {
+  static void assignIDs(std::vector<OctreeLeafNode<Particle_T> *> &leaves, int startID = 0) {
     for (int i = 0; i < leaves.size(); ++i) {
       leaves[i]->setID(startID + i);
     }
@@ -94,13 +94,13 @@ class OTC18Traversal : public CellTraversal<OctreeLeafNode<ParticleT>>,
     auto *haloWrapper = this->getHalo();
 
     // Get neighboring cells for each leaf
-    for (OctreeLeafNode<ParticleT> *leaf : this->_ownedLeaves) {
+    for (OctreeLeafNode<Particle_T> *leaf : this->_ownedLeaves) {
       // Process cell itself
       _cellFunctor.processCell(*leaf);
 
       // Process connection to all neighbors
       auto uniqueNeighboringLeaves = leaf->getNeighborLeaves();
-      for (OctreeLeafNode<ParticleT> *neighborLeaf : uniqueNeighboringLeaves) {
+      for (OctreeLeafNode<Particle_T> *neighborLeaf : uniqueNeighboringLeaves) {
         if (leaf->getID() < neighborLeaf->getID()) {
           // Execute the cell functor
           _cellFunctor.processCellPair(*leaf, *neighborLeaf);
@@ -112,7 +112,7 @@ class OTC18Traversal : public CellTraversal<OctreeLeafNode<ParticleT>>,
       auto max = leaf->getBoxMax() + this->_interactionLength;
       auto haloNeighbors = haloWrapper->getLeavesInRange(min, max);
 
-      for (OctreeLeafNode<ParticleT> *neighborLeaf : haloNeighbors) {
+      for (OctreeLeafNode<Particle_T> *neighborLeaf : haloNeighbors) {
         if (leaf->getID() < neighborLeaf->getID()) {
           _cellFunctor.processCellPair(*leaf, *neighborLeaf);
         }

--- a/src/autopas/containers/verletClusterLists/Cluster.h
+++ b/src/autopas/containers/verletClusterLists/Cluster.h
@@ -19,10 +19,10 @@ namespace autopas::internal {
  *
  * It contains a pointer to the particles for AoS, a SoAView for SoA, and the neighbor list for this cluster.
  *
- * @tparam ParticleT The type of the particles this cluster consists of.
+ * @tparam Particle_T The type of the particles this cluster consists of.
  * @tparam clusterSize The number of particles in the cluster.
  */
-template <class ParticleT>
+template <class Particle_T>
 class Cluster {
  public:
   /**
@@ -33,7 +33,7 @@ class Cluster {
    * @param firstParticle A pointer to the first particle of the cluster.
    * @param clusterSize Number of particles in the cluster.
    */
-  explicit Cluster(ParticleT *firstParticle, size_t clusterSize)
+  explicit Cluster(Particle_T *firstParticle, size_t clusterSize)
       : _firstParticle(firstParticle), _clusterSize(clusterSize) {}
 
   /**
@@ -44,12 +44,12 @@ class Cluster {
    * @param index The index of the particle to return.
    * @return the particle at position index in the cluster.
    */
-  ParticleT &operator[](size_t index) { return *(_firstParticle + index); }
+  Particle_T &operator[](size_t index) { return *(_firstParticle + index); }
 
   /**
    * @copydoc operator[](size_t)
    */
-  const ParticleT &operator[](size_t index) const { return *(_firstParticle + index); }
+  const Particle_T &operator[](size_t index) const { return *(_firstParticle + index); }
 
   /**
    * Indicates if the cluster contains any non-dummy particles.
@@ -93,25 +93,25 @@ class Cluster {
    * Set the SoAView for this cluster.
    * @param view the new SoAView for this cluster.
    */
-  void setSoAView(const SoAView<typename ParticleT::SoAArraysType> &view) { _soaView = view; }
+  void setSoAView(const SoAView<typename Particle_T::SoAArraysType> &view) { _soaView = view; }
 
   /**
    * Set the internal neighbor list pointer to an allocated, but not necessarily complete, existing list.
    * @param neighborList Allocated neighbor list.
    */
-  void setNeighborList(std::vector<Cluster<ParticleT> *> *neighborList) { _neighborClusters = neighborList; }
+  void setNeighborList(std::vector<Cluster<Particle_T> *> *neighborList) { _neighborClusters = neighborList; }
 
   /**
    * Returns the reference to the neighbor list for this cluster.
    * @return reference to the neighbor list.
    */
-  std::vector<Cluster<ParticleT> *> *getNeighbors() { return _neighborClusters; }
+  std::vector<Cluster<Particle_T> *> *getNeighbors() { return _neighborClusters; }
 
   /**
    * Adds the given cluster to the neighbor list of this cluster.
    * @param neighbor The cluster to add as neighbor.
    */
-  void addNeighbor(Cluster<ParticleT> &neighbor) { _neighborClusters->push_back(&neighbor); }
+  void addNeighbor(Cluster<Particle_T> &neighbor) { _neighborClusters->push_back(&neighbor); }
 
   /**
    * Remove all neighbors.
@@ -126,7 +126,7 @@ class Cluster {
    *
    * @param firstParticle
    */
-  void reset(ParticleT *firstParticle) { _firstParticle = firstParticle; }
+  void reset(Particle_T *firstParticle) { _firstParticle = firstParticle; }
 
   /**
    * Get the bounding box of this cluster
@@ -157,11 +157,11 @@ class Cluster {
   /**
    * A pointer to the first particle of the cluster.
    */
-  ParticleT *_firstParticle = nullptr;
+  Particle_T *_firstParticle = nullptr;
   /**
    * The SoAView for this cluster.
    */
-  SoAView<typename ParticleT::SoAArraysType> _soaView;
+  SoAView<typename Particle_T::SoAArraysType> _soaView;
   /**
    * The list of neighbor clusters of this cluster.
    */

--- a/src/autopas/containers/verletClusterLists/Cluster.h
+++ b/src/autopas/containers/verletClusterLists/Cluster.h
@@ -19,10 +19,10 @@ namespace autopas::internal {
  *
  * It contains a pointer to the particles for AoS, a SoAView for SoA, and the neighbor list for this cluster.
  *
- * @tparam Particle The type of the particles this cluster consists of.
+ * @tparam ParticleT The type of the particles this cluster consists of.
  * @tparam clusterSize The number of particles in the cluster.
  */
-template <class Particle>
+template <class ParticleT>
 class Cluster {
  public:
   /**
@@ -33,7 +33,7 @@ class Cluster {
    * @param firstParticle A pointer to the first particle of the cluster.
    * @param clusterSize Number of particles in the cluster.
    */
-  explicit Cluster(Particle *firstParticle, size_t clusterSize)
+  explicit Cluster(ParticleT *firstParticle, size_t clusterSize)
       : _firstParticle(firstParticle), _clusterSize(clusterSize) {}
 
   /**
@@ -44,12 +44,12 @@ class Cluster {
    * @param index The index of the particle to return.
    * @return the particle at position index in the cluster.
    */
-  Particle &operator[](size_t index) { return *(_firstParticle + index); }
+  ParticleT &operator[](size_t index) { return *(_firstParticle + index); }
 
   /**
    * @copydoc operator[](size_t)
    */
-  const Particle &operator[](size_t index) const { return *(_firstParticle + index); }
+  const ParticleT &operator[](size_t index) const { return *(_firstParticle + index); }
 
   /**
    * Indicates if the cluster contains any non-dummy particles.
@@ -93,25 +93,25 @@ class Cluster {
    * Set the SoAView for this cluster.
    * @param view the new SoAView for this cluster.
    */
-  void setSoAView(const SoAView<typename Particle::SoAArraysType> &view) { _soaView = view; }
+  void setSoAView(const SoAView<typename ParticleT::SoAArraysType> &view) { _soaView = view; }
 
   /**
    * Set the internal neighbor list pointer to an allocated, but not necessarily complete, existing list.
    * @param neighborList Allocated neighbor list.
    */
-  void setNeighborList(std::vector<Cluster<Particle> *> *neighborList) { _neighborClusters = neighborList; }
+  void setNeighborList(std::vector<Cluster<ParticleT> *> *neighborList) { _neighborClusters = neighborList; }
 
   /**
    * Returns the reference to the neighbor list for this cluster.
    * @return reference to the neighbor list.
    */
-  std::vector<Cluster<Particle> *> *getNeighbors() { return _neighborClusters; }
+  std::vector<Cluster<ParticleT> *> *getNeighbors() { return _neighborClusters; }
 
   /**
    * Adds the given cluster to the neighbor list of this cluster.
    * @param neighbor The cluster to add as neighbor.
    */
-  void addNeighbor(Cluster<Particle> &neighbor) { _neighborClusters->push_back(&neighbor); }
+  void addNeighbor(Cluster<ParticleT> &neighbor) { _neighborClusters->push_back(&neighbor); }
 
   /**
    * Remove all neighbors.
@@ -126,7 +126,7 @@ class Cluster {
    *
    * @param firstParticle
    */
-  void reset(Particle *firstParticle) { _firstParticle = firstParticle; }
+  void reset(ParticleT *firstParticle) { _firstParticle = firstParticle; }
 
   /**
    * Get the bounding box of this cluster
@@ -157,11 +157,11 @@ class Cluster {
   /**
    * A pointer to the first particle of the cluster.
    */
-  Particle *_firstParticle = nullptr;
+  ParticleT *_firstParticle = nullptr;
   /**
    * The SoAView for this cluster.
    */
-  SoAView<typename Particle::SoAArraysType> _soaView;
+  SoAView<typename ParticleT::SoAArraysType> _soaView;
   /**
    * The list of neighbor clusters of this cluster.
    */

--- a/src/autopas/containers/verletClusterLists/ClusterTower.h
+++ b/src/autopas/containers/verletClusterLists/ClusterTower.h
@@ -224,7 +224,7 @@ class ClusterTower : public FullParticleCell<ParticleT> {
    * @return Vector of particles that should be stored somewhere else.
    */
   std::vector<ParticleT> collectOutOfBoundsParticles(const std::array<double, 3> &boxMin,
-                                                    const std::array<double, 3> &boxMax) {
+                                                     const std::array<double, 3> &boxMax) {
     // make sure to get rid of all dummies
     deleteDummyParticles();
     // move all particles that are not in the tower to the back of the storage

--- a/src/autopas/containers/verletClusterLists/ClusterTower.h
+++ b/src/autopas/containers/verletClusterLists/ClusterTower.h
@@ -36,16 +36,16 @@ namespace autopas::internal {
  * calling addParticle() again, since doing otherwise will mess up the dummy particles and actual particles will likely
  * get lost.
  *
- * @tparam ParticleT
+ * @tparam Particle_T
  * @tparam clusterSize
  */
-template <class ParticleT>
-class ClusterTower : public FullParticleCell<ParticleT> {
+template <class Particle_T>
+class ClusterTower : public FullParticleCell<Particle_T> {
  public:
   /**
    * Type that holds or refers to the actual particles.
    */
-  using StorageType = typename FullParticleCell<ParticleT>::StorageType;
+  using StorageType = typename FullParticleCell<Particle_T>::StorageType;
 
   /**
    * Dummy constructor.
@@ -65,7 +65,7 @@ class ClusterTower : public FullParticleCell<ParticleT> {
    */
   void clear() override {
     _clusters.clear();
-    FullParticleCell<ParticleT>::clear();
+    FullParticleCell<Particle_T>::clear();
     _firstOwnedCluster = _clusters.end();
     _firstTailHaloCluster = _clusters.end();
     _numDummyParticles = 0;
@@ -82,7 +82,7 @@ class ClusterTower : public FullParticleCell<ParticleT> {
    */
   size_t generateClusters() {
     if (getNumActualParticles() == 0) {
-      _clusters.resize(0, Cluster<ParticleT>(nullptr, _clusterSize));
+      _clusters.resize(0, Cluster<Particle_T>(nullptr, _clusterSize));
       _firstOwnedCluster = _clusters.end();
       _firstTailHaloCluster = _clusters.end();
       return 0;
@@ -102,7 +102,7 @@ class ClusterTower : public FullParticleCell<ParticleT> {
 
     // Mark start of the different clusters by adding pointers to _particles
     const size_t numClusters = this->_particles.size() / _clusterSize;
-    _clusters.resize(numClusters, Cluster<ParticleT>(nullptr, _clusterSize));
+    _clusters.resize(numClusters, Cluster<Particle_T>(nullptr, _clusterSize));
     bool foundFirstOwnedCluster = false;
     bool foundFirstTailHaloCluster = false;
 
@@ -204,7 +204,7 @@ class ClusterTower : public FullParticleCell<ParticleT> {
    * clear() has to called afterwards!
    * @return
    */
-  std::vector<ParticleT> &&collectAllActualParticles() {
+  std::vector<Particle_T> &&collectAllActualParticles() {
     if (not this->_particles.empty()) {
       // Workaround to remove requirement of default constructible particles.
       // This function will always only shrink the array, particles are not actually inserted.
@@ -223,8 +223,8 @@ class ClusterTower : public FullParticleCell<ParticleT> {
    * @param boxMax
    * @return Vector of particles that should be stored somewhere else.
    */
-  std::vector<ParticleT> collectOutOfBoundsParticles(const std::array<double, 3> &boxMin,
-                                                     const std::array<double, 3> &boxMax) {
+  std::vector<Particle_T> collectOutOfBoundsParticles(const std::array<double, 3> &boxMin,
+                                                      const std::array<double, 3> &boxMax) {
     // make sure to get rid of all dummies
     deleteDummyParticles();
     // move all particles that are not in the tower to the back of the storage
@@ -233,7 +233,7 @@ class ClusterTower : public FullParticleCell<ParticleT> {
                        [&](const auto &p) { return utils::inBox(p.getR(), boxMin, boxMax); });
 
     // copy out of bounds particles
-    std::vector<ParticleT> outOfBoundsParticles(firstOutOfBoundsParticleIter, this->_particles.end());
+    std::vector<Particle_T> outOfBoundsParticles(firstOutOfBoundsParticleIter, this->_particles.end());
     // shrink the particle storage so all out of bounds particles are cut away
     this->_particles.resize(std::distance(this->_particles.begin(), firstOutOfBoundsParticleIter),
                             *this->_particles.begin());
@@ -277,7 +277,7 @@ class ClusterTower : public FullParticleCell<ParticleT> {
    * Returns an iterator to the first cluster that contains at least one owned particle.
    * @return
    */
-  [[nodiscard]] const typename std::vector<autopas::internal::Cluster<ParticleT>>::iterator &getFirstOwnedCluster()
+  [[nodiscard]] const typename std::vector<autopas::internal::Cluster<Particle_T>>::iterator &getFirstOwnedCluster()
       const {
     return _firstOwnedCluster;
   }
@@ -294,7 +294,7 @@ class ClusterTower : public FullParticleCell<ParticleT> {
    * Returns an iterator to the first particle after the owned clusters, that contains no owned particles anymore.
    * @return
    */
-  [[nodiscard]] const typename std::vector<autopas::internal::Cluster<ParticleT>>::iterator &getFirstTailHaloCluster()
+  [[nodiscard]] const typename std::vector<autopas::internal::Cluster<Particle_T>>::iterator &getFirstTailHaloCluster()
       const {
     return _firstTailHaloCluster;
   }
@@ -323,7 +323,7 @@ class ClusterTower : public FullParticleCell<ParticleT> {
 
   void deleteDummyParticles() override {
     // call super function to do the actual delete
-    FullParticleCell<ParticleT>::deleteDummyParticles();
+    FullParticleCell<Particle_T>::deleteDummyParticles();
     _numDummyParticles = 0;
   }
 
@@ -390,7 +390,7 @@ class ClusterTower : public FullParticleCell<ParticleT> {
   /**
    * The clusters that are contained in this tower.
    */
-  std::vector<Cluster<ParticleT>> _clusters;
+  std::vector<Cluster<Particle_T>> _clusters;
 
   /**
    * Iterator pointing to the first cluster that contains at least one owned particle.

--- a/src/autopas/containers/verletClusterLists/ClusterTower.h
+++ b/src/autopas/containers/verletClusterLists/ClusterTower.h
@@ -36,16 +36,16 @@ namespace autopas::internal {
  * calling addParticle() again, since doing otherwise will mess up the dummy particles and actual particles will likely
  * get lost.
  *
- * @tparam Particle
+ * @tparam ParticleT
  * @tparam clusterSize
  */
-template <class Particle>
-class ClusterTower : public FullParticleCell<Particle> {
+template <class ParticleT>
+class ClusterTower : public FullParticleCell<ParticleT> {
  public:
   /**
    * Type that holds or refers to the actual particles.
    */
-  using StorageType = typename FullParticleCell<Particle>::StorageType;
+  using StorageType = typename FullParticleCell<ParticleT>::StorageType;
 
   /**
    * Dummy constructor.
@@ -65,7 +65,7 @@ class ClusterTower : public FullParticleCell<Particle> {
    */
   void clear() override {
     _clusters.clear();
-    FullParticleCell<Particle>::clear();
+    FullParticleCell<ParticleT>::clear();
     _firstOwnedCluster = _clusters.end();
     _firstTailHaloCluster = _clusters.end();
     _numDummyParticles = 0;
@@ -82,7 +82,7 @@ class ClusterTower : public FullParticleCell<Particle> {
    */
   size_t generateClusters() {
     if (getNumActualParticles() == 0) {
-      _clusters.resize(0, Cluster<Particle>(nullptr, _clusterSize));
+      _clusters.resize(0, Cluster<ParticleT>(nullptr, _clusterSize));
       _firstOwnedCluster = _clusters.end();
       _firstTailHaloCluster = _clusters.end();
       return 0;
@@ -102,7 +102,7 @@ class ClusterTower : public FullParticleCell<Particle> {
 
     // Mark start of the different clusters by adding pointers to _particles
     const size_t numClusters = this->_particles.size() / _clusterSize;
-    _clusters.resize(numClusters, Cluster<Particle>(nullptr, _clusterSize));
+    _clusters.resize(numClusters, Cluster<ParticleT>(nullptr, _clusterSize));
     bool foundFirstOwnedCluster = false;
     bool foundFirstTailHaloCluster = false;
 
@@ -204,7 +204,7 @@ class ClusterTower : public FullParticleCell<Particle> {
    * clear() has to called afterwards!
    * @return
    */
-  std::vector<Particle> &&collectAllActualParticles() {
+  std::vector<ParticleT> &&collectAllActualParticles() {
     if (not this->_particles.empty()) {
       // Workaround to remove requirement of default constructible particles.
       // This function will always only shrink the array, particles are not actually inserted.
@@ -223,7 +223,7 @@ class ClusterTower : public FullParticleCell<Particle> {
    * @param boxMax
    * @return Vector of particles that should be stored somewhere else.
    */
-  std::vector<Particle> collectOutOfBoundsParticles(const std::array<double, 3> &boxMin,
+  std::vector<ParticleT> collectOutOfBoundsParticles(const std::array<double, 3> &boxMin,
                                                     const std::array<double, 3> &boxMax) {
     // make sure to get rid of all dummies
     deleteDummyParticles();
@@ -233,7 +233,7 @@ class ClusterTower : public FullParticleCell<Particle> {
                        [&](const auto &p) { return utils::inBox(p.getR(), boxMin, boxMax); });
 
     // copy out of bounds particles
-    std::vector<Particle> outOfBoundsParticles(firstOutOfBoundsParticleIter, this->_particles.end());
+    std::vector<ParticleT> outOfBoundsParticles(firstOutOfBoundsParticleIter, this->_particles.end());
     // shrink the particle storage so all out of bounds particles are cut away
     this->_particles.resize(std::distance(this->_particles.begin(), firstOutOfBoundsParticleIter),
                             *this->_particles.begin());
@@ -277,7 +277,7 @@ class ClusterTower : public FullParticleCell<Particle> {
    * Returns an iterator to the first cluster that contains at least one owned particle.
    * @return
    */
-  [[nodiscard]] const typename std::vector<autopas::internal::Cluster<Particle>>::iterator &getFirstOwnedCluster()
+  [[nodiscard]] const typename std::vector<autopas::internal::Cluster<ParticleT>>::iterator &getFirstOwnedCluster()
       const {
     return _firstOwnedCluster;
   }
@@ -294,7 +294,7 @@ class ClusterTower : public FullParticleCell<Particle> {
    * Returns an iterator to the first particle after the owned clusters, that contains no owned particles anymore.
    * @return
    */
-  [[nodiscard]] const typename std::vector<autopas::internal::Cluster<Particle>>::iterator &getFirstTailHaloCluster()
+  [[nodiscard]] const typename std::vector<autopas::internal::Cluster<ParticleT>>::iterator &getFirstTailHaloCluster()
       const {
     return _firstTailHaloCluster;
   }
@@ -323,7 +323,7 @@ class ClusterTower : public FullParticleCell<Particle> {
 
   void deleteDummyParticles() override {
     // call super function to do the actual delete
-    FullParticleCell<Particle>::deleteDummyParticles();
+    FullParticleCell<ParticleT>::deleteDummyParticles();
     _numDummyParticles = 0;
   }
 
@@ -390,7 +390,7 @@ class ClusterTower : public FullParticleCell<Particle> {
   /**
    * The clusters that are contained in this tower.
    */
-  std::vector<Cluster<Particle>> _clusters;
+  std::vector<Cluster<ParticleT>> _clusters;
 
   /**
    * Iterator pointing to the first cluster that contains at least one owned particle.

--- a/src/autopas/containers/verletClusterLists/ClusterTowerBlock2D.h
+++ b/src/autopas/containers/verletClusterLists/ClusterTowerBlock2D.h
@@ -19,9 +19,9 @@ namespace autopas::internal {
  * Class to manage the grid of towers for the Verlet Cluster Lists container.
  * This also includes the geometric shape of the container.
  *
- * @tparam ParticleT
+ * @tparam Particle_T
  */
-template <class ParticleT>
+template <class Particle_T>
 class ClusterTowerBlock2D : public CellBorderAndFlagManager {
  public:
   /**
@@ -44,36 +44,36 @@ class ClusterTowerBlock2D : public CellBorderAndFlagManager {
    * Start iterator over towers.
    * @return
    */
-  typename std::vector<ClusterTower<ParticleT>>::iterator begin() { return _towers.begin(); }
+  typename std::vector<ClusterTower<Particle_T>>::iterator begin() { return _towers.begin(); }
   /**
    * Start iterator over towers.
    * @return
    */
-  typename std::vector<ClusterTower<ParticleT>>::const_iterator begin() const { return _towers.begin(); }
+  typename std::vector<ClusterTower<Particle_T>>::const_iterator begin() const { return _towers.begin(); }
   /**
    * End iterator over towers.
    * @return
    */
-  typename std::vector<ClusterTower<ParticleT>>::iterator end() { return _towers.end(); }
+  typename std::vector<ClusterTower<Particle_T>>::iterator end() { return _towers.end(); }
   /**
    * End iterator over towers.
    * @return
    */
-  typename std::vector<ClusterTower<ParticleT>>::const_iterator end() const { return _towers.end(); }
+  typename std::vector<ClusterTower<Particle_T>>::const_iterator end() const { return _towers.end(); }
 
   /**
    * Access operator for towers.
    * @param i 1D tower index
    * @return
    */
-  ClusterTower<ParticleT> &operator[](size_t i) { return _towers[i]; }
+  ClusterTower<Particle_T> &operator[](size_t i) { return _towers[i]; }
 
   /**
    * Access operator for towers.
    * @param i 1D tower index
    * @return
    */
-  const ClusterTower<ParticleT> &operator[](size_t i) const { return _towers[i]; }
+  const ClusterTower<Particle_T> &operator[](size_t i) const { return _towers[i]; }
 
   /**
    * Return the number of towers.
@@ -257,7 +257,7 @@ class ClusterTowerBlock2D : public CellBorderAndFlagManager {
    * @param pos
    * @return
    */
-  ClusterTower<ParticleT> &getTowerAtPosition(const std::array<double, 3> &pos) {
+  ClusterTower<Particle_T> &getTowerAtPosition(const std::array<double, 3> &pos) {
     const auto [x, y] = getTowerIndex2DAtPosition(pos);
     return getTowerByIndex2D(x, y);
   }
@@ -268,7 +268,9 @@ class ClusterTowerBlock2D : public CellBorderAndFlagManager {
    * @param y The y-th tower in y direction.
    * @return a reference to the tower for the given tower grid coordinates.
    */
-  ClusterTower<ParticleT> &getTowerByIndex2D(const size_t x, const size_t y) { return _towers[towerIndex2DTo1D(x, y)]; }
+  ClusterTower<Particle_T> &getTowerByIndex2D(const size_t x, const size_t y) {
+    return _towers[towerIndex2DTo1D(x, y)];
+  }
 
   /**
    * Returns the 1D index for the given 2D-coordinates of a tower.
@@ -337,12 +339,12 @@ class ClusterTowerBlock2D : public CellBorderAndFlagManager {
    * Getter
    * @return
    */
-  const std::vector<ClusterTower<ParticleT>> &getTowers() const { return _towers; }
+  const std::vector<ClusterTower<Particle_T>> &getTowers() const { return _towers; }
   /**
    * Getter for a mutable reference
    * @return
    */
-  std::vector<ClusterTower<ParticleT>> &getTowersRef() { return _towers; }
+  std::vector<ClusterTower<Particle_T>> &getTowersRef() { return _towers; }
   /**
    * Getter
    * @return
@@ -423,7 +425,7 @@ class ClusterTowerBlock2D : public CellBorderAndFlagManager {
   /**
    * Internal storage, particles are split into a grid in xy-dimension.
    */
-  std::vector<ClusterTower<ParticleT>> _towers;
+  std::vector<ClusterTower<Particle_T>> _towers;
 
   /**
    * Dimensions of the 2D xy-grid including halo.

--- a/src/autopas/containers/verletClusterLists/ClusterTowerBlock2D.h
+++ b/src/autopas/containers/verletClusterLists/ClusterTowerBlock2D.h
@@ -19,9 +19,9 @@ namespace autopas::internal {
  * Class to manage the grid of towers for the Verlet Cluster Lists container.
  * This also includes the geometric shape of the container.
  *
- * @tparam Particle
+ * @tparam ParticleT
  */
-template <class Particle>
+template <class ParticleT>
 class ClusterTowerBlock2D : public CellBorderAndFlagManager {
  public:
   /**
@@ -44,36 +44,36 @@ class ClusterTowerBlock2D : public CellBorderAndFlagManager {
    * Start iterator over towers.
    * @return
    */
-  typename std::vector<ClusterTower<Particle>>::iterator begin() { return _towers.begin(); }
+  typename std::vector<ClusterTower<ParticleT>>::iterator begin() { return _towers.begin(); }
   /**
    * Start iterator over towers.
    * @return
    */
-  typename std::vector<ClusterTower<Particle>>::const_iterator begin() const { return _towers.begin(); }
+  typename std::vector<ClusterTower<ParticleT>>::const_iterator begin() const { return _towers.begin(); }
   /**
    * End iterator over towers.
    * @return
    */
-  typename std::vector<ClusterTower<Particle>>::iterator end() { return _towers.end(); }
+  typename std::vector<ClusterTower<ParticleT>>::iterator end() { return _towers.end(); }
   /**
    * End iterator over towers.
    * @return
    */
-  typename std::vector<ClusterTower<Particle>>::const_iterator end() const { return _towers.end(); }
+  typename std::vector<ClusterTower<ParticleT>>::const_iterator end() const { return _towers.end(); }
 
   /**
    * Access operator for towers.
    * @param i 1D tower index
    * @return
    */
-  ClusterTower<Particle> &operator[](size_t i) { return _towers[i]; }
+  ClusterTower<ParticleT> &operator[](size_t i) { return _towers[i]; }
 
   /**
    * Access operator for towers.
    * @param i 1D tower index
    * @return
    */
-  const ClusterTower<Particle> &operator[](size_t i) const { return _towers[i]; }
+  const ClusterTower<ParticleT> &operator[](size_t i) const { return _towers[i]; }
 
   /**
    * Return the number of towers.
@@ -257,7 +257,7 @@ class ClusterTowerBlock2D : public CellBorderAndFlagManager {
    * @param pos
    * @return
    */
-  ClusterTower<Particle> &getTowerAtPosition(const std::array<double, 3> &pos) {
+  ClusterTower<ParticleT> &getTowerAtPosition(const std::array<double, 3> &pos) {
     const auto [x, y] = getTowerIndex2DAtPosition(pos);
     return getTowerByIndex2D(x, y);
   }
@@ -268,7 +268,7 @@ class ClusterTowerBlock2D : public CellBorderAndFlagManager {
    * @param y The y-th tower in y direction.
    * @return a reference to the tower for the given tower grid coordinates.
    */
-  ClusterTower<Particle> &getTowerByIndex2D(const size_t x, const size_t y) { return _towers[towerIndex2DTo1D(x, y)]; }
+  ClusterTower<ParticleT> &getTowerByIndex2D(const size_t x, const size_t y) { return _towers[towerIndex2DTo1D(x, y)]; }
 
   /**
    * Returns the 1D index for the given 2D-coordinates of a tower.
@@ -337,12 +337,12 @@ class ClusterTowerBlock2D : public CellBorderAndFlagManager {
    * Getter
    * @return
    */
-  const std::vector<ClusterTower<Particle>> &getTowers() const { return _towers; }
+  const std::vector<ClusterTower<ParticleT>> &getTowers() const { return _towers; }
   /**
    * Getter for a mutable reference
    * @return
    */
-  std::vector<ClusterTower<Particle>> &getTowersRef() { return _towers; }
+  std::vector<ClusterTower<ParticleT>> &getTowersRef() { return _towers; }
   /**
    * Getter
    * @return
@@ -423,7 +423,7 @@ class ClusterTowerBlock2D : public CellBorderAndFlagManager {
   /**
    * Internal storage, particles are split into a grid in xy-dimension.
    */
-  std::vector<ClusterTower<Particle>> _towers;
+  std::vector<ClusterTower<ParticleT>> _towers;
 
   /**
    * Dimensions of the 2D xy-grid including halo.

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -251,13 +251,13 @@ class VerletClusterLists : public ParticleContainerInterface<ParticleT>, public 
   }
 
   std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
-                                                           IteratorBehavior iteratorBehavior,
-                                                           const std::array<double, 3> &boxMin,
-                                                           const std::array<double, 3> &boxMax) const override {
+                                                            IteratorBehavior iteratorBehavior,
+                                                            const std::array<double, 3> &boxMin,
+                                                            const std::array<double, 3> &boxMax) const override {
     return getParticleImpl<true>(cellIndex, particleIndex, iteratorBehavior, boxMin, boxMax);
   }
   std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
-                                                           IteratorBehavior iteratorBehavior) const override {
+                                                            IteratorBehavior iteratorBehavior) const override {
     // this is not a region iter hence we stretch the bounding box to the numeric max
     constexpr std::array<double, 3> boxMin{std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(),
                                            std::numeric_limits<double>::lowest()};
@@ -280,9 +280,9 @@ class VerletClusterLists : public ParticleContainerInterface<ParticleT>, public 
    */
   template <bool regionIter>
   std::tuple<const ParticleT *, size_t, size_t> getParticleImpl(size_t cellIndex, size_t particleIndex,
-                                                               IteratorBehavior iteratorBehavior,
-                                                               const std::array<double, 3> &boxMin,
-                                                               const std::array<double, 3> &boxMax) const {
+                                                                IteratorBehavior iteratorBehavior,
+                                                                const std::array<double, 3> &boxMin,
+                                                                const std::array<double, 3> &boxMax) const {
     using namespace autopas::utils::ArrayMath::literals;
 
     // in this context cell == tower
@@ -431,7 +431,8 @@ class VerletClusterLists : public ParticleContainerInterface<ParticleT>, public 
    */
   [[nodiscard]] ContainerIterator<ParticleT, false, false> begin(
       IteratorBehavior behavior = autopas::IteratorBehavior::ownedOrHalo,
-      typename ContainerIterator<ParticleT, false, false>::ParticleVecType *additionalVectors = nullptr) const override {
+      typename ContainerIterator<ParticleT, false, false>::ParticleVecType *additionalVectors =
+          nullptr) const override {
     // Note: particlesToAddEmpty() can only be called if the container status is not invalid. If the status is set to
     // invalid, we do writing operations on _particlesToAdd and can not read from from it without race conditions.
     if (_isValid != ValidityState::invalid) {
@@ -575,7 +576,7 @@ class VerletClusterLists : public ParticleContainerInterface<ParticleT>, public 
       typename ContainerIterator<ParticleT, true, true>::ParticleVecType additionalVectorsToPass;
       appendBuffersHelper(additionalVectors, additionalVectorsToPass);
       return ContainerIterator<ParticleT, true, true>(*this, behavior, &additionalVectorsToPass, lowerCorner,
-                                                     higherCorner);
+                                                      higherCorner);
     }
   }
 
@@ -605,7 +606,7 @@ class VerletClusterLists : public ParticleContainerInterface<ParticleT>, public 
       typename ContainerIterator<ParticleT, false, true>::ParticleVecType additionalVectorsToPass;
       appendBuffersHelper(additionalVectors, additionalVectorsToPass);
       return ContainerIterator<ParticleT, false, true>(*this, behavior, &additionalVectorsToPass, lowerCorner,
-                                                      higherCorner);
+                                                       higherCorner);
     }
   }
 

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -50,10 +50,10 @@ namespace autopas {
  *
  * @note See VerletClusterListsRebuilder for the layout of the towers and clusters.
  *
- * @tparam Particle
+ * @tparam ParticleT
  */
-template <class Particle>
-class VerletClusterLists : public ParticleContainerInterface<Particle>, public internal::ParticleDeletedObserver {
+template <class ParticleT>
+class VerletClusterLists : public ParticleContainerInterface<ParticleT>, public internal::ParticleDeletedObserver {
  public:
   /**
    * Defines a cluster range used in the static cluster-thread-partition.
@@ -89,7 +89,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
   VerletClusterLists(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax, double cutoff,
                      double skin, unsigned int rebuildFrequency, size_t clusterSize,
                      LoadEstimatorOption loadEstimator = LoadEstimatorOption::none)
-      : ParticleContainerInterface<Particle>(skin),
+      : ParticleContainerInterface<ParticleT>(skin),
         _towerBlock{boxMin, boxMax, cutoff + skin},
         _clusterSize{clusterSize},
         _particlesToAdd(autopas_get_max_threads()),
@@ -147,7 +147,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
           "not "
           "valid.");
     }
-    auto *traversalInterface = dynamic_cast<VCLTraversalInterface<Particle> *>(traversal);
+    auto *traversalInterface = dynamic_cast<VCLTraversalInterface<ParticleT> *>(traversal);
     if (traversalInterface) {
       traversalInterface->setClusterLists(*this);
       traversalInterface->setTowers(_towerBlock.getTowersRef());
@@ -177,17 +177,17 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
    * in.
    * @param p The particle to add.
    */
-  void addParticleImpl(const Particle &p) override {
+  void addParticleImpl(const ParticleT &p) override {
     _isValid.store(ValidityState::invalid, std::memory_order::memory_order_relaxed);
     _particlesToAdd[autopas_get_thread_num()].push_back(p);
   }
 
-  void addHaloParticleImpl(const Particle &haloParticle) override {
+  void addHaloParticleImpl(const ParticleT &haloParticle) override {
     _isValid.store(ValidityState::invalid, std::memory_order::memory_order_relaxed);
     _particlesToAdd[autopas_get_thread_num()].push_back(haloParticle);
   }
 
-  bool updateHaloParticle(const Particle &haloParticle) override {
+  bool updateHaloParticle(const ParticleT &haloParticle) override {
     using namespace autopas::utils::ArrayMath::literals;
 
     const auto &haloPos = haloParticle.getR();
@@ -250,13 +250,13 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
     }
   }
 
-  std::tuple<const Particle *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
+  std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
                                                            IteratorBehavior iteratorBehavior,
                                                            const std::array<double, 3> &boxMin,
                                                            const std::array<double, 3> &boxMax) const override {
     return getParticleImpl<true>(cellIndex, particleIndex, iteratorBehavior, boxMin, boxMax);
   }
-  std::tuple<const Particle *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
+  std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
                                                            IteratorBehavior iteratorBehavior) const override {
     // this is not a region iter hence we stretch the bounding box to the numeric max
     constexpr std::array<double, 3> boxMin{std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(),
@@ -279,7 +279,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
    * @return tuple<ParticlePointer, CellIndex, ParticleIndex>
    */
   template <bool regionIter>
-  std::tuple<const Particle *, size_t, size_t> getParticleImpl(size_t cellIndex, size_t particleIndex,
+  std::tuple<const ParticleT *, size_t, size_t> getParticleImpl(size_t cellIndex, size_t particleIndex,
                                                                IteratorBehavior iteratorBehavior,
                                                                const std::array<double, 3> &boxMin,
                                                                const std::array<double, 3> &boxMax) const {
@@ -338,12 +338,12 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
     if (cellIndex > endCellIndex) {
       return {nullptr, 0, 0};
     }
-    const Particle *retPtr = &_towerBlock[cellIndex][particleIndex];
+    const ParticleT *retPtr = &_towerBlock[cellIndex][particleIndex];
 
     return {retPtr, cellIndex, particleIndex};
   }
 
-  bool deleteParticle(Particle &particle) override {
+  bool deleteParticle(ParticleT &particle) override {
     // This function doesn't actually delete anything as it would mess up the clusters' references.
     internal::markParticleAsDeleted(particle);
     return false;
@@ -355,7 +355,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
     return false;
   }
 
-  [[nodiscard]] std::vector<Particle> updateContainer(bool keepNeighborListsValid) override {
+  [[nodiscard]] std::vector<ParticleT> updateContainer(bool keepNeighborListsValid) override {
     if (keepNeighborListsValid) {
       return autopas::LeavingParticleCollector::collectParticlesAndMarkNonOwnedAsDummy(*this);
     }
@@ -368,11 +368,11 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
     }
 
     // next find invalid particles
-    std::vector<Particle> invalidParticles;
+    std::vector<ParticleT> invalidParticles;
 
     // custom openmp reduction to concatenate all local vectors to one at the end of a parallel region
     AUTOPAS_OPENMP(declare reduction(vecMergeParticle :                                                 \
-                                     std::vector<Particle> :                                            \
+                                     std::vector<ParticleT> :                                            \
                                          omp_out.insert(omp_out.end(), omp_in.begin(), omp_in.end())))
     AUTOPAS_OPENMP(parallel reduction(vecMergeParticle : invalidParticles)) {
       for (auto iter = this->begin(IteratorBehavior::owned); iter.isValid(); ++iter) {
@@ -401,9 +401,9 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
   /**
    * @copydoc autopas::ParticleContainerInterface::begin()
    */
-  [[nodiscard]] ContainerIterator<Particle, true, false> begin(
+  [[nodiscard]] ContainerIterator<ParticleT, true, false> begin(
       IteratorBehavior behavior = autopas::IteratorBehavior::ownedOrHalo,
-      typename ContainerIterator<Particle, true, false>::ParticleVecType *additionalVectors = nullptr) override {
+      typename ContainerIterator<ParticleT, true, false>::ParticleVecType *additionalVectors = nullptr) override {
     // Note: particlesToAddEmpty() can only be called if the container status is not invalid. If the status is set to
     // invalid, we do writing operations on _particlesToAdd and can not read from it without race conditions.
     if (_isValid != ValidityState::invalid) {
@@ -415,13 +415,13 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
       }
       // If the particles are sorted into the towers, we can simply use the iteration over towers + additionalVectors
       // from LogicHandler.
-      return ContainerIterator<Particle, true, false>(*this, behavior, additionalVectors);
+      return ContainerIterator<ParticleT, true, false>(*this, behavior, additionalVectors);
     } else {
       // if the particles are not sorted into the towers, we have to also iterate over _particlesToAdd.
       // store all pointers in a temporary which is passed to the ParticleIterator constructor.
-      typename ContainerIterator<Particle, true, false>::ParticleVecType additionalVectorsToPass;
+      typename ContainerIterator<ParticleT, true, false>::ParticleVecType additionalVectorsToPass;
       appendBuffersHelper(additionalVectors, additionalVectorsToPass);
-      return ContainerIterator<Particle, true, false>(*this, behavior, &additionalVectorsToPass);
+      return ContainerIterator<ParticleT, true, false>(*this, behavior, &additionalVectorsToPass);
     }
   }
 
@@ -429,9 +429,9 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
    * @copydoc autopas::ParticleContainerInterface::begin()
    * @note const version.
    */
-  [[nodiscard]] ContainerIterator<Particle, false, false> begin(
+  [[nodiscard]] ContainerIterator<ParticleT, false, false> begin(
       IteratorBehavior behavior = autopas::IteratorBehavior::ownedOrHalo,
-      typename ContainerIterator<Particle, false, false>::ParticleVecType *additionalVectors = nullptr) const override {
+      typename ContainerIterator<ParticleT, false, false>::ParticleVecType *additionalVectors = nullptr) const override {
     // Note: particlesToAddEmpty() can only be called if the container status is not invalid. If the status is set to
     // invalid, we do writing operations on _particlesToAdd and can not read from from it without race conditions.
     if (_isValid != ValidityState::invalid) {
@@ -443,13 +443,13 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
       }
       // If the particles are sorted into the towers, we can simply use the iteration over towers + additionalVectors
       // from LogicHandler.
-      return ContainerIterator<Particle, false, false>(*this, behavior, additionalVectors);
+      return ContainerIterator<ParticleT, false, false>(*this, behavior, additionalVectors);
     } else {
       // if the particles are not sorted into the towers, we have to also iterate over _particlesToAdd.
       // store all pointers in a temporary which is passed to the ParticleIterator constructor.
-      typename ContainerIterator<Particle, false, false>::ParticleVecType additionalVectorsToPass;
+      typename ContainerIterator<ParticleT, false, false>::ParticleVecType additionalVectorsToPass;
       appendBuffersHelper(additionalVectors, additionalVectorsToPass);
-      return ContainerIterator<Particle, false, false>(*this, behavior, &additionalVectorsToPass);
+      return ContainerIterator<ParticleT, false, false>(*this, behavior, &additionalVectorsToPass);
     }
   }
 
@@ -554,9 +554,9 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
   /**
    * @copydoc autopas::ParticleContainerInterface::getRegionIterator()
    */
-  [[nodiscard]] ContainerIterator<Particle, true, true> getRegionIterator(
+  [[nodiscard]] ContainerIterator<ParticleT, true, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner, IteratorBehavior behavior,
-      typename ContainerIterator<Particle, true, true>::ParticleVecType *additionalVectors = nullptr) override {
+      typename ContainerIterator<ParticleT, true, true>::ParticleVecType *additionalVectors = nullptr) override {
     // Note: particlesToAddEmpty() can only be called if the container status is not invalid. If the status is set to
     // invalid, we do writing operations on _particlesToAdd and can not read from from it without race conditions.
     if (_isValid != ValidityState::invalid) {
@@ -568,13 +568,13 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
       }
       // If the particles are sorted into the towers, we can simply use the iteration over towers + additionalVectors
       // from LogicHandler.
-      return ContainerIterator<Particle, true, true>(*this, behavior, additionalVectors, lowerCorner, higherCorner);
+      return ContainerIterator<ParticleT, true, true>(*this, behavior, additionalVectors, lowerCorner, higherCorner);
     } else {
       // if the particles are not sorted into the towers, we have to also iterate over _particlesToAdd.
       // store all pointers in a temporary which is passed to the ParticleIterator constructor.
-      typename ContainerIterator<Particle, true, true>::ParticleVecType additionalVectorsToPass;
+      typename ContainerIterator<ParticleT, true, true>::ParticleVecType additionalVectorsToPass;
       appendBuffersHelper(additionalVectors, additionalVectorsToPass);
-      return ContainerIterator<Particle, true, true>(*this, behavior, &additionalVectorsToPass, lowerCorner,
+      return ContainerIterator<ParticleT, true, true>(*this, behavior, &additionalVectorsToPass, lowerCorner,
                                                      higherCorner);
     }
   }
@@ -583,9 +583,9 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
    * @copydoc autopas::ParticleContainerInterface::getRegionIterator()
    * @note const version.
    */
-  [[nodiscard]] ContainerIterator<Particle, false, true> getRegionIterator(
+  [[nodiscard]] ContainerIterator<ParticleT, false, true> getRegionIterator(
       const std::array<double, 3> &lowerCorner, const std::array<double, 3> &higherCorner, IteratorBehavior behavior,
-      typename ContainerIterator<Particle, false, true>::ParticleVecType *additionalVectors = nullptr) const override {
+      typename ContainerIterator<ParticleT, false, true>::ParticleVecType *additionalVectors = nullptr) const override {
     // Note: particlesToAddEmpty() can only be called if the container status is not invalid. If the status is set to
     // invalid, we do writing operations on _particlesToAdd and can not read from from it without race conditions.
     if (_isValid != ValidityState::invalid) {
@@ -598,13 +598,13 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
       }
       // If the particles are sorted into the towers, we can simply use the iteration over towers + additionalVectors
       // from LogicHandler.
-      return ContainerIterator<Particle, false, true>(*this, behavior, additionalVectors, lowerCorner, higherCorner);
+      return ContainerIterator<ParticleT, false, true>(*this, behavior, additionalVectors, lowerCorner, higherCorner);
     } else {
       // if the particles are not sorted into the towers, we have to also iterate over _particlesToAdd.
       // store all pointers in a temporary which is passed to the ParticleIterator constructor.
-      typename ContainerIterator<Particle, false, true>::ParticleVecType additionalVectorsToPass;
+      typename ContainerIterator<ParticleT, false, true>::ParticleVecType additionalVectorsToPass;
       appendBuffersHelper(additionalVectors, additionalVectorsToPass);
-      return ContainerIterator<Particle, false, true>(*this, behavior, &additionalVectorsToPass, lowerCorner,
+      return ContainerIterator<ParticleT, false, true>(*this, behavior, &additionalVectorsToPass, lowerCorner,
                                                       higherCorner);
     }
   }
@@ -772,7 +772,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
     }
     _builder->rebuildNeighborListsAndFillClusters();
 
-    auto *clusterTraversalInterface = dynamic_cast<VCLTraversalInterface<Particle> *>(traversal);
+    auto *clusterTraversalInterface = dynamic_cast<VCLTraversalInterface<ParticleT> *>(traversal);
     if (clusterTraversalInterface) {
       if (clusterTraversalInterface->needsStaticClusterThreadPartition()) {
         calculateClusterThreadPartition();
@@ -906,7 +906,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
    * @param y The y-th tower in y direction.
    * @return a reference to the tower for the given tower grid coordinates.
    */
-  internal::ClusterTower<Particle> &getTowerByIndex(size_t x, size_t y) { return _towerBlock.getTowerByIndex2D(x, y); }
+  internal::ClusterTower<ParticleT> &getTowerByIndex(size_t x, size_t y) { return _towerBlock.getTowerByIndex2D(x, y); }
 
   /**
    * Getter for the cell block.
@@ -915,7 +915,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
    *
    * @return
    */
-  internal::ClusterTowerBlock2D<Particle> &getTowerBlock() { return _towerBlock; }
+  internal::ClusterTowerBlock2D<ParticleT> &getTowerBlock() { return _towerBlock; }
 
   [[nodiscard]] const std::array<double, 3> &getBoxMax() const override { return _towerBlock.getBoxMax(); }
 
@@ -969,7 +969,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
    * Get the neighbor lists buffer object.
    * @return
    */
-  const typename internal::VerletClusterListsRebuilder<Particle>::NeighborListsBuffer_T &getNeighborLists() const {
+  const typename internal::VerletClusterListsRebuilder<ParticleT>::NeighborListsBuffer_T &getNeighborLists() const {
     return _neighborLists;
   }
 
@@ -992,7 +992,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
     });
 
     const double interactionLength = _cutoff + this->_skin;
-    _builder = std::make_unique<internal::VerletClusterListsRebuilder<Particle>>(
+    _builder = std::make_unique<internal::VerletClusterListsRebuilder<ParticleT>>(
         _towerBlock, particlesToAdd, _neighborLists, _clusterSize, interactionLength * interactionLength, newton3);
 
     _numClusters = _builder->rebuildTowersAndClusters();
@@ -1217,7 +1217,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
     return {cellIndex, particleIndex};
   }
 
-  internal::ClusterTowerBlock2D<Particle> _towerBlock;
+  internal::ClusterTowerBlock2D<ParticleT> _towerBlock;
 
   /**
    * load estimation algorithm for balanced traversals.
@@ -1239,7 +1239,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
    * Outer vector is for Thread buffer to allow parallel particle insertion.
    * This has to be a mutable so we can call appendBuffersHelper() from const and non-const functions.
    */
-  mutable std::vector<std::vector<Particle>> _particlesToAdd;
+  mutable std::vector<std::vector<ParticleT>> _particlesToAdd;
 
   /**
    * Checks if there are particles in the buffers of _particlesToAdd.
@@ -1311,12 +1311,12 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
   /**
    * The builder for the verlet cluster lists.
    */
-  std::unique_ptr<internal::VerletClusterListsRebuilder<Particle>> _builder;
+  std::unique_ptr<internal::VerletClusterListsRebuilder<ParticleT>> _builder;
 
   /**
    * Structure to provide persistent memory for neighbor lists. Will be filled by the builder.
    */
-  typename internal::VerletClusterListsRebuilder<Particle>::NeighborListsBuffer_T _neighborLists{};
+  typename internal::VerletClusterListsRebuilder<ParticleT>::NeighborListsBuffer_T _neighborLists{};
 };
 
 }  // namespace autopas

--- a/src/autopas/containers/verletClusterLists/VerletClusterListsRebuilder.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterListsRebuilder.h
@@ -18,21 +18,21 @@ namespace autopas::internal {
  *
  * @note Towers are always built on the xy plane towering into the z dimension.
  *
- * @tparam Particle The type of the particle the container contains.
+ * @tparam ParticleT The type of the particle the container contains.
  */
-template <class Particle>
+template <class ParticleT>
 class VerletClusterListsRebuilder {
  public:
   /**
    * Type alias for the neighbor list buffer.
    */
-  using NeighborListsBuffer_T = NeighborListsBuffer<const internal::Cluster<Particle> *, internal::Cluster<Particle> *>;
+  using NeighborListsBuffer_T = NeighborListsBuffer<const internal::Cluster<ParticleT> *, internal::Cluster<ParticleT> *>;
 
  private:
   size_t _clusterSize;
   NeighborListsBuffer_T &_neighborListsBuffer;
-  std::vector<Particle> &_particlesToAdd;
-  ClusterTowerBlock2D<Particle> &_towerBlock;
+  std::vector<ParticleT> &_particlesToAdd;
+  ClusterTowerBlock2D<ParticleT> &_towerBlock;
   double _interactionLengthSqr;
   bool _newton3;
 
@@ -47,7 +47,7 @@ class VerletClusterListsRebuilder {
    * @param interactionLengthSqr Squared interaction length (cutoff + skin)^2
    * @param newton3 If the current configuration uses newton3
    */
-  VerletClusterListsRebuilder(ClusterTowerBlock2D<Particle> &towerBlock, std::vector<Particle> &particlesToAdd,
+  VerletClusterListsRebuilder(ClusterTowerBlock2D<ParticleT> &towerBlock, std::vector<ParticleT> &particlesToAdd,
                               NeighborListsBuffer_T &neighborListsBuffer, size_t clusterSize,
                               double interactionLengthSqr, bool newton3)
       : _clusterSize(clusterSize),
@@ -86,7 +86,7 @@ class VerletClusterListsRebuilder {
     const auto numTowersNew = numTowersPerDim[0] * numTowersPerDim[1];
 
     // collect all particles that are now not in the right tower anymore
-    std::vector<std::vector<Particle>> invalidParticles{};
+    std::vector<std::vector<ParticleT>> invalidParticles{};
     // Reserve for:
     //   - _particlesToAdd (+1)
     //   - surplus towers (+max(0, numTowersNew - numTowersOld))
@@ -179,8 +179,8 @@ class VerletClusterListsRebuilder {
    * Takes all particles from all towers and returns them. Towers are cleared afterwards.
    * @return All particles in the container sorted in 2D as they were in the towers.
    */
-  std::vector<std::vector<Particle>> collectAllParticlesFromTowers() {
-    std::vector<std::vector<Particle>> invalidParticles;
+  std::vector<std::vector<ParticleT>> collectAllParticlesFromTowers() {
+    std::vector<std::vector<ParticleT>> invalidParticles;
     invalidParticles.resize(_towerBlock.size());
     for (size_t towerIndex = 0; towerIndex < _towerBlock.size(); towerIndex++) {
       invalidParticles[towerIndex] = _towerBlock[towerIndex].collectAllActualParticles();
@@ -195,8 +195,8 @@ class VerletClusterListsRebuilder {
    *
    * @return
    */
-  std::vector<std::vector<Particle>> collectOutOfBoundsParticlesFromTowers() {
-    std::vector<std::vector<Particle>> outOfBoundsParticles;
+  std::vector<std::vector<ParticleT>> collectOutOfBoundsParticlesFromTowers() {
+    std::vector<std::vector<ParticleT>> outOfBoundsParticles;
     outOfBoundsParticles.resize(_towerBlock.size());
     for (size_t towerIndex = 0; towerIndex < _towerBlock.size(); towerIndex++) {
       const auto &[towerBoxMin, towerBoxMax] = _towerBlock.getTowerBoundingBox(towerIndex);
@@ -213,11 +213,11 @@ class VerletClusterListsRebuilder {
    *
    * @param particles2D The particles to sort in the towers.
    */
-  void sortParticlesIntoTowers(const std::vector<std::vector<Particle>> &particles2D) {
+  void sortParticlesIntoTowers(const std::vector<std::vector<ParticleT>> &particles2D) {
     const auto numVectors = particles2D.size();
     AUTOPAS_OPENMP(parallel for schedule(dynamic))
     for (size_t index = 0; index < numVectors; index++) {
-      const std::vector<Particle> &vector = particles2D[index];
+      const std::vector<ParticleT> &vector = particles2D[index];
       for (const auto &particle : vector) {
         if (utils::inBox(particle.getR(), _towerBlock.getHaloBoxMin(), _towerBlock.getHaloBoxMax())) {
           auto &tower = _towerBlock.getTowerAtPosition(particle.getR());
@@ -362,8 +362,8 @@ class VerletClusterListsRebuilder {
    * interaction lists of the custers (for newton3 == true) or show up in the interaction lists of both (for newton3 ==
    * false)
    */
-  void calculateNeighborsBetweenTowers(internal::ClusterTower<Particle> &towerA,
-                                       internal::ClusterTower<Particle> &towerB) {
+  void calculateNeighborsBetweenTowers(internal::ClusterTower<ParticleT> &towerA,
+                                       internal::ClusterTower<ParticleT> &towerB) {
     using autopas::utils::ArrayMath::boxDistanceSquared;
 
     const auto interactionLengthFracOfDomainZ =

--- a/src/autopas/containers/verletClusterLists/VerletClusterListsRebuilder.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterListsRebuilder.h
@@ -18,22 +18,22 @@ namespace autopas::internal {
  *
  * @note Towers are always built on the xy plane towering into the z dimension.
  *
- * @tparam ParticleT The type of the particle the container contains.
+ * @tparam Particle_T The type of the particle the container contains.
  */
-template <class ParticleT>
+template <class Particle_T>
 class VerletClusterListsRebuilder {
  public:
   /**
    * Type alias for the neighbor list buffer.
    */
   using NeighborListsBuffer_T =
-      NeighborListsBuffer<const internal::Cluster<ParticleT> *, internal::Cluster<ParticleT> *>;
+      NeighborListsBuffer<const internal::Cluster<Particle_T> *, internal::Cluster<Particle_T> *>;
 
  private:
   size_t _clusterSize;
   NeighborListsBuffer_T &_neighborListsBuffer;
-  std::vector<ParticleT> &_particlesToAdd;
-  ClusterTowerBlock2D<ParticleT> &_towerBlock;
+  std::vector<Particle_T> &_particlesToAdd;
+  ClusterTowerBlock2D<Particle_T> &_towerBlock;
   double _interactionLengthSqr;
   bool _newton3;
 
@@ -48,7 +48,7 @@ class VerletClusterListsRebuilder {
    * @param interactionLengthSqr Squared interaction length (cutoff + skin)^2
    * @param newton3 If the current configuration uses newton3
    */
-  VerletClusterListsRebuilder(ClusterTowerBlock2D<ParticleT> &towerBlock, std::vector<ParticleT> &particlesToAdd,
+  VerletClusterListsRebuilder(ClusterTowerBlock2D<Particle_T> &towerBlock, std::vector<Particle_T> &particlesToAdd,
                               NeighborListsBuffer_T &neighborListsBuffer, size_t clusterSize,
                               double interactionLengthSqr, bool newton3)
       : _clusterSize(clusterSize),
@@ -87,7 +87,7 @@ class VerletClusterListsRebuilder {
     const auto numTowersNew = numTowersPerDim[0] * numTowersPerDim[1];
 
     // collect all particles that are now not in the right tower anymore
-    std::vector<std::vector<ParticleT>> invalidParticles{};
+    std::vector<std::vector<Particle_T>> invalidParticles{};
     // Reserve for:
     //   - _particlesToAdd (+1)
     //   - surplus towers (+max(0, numTowersNew - numTowersOld))
@@ -180,8 +180,8 @@ class VerletClusterListsRebuilder {
    * Takes all particles from all towers and returns them. Towers are cleared afterwards.
    * @return All particles in the container sorted in 2D as they were in the towers.
    */
-  std::vector<std::vector<ParticleT>> collectAllParticlesFromTowers() {
-    std::vector<std::vector<ParticleT>> invalidParticles;
+  std::vector<std::vector<Particle_T>> collectAllParticlesFromTowers() {
+    std::vector<std::vector<Particle_T>> invalidParticles;
     invalidParticles.resize(_towerBlock.size());
     for (size_t towerIndex = 0; towerIndex < _towerBlock.size(); towerIndex++) {
       invalidParticles[towerIndex] = _towerBlock[towerIndex].collectAllActualParticles();
@@ -196,8 +196,8 @@ class VerletClusterListsRebuilder {
    *
    * @return
    */
-  std::vector<std::vector<ParticleT>> collectOutOfBoundsParticlesFromTowers() {
-    std::vector<std::vector<ParticleT>> outOfBoundsParticles;
+  std::vector<std::vector<Particle_T>> collectOutOfBoundsParticlesFromTowers() {
+    std::vector<std::vector<Particle_T>> outOfBoundsParticles;
     outOfBoundsParticles.resize(_towerBlock.size());
     for (size_t towerIndex = 0; towerIndex < _towerBlock.size(); towerIndex++) {
       const auto &[towerBoxMin, towerBoxMax] = _towerBlock.getTowerBoundingBox(towerIndex);
@@ -214,11 +214,11 @@ class VerletClusterListsRebuilder {
    *
    * @param particles2D The particles to sort in the towers.
    */
-  void sortParticlesIntoTowers(const std::vector<std::vector<ParticleT>> &particles2D) {
+  void sortParticlesIntoTowers(const std::vector<std::vector<Particle_T>> &particles2D) {
     const auto numVectors = particles2D.size();
     AUTOPAS_OPENMP(parallel for schedule(dynamic))
     for (size_t index = 0; index < numVectors; index++) {
-      const std::vector<ParticleT> &vector = particles2D[index];
+      const std::vector<Particle_T> &vector = particles2D[index];
       for (const auto &particle : vector) {
         if (utils::inBox(particle.getR(), _towerBlock.getHaloBoxMin(), _towerBlock.getHaloBoxMax())) {
           auto &tower = _towerBlock.getTowerAtPosition(particle.getR());
@@ -363,8 +363,8 @@ class VerletClusterListsRebuilder {
    * interaction lists of the custers (for newton3 == true) or show up in the interaction lists of both (for newton3 ==
    * false)
    */
-  void calculateNeighborsBetweenTowers(internal::ClusterTower<ParticleT> &towerA,
-                                       internal::ClusterTower<ParticleT> &towerB) {
+  void calculateNeighborsBetweenTowers(internal::ClusterTower<Particle_T> &towerA,
+                                       internal::ClusterTower<Particle_T> &towerB) {
     using autopas::utils::ArrayMath::boxDistanceSquared;
 
     const auto interactionLengthFracOfDomainZ =

--- a/src/autopas/containers/verletClusterLists/VerletClusterListsRebuilder.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterListsRebuilder.h
@@ -26,7 +26,8 @@ class VerletClusterListsRebuilder {
   /**
    * Type alias for the neighbor list buffer.
    */
-  using NeighborListsBuffer_T = NeighborListsBuffer<const internal::Cluster<ParticleT> *, internal::Cluster<ParticleT> *>;
+  using NeighborListsBuffer_T =
+      NeighborListsBuffer<const internal::Cluster<ParticleT> *, internal::Cluster<ParticleT> *>;
 
  private:
   size_t _clusterSize;

--- a/src/autopas/containers/verletClusterLists/traversals/VCLC01BalancedTraversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VCLC01BalancedTraversal.h
@@ -16,11 +16,11 @@ namespace autopas {
  * Traversal for VerletClusterLists. Does not support newton 3.
  *
  * It uses a static scheduling that gives each thread about the same amount of cluster pairs to handle.
- * @tparam ParticleCell
+ * @tparam ParticleT Particle Type.
  * @tparam PairwiseFunctor The type of the functor.
  */
-template <class Particle, class PairwiseFunctor>
-class VCLC01BalancedTraversal : public TraversalInterface, public VCLTraversalInterface<Particle> {
+template <class ParticleT, class PairwiseFunctor>
+class VCLC01BalancedTraversal : public TraversalInterface, public VCLTraversalInterface<ParticleT> {
  public:
   /**
    * Constructor of the VCLC01BalancedTraversal.
@@ -44,26 +44,26 @@ class VCLC01BalancedTraversal : public TraversalInterface, public VCLTraversalIn
   void initTraversal() override {
     if (_dataLayout != DataLayoutOption::soa) return;
 
-    auto &clusterList = *VCLTraversalInterface<Particle>::_verletClusterLists;
+    auto &clusterList = *VCLTraversalInterface<ParticleT>::_verletClusterLists;
     clusterList.loadParticlesIntoSoAs(_functor);
   }
 
   void endTraversal() override {
     if (_dataLayout != DataLayoutOption::soa) return;
 
-    auto &clusterList = *VCLTraversalInterface<Particle>::_verletClusterLists;
+    auto &clusterList = *VCLTraversalInterface<ParticleT>::_verletClusterLists;
     clusterList.extractParticlesFromSoAs(_functor);
   }
 
   void traverseParticles() override {
-    auto &clusterList = *VCLTraversalInterface<Particle>::_verletClusterLists;
+    auto &clusterList = *VCLTraversalInterface<ParticleT>::_verletClusterLists;
     auto &clusterThreadPartition = clusterList.getClusterThreadPartition();
 
     auto numThreads = clusterThreadPartition.size();
     AUTOPAS_OPENMP(parallel num_threads(numThreads)) {
       auto threadNum = autopas_get_thread_num();
       const auto &clusterRange = clusterThreadPartition[threadNum];
-      auto &towers = *VCLTraversalInterface<Particle>::_towers;
+      auto &towers = *VCLTraversalInterface<ParticleT>::_towers;
       size_t clusterCount = 0;
       for (size_t towerIndex = clusterRange.startTowerIndex;
            clusterCount < clusterRange.numClusters and towerIndex < towers.size(); towerIndex++) {
@@ -91,6 +91,6 @@ class VCLC01BalancedTraversal : public TraversalInterface, public VCLTraversalIn
 
  private:
   PairwiseFunctor *_functor;
-  internal::VCLClusterFunctor<Particle, PairwiseFunctor> _clusterFunctor;
+  internal::VCLClusterFunctor<ParticleT, PairwiseFunctor> _clusterFunctor;
 };
 }  // namespace autopas

--- a/src/autopas/containers/verletClusterLists/traversals/VCLC01BalancedTraversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VCLC01BalancedTraversal.h
@@ -16,11 +16,11 @@ namespace autopas {
  * Traversal for VerletClusterLists. Does not support newton 3.
  *
  * It uses a static scheduling that gives each thread about the same amount of cluster pairs to handle.
- * @tparam ParticleT Particle Type.
+ * @tparam Particle_T Particle Type.
  * @tparam PairwiseFunctor The type of the functor.
  */
-template <class ParticleT, class PairwiseFunctor>
-class VCLC01BalancedTraversal : public TraversalInterface, public VCLTraversalInterface<ParticleT> {
+template <class Particle_T, class PairwiseFunctor>
+class VCLC01BalancedTraversal : public TraversalInterface, public VCLTraversalInterface<Particle_T> {
  public:
   /**
    * Constructor of the VCLC01BalancedTraversal.
@@ -44,26 +44,26 @@ class VCLC01BalancedTraversal : public TraversalInterface, public VCLTraversalIn
   void initTraversal() override {
     if (_dataLayout != DataLayoutOption::soa) return;
 
-    auto &clusterList = *VCLTraversalInterface<ParticleT>::_verletClusterLists;
+    auto &clusterList = *VCLTraversalInterface<Particle_T>::_verletClusterLists;
     clusterList.loadParticlesIntoSoAs(_functor);
   }
 
   void endTraversal() override {
     if (_dataLayout != DataLayoutOption::soa) return;
 
-    auto &clusterList = *VCLTraversalInterface<ParticleT>::_verletClusterLists;
+    auto &clusterList = *VCLTraversalInterface<Particle_T>::_verletClusterLists;
     clusterList.extractParticlesFromSoAs(_functor);
   }
 
   void traverseParticles() override {
-    auto &clusterList = *VCLTraversalInterface<ParticleT>::_verletClusterLists;
+    auto &clusterList = *VCLTraversalInterface<Particle_T>::_verletClusterLists;
     auto &clusterThreadPartition = clusterList.getClusterThreadPartition();
 
     auto numThreads = clusterThreadPartition.size();
     AUTOPAS_OPENMP(parallel num_threads(numThreads)) {
       auto threadNum = autopas_get_thread_num();
       const auto &clusterRange = clusterThreadPartition[threadNum];
-      auto &towers = *VCLTraversalInterface<ParticleT>::_towers;
+      auto &towers = *VCLTraversalInterface<Particle_T>::_towers;
       size_t clusterCount = 0;
       for (size_t towerIndex = clusterRange.startTowerIndex;
            clusterCount < clusterRange.numClusters and towerIndex < towers.size(); towerIndex++) {
@@ -91,6 +91,6 @@ class VCLC01BalancedTraversal : public TraversalInterface, public VCLTraversalIn
 
  private:
   PairwiseFunctor *_functor;
-  internal::VCLClusterFunctor<ParticleT, PairwiseFunctor> _clusterFunctor;
+  internal::VCLClusterFunctor<Particle_T, PairwiseFunctor> _clusterFunctor;
 };
 }  // namespace autopas

--- a/src/autopas/containers/verletClusterLists/traversals/VCLC06Traversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VCLC06Traversal.h
@@ -27,7 +27,7 @@ template <class ParticleCell, class PairwiseFunctor>
 class VCLC06Traversal : public ColorBasedTraversal<ParticleCell, PairwiseFunctor>,
                         public VCLTraversalInterface<typename ParticleCell::ParticleType> {
  private:
-  using Particle = typename ParticleCell::ParticleType;
+  using ParticleType = typename ParticleCell::ParticleType;
 
   /**
    * Each base step looks like this:
@@ -71,18 +71,18 @@ class VCLC06Traversal : public ColorBasedTraversal<ParticleCell, PairwiseFunctor
 
   void initTraversal() override {
     if (this->_dataLayout == DataLayoutOption::soa) {
-      VCLTraversalInterface<Particle>::_verletClusterLists->loadParticlesIntoSoAs(_functor);
+      VCLTraversalInterface<ParticleType>::_verletClusterLists->loadParticlesIntoSoAs(_functor);
     }
   }
 
   void endTraversal() override {
     if (this->_dataLayout == DataLayoutOption::soa) {
-      VCLTraversalInterface<Particle>::_verletClusterLists->extractParticlesFromSoAs(_functor);
+      VCLTraversalInterface<ParticleType>::_verletClusterLists->extractParticlesFromSoAs(_functor);
     }
   }
 
   void traverseParticles() override {
-    auto &clusterList = *VCLTraversalInterface<Particle>::_verletClusterLists;
+    auto &clusterList = *VCLTraversalInterface<ParticleType>::_verletClusterLists;
 
     const auto towersPerColoringCell = clusterList.getNumTowersPerInteractionLength();
     std::array<unsigned long, 2> coloringCellsPerDim{};
@@ -109,7 +109,7 @@ class VCLC06Traversal : public ColorBasedTraversal<ParticleCell, PairwiseFunctor
 
  private:
   PairwiseFunctor *_functor;
-  internal::VCLClusterFunctor<Particle, PairwiseFunctor> _clusterFunctor;
+  internal::VCLClusterFunctor<ParticleType, PairwiseFunctor> _clusterFunctor;
 };
 
 template <class ParticleCell, class PairwiseFunctor>
@@ -122,7 +122,7 @@ void VCLC06Traversal<ParticleCell, PairwiseFunctor>::processColorCell(unsigned l
     autopas::utils::ExceptionHandler::exception("Coloring should only be 2D, not in z-direction!");
   }
 
-  auto &clusterList = *VCLTraversalInterface<Particle>::_verletClusterLists;
+  auto &clusterList = *VCLTraversalInterface<ParticleType>::_verletClusterLists;
   const auto towersPerDim = clusterList.getTowersPerDimension();
 
   for (int yInner = 0; yInner < towersPerColoringCell; yInner++) {

--- a/src/autopas/containers/verletClusterLists/traversals/VCLClusterFunctor.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VCLClusterFunctor.h
@@ -14,10 +14,10 @@ namespace autopas::internal {
 /**
  * Provides methods to traverse a single cluster and a pair of clusters.
  *
- * @tparam Particle The type of particle the clusters contain.
+ * @tparam ParticleT The type of particle the clusters contain.
  * @tparam PairwiseFunctor The type of the functor the VCLClusterFunctor should use.
  */
-template <class Particle, class PairwiseFunctor>
+template <class ParticleT, class PairwiseFunctor>
 class VCLClusterFunctor {
  public:
   /**
@@ -35,7 +35,7 @@ class VCLClusterFunctor {
    * @param cluster
    * @param isHaloCluster
    */
-  void processCluster(internal::Cluster<Particle> &cluster, bool isHaloCluster) {
+  void processCluster(internal::Cluster<ParticleT> &cluster, bool isHaloCluster) {
     if (not isHaloCluster) {
       traverseCluster(cluster);
     }
@@ -53,7 +53,7 @@ class VCLClusterFunctor {
    * Traverses pairs of all particles in the given cluster. Always uses newton 3 in the AoS data layout.
    * @param cluster The cluster to traverse.
    */
-  void traverseCluster(internal::Cluster<Particle> &cluster) {
+  void traverseCluster(internal::Cluster<ParticleT> &cluster) {
     if (_dataLayout == DataLayoutOption::aos) {
       for (size_t i = 0; i < _clusterSize; i++) {
         for (size_t j = i + 1; j < _clusterSize; j++) {
@@ -76,7 +76,7 @@ class VCLClusterFunctor {
    * @param cluster The first cluster.
    * @param neighborCluster The second cluster.
    */
-  void traverseClusterPair(internal::Cluster<Particle> &cluster, internal::Cluster<Particle> &neighborCluster) {
+  void traverseClusterPair(internal::Cluster<ParticleT> &cluster, internal::Cluster<ParticleT> &neighborCluster) {
     if (_dataLayout == DataLayoutOption::aos) {
       for (size_t i = 0; i < _clusterSize; i++) {
         for (size_t j = 0; j < _clusterSize; j++) {

--- a/src/autopas/containers/verletClusterLists/traversals/VCLClusterFunctor.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VCLClusterFunctor.h
@@ -14,10 +14,10 @@ namespace autopas::internal {
 /**
  * Provides methods to traverse a single cluster and a pair of clusters.
  *
- * @tparam ParticleT The type of particle the clusters contain.
+ * @tparam Particle_T The type of particle the clusters contain.
  * @tparam PairwiseFunctor The type of the functor the VCLClusterFunctor should use.
  */
-template <class ParticleT, class PairwiseFunctor>
+template <class Particle_T, class PairwiseFunctor>
 class VCLClusterFunctor {
  public:
   /**
@@ -35,7 +35,7 @@ class VCLClusterFunctor {
    * @param cluster
    * @param isHaloCluster
    */
-  void processCluster(internal::Cluster<ParticleT> &cluster, bool isHaloCluster) {
+  void processCluster(internal::Cluster<Particle_T> &cluster, bool isHaloCluster) {
     if (not isHaloCluster) {
       traverseCluster(cluster);
     }
@@ -53,7 +53,7 @@ class VCLClusterFunctor {
    * Traverses pairs of all particles in the given cluster. Always uses newton 3 in the AoS data layout.
    * @param cluster The cluster to traverse.
    */
-  void traverseCluster(internal::Cluster<ParticleT> &cluster) {
+  void traverseCluster(internal::Cluster<Particle_T> &cluster) {
     if (_dataLayout == DataLayoutOption::aos) {
       for (size_t i = 0; i < _clusterSize; i++) {
         for (size_t j = i + 1; j < _clusterSize; j++) {
@@ -76,7 +76,7 @@ class VCLClusterFunctor {
    * @param cluster The first cluster.
    * @param neighborCluster The second cluster.
    */
-  void traverseClusterPair(internal::Cluster<ParticleT> &cluster, internal::Cluster<ParticleT> &neighborCluster) {
+  void traverseClusterPair(internal::Cluster<Particle_T> &cluster, internal::Cluster<Particle_T> &neighborCluster) {
     if (_dataLayout == DataLayoutOption::aos) {
       for (size_t i = 0; i < _clusterSize; i++) {
         for (size_t j = 0; j < _clusterSize; j++) {

--- a/src/autopas/containers/verletClusterLists/traversals/VCLClusterIterationTraversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VCLClusterIterationTraversal.h
@@ -21,7 +21,7 @@ namespace autopas {
 template <class ParticleCell, class PairwiseFunctor>
 class VCLClusterIterationTraversal : public TraversalInterface,
                                      public VCLTraversalInterface<typename ParticleCell::ParticleType> {
-  using Particle = typename ParticleCell::ParticleType;
+  using ParticleType = typename ParticleCell::ParticleType;
 
  public:
   /**
@@ -45,20 +45,20 @@ class VCLClusterIterationTraversal : public TraversalInterface,
 
   void initTraversal() override {
     if (_dataLayout == DataLayoutOption::soa) {
-      VCLTraversalInterface<Particle>::_verletClusterLists->loadParticlesIntoSoAs(_functor);
+      VCLTraversalInterface<ParticleType>::_verletClusterLists->loadParticlesIntoSoAs(_functor);
     }
   }
 
   void endTraversal() override {
     if (_dataLayout == DataLayoutOption::soa) {
-      VCLTraversalInterface<Particle>::_verletClusterLists->extractParticlesFromSoAs(_functor);
+      VCLTraversalInterface<ParticleType>::_verletClusterLists->extractParticlesFromSoAs(_functor);
     }
   }
 
   void traverseParticles() override {
-    auto &clusterList = *VCLTraversalInterface<Particle>::_verletClusterLists;
+    auto &clusterList = *VCLTraversalInterface<ParticleType>::_verletClusterLists;
 
-    const auto _clusterTraverseFunctor = [this](internal::Cluster<Particle> &cluster) {
+    const auto _clusterTraverseFunctor = [this](internal::Cluster<ParticleType> &cluster) {
       _clusterFunctor.processCluster(cluster, false);
     };
 
@@ -67,6 +67,6 @@ class VCLClusterIterationTraversal : public TraversalInterface,
 
  private:
   PairwiseFunctor *_functor;
-  internal::VCLClusterFunctor<Particle, PairwiseFunctor> _clusterFunctor;
+  internal::VCLClusterFunctor<ParticleType, PairwiseFunctor> _clusterFunctor;
 };
 }  // namespace autopas

--- a/src/autopas/containers/verletClusterLists/traversals/VCLSlicedBalancedTraversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VCLSlicedBalancedTraversal.h
@@ -25,13 +25,13 @@ template <class ParticleCell, class PairwiseFunctor>
 class VCLSlicedBalancedTraversal : public SlicedBalancedBasedTraversal<ParticleCell, PairwiseFunctor>,
                                    public VCLTraversalInterface<typename ParticleCell::ParticleType> {
  private:
-  using Particle = typename ParticleCell::ParticleType;
+  using ParticleType = typename ParticleCell::ParticleType;
 
   PairwiseFunctor *_functor;
-  internal::VCLClusterFunctor<Particle, PairwiseFunctor> _clusterFunctor;
+  internal::VCLClusterFunctor<ParticleType, PairwiseFunctor> _clusterFunctor;
 
   void processBaseStep(unsigned long x, unsigned long y) {
-    auto &clusterList = *VCLTraversalInterface<Particle>::_verletClusterLists;
+    auto &clusterList = *VCLTraversalInterface<ParticleType>::_verletClusterLists;
     auto &currentTower = clusterList.getTowerByIndex(x, y);
 
     for (auto clusterIter =
@@ -68,13 +68,13 @@ class VCLSlicedBalancedTraversal : public SlicedBalancedBasedTraversal<ParticleC
 
   void loadDataLayout() override {
     if (this->_dataLayout == DataLayoutOption::soa) {
-      VCLTraversalInterface<Particle>::_verletClusterLists->loadParticlesIntoSoAs(_functor);
+      VCLTraversalInterface<ParticleType>::_verletClusterLists->loadParticlesIntoSoAs(_functor);
     }
   }
 
   void endTraversal() override {
     if (this->_dataLayout == DataLayoutOption::soa) {
-      VCLTraversalInterface<Particle>::_verletClusterLists->extractParticlesFromSoAs(_functor);
+      VCLTraversalInterface<ParticleType>::_verletClusterLists->extractParticlesFromSoAs(_functor);
     }
   }
 

--- a/src/autopas/containers/verletClusterLists/traversals/VCLSlicedC02Traversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VCLSlicedC02Traversal.h
@@ -25,13 +25,13 @@ template <class ParticleCell, class PairwiseFunctor>
 class VCLSlicedC02Traversal : public SlicedC02BasedTraversal<ParticleCell, PairwiseFunctor>,
                               public VCLTraversalInterface<typename ParticleCell::ParticleType> {
  private:
-  using Particle = typename ParticleCell::ParticleType;
+  using ParticleType = typename ParticleCell::ParticleType;
 
   PairwiseFunctor *_functor;
-  internal::VCLClusterFunctor<Particle, PairwiseFunctor> _clusterFunctor;
+  internal::VCLClusterFunctor<ParticleType, PairwiseFunctor> _clusterFunctor;
 
   void processBaseStep(unsigned long x, unsigned long y) {
-    auto &clusterList = *VCLTraversalInterface<Particle>::_verletClusterLists;
+    auto &clusterList = *VCLTraversalInterface<ParticleType>::_verletClusterLists;
     auto &currentTower = clusterList.getTowerByIndex(x, y);
     for (auto clusterIter =
              (this->_useNewton3 ? currentTower.getClusters().begin() : currentTower.getFirstOwnedCluster());
@@ -67,13 +67,13 @@ class VCLSlicedC02Traversal : public SlicedC02BasedTraversal<ParticleCell, Pairw
 
   void loadDataLayout() override {
     if (this->_dataLayout == DataLayoutOption::soa) {
-      VCLTraversalInterface<Particle>::_verletClusterLists->loadParticlesIntoSoAs(_functor);
+      VCLTraversalInterface<ParticleType>::_verletClusterLists->loadParticlesIntoSoAs(_functor);
     }
   }
 
   void endTraversal() override {
     if (this->_dataLayout == DataLayoutOption::soa) {
-      VCLTraversalInterface<Particle>::_verletClusterLists->extractParticlesFromSoAs(_functor);
+      VCLTraversalInterface<ParticleType>::_verletClusterLists->extractParticlesFromSoAs(_functor);
     }
   }
 

--- a/src/autopas/containers/verletClusterLists/traversals/VCLSlicedTraversal.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VCLSlicedTraversal.h
@@ -26,13 +26,13 @@ template <class ParticleCell, class PairwiseFunctor>
 class VCLSlicedTraversal : public SlicedLockBasedTraversal<ParticleCell, PairwiseFunctor>,
                            public VCLTraversalInterface<typename ParticleCell::ParticleType> {
  private:
-  using Particle = typename ParticleCell::ParticleType;
+  using ParticleType = typename ParticleCell::ParticleType;
 
   PairwiseFunctor *_functor;
-  internal::VCLClusterFunctor<Particle, PairwiseFunctor> _clusterFunctor;
+  internal::VCLClusterFunctor<ParticleType, PairwiseFunctor> _clusterFunctor;
 
   void processBaseStep(unsigned long x, unsigned long y) {
-    auto &clusterList = *VCLTraversalInterface<Particle>::_verletClusterLists;
+    auto &clusterList = *VCLTraversalInterface<ParticleType>::_verletClusterLists;
     auto &currentTower = clusterList.getTowerByIndex(x, y);
     for (auto clusterIter =
              (this->_useNewton3 ? currentTower.getClusters().begin() : currentTower.getFirstOwnedCluster());
@@ -68,13 +68,13 @@ class VCLSlicedTraversal : public SlicedLockBasedTraversal<ParticleCell, Pairwis
 
   void loadDataLayout() override {
     if (this->_dataLayout == DataLayoutOption::soa) {
-      VCLTraversalInterface<Particle>::_verletClusterLists->loadParticlesIntoSoAs(_functor);
+      VCLTraversalInterface<ParticleType>::_verletClusterLists->loadParticlesIntoSoAs(_functor);
     }
   }
 
   void endTraversal() override {
     if (this->_dataLayout == DataLayoutOption::soa) {
-      VCLTraversalInterface<Particle>::_verletClusterLists->extractParticlesFromSoAs(_functor);
+      VCLTraversalInterface<ParticleType>::_verletClusterLists->extractParticlesFromSoAs(_functor);
     }
   }
 

--- a/src/autopas/containers/verletClusterLists/traversals/VCLTraversalInterface.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VCLTraversalInterface.h
@@ -10,13 +10,13 @@
 
 namespace autopas {
 
-template <class Particle>
+template <class ParticleT>
 class VerletClusterLists;
 
 /**
  * Interface for traversals of the VerletClusterLists container.
  */
-template <class Particle>
+template <class ParticleT>
 class VCLTraversalInterface {
  public:
   /**
@@ -28,7 +28,7 @@ class VCLTraversalInterface {
    * Sets the cluster list for the traversal to iterate over.
    * @param verletClusterLists the cluster list to iterate over.
    */
-  virtual void setClusterLists(VerletClusterLists<Particle> &verletClusterLists) {
+  virtual void setClusterLists(VerletClusterLists<ParticleT> &verletClusterLists) {
     _verletClusterLists = &verletClusterLists;
   }
 
@@ -36,7 +36,7 @@ class VCLTraversalInterface {
    * Sets the towers of the cluster list for the traversal to iterate over.
    * @param towers towers of the cluster list for the traversal to iterate over.
    */
-  virtual void setTowers(std::vector<internal::ClusterTower<Particle>> &towers) { _towers = &towers; }
+  virtual void setTowers(std::vector<internal::ClusterTower<ParticleT>> &towers) { _towers = &towers; }
   /**
    * Returns whether this traversal needs the static cluster thread partiton of the cluster list.
    * @return whether this traversal needs the static cluster thread partiton of the cluster list.
@@ -50,12 +50,12 @@ class VCLTraversalInterface {
    * It provides methods to iterate over the clusters. If more control over the iteration is needed, traversals can also
    * iterate over the towers directly. They are accessible through _towers.
    */
-  VerletClusterLists<Particle> *_verletClusterLists;
+  VerletClusterLists<ParticleT> *_verletClusterLists;
 
   /**
    * The towers of the cluster list to iterate over. These directly contain the particles to be modified by the
    * traversal.
    */
-  std::vector<internal::ClusterTower<Particle>> *_towers;
+  std::vector<internal::ClusterTower<ParticleT>> *_towers;
 };
 }  // namespace autopas

--- a/src/autopas/containers/verletClusterLists/traversals/VCLTraversalInterface.h
+++ b/src/autopas/containers/verletClusterLists/traversals/VCLTraversalInterface.h
@@ -10,13 +10,13 @@
 
 namespace autopas {
 
-template <class ParticleT>
+template <class Particle_T>
 class VerletClusterLists;
 
 /**
  * Interface for traversals of the VerletClusterLists container.
  */
-template <class ParticleT>
+template <class Particle_T>
 class VCLTraversalInterface {
  public:
   /**
@@ -28,7 +28,7 @@ class VCLTraversalInterface {
    * Sets the cluster list for the traversal to iterate over.
    * @param verletClusterLists the cluster list to iterate over.
    */
-  virtual void setClusterLists(VerletClusterLists<ParticleT> &verletClusterLists) {
+  virtual void setClusterLists(VerletClusterLists<Particle_T> &verletClusterLists) {
     _verletClusterLists = &verletClusterLists;
   }
 
@@ -36,7 +36,7 @@ class VCLTraversalInterface {
    * Sets the towers of the cluster list for the traversal to iterate over.
    * @param towers towers of the cluster list for the traversal to iterate over.
    */
-  virtual void setTowers(std::vector<internal::ClusterTower<ParticleT>> &towers) { _towers = &towers; }
+  virtual void setTowers(std::vector<internal::ClusterTower<Particle_T>> &towers) { _towers = &towers; }
   /**
    * Returns whether this traversal needs the static cluster thread partiton of the cluster list.
    * @return whether this traversal needs the static cluster thread partiton of the cluster list.
@@ -50,12 +50,12 @@ class VCLTraversalInterface {
    * It provides methods to iterate over the clusters. If more control over the iteration is needed, traversals can also
    * iterate over the towers directly. They are accessible through _towers.
    */
-  VerletClusterLists<ParticleT> *_verletClusterLists;
+  VerletClusterLists<Particle_T> *_verletClusterLists;
 
   /**
    * The towers of the cluster list to iterate over. These directly contain the particles to be modified by the
    * traversal.
    */
-  std::vector<internal::ClusterTower<ParticleT>> *_towers;
+  std::vector<internal::ClusterTower<Particle_T>> *_towers;
 };
 }  // namespace autopas

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -117,13 +117,13 @@ class VerletListsLinkedBase : public ParticleContainerInterface<ParticleT> {
   }
 
   std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
-                                                           IteratorBehavior iteratorBehavior,
-                                                           const std::array<double, 3> &boxMin,
-                                                           const std::array<double, 3> &boxMax) const override {
+                                                            IteratorBehavior iteratorBehavior,
+                                                            const std::array<double, 3> &boxMin,
+                                                            const std::array<double, 3> &boxMax) const override {
     return getParticleImpl<true>(cellIndex, particleIndex, iteratorBehavior, boxMin, boxMax);
   }
   std::tuple<const ParticleT *, size_t, size_t> getParticle(size_t cellIndex, size_t particleIndex,
-                                                           IteratorBehavior iteratorBehavior) const override {
+                                                            IteratorBehavior iteratorBehavior) const override {
     // this is not a region iter hence we stretch the bounding box to the numeric max
     constexpr std::array<double, 3> boxMin{std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(),
                                            std::numeric_limits<double>::lowest()};
@@ -146,9 +146,9 @@ class VerletListsLinkedBase : public ParticleContainerInterface<ParticleT> {
    */
   template <bool regionIter>
   std::tuple<const ParticleT *, size_t, size_t> getParticleImpl(size_t cellIndex, size_t particleIndex,
-                                                               IteratorBehavior iteratorBehavior,
-                                                               const std::array<double, 3> &boxMin,
-                                                               const std::array<double, 3> &boxMax) const {
+                                                                IteratorBehavior iteratorBehavior,
+                                                                const std::array<double, 3> &boxMin,
+                                                                const std::array<double, 3> &boxMax) const {
     return _linkedCells.template getParticleImpl<regionIter>(cellIndex, particleIndex, iteratorBehavior, boxMin,
                                                              boxMax);
   }
@@ -213,7 +213,8 @@ class VerletListsLinkedBase : public ParticleContainerInterface<ParticleT> {
    */
   [[nodiscard]] ContainerIterator<ParticleT, false, false> begin(
       IteratorBehavior behavior = IteratorBehavior::ownedOrHalo,
-      typename ContainerIterator<ParticleT, false, false>::ParticleVecType *additionalVectors = nullptr) const override {
+      typename ContainerIterator<ParticleT, false, false>::ParticleVecType *additionalVectors =
+          nullptr) const override {
     return _linkedCells.begin(behavior, additionalVectors);
   }
 

--- a/src/autopas/containers/verletListsCellBased/varVerletLists/VarVerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/varVerletLists/VarVerletLists.h
@@ -32,7 +32,7 @@ class VarVerletLists : public VerletListsLinkedBase<ParticleT> {
   VarVerletLists(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax, const double cutoff,
                  const double skin, const unsigned int rebuildFrequency, const double cellSizeFactor = 1.0)
       : VerletListsLinkedBase<ParticleT>(boxMin, boxMax, cutoff, skin, rebuildFrequency,
-                                        compatibleTraversals::allVarVLAsBuildCompatibleTraversals(), cellSizeFactor),
+                                         compatibleTraversals::allVarVLAsBuildCompatibleTraversals(), cellSizeFactor),
         _neighborList{} {}
 
   /**

--- a/src/autopas/containers/verletListsCellBased/varVerletLists/VarVerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/varVerletLists/VarVerletLists.h
@@ -13,11 +13,11 @@ namespace autopas {
 
 /**
  * Variable Verlet Lists container with different neighbor lists.
- * @tparam ParticleT The particle type this container contains.
+ * @tparam Particle_T The particle type this container contains.
  * @tparam NeighborList The Neighbor List this Verlet Container uses.
  */
-template <class ParticleT, class NeighborList>
-class VarVerletLists : public VerletListsLinkedBase<ParticleT> {
+template <class Particle_T, class NeighborList>
+class VarVerletLists : public VerletListsLinkedBase<Particle_T> {
  public:
   /**
    * Constructor of the Variable VerletLists class.
@@ -31,8 +31,8 @@ class VarVerletLists : public VerletListsLinkedBase<ParticleT> {
    */
   VarVerletLists(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax, const double cutoff,
                  const double skin, const unsigned int rebuildFrequency, const double cellSizeFactor = 1.0)
-      : VerletListsLinkedBase<ParticleT>(boxMin, boxMax, cutoff, skin, rebuildFrequency,
-                                         compatibleTraversals::allVarVLAsBuildCompatibleTraversals(), cellSizeFactor),
+      : VerletListsLinkedBase<Particle_T>(boxMin, boxMax, cutoff, skin, rebuildFrequency,
+                                          compatibleTraversals::allVarVLAsBuildCompatibleTraversals(), cellSizeFactor),
         _neighborList{} {}
 
   /**

--- a/src/autopas/containers/verletListsCellBased/varVerletLists/VarVerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/varVerletLists/VarVerletLists.h
@@ -13,11 +13,11 @@ namespace autopas {
 
 /**
  * Variable Verlet Lists container with different neighbor lists.
- * @tparam Particle The particle type this container contains.
+ * @tparam ParticleT The particle type this container contains.
  * @tparam NeighborList The Neighbor List this Verlet Container uses.
  */
-template <class Particle, class NeighborList>
-class VarVerletLists : public VerletListsLinkedBase<Particle> {
+template <class ParticleT, class NeighborList>
+class VarVerletLists : public VerletListsLinkedBase<ParticleT> {
  public:
   /**
    * Constructor of the Variable VerletLists class.
@@ -31,7 +31,7 @@ class VarVerletLists : public VerletListsLinkedBase<Particle> {
    */
   VarVerletLists(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax, const double cutoff,
                  const double skin, const unsigned int rebuildFrequency, const double cellSizeFactor = 1.0)
-      : VerletListsLinkedBase<Particle>(boxMin, boxMax, cutoff, skin, rebuildFrequency,
+      : VerletListsLinkedBase<ParticleT>(boxMin, boxMax, cutoff, skin, rebuildFrequency,
                                         compatibleTraversals::allVarVLAsBuildCompatibleTraversals(), cellSizeFactor),
         _neighborList{} {}
 

--- a/src/autopas/containers/verletListsCellBased/varVerletLists/neighborLists/VerletNeighborListInterface.h
+++ b/src/autopas/containers/verletListsCellBased/varVerletLists/neighborLists/VerletNeighborListInterface.h
@@ -15,9 +15,9 @@
 namespace autopas {
 /**
  * Interface for neighbor lists used by VarVerletLists.
- * @tparam ParticleT The particle type this neighbor list uses.
+ * @tparam Particle_T The particle type this neighbor list uses.
  */
-template <class ParticleT>
+template <class Particle_T>
 class VerletNeighborListInterface {
  public:
   /**
@@ -36,7 +36,7 @@ class VerletNeighborListInterface {
    * @param linkedCells The linked cells to use for building the neighbor list.
    * @param useNewton3 If true, use newton 3 for the neighbor list.
    */
-  virtual void buildAoSNeighborList(LinkedCells<ParticleT> &linkedCells, bool useNewton3) = 0;
+  virtual void buildAoSNeighborList(LinkedCells<Particle_T> &linkedCells, bool useNewton3) = 0;
 
   /**
    * Checks if the neighbor list contains all pairs that is should.

--- a/src/autopas/containers/verletListsCellBased/varVerletLists/neighborLists/VerletNeighborListInterface.h
+++ b/src/autopas/containers/verletListsCellBased/varVerletLists/neighborLists/VerletNeighborListInterface.h
@@ -15,9 +15,9 @@
 namespace autopas {
 /**
  * Interface for neighbor lists used by VarVerletLists.
- * @tparam Particle The particle type this neighbor list uses.
+ * @tparam ParticleT The particle type this neighbor list uses.
  */
-template <class Particle>
+template <class ParticleT>
 class VerletNeighborListInterface {
  public:
   /**
@@ -36,7 +36,7 @@ class VerletNeighborListInterface {
    * @param linkedCells The linked cells to use for building the neighbor list.
    * @param useNewton3 If true, use newton 3 for the neighbor list.
    */
-  virtual void buildAoSNeighborList(LinkedCells<Particle> &linkedCells, bool useNewton3) = 0;
+  virtual void buildAoSNeighborList(LinkedCells<ParticleT> &linkedCells, bool useNewton3) = 0;
 
   /**
    * Checks if the neighbor list contains all pairs that is should.

--- a/src/autopas/containers/verletListsCellBased/varVerletLists/neighborLists/asBuild/AsBuildPairGeneratorFunctor.h
+++ b/src/autopas/containers/verletListsCellBased/varVerletLists/neighborLists/asBuild/AsBuildPairGeneratorFunctor.h
@@ -12,7 +12,7 @@
 
 namespace autopas {
 
-template <class Particle>
+template <class ParticleT>
 class VerletNeighborListAsBuild;
 
 namespace internal {
@@ -21,41 +21,41 @@ namespace internal {
  * This functor can generate or check variable verlet lists using the typical pairwise
  * traversal.
  *
- * @tparam Particle The particle class.
+ * @tparam ParticleT The particle class.
  * @tparam callCheckInstead If false, generate a neighbor list. If true, check the current for validity. Checking
  * validity only works with the AoSFunctor().
  */
-template <class Particle, bool callCheckInstead = false>
+template <class ParticleT, bool callCheckInstead = false>
 class AsBuildPairGeneratorFunctor
-    : public autopas::PairwiseFunctor<Particle, AsBuildPairGeneratorFunctor<Particle, callCheckInstead>> {
+    : public autopas::PairwiseFunctor<ParticleT, AsBuildPairGeneratorFunctor<ParticleT, callCheckInstead>> {
  public:
   /**
    * The structure of the SoAs is defined by the particle.
    */
-  using SoAArraysType = typename Particle::SoAArraysType;
+  using SoAArraysType = typename ParticleT::SoAArraysType;
 
   /**
    * @copydoc Functor::getNeededAttr()
    */
   constexpr static auto getNeededAttr() {
-    return std::array<typename Particle::AttributeNames, 4>{
-        Particle::AttributeNames::ptr, Particle::AttributeNames::posX, Particle::AttributeNames::posY,
-        Particle::AttributeNames::posZ};
+    return std::array<typename ParticleT::AttributeNames, 4>{
+        ParticleT::AttributeNames::ptr, ParticleT::AttributeNames::posX, ParticleT::AttributeNames::posY,
+        ParticleT::AttributeNames::posZ};
   }
 
   /**
    * @copydoc Functor::getNeededAttr(std::false_type)
    */
   constexpr static auto getNeededAttr(std::false_type) {
-    return std::array<typename Particle::AttributeNames, 4>{
-        Particle::AttributeNames::id, Particle::AttributeNames::posX, Particle::AttributeNames::posY,
-        Particle::AttributeNames::posZ};
+    return std::array<typename ParticleT::AttributeNames, 4>{
+        ParticleT::AttributeNames::id, ParticleT::AttributeNames::posX, ParticleT::AttributeNames::posY,
+        ParticleT::AttributeNames::posZ};
   }
 
   /**
    * @copydoc Functor::getComputedAttr()
    */
-  constexpr static auto getComputedAttr() { return std::array<typename Particle::AttributeNames, 0>{}; }
+  constexpr static auto getComputedAttr() { return std::array<typename ParticleT::AttributeNames, 0>{}; }
 
   bool allowsNewton3() override { return true; }
   bool allowsNonNewton3() override { return true; }
@@ -65,8 +65,8 @@ class AsBuildPairGeneratorFunctor
    * @param neighborList The neighbor list to fill.
    * @param cutoffskin The cutoff skin to use.
    */
-  AsBuildPairGeneratorFunctor(VerletNeighborListAsBuild<Particle> &neighborList, double cutoffskin)
-      : autopas::PairwiseFunctor<Particle, AsBuildPairGeneratorFunctor>(cutoffskin),
+  AsBuildPairGeneratorFunctor(VerletNeighborListAsBuild<ParticleT> &neighborList, double cutoffskin)
+      : autopas::PairwiseFunctor<ParticleT, AsBuildPairGeneratorFunctor>(cutoffskin),
         _list(neighborList),
         _cutoffskinsquared(cutoffskin * cutoffskin) {}
 
@@ -80,7 +80,7 @@ class AsBuildPairGeneratorFunctor
    * @param j The second particle of the pair.
    * @param newton3 Not used!
    */
-  void AoSFunctor(Particle &i, Particle &j, bool newton3) override {
+  void AoSFunctor(ParticleT &i, ParticleT &j, bool newton3) override {
     using namespace autopas::utils::ArrayMath::literals;
 
     const auto dist = i.getR() - j.getR();
@@ -102,10 +102,10 @@ class AsBuildPairGeneratorFunctor
   void SoAFunctorSingle(SoAView<SoAArraysType> soa, bool newton3) override {
     if (soa.size() == 0) return;
 
-    auto **const __restrict ptrptr = soa.template begin<Particle::AttributeNames::ptr>();
-    double *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
+    auto **const __restrict ptrptr = soa.template begin<ParticleT::AttributeNames::ptr>();
+    double *const __restrict xptr = soa.template begin<ParticleT::AttributeNames::posX>();
+    double *const __restrict yptr = soa.template begin<ParticleT::AttributeNames::posY>();
+    double *const __restrict zptr = soa.template begin<ParticleT::AttributeNames::posZ>();
 
     size_t numPart = soa.size();
     for (unsigned int i = 0; i < numPart; ++i) {
@@ -138,15 +138,15 @@ class AsBuildPairGeneratorFunctor
   void SoAFunctorPair(SoAView<SoAArraysType> soa1, SoAView<SoAArraysType> soa2, bool /*newton3*/) override {
     if (soa1.size() == 0 || soa2.size() == 0) return;
 
-    auto **const __restrict ptrptr1 = soa1.template begin<Particle::AttributeNames::ptr>();
-    double *const __restrict x1ptr = soa1.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict y1ptr = soa1.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict z1ptr = soa1.template begin<Particle::AttributeNames::posZ>();
+    auto **const __restrict ptrptr1 = soa1.template begin<ParticleT::AttributeNames::ptr>();
+    double *const __restrict x1ptr = soa1.template begin<ParticleT::AttributeNames::posX>();
+    double *const __restrict y1ptr = soa1.template begin<ParticleT::AttributeNames::posY>();
+    double *const __restrict z1ptr = soa1.template begin<ParticleT::AttributeNames::posZ>();
 
-    auto **const __restrict ptrptr2 = soa2.template begin<Particle::AttributeNames::ptr>();
-    double *const __restrict x2ptr = soa2.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict y2ptr = soa2.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict z2ptr = soa2.template begin<Particle::AttributeNames::posZ>();
+    auto **const __restrict ptrptr2 = soa2.template begin<ParticleT::AttributeNames::ptr>();
+    double *const __restrict x2ptr = soa2.template begin<ParticleT::AttributeNames::posX>();
+    double *const __restrict y2ptr = soa2.template begin<ParticleT::AttributeNames::posY>();
+    double *const __restrict z2ptr = soa2.template begin<ParticleT::AttributeNames::posZ>();
 
     size_t numPart1 = soa1.size();
     for (unsigned int i = 0; i < numPart1; ++i) {
@@ -173,7 +173,7 @@ class AsBuildPairGeneratorFunctor
   /**
    * The neighbor list to fill.
    */
-  VerletNeighborListAsBuild<Particle> &_list;
+  VerletNeighborListAsBuild<ParticleT> &_list;
   /**
    * The squared cutoff skin to determine if a pair should be added to the list.
    */

--- a/src/autopas/containers/verletListsCellBased/varVerletLists/neighborLists/asBuild/AsBuildPairGeneratorFunctor.h
+++ b/src/autopas/containers/verletListsCellBased/varVerletLists/neighborLists/asBuild/AsBuildPairGeneratorFunctor.h
@@ -12,7 +12,7 @@
 
 namespace autopas {
 
-template <class ParticleT>
+template <class Particle_T>
 class VerletNeighborListAsBuild;
 
 namespace internal {
@@ -21,41 +21,41 @@ namespace internal {
  * This functor can generate or check variable verlet lists using the typical pairwise
  * traversal.
  *
- * @tparam ParticleT The particle class.
+ * @tparam Particle_T The particle class.
  * @tparam callCheckInstead If false, generate a neighbor list. If true, check the current for validity. Checking
  * validity only works with the AoSFunctor().
  */
-template <class ParticleT, bool callCheckInstead = false>
+template <class Particle_T, bool callCheckInstead = false>
 class AsBuildPairGeneratorFunctor
-    : public autopas::PairwiseFunctor<ParticleT, AsBuildPairGeneratorFunctor<ParticleT, callCheckInstead>> {
+    : public autopas::PairwiseFunctor<Particle_T, AsBuildPairGeneratorFunctor<Particle_T, callCheckInstead>> {
  public:
   /**
    * The structure of the SoAs is defined by the particle.
    */
-  using SoAArraysType = typename ParticleT::SoAArraysType;
+  using SoAArraysType = typename Particle_T::SoAArraysType;
 
   /**
    * @copydoc Functor::getNeededAttr()
    */
   constexpr static auto getNeededAttr() {
-    return std::array<typename ParticleT::AttributeNames, 4>{
-        ParticleT::AttributeNames::ptr, ParticleT::AttributeNames::posX, ParticleT::AttributeNames::posY,
-        ParticleT::AttributeNames::posZ};
+    return std::array<typename Particle_T::AttributeNames, 4>{
+        Particle_T::AttributeNames::ptr, Particle_T::AttributeNames::posX, Particle_T::AttributeNames::posY,
+        Particle_T::AttributeNames::posZ};
   }
 
   /**
    * @copydoc Functor::getNeededAttr(std::false_type)
    */
   constexpr static auto getNeededAttr(std::false_type) {
-    return std::array<typename ParticleT::AttributeNames, 4>{
-        ParticleT::AttributeNames::id, ParticleT::AttributeNames::posX, ParticleT::AttributeNames::posY,
-        ParticleT::AttributeNames::posZ};
+    return std::array<typename Particle_T::AttributeNames, 4>{
+        Particle_T::AttributeNames::id, Particle_T::AttributeNames::posX, Particle_T::AttributeNames::posY,
+        Particle_T::AttributeNames::posZ};
   }
 
   /**
    * @copydoc Functor::getComputedAttr()
    */
-  constexpr static auto getComputedAttr() { return std::array<typename ParticleT::AttributeNames, 0>{}; }
+  constexpr static auto getComputedAttr() { return std::array<typename Particle_T::AttributeNames, 0>{}; }
 
   bool allowsNewton3() override { return true; }
   bool allowsNonNewton3() override { return true; }
@@ -65,8 +65,8 @@ class AsBuildPairGeneratorFunctor
    * @param neighborList The neighbor list to fill.
    * @param cutoffskin The cutoff skin to use.
    */
-  AsBuildPairGeneratorFunctor(VerletNeighborListAsBuild<ParticleT> &neighborList, double cutoffskin)
-      : autopas::PairwiseFunctor<ParticleT, AsBuildPairGeneratorFunctor>(cutoffskin),
+  AsBuildPairGeneratorFunctor(VerletNeighborListAsBuild<Particle_T> &neighborList, double cutoffskin)
+      : autopas::PairwiseFunctor<Particle_T, AsBuildPairGeneratorFunctor>(cutoffskin),
         _list(neighborList),
         _cutoffskinsquared(cutoffskin * cutoffskin) {}
 
@@ -80,7 +80,7 @@ class AsBuildPairGeneratorFunctor
    * @param j The second particle of the pair.
    * @param newton3 Not used!
    */
-  void AoSFunctor(ParticleT &i, ParticleT &j, bool newton3) override {
+  void AoSFunctor(Particle_T &i, Particle_T &j, bool newton3) override {
     using namespace autopas::utils::ArrayMath::literals;
 
     const auto dist = i.getR() - j.getR();
@@ -102,10 +102,10 @@ class AsBuildPairGeneratorFunctor
   void SoAFunctorSingle(SoAView<SoAArraysType> soa, bool newton3) override {
     if (soa.size() == 0) return;
 
-    auto **const __restrict ptrptr = soa.template begin<ParticleT::AttributeNames::ptr>();
-    double *const __restrict xptr = soa.template begin<ParticleT::AttributeNames::posX>();
-    double *const __restrict yptr = soa.template begin<ParticleT::AttributeNames::posY>();
-    double *const __restrict zptr = soa.template begin<ParticleT::AttributeNames::posZ>();
+    auto **const __restrict ptrptr = soa.template begin<Particle_T::AttributeNames::ptr>();
+    double *const __restrict xptr = soa.template begin<Particle_T::AttributeNames::posX>();
+    double *const __restrict yptr = soa.template begin<Particle_T::AttributeNames::posY>();
+    double *const __restrict zptr = soa.template begin<Particle_T::AttributeNames::posZ>();
 
     size_t numPart = soa.size();
     for (unsigned int i = 0; i < numPart; ++i) {
@@ -138,15 +138,15 @@ class AsBuildPairGeneratorFunctor
   void SoAFunctorPair(SoAView<SoAArraysType> soa1, SoAView<SoAArraysType> soa2, bool /*newton3*/) override {
     if (soa1.size() == 0 || soa2.size() == 0) return;
 
-    auto **const __restrict ptrptr1 = soa1.template begin<ParticleT::AttributeNames::ptr>();
-    double *const __restrict x1ptr = soa1.template begin<ParticleT::AttributeNames::posX>();
-    double *const __restrict y1ptr = soa1.template begin<ParticleT::AttributeNames::posY>();
-    double *const __restrict z1ptr = soa1.template begin<ParticleT::AttributeNames::posZ>();
+    auto **const __restrict ptrptr1 = soa1.template begin<Particle_T::AttributeNames::ptr>();
+    double *const __restrict x1ptr = soa1.template begin<Particle_T::AttributeNames::posX>();
+    double *const __restrict y1ptr = soa1.template begin<Particle_T::AttributeNames::posY>();
+    double *const __restrict z1ptr = soa1.template begin<Particle_T::AttributeNames::posZ>();
 
-    auto **const __restrict ptrptr2 = soa2.template begin<ParticleT::AttributeNames::ptr>();
-    double *const __restrict x2ptr = soa2.template begin<ParticleT::AttributeNames::posX>();
-    double *const __restrict y2ptr = soa2.template begin<ParticleT::AttributeNames::posY>();
-    double *const __restrict z2ptr = soa2.template begin<ParticleT::AttributeNames::posZ>();
+    auto **const __restrict ptrptr2 = soa2.template begin<Particle_T::AttributeNames::ptr>();
+    double *const __restrict x2ptr = soa2.template begin<Particle_T::AttributeNames::posX>();
+    double *const __restrict y2ptr = soa2.template begin<Particle_T::AttributeNames::posY>();
+    double *const __restrict z2ptr = soa2.template begin<Particle_T::AttributeNames::posZ>();
 
     size_t numPart1 = soa1.size();
     for (unsigned int i = 0; i < numPart1; ++i) {
@@ -173,7 +173,7 @@ class AsBuildPairGeneratorFunctor
   /**
    * The neighbor list to fill.
    */
-  VerletNeighborListAsBuild<ParticleT> &_list;
+  VerletNeighborListAsBuild<Particle_T> &_list;
   /**
    * The squared cutoff skin to determine if a pair should be added to the list.
    */

--- a/src/autopas/containers/verletListsCellBased/varVerletLists/neighborLists/asBuild/VerletNeighborListAsBuild.h
+++ b/src/autopas/containers/verletListsCellBased/varVerletLists/neighborLists/asBuild/VerletNeighborListAsBuild.h
@@ -16,20 +16,20 @@ namespace autopas {
 /**
  * This class implements a neighbor list that remembers which thread added which particle pair and at which color
  * during the build with C08 from LinkedCells.
- * @tparam ParticleT The particle type the class uses.
+ * @tparam Particle_T The particle type the class uses.
  */
-template <class ParticleT>
-class VerletNeighborListAsBuild : public VerletNeighborListInterface<ParticleT>, ColorChangeObserver {
+template <class Particle_T>
+class VerletNeighborListAsBuild : public VerletNeighborListInterface<Particle_T>, ColorChangeObserver {
   /**
    * Adds the generator functor for validation checks as friend so it can call checkPair().
    *  @param true mark that it is for validation checks.
    */
-  friend class internal::AsBuildPairGeneratorFunctor<ParticleT, true>;
+  friend class internal::AsBuildPairGeneratorFunctor<Particle_T, true>;
   /**
    * Adds the generator functor for adding pairs as friend so it can call addPair().
    *  @param false test mark that it is for adding pairs.
    */
-  friend class internal::AsBuildPairGeneratorFunctor<ParticleT, false>;
+  friend class internal::AsBuildPairGeneratorFunctor<Particle_T, false>;
 
  private:
   /**
@@ -40,11 +40,11 @@ class VerletNeighborListAsBuild : public VerletNeighborListInterface<ParticleT>,
    */
   template <bool useNewton3, bool validationMode = false>
   void applyGeneratorFunctor(double cutoff) {
-    internal::AsBuildPairGeneratorFunctor<ParticleT, validationMode> generatorFunctor(*this, cutoff);
+    internal::AsBuildPairGeneratorFunctor<Particle_T, validationMode> generatorFunctor(*this, cutoff);
     // Use SoA traversal for generation and AoS traversal for validation check.
     constexpr auto dataLayout = validationMode ? DataLayoutOption::aos : DataLayoutOption::soa;
-    auto traversal = C08TraversalColorChangeNotify<FullParticleCell<ParticleT>,
-                                                   internal::AsBuildPairGeneratorFunctor<ParticleT, validationMode>>(
+    auto traversal = C08TraversalColorChangeNotify<FullParticleCell<Particle_T>,
+                                                   internal::AsBuildPairGeneratorFunctor<Particle_T, validationMode>>(
         _baseLinkedCells->getCellBlock().getCellsPerDimensionWithHalo(), &generatorFunctor,
         _baseLinkedCells->getInteractionLength(), _baseLinkedCells->getCellBlock().getCellLength(), this, dataLayout,
         useNewton3);
@@ -55,7 +55,7 @@ class VerletNeighborListAsBuild : public VerletNeighborListInterface<ParticleT>,
   /**
    * This type represents the neighbor list that each thread has for each color.
    */
-  using AoSThreadNeighborList = std::unordered_map<ParticleT *, std::vector<ParticleT *>>;
+  using AoSThreadNeighborList = std::unordered_map<Particle_T *, std::vector<Particle_T *>>;
   /**
    * This type represents the thread lists for all colors.
    */
@@ -83,7 +83,7 @@ class VerletNeighborListAsBuild : public VerletNeighborListInterface<ParticleT>,
    * It executes C08 on the passed LinkedCells container and saves the resulting pairs in the neighbor list, remembering
    * the thread and current color for each pair.
    */
-  void buildAoSNeighborList(LinkedCells<ParticleT> &linkedCells, bool useNewton3) override {
+  void buildAoSNeighborList(LinkedCells<Particle_T> &linkedCells, bool useNewton3) override {
     _soaListIsValid = false;
     _baseLinkedCells = &linkedCells;
 
@@ -127,7 +127,7 @@ class VerletNeighborListAsBuild : public VerletNeighborListInterface<ParticleT>,
    * _aosNeighborList
    * = std::array<AoSColorNeighborList, _numColors>
    * = std::array<std::vector<AoSThreadNeighborList>>, _numColors>
-   * = std::array<std::vector<std::unordered_map<ParticleT *, std::vector<ParticleT *>>>, _numColors>
+   * = std::array<std::vector<std::unordered_map<Particle_T *, std::vector<Particle_T *>>>, _numColors>
    *
    * @return the internal AoS neighbor list.
    */
@@ -158,7 +158,7 @@ class VerletNeighborListAsBuild : public VerletNeighborListInterface<ParticleT>,
   void generateSoAFromAoS() override {
     // Generate a map from pointer to particle index in the SoA. This works, because during loadSoA"()" the particles
     // are loaded in the same order.
-    std::unordered_map<ParticleT *, size_t> _aos2soaMap;
+    std::unordered_map<Particle_T *, size_t> _aos2soaMap;
     _aos2soaMap.reserve(_baseLinkedCells->size());
     size_t i = 0;
     // needs to iterate also over dummies!
@@ -247,7 +247,7 @@ class VerletNeighborListAsBuild : public VerletNeighborListInterface<ParticleT>,
   /**
    * Called from VarVerletListGeneratorFunctor
    */
-  void addPair(ParticleT *first, ParticleT *second) {
+  void addPair(Particle_T *first, Particle_T *second) {
     int currentThreadIndex = autopas_get_thread_num();
     _aosNeighborList[_currentColor][currentThreadIndex][first].push_back(second);
   }
@@ -255,7 +255,7 @@ class VerletNeighborListAsBuild : public VerletNeighborListInterface<ParticleT>,
   /**
    * Called from VarVerletListGeneratorFunctor
    */
-  void checkPair(ParticleT *first, ParticleT *second) {
+  void checkPair(Particle_T *first, Particle_T *second) {
     int currentThreadIndex = autopas_get_thread_num();
 
     // Check all neighbor lists for the pair, but the one that the pair would be in if it was not moved first.
@@ -280,7 +280,7 @@ class VerletNeighborListAsBuild : public VerletNeighborListInterface<ParticleT>,
    * Helper method for checkPair()
    * @return True, if the pair is present, false otherwise.
    */
-  bool isPairInList(AoSThreadNeighborList &currentNeighborList, ParticleT *first, ParticleT *second) {
+  bool isPairInList(AoSThreadNeighborList &currentNeighborList, Particle_T *first, Particle_T *second) {
     auto iteratorFound = std::find(currentNeighborList[first].begin(), currentNeighborList[first].end(), second);
 
     return iteratorFound != currentNeighborList[first].end();
@@ -300,7 +300,7 @@ class VerletNeighborListAsBuild : public VerletNeighborListInterface<ParticleT>,
   /**
    * The LinkedCells object this neighbor list should use to build.
    */
-  LinkedCells<ParticleT> *_baseLinkedCells;
+  LinkedCells<Particle_T> *_baseLinkedCells;
 
   /**
    * The internal SoA neighbor list. For format, see getSoANeighborList().
@@ -310,7 +310,7 @@ class VerletNeighborListAsBuild : public VerletNeighborListInterface<ParticleT>,
   /**
    * The SoA used.
    */
-  SoA<typename ParticleT::SoAArraysType> _soa;
+  SoA<typename Particle_T::SoAArraysType> _soa;
 
   /**
    * If the SoA is valid, see isSoAListValid().

--- a/src/autopas/containers/verletListsCellBased/varVerletLists/neighborLists/asBuild/VerletNeighborListAsBuild.h
+++ b/src/autopas/containers/verletListsCellBased/varVerletLists/neighborLists/asBuild/VerletNeighborListAsBuild.h
@@ -16,20 +16,20 @@ namespace autopas {
 /**
  * This class implements a neighbor list that remembers which thread added which particle pair and at which color
  * during the build with C08 from LinkedCells.
- * @tparam Particle The particle type the class uses.
+ * @tparam ParticleT The particle type the class uses.
  */
-template <class Particle>
-class VerletNeighborListAsBuild : public VerletNeighborListInterface<Particle>, ColorChangeObserver {
+template <class ParticleT>
+class VerletNeighborListAsBuild : public VerletNeighborListInterface<ParticleT>, ColorChangeObserver {
   /**
    * Adds the generator functor for validation checks as friend so it can call checkPair().
    *  @param true mark that it is for validation checks.
    */
-  friend class internal::AsBuildPairGeneratorFunctor<Particle, true>;
+  friend class internal::AsBuildPairGeneratorFunctor<ParticleT, true>;
   /**
    * Adds the generator functor for adding pairs as friend so it can call addPair().
    *  @param false test mark that it is for adding pairs.
    */
-  friend class internal::AsBuildPairGeneratorFunctor<Particle, false>;
+  friend class internal::AsBuildPairGeneratorFunctor<ParticleT, false>;
 
  private:
   /**
@@ -40,11 +40,11 @@ class VerletNeighborListAsBuild : public VerletNeighborListInterface<Particle>, 
    */
   template <bool useNewton3, bool validationMode = false>
   void applyGeneratorFunctor(double cutoff) {
-    internal::AsBuildPairGeneratorFunctor<Particle, validationMode> generatorFunctor(*this, cutoff);
+    internal::AsBuildPairGeneratorFunctor<ParticleT, validationMode> generatorFunctor(*this, cutoff);
     // Use SoA traversal for generation and AoS traversal for validation check.
     constexpr auto dataLayout = validationMode ? DataLayoutOption::aos : DataLayoutOption::soa;
-    auto traversal = C08TraversalColorChangeNotify<FullParticleCell<Particle>,
-                                                   internal::AsBuildPairGeneratorFunctor<Particle, validationMode>>(
+    auto traversal = C08TraversalColorChangeNotify<FullParticleCell<ParticleT>,
+                                                   internal::AsBuildPairGeneratorFunctor<ParticleT, validationMode>>(
         _baseLinkedCells->getCellBlock().getCellsPerDimensionWithHalo(), &generatorFunctor,
         _baseLinkedCells->getInteractionLength(), _baseLinkedCells->getCellBlock().getCellLength(), this, dataLayout,
         useNewton3);
@@ -55,7 +55,7 @@ class VerletNeighborListAsBuild : public VerletNeighborListInterface<Particle>, 
   /**
    * This type represents the neighbor list that each thread has for each color.
    */
-  using AoSThreadNeighborList = std::unordered_map<Particle *, std::vector<Particle *>>;
+  using AoSThreadNeighborList = std::unordered_map<ParticleT *, std::vector<ParticleT *>>;
   /**
    * This type represents the thread lists for all colors.
    */
@@ -83,7 +83,7 @@ class VerletNeighborListAsBuild : public VerletNeighborListInterface<Particle>, 
    * It executes C08 on the passed LinkedCells container and saves the resulting pairs in the neighbor list, remembering
    * the thread and current color for each pair.
    */
-  void buildAoSNeighborList(LinkedCells<Particle> &linkedCells, bool useNewton3) override {
+  void buildAoSNeighborList(LinkedCells<ParticleT> &linkedCells, bool useNewton3) override {
     _soaListIsValid = false;
     _baseLinkedCells = &linkedCells;
 
@@ -127,7 +127,7 @@ class VerletNeighborListAsBuild : public VerletNeighborListInterface<Particle>, 
    * _aosNeighborList
    * = std::array<AoSColorNeighborList, _numColors>
    * = std::array<std::vector<AoSThreadNeighborList>>, _numColors>
-   * = std::array<std::vector<std::unordered_map<Particle *, std::vector<Particle *>>>, _numColors>
+   * = std::array<std::vector<std::unordered_map<ParticleT *, std::vector<ParticleT *>>>, _numColors>
    *
    * @return the internal AoS neighbor list.
    */
@@ -158,7 +158,7 @@ class VerletNeighborListAsBuild : public VerletNeighborListInterface<Particle>, 
   void generateSoAFromAoS() override {
     // Generate a map from pointer to particle index in the SoA. This works, because during loadSoA"()" the particles
     // are loaded in the same order.
-    std::unordered_map<Particle *, size_t> _aos2soaMap;
+    std::unordered_map<ParticleT *, size_t> _aos2soaMap;
     _aos2soaMap.reserve(_baseLinkedCells->size());
     size_t i = 0;
     // needs to iterate also over dummies!
@@ -247,7 +247,7 @@ class VerletNeighborListAsBuild : public VerletNeighborListInterface<Particle>, 
   /**
    * Called from VarVerletListGeneratorFunctor
    */
-  void addPair(Particle *first, Particle *second) {
+  void addPair(ParticleT *first, ParticleT *second) {
     int currentThreadIndex = autopas_get_thread_num();
     _aosNeighborList[_currentColor][currentThreadIndex][first].push_back(second);
   }
@@ -255,7 +255,7 @@ class VerletNeighborListAsBuild : public VerletNeighborListInterface<Particle>, 
   /**
    * Called from VarVerletListGeneratorFunctor
    */
-  void checkPair(Particle *first, Particle *second) {
+  void checkPair(ParticleT *first, ParticleT *second) {
     int currentThreadIndex = autopas_get_thread_num();
 
     // Check all neighbor lists for the pair, but the one that the pair would be in if it was not moved first.
@@ -280,7 +280,7 @@ class VerletNeighborListAsBuild : public VerletNeighborListInterface<Particle>, 
    * Helper method for checkPair()
    * @return True, if the pair is present, false otherwise.
    */
-  bool isPairInList(AoSThreadNeighborList &currentNeighborList, Particle *first, Particle *second) {
+  bool isPairInList(AoSThreadNeighborList &currentNeighborList, ParticleT *first, ParticleT *second) {
     auto iteratorFound = std::find(currentNeighborList[first].begin(), currentNeighborList[first].end(), second);
 
     return iteratorFound != currentNeighborList[first].end();
@@ -300,7 +300,7 @@ class VerletNeighborListAsBuild : public VerletNeighborListInterface<Particle>, 
   /**
    * The LinkedCells object this neighbor list should use to build.
    */
-  LinkedCells<Particle> *_baseLinkedCells;
+  LinkedCells<ParticleT> *_baseLinkedCells;
 
   /**
    * The internal SoA neighbor list. For format, see getSoANeighborList().
@@ -310,7 +310,7 @@ class VerletNeighborListAsBuild : public VerletNeighborListInterface<Particle>, 
   /**
    * The SoA used.
    */
-  SoA<typename Particle::SoAArraysType> _soa;
+  SoA<typename ParticleT::SoAArraysType> _soa;
 
   /**
    * If the SoA is valid, see isSoAListValid().

--- a/src/autopas/containers/verletListsCellBased/varVerletLists/traversals/VVLAsBuildTraversal.h
+++ b/src/autopas/containers/verletListsCellBased/varVerletLists/traversals/VVLAsBuildTraversal.h
@@ -17,24 +17,24 @@ namespace autopas {
  * by the same thread in the same color as during the build of the neighbor list.
  *
  * @tparam ParticleCell
- * @tparam Particle The particle type used by the neighbor list.
+ * @tparam ParticleT The particle type used by the neighbor list.
  * @tparam PairwiseFunctor The type of the functor to use for the iteration.
  */
-template <class ParticleCell, class Particle, class PairwiseFunctor>
-class VVLAsBuildTraversal : public VVLTraversalInterface<VerletNeighborListAsBuild<Particle>>,
+template <class ParticleCell, class ParticleT, class PairwiseFunctor>
+class VVLAsBuildTraversal : public VVLTraversalInterface<VerletNeighborListAsBuild<ParticleT>>,
                             public TraversalInterface {
  private:
   /**
    * Internal iterate method for AoS.
    * @param neighborList The neighbor list to iterate over.
    */
-  void iterateAoS(VerletNeighborListAsBuild<Particle> &neighborList);
+  void iterateAoS(VerletNeighborListAsBuild<ParticleT> &neighborList);
 
   /**
    * Internal iterate method for SoA.
    * @param neighborList The neighbor list to iterate over.
    */
-  void iterateSoA(VerletNeighborListAsBuild<Particle> &neighborList);
+  void iterateSoA(VerletNeighborListAsBuild<ParticleT> &neighborList);
 
  public:
   /**
@@ -89,12 +89,12 @@ class VVLAsBuildTraversal : public VVLTraversalInterface<VerletNeighborListAsBui
   /**
    * A pointer to the SoA to iterate over if DataLayout is soa.
    */
-  SoA<typename Particle::SoAArraysType> *_soa;
+  SoA<typename ParticleT::SoAArraysType> *_soa;
 };
 
-template <class ParticleCell, class Particle, class PairwiseFunctor>
-void VVLAsBuildTraversal<ParticleCell, Particle, PairwiseFunctor>::iterateAoS(
-    VerletNeighborListAsBuild<Particle> &neighborList) {
+template <class ParticleCell, class ParticleT, class PairwiseFunctor>
+void VVLAsBuildTraversal<ParticleCell, ParticleT, PairwiseFunctor>::iterateAoS(
+    VerletNeighborListAsBuild<ParticleT> &neighborList) {
   const auto &list = neighborList.getAoSNeighborList();
 
   AUTOPAS_OPENMP(parallel num_threads(list[0].size())) {
@@ -113,9 +113,9 @@ void VVLAsBuildTraversal<ParticleCell, Particle, PairwiseFunctor>::iterateAoS(
   }
 }
 
-template <class ParticleCell, class Particle, class PairwiseFunctor>
-void VVLAsBuildTraversal<ParticleCell, Particle, PairwiseFunctor>::iterateSoA(
-    VerletNeighborListAsBuild<Particle> &neighborList) {
+template <class ParticleCell, class ParticleT, class PairwiseFunctor>
+void VVLAsBuildTraversal<ParticleCell, ParticleT, PairwiseFunctor>::iterateSoA(
+    VerletNeighborListAsBuild<ParticleT> &neighborList) {
   const auto &soaNeighborList = neighborList.getSoANeighborList();
 
   AUTOPAS_OPENMP(parallel num_threads(soaNeighborList[0].size())) {

--- a/src/autopas/containers/verletListsCellBased/varVerletLists/traversals/VVLAsBuildTraversal.h
+++ b/src/autopas/containers/verletListsCellBased/varVerletLists/traversals/VVLAsBuildTraversal.h
@@ -17,24 +17,24 @@ namespace autopas {
  * by the same thread in the same color as during the build of the neighbor list.
  *
  * @tparam ParticleCell
- * @tparam ParticleT The particle type used by the neighbor list.
+ * @tparam Particle_T The particle type used by the neighbor list.
  * @tparam PairwiseFunctor The type of the functor to use for the iteration.
  */
-template <class ParticleCell, class ParticleT, class PairwiseFunctor>
-class VVLAsBuildTraversal : public VVLTraversalInterface<VerletNeighborListAsBuild<ParticleT>>,
+template <class ParticleCell, class Particle_T, class PairwiseFunctor>
+class VVLAsBuildTraversal : public VVLTraversalInterface<VerletNeighborListAsBuild<Particle_T>>,
                             public TraversalInterface {
  private:
   /**
    * Internal iterate method for AoS.
    * @param neighborList The neighbor list to iterate over.
    */
-  void iterateAoS(VerletNeighborListAsBuild<ParticleT> &neighborList);
+  void iterateAoS(VerletNeighborListAsBuild<Particle_T> &neighborList);
 
   /**
    * Internal iterate method for SoA.
    * @param neighborList The neighbor list to iterate over.
    */
-  void iterateSoA(VerletNeighborListAsBuild<ParticleT> &neighborList);
+  void iterateSoA(VerletNeighborListAsBuild<Particle_T> &neighborList);
 
  public:
   /**
@@ -89,12 +89,12 @@ class VVLAsBuildTraversal : public VVLTraversalInterface<VerletNeighborListAsBui
   /**
    * A pointer to the SoA to iterate over if DataLayout is soa.
    */
-  SoA<typename ParticleT::SoAArraysType> *_soa;
+  SoA<typename Particle_T::SoAArraysType> *_soa;
 };
 
-template <class ParticleCell, class ParticleT, class PairwiseFunctor>
-void VVLAsBuildTraversal<ParticleCell, ParticleT, PairwiseFunctor>::iterateAoS(
-    VerletNeighborListAsBuild<ParticleT> &neighborList) {
+template <class ParticleCell, class Particle_T, class PairwiseFunctor>
+void VVLAsBuildTraversal<ParticleCell, Particle_T, PairwiseFunctor>::iterateAoS(
+    VerletNeighborListAsBuild<Particle_T> &neighborList) {
   const auto &list = neighborList.getAoSNeighborList();
 
   AUTOPAS_OPENMP(parallel num_threads(list[0].size())) {
@@ -113,9 +113,9 @@ void VVLAsBuildTraversal<ParticleCell, ParticleT, PairwiseFunctor>::iterateAoS(
   }
 }
 
-template <class ParticleCell, class ParticleT, class PairwiseFunctor>
-void VVLAsBuildTraversal<ParticleCell, ParticleT, PairwiseFunctor>::iterateSoA(
-    VerletNeighborListAsBuild<ParticleT> &neighborList) {
+template <class ParticleCell, class Particle_T, class PairwiseFunctor>
+void VVLAsBuildTraversal<ParticleCell, Particle_T, PairwiseFunctor>::iterateSoA(
+    VerletNeighborListAsBuild<Particle_T> &neighborList) {
   const auto &soaNeighborList = neighborList.getSoANeighborList();
 
   AUTOPAS_OPENMP(parallel num_threads(soaNeighborList[0].size())) {

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
@@ -15,25 +15,25 @@ namespace autopas {
 
 /**
  * Class of helpers for the VerletLists class.
- * @tparam ParticleT
+ * @tparam Particle_T
  */
-template <class ParticleT>
+template <class Particle_T>
 class VerletListHelpers {
  public:
   /**
    * Neighbor list AoS style.
    */
-  using NeighborListAoSType = std::unordered_map<ParticleT *, std::vector<ParticleT *>>;
+  using NeighborListAoSType = std::unordered_map<Particle_T *, std::vector<Particle_T *>>;
 
   /**
    * This functor can generate verlet lists using the typical pairwise traversal.
    */
-  class VerletListGeneratorFunctor : public PairwiseFunctor<ParticleT, VerletListGeneratorFunctor> {
+  class VerletListGeneratorFunctor : public PairwiseFunctor<Particle_T, VerletListGeneratorFunctor> {
    public:
     /**
      * Structure of the SoAs defined by the particle.
      */
-    using SoAArraysType = typename ParticleT::SoAArraysType;
+    using SoAArraysType = typename Particle_T::SoAArraysType;
 
     /**
      * Constructor
@@ -41,7 +41,7 @@ class VerletListHelpers {
      * @param interactionLength
      */
     VerletListGeneratorFunctor(NeighborListAoSType &verletListsAoS, double interactionLength)
-        : PairwiseFunctor<ParticleT, VerletListGeneratorFunctor>(interactionLength),
+        : PairwiseFunctor<Particle_T, VerletListGeneratorFunctor>(interactionLength),
           _verletListsAoS(verletListsAoS),
           _interactionLengthSquared(interactionLength * interactionLength) {}
 
@@ -61,7 +61,7 @@ class VerletListHelpers {
       return true;
     }
 
-    void AoSFunctor(ParticleT &i, ParticleT &j, bool /*newton3*/) override {
+    void AoSFunctor(Particle_T &i, Particle_T &j, bool /*newton3*/) override {
       using namespace autopas::utils::ArrayMath::literals;
 
       if (i.isDummy() or j.isDummy()) {
@@ -90,10 +90,10 @@ class VerletListHelpers {
     void SoAFunctorSingle(SoAView<SoAArraysType> soa, bool newton3) override {
       if (soa.size() == 0) return;
 
-      auto **const __restrict ptrptr = soa.template begin<ParticleT::AttributeNames::ptr>();
-      const double *const __restrict xptr = soa.template begin<ParticleT::AttributeNames::posX>();
-      const double *const __restrict yptr = soa.template begin<ParticleT::AttributeNames::posY>();
-      const double *const __restrict zptr = soa.template begin<ParticleT::AttributeNames::posZ>();
+      auto **const __restrict ptrptr = soa.template begin<Particle_T::AttributeNames::ptr>();
+      const double *const __restrict xptr = soa.template begin<Particle_T::AttributeNames::posX>();
+      const double *const __restrict yptr = soa.template begin<Particle_T::AttributeNames::posY>();
+      const double *const __restrict zptr = soa.template begin<Particle_T::AttributeNames::posZ>();
 
       size_t numPart = soa.size();
       for (unsigned int i = 0; i < numPart; ++i) {
@@ -130,15 +130,15 @@ class VerletListHelpers {
     void SoAFunctorPair(SoAView<SoAArraysType> soa1, SoAView<SoAArraysType> soa2, bool /*newton3*/) override {
       if (soa1.size() == 0 || soa2.size() == 0) return;
 
-      auto **const __restrict ptr1ptr = soa1.template begin<ParticleT::AttributeNames::ptr>();
-      const double *const __restrict x1ptr = soa1.template begin<ParticleT::AttributeNames::posX>();
-      const double *const __restrict y1ptr = soa1.template begin<ParticleT::AttributeNames::posY>();
-      const double *const __restrict z1ptr = soa1.template begin<ParticleT::AttributeNames::posZ>();
+      auto **const __restrict ptr1ptr = soa1.template begin<Particle_T::AttributeNames::ptr>();
+      const double *const __restrict x1ptr = soa1.template begin<Particle_T::AttributeNames::posX>();
+      const double *const __restrict y1ptr = soa1.template begin<Particle_T::AttributeNames::posY>();
+      const double *const __restrict z1ptr = soa1.template begin<Particle_T::AttributeNames::posZ>();
 
-      auto **const __restrict ptr2ptr = soa2.template begin<ParticleT::AttributeNames::ptr>();
-      const double *const __restrict x2ptr = soa2.template begin<ParticleT::AttributeNames::posX>();
-      const double *const __restrict y2ptr = soa2.template begin<ParticleT::AttributeNames::posY>();
-      const double *const __restrict z2ptr = soa2.template begin<ParticleT::AttributeNames::posZ>();
+      auto **const __restrict ptr2ptr = soa2.template begin<Particle_T::AttributeNames::ptr>();
+      const double *const __restrict x2ptr = soa2.template begin<Particle_T::AttributeNames::posX>();
+      const double *const __restrict y2ptr = soa2.template begin<Particle_T::AttributeNames::posY>();
+      const double *const __restrict z2ptr = soa2.template begin<Particle_T::AttributeNames::posZ>();
 
       size_t numPart1 = soa1.size();
       for (unsigned int i = 0; i < numPart1; ++i) {
@@ -167,17 +167,17 @@ class VerletListHelpers {
     /**
      * @copydoc autopas::Functor::getNeededAttr()
      */
-    constexpr static std::array<typename ParticleT::AttributeNames, 4> getNeededAttr() {
-      return std::array<typename ParticleT::AttributeNames, 4>{
-          ParticleT::AttributeNames::ptr, ParticleT::AttributeNames::posX, ParticleT::AttributeNames::posY,
-          ParticleT::AttributeNames::posZ};
+    constexpr static std::array<typename Particle_T::AttributeNames, 4> getNeededAttr() {
+      return std::array<typename Particle_T::AttributeNames, 4>{
+          Particle_T::AttributeNames::ptr, Particle_T::AttributeNames::posX, Particle_T::AttributeNames::posY,
+          Particle_T::AttributeNames::posZ};
     }
 
     /**
      * @copydoc autopas::Functor::getComputedAttr()
      */
-    constexpr static std::array<typename ParticleT::AttributeNames, 0> getComputedAttr() {
-      return std::array<typename ParticleT::AttributeNames, 0>{/*Nothing*/};
+    constexpr static std::array<typename Particle_T::AttributeNames, 0> getComputedAttr() {
+      return std::array<typename Particle_T::AttributeNames, 0>{/*Nothing*/};
     }
 
    private:
@@ -193,12 +193,12 @@ class VerletListHelpers {
    * and neighborlistsAreValid()  will return false.
    * @todo: SoA?
    */
-  class VerletListValidityCheckerFunctor : public PairwiseFunctor<ParticleT, VerletListValidityCheckerFunctor> {
+  class VerletListValidityCheckerFunctor : public PairwiseFunctor<Particle_T, VerletListValidityCheckerFunctor> {
    public:
     /**
      * Structure of the SoAs defined by the particle.
      */
-    using SoAArraysType = typename ParticleT::SoAArraysType;
+    using SoAArraysType = typename Particle_T::SoAArraysType;
 
     /**
      * Constructor
@@ -206,7 +206,7 @@ class VerletListHelpers {
      * @param cutoff
      */
     VerletListValidityCheckerFunctor(NeighborListAoSType &verletListsAoS, double cutoff)
-        : PairwiseFunctor<ParticleT, VerletListValidityCheckerFunctor>(cutoff),
+        : PairwiseFunctor<Particle_T, VerletListValidityCheckerFunctor>(cutoff),
           _verletListsAoS(verletListsAoS),
           _cutoffsquared(cutoff * cutoff),
           _valid(true) {}
@@ -227,7 +227,7 @@ class VerletListHelpers {
       return true;
     }
 
-    void AoSFunctor(ParticleT &i, ParticleT &j, bool newton3) override {
+    void AoSFunctor(Particle_T &i, Particle_T &j, bool newton3) override {
       using namespace autopas::utils::ArrayMath::literals;
 
       auto dist = i.getR() - j.getR();

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
@@ -15,25 +15,25 @@ namespace autopas {
 
 /**
  * Class of helpers for the VerletLists class.
- * @tparam Particle
+ * @tparam ParticleT
  */
-template <class Particle>
+template <class ParticleT>
 class VerletListHelpers {
  public:
   /**
    * Neighbor list AoS style.
    */
-  using NeighborListAoSType = std::unordered_map<Particle *, std::vector<Particle *>>;
+  using NeighborListAoSType = std::unordered_map<ParticleT *, std::vector<ParticleT *>>;
 
   /**
    * This functor can generate verlet lists using the typical pairwise traversal.
    */
-  class VerletListGeneratorFunctor : public PairwiseFunctor<Particle, VerletListGeneratorFunctor> {
+  class VerletListGeneratorFunctor : public PairwiseFunctor<ParticleT, VerletListGeneratorFunctor> {
    public:
     /**
      * Structure of the SoAs defined by the particle.
      */
-    using SoAArraysType = typename Particle::SoAArraysType;
+    using SoAArraysType = typename ParticleT::SoAArraysType;
 
     /**
      * Constructor
@@ -41,7 +41,7 @@ class VerletListHelpers {
      * @param interactionLength
      */
     VerletListGeneratorFunctor(NeighborListAoSType &verletListsAoS, double interactionLength)
-        : PairwiseFunctor<Particle, VerletListGeneratorFunctor>(interactionLength),
+        : PairwiseFunctor<ParticleT, VerletListGeneratorFunctor>(interactionLength),
           _verletListsAoS(verletListsAoS),
           _interactionLengthSquared(interactionLength * interactionLength) {}
 
@@ -61,7 +61,7 @@ class VerletListHelpers {
       return true;
     }
 
-    void AoSFunctor(Particle &i, Particle &j, bool /*newton3*/) override {
+    void AoSFunctor(ParticleT &i, ParticleT &j, bool /*newton3*/) override {
       using namespace autopas::utils::ArrayMath::literals;
 
       if (i.isDummy() or j.isDummy()) {
@@ -90,10 +90,10 @@ class VerletListHelpers {
     void SoAFunctorSingle(SoAView<SoAArraysType> soa, bool newton3) override {
       if (soa.size() == 0) return;
 
-      auto **const __restrict ptrptr = soa.template begin<Particle::AttributeNames::ptr>();
-      const double *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
-      const double *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
-      const double *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
+      auto **const __restrict ptrptr = soa.template begin<ParticleT::AttributeNames::ptr>();
+      const double *const __restrict xptr = soa.template begin<ParticleT::AttributeNames::posX>();
+      const double *const __restrict yptr = soa.template begin<ParticleT::AttributeNames::posY>();
+      const double *const __restrict zptr = soa.template begin<ParticleT::AttributeNames::posZ>();
 
       size_t numPart = soa.size();
       for (unsigned int i = 0; i < numPart; ++i) {
@@ -130,15 +130,15 @@ class VerletListHelpers {
     void SoAFunctorPair(SoAView<SoAArraysType> soa1, SoAView<SoAArraysType> soa2, bool /*newton3*/) override {
       if (soa1.size() == 0 || soa2.size() == 0) return;
 
-      auto **const __restrict ptr1ptr = soa1.template begin<Particle::AttributeNames::ptr>();
-      const double *const __restrict x1ptr = soa1.template begin<Particle::AttributeNames::posX>();
-      const double *const __restrict y1ptr = soa1.template begin<Particle::AttributeNames::posY>();
-      const double *const __restrict z1ptr = soa1.template begin<Particle::AttributeNames::posZ>();
+      auto **const __restrict ptr1ptr = soa1.template begin<ParticleT::AttributeNames::ptr>();
+      const double *const __restrict x1ptr = soa1.template begin<ParticleT::AttributeNames::posX>();
+      const double *const __restrict y1ptr = soa1.template begin<ParticleT::AttributeNames::posY>();
+      const double *const __restrict z1ptr = soa1.template begin<ParticleT::AttributeNames::posZ>();
 
-      auto **const __restrict ptr2ptr = soa2.template begin<Particle::AttributeNames::ptr>();
-      const double *const __restrict x2ptr = soa2.template begin<Particle::AttributeNames::posX>();
-      const double *const __restrict y2ptr = soa2.template begin<Particle::AttributeNames::posY>();
-      const double *const __restrict z2ptr = soa2.template begin<Particle::AttributeNames::posZ>();
+      auto **const __restrict ptr2ptr = soa2.template begin<ParticleT::AttributeNames::ptr>();
+      const double *const __restrict x2ptr = soa2.template begin<ParticleT::AttributeNames::posX>();
+      const double *const __restrict y2ptr = soa2.template begin<ParticleT::AttributeNames::posY>();
+      const double *const __restrict z2ptr = soa2.template begin<ParticleT::AttributeNames::posZ>();
 
       size_t numPart1 = soa1.size();
       for (unsigned int i = 0; i < numPart1; ++i) {
@@ -167,17 +167,17 @@ class VerletListHelpers {
     /**
      * @copydoc autopas::Functor::getNeededAttr()
      */
-    constexpr static std::array<typename Particle::AttributeNames, 4> getNeededAttr() {
-      return std::array<typename Particle::AttributeNames, 4>{
-          Particle::AttributeNames::ptr, Particle::AttributeNames::posX, Particle::AttributeNames::posY,
-          Particle::AttributeNames::posZ};
+    constexpr static std::array<typename ParticleT::AttributeNames, 4> getNeededAttr() {
+      return std::array<typename ParticleT::AttributeNames, 4>{
+          ParticleT::AttributeNames::ptr, ParticleT::AttributeNames::posX, ParticleT::AttributeNames::posY,
+          ParticleT::AttributeNames::posZ};
     }
 
     /**
      * @copydoc autopas::Functor::getComputedAttr()
      */
-    constexpr static std::array<typename Particle::AttributeNames, 0> getComputedAttr() {
-      return std::array<typename Particle::AttributeNames, 0>{/*Nothing*/};
+    constexpr static std::array<typename ParticleT::AttributeNames, 0> getComputedAttr() {
+      return std::array<typename ParticleT::AttributeNames, 0>{/*Nothing*/};
     }
 
    private:
@@ -193,12 +193,12 @@ class VerletListHelpers {
    * and neighborlistsAreValid()  will return false.
    * @todo: SoA?
    */
-  class VerletListValidityCheckerFunctor : public PairwiseFunctor<Particle, VerletListValidityCheckerFunctor> {
+  class VerletListValidityCheckerFunctor : public PairwiseFunctor<ParticleT, VerletListValidityCheckerFunctor> {
    public:
     /**
      * Structure of the SoAs defined by the particle.
      */
-    using SoAArraysType = typename Particle::SoAArraysType;
+    using SoAArraysType = typename ParticleT::SoAArraysType;
 
     /**
      * Constructor
@@ -206,7 +206,7 @@ class VerletListHelpers {
      * @param cutoff
      */
     VerletListValidityCheckerFunctor(NeighborListAoSType &verletListsAoS, double cutoff)
-        : PairwiseFunctor<Particle, VerletListValidityCheckerFunctor>(cutoff),
+        : PairwiseFunctor<ParticleT, VerletListValidityCheckerFunctor>(cutoff),
           _verletListsAoS(verletListsAoS),
           _cutoffsquared(cutoff * cutoff),
           _valid(true) {}
@@ -227,7 +227,7 @@ class VerletListHelpers {
       return true;
     }
 
-    void AoSFunctor(Particle &i, Particle &j, bool newton3) override {
+    void AoSFunctor(ParticleT &i, ParticleT &j, bool newton3) override {
       using namespace autopas::utils::ArrayMath::literals;
 
       auto dist = i.getR() - j.getR();

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -26,11 +26,11 @@ namespace autopas {
  * It is optimized for a constant, i.e. particle independent, cutoff radius of
  * the interaction.
  * Cells are created using a cell size of at least cutoff + skin radius.
- * @tparam Particle
+ * @tparam ParticleT
  */
-template <class Particle>
-class VerletLists : public VerletListsLinkedBase<Particle> {
-  using LinkedParticleCell = FullParticleCell<Particle>;
+template <class ParticleT>
+class VerletLists : public VerletListsLinkedBase<ParticleT> {
+  using LinkedParticleCell = FullParticleCell<ParticleT>;
 
  public:
   /**
@@ -62,7 +62,7 @@ class VerletLists : public VerletListsLinkedBase<Particle> {
               const double skin, const unsigned int rebuildFrequency,
               const BuildVerletListType buildVerletListType = BuildVerletListType::VerletSoA,
               const double cellSizeFactor = 1.0)
-      : VerletListsLinkedBase<Particle>(boxMin, boxMax, cutoff, skin, rebuildFrequency,
+      : VerletListsLinkedBase<ParticleT>(boxMin, boxMax, cutoff, skin, rebuildFrequency,
                                         compatibleTraversals::allVLCompatibleTraversals(), cellSizeFactor),
         _buildVerletListType(buildVerletListType) {}
 
@@ -88,10 +88,10 @@ class VerletLists : public VerletListsLinkedBase<Particle> {
   }
 
   /**
-   * get the actual neighbour list
-   * @return the neighbour list
+   * get the actual neighbor list
+   * @return the neighbor list
    */
-  typename VerletListHelpers<Particle>::NeighborListAoSType &getVerletListsAoS() { return _aosNeighborLists; }
+  typename VerletListHelpers<ParticleT>::NeighborListAoSType &getVerletListsAoS() { return _aosNeighborLists; }
 
   /**
    * Rebuilds the verlet lists, marks them valid and resets the internal counter.
@@ -117,7 +117,7 @@ class VerletLists : public VerletListsLinkedBase<Particle> {
    */
   virtual void updateVerletListsAoS(bool useNewton3) {
     generateAoSNeighborLists();
-    typename VerletListHelpers<Particle>::VerletListGeneratorFunctor f(_aosNeighborLists,
+    typename VerletListHelpers<ParticleT>::VerletListGeneratorFunctor f(_aosNeighborLists,
                                                                        this->getCutoff() + this->getVerletSkin());
 
     /// @todo autotune traversal
@@ -131,7 +131,7 @@ class VerletLists : public VerletListsLinkedBase<Particle> {
                                          _buildVerletListType);
     }
     auto traversal =
-        LCC08Traversal<LinkedParticleCell, typename VerletListHelpers<Particle>::VerletListGeneratorFunctor>(
+        LCC08Traversal<LinkedParticleCell, typename VerletListHelpers<ParticleT>::VerletListGeneratorFunctor>(
             this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), &f, this->getInteractionLength(),
             this->_linkedCells.getCellBlock().getCellLength(), dataLayout, useNewton3);
     this->_linkedCells.computeInteractions(&traversal);
@@ -199,13 +199,13 @@ class VerletLists : public VerletListsLinkedBase<Particle> {
   /**
    * Neighbor Lists: Map of particle pointers to vector of particle pointers.
    */
-  typename VerletListHelpers<Particle>::NeighborListAoSType _aosNeighborLists;
+  typename VerletListHelpers<ParticleT>::NeighborListAoSType _aosNeighborLists;
 
   /**
    * Mapping of every particle, represented by its pointer, to an index.
    * The index indexes all particles in the container.
    */
-  std::unordered_map<const Particle *, size_t> _particlePtr2indexMap;
+  std::unordered_map<const ParticleT *, size_t> _particlePtr2indexMap;
 
   /**
    * verlet list for SoA:

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -63,7 +63,7 @@ class VerletLists : public VerletListsLinkedBase<ParticleT> {
               const BuildVerletListType buildVerletListType = BuildVerletListType::VerletSoA,
               const double cellSizeFactor = 1.0)
       : VerletListsLinkedBase<ParticleT>(boxMin, boxMax, cutoff, skin, rebuildFrequency,
-                                        compatibleTraversals::allVLCompatibleTraversals(), cellSizeFactor),
+                                         compatibleTraversals::allVLCompatibleTraversals(), cellSizeFactor),
         _buildVerletListType(buildVerletListType) {}
 
   /**
@@ -118,7 +118,7 @@ class VerletLists : public VerletListsLinkedBase<ParticleT> {
   virtual void updateVerletListsAoS(bool useNewton3) {
     generateAoSNeighborLists();
     typename VerletListHelpers<ParticleT>::VerletListGeneratorFunctor f(_aosNeighborLists,
-                                                                       this->getCutoff() + this->getVerletSkin());
+                                                                        this->getCutoff() + this->getVerletSkin());
 
     /// @todo autotune traversal
     DataLayoutOption dataLayout;

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletLists.h
@@ -26,11 +26,11 @@ namespace autopas {
  * It is optimized for a constant, i.e. particle independent, cutoff radius of
  * the interaction.
  * Cells are created using a cell size of at least cutoff + skin radius.
- * @tparam ParticleT
+ * @tparam Particle_T
  */
-template <class ParticleT>
-class VerletLists : public VerletListsLinkedBase<ParticleT> {
-  using LinkedParticleCell = FullParticleCell<ParticleT>;
+template <class Particle_T>
+class VerletLists : public VerletListsLinkedBase<Particle_T> {
+  using LinkedParticleCell = FullParticleCell<Particle_T>;
 
  public:
   /**
@@ -62,8 +62,8 @@ class VerletLists : public VerletListsLinkedBase<ParticleT> {
               const double skin, const unsigned int rebuildFrequency,
               const BuildVerletListType buildVerletListType = BuildVerletListType::VerletSoA,
               const double cellSizeFactor = 1.0)
-      : VerletListsLinkedBase<ParticleT>(boxMin, boxMax, cutoff, skin, rebuildFrequency,
-                                         compatibleTraversals::allVLCompatibleTraversals(), cellSizeFactor),
+      : VerletListsLinkedBase<Particle_T>(boxMin, boxMax, cutoff, skin, rebuildFrequency,
+                                          compatibleTraversals::allVLCompatibleTraversals(), cellSizeFactor),
         _buildVerletListType(buildVerletListType) {}
 
   /**
@@ -91,7 +91,7 @@ class VerletLists : public VerletListsLinkedBase<ParticleT> {
    * get the actual neighbor list
    * @return the neighbor list
    */
-  typename VerletListHelpers<ParticleT>::NeighborListAoSType &getVerletListsAoS() { return _aosNeighborLists; }
+  typename VerletListHelpers<Particle_T>::NeighborListAoSType &getVerletListsAoS() { return _aosNeighborLists; }
 
   /**
    * Rebuilds the verlet lists, marks them valid and resets the internal counter.
@@ -117,8 +117,8 @@ class VerletLists : public VerletListsLinkedBase<ParticleT> {
    */
   virtual void updateVerletListsAoS(bool useNewton3) {
     generateAoSNeighborLists();
-    typename VerletListHelpers<ParticleT>::VerletListGeneratorFunctor f(_aosNeighborLists,
-                                                                        this->getCutoff() + this->getVerletSkin());
+    typename VerletListHelpers<Particle_T>::VerletListGeneratorFunctor f(_aosNeighborLists,
+                                                                         this->getCutoff() + this->getVerletSkin());
 
     /// @todo autotune traversal
     DataLayoutOption dataLayout;
@@ -131,7 +131,7 @@ class VerletLists : public VerletListsLinkedBase<ParticleT> {
                                          _buildVerletListType);
     }
     auto traversal =
-        LCC08Traversal<LinkedParticleCell, typename VerletListHelpers<ParticleT>::VerletListGeneratorFunctor>(
+        LCC08Traversal<LinkedParticleCell, typename VerletListHelpers<Particle_T>::VerletListGeneratorFunctor>(
             this->_linkedCells.getCellBlock().getCellsPerDimensionWithHalo(), &f, this->getInteractionLength(),
             this->_linkedCells.getCellBlock().getCellLength(), dataLayout, useNewton3);
     this->_linkedCells.computeInteractions(&traversal);
@@ -199,13 +199,13 @@ class VerletLists : public VerletListsLinkedBase<ParticleT> {
   /**
    * Neighbor Lists: Map of particle pointers to vector of particle pointers.
    */
-  typename VerletListHelpers<ParticleT>::NeighborListAoSType _aosNeighborLists;
+  typename VerletListHelpers<Particle_T>::NeighborListAoSType _aosNeighborLists;
 
   /**
    * Mapping of every particle, represented by its pointer, to an index.
    * The index indexes all particles in the container.
    */
-  std::unordered_map<const ParticleT *, size_t> _particlePtr2indexMap;
+  std::unordered_map<const Particle_T *, size_t> _particlePtr2indexMap;
 
   /**
    * verlet list for SoA:

--- a/src/autopas/containers/verletListsCellBased/verletLists/traversals/VLListIterationTraversal.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/traversals/VLListIterationTraversal.h
@@ -22,7 +22,7 @@ namespace autopas {
  */
 template <class ParticleCell, class PairwiseFunctor>
 class VLListIterationTraversal : public TraversalInterface, public VLTraversalInterface<ParticleCell> {
-  using Particle = typename ParticleCell::ParticleType;
+  using ParticleType = typename ParticleCell::ParticleType;
 
  public:
   /**
@@ -84,18 +84,18 @@ class VLListIterationTraversal : public TraversalInterface, public VLTraversalIn
           for (size_t bucketId = 0; bucketId < buckets; bucketId++) {
             auto endIter = aosNeighborLists.end(bucketId);
             for (auto bucketIter = aosNeighborLists.begin(bucketId); bucketIter != endIter; ++bucketIter) {
-              Particle &particle = *(bucketIter->first);
+              ParticleType &particle = *(bucketIter->first);
               for (auto neighborPtr : bucketIter->second) {
-                Particle &neighbor = *neighborPtr;
+                ParticleType &neighbor = *neighborPtr;
                 _functor->AoSFunctor(particle, neighbor, false);
               }
             }
           }
         } else {
           for (auto &[particlePtr, neighborPtrList] : aosNeighborLists) {
-            Particle &particle = *particlePtr;
+            ParticleType &particle = *particlePtr;
             for (auto neighborPtr : neighborPtrList) {
-              Particle &neighbor = *neighborPtr;
+              ParticleType &neighbor = *neighborPtr;
               _functor->AoSFunctor(particle, neighbor, _useNewton3);
             }
           }
@@ -133,7 +133,7 @@ class VLListIterationTraversal : public TraversalInterface, public VLTraversalIn
   /**
    * SoA buffer of verlet lists.
    */
-  SoA<typename Particle::SoAArraysType> _soa;
+  SoA<typename ParticleType::SoAArraysType> _soa;
 };
 
 }  // namespace autopas

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
@@ -28,13 +28,13 @@ namespace autopas {
  * It is optimized for a constant, i.e. particle independent, cutoff radius of
  * the interaction.
  * Cells are created using a cell size of at least cutoff + skin.
- * @tparam ParticleT
+ * @tparam Particle_T
  * @tparam NeighborList The neighbor list used by this container.
  */
 
-template <class ParticleT, class NeighborList>
-class VerletListsCells : public VerletListsLinkedBase<ParticleT> {
-  using ParticleCell = FullParticleCell<ParticleT>;
+template <class Particle_T, class NeighborList>
+class VerletListsCells : public VerletListsLinkedBase<Particle_T> {
+  using ParticleCell = FullParticleCell<Particle_T>;
 
  public:
   /**
@@ -54,8 +54,8 @@ class VerletListsCells : public VerletListsLinkedBase<ParticleT> {
                    const LoadEstimatorOption loadEstimator = LoadEstimatorOption::squaredParticlesPerCell,
                    typename VerletListsCellsHelpers::VLCBuildType dataLayoutDuringListRebuild =
                        VerletListsCellsHelpers::VLCBuildType::soaBuild)
-      : VerletListsLinkedBase<ParticleT>(boxMin, boxMax, cutoff, skin, rebuildFrequency,
-                                         compatibleTraversals::allVLCCompatibleTraversals(), cellSizeFactor),
+      : VerletListsLinkedBase<Particle_T>(boxMin, boxMax, cutoff, skin, rebuildFrequency,
+                                          compatibleTraversals::allVLCCompatibleTraversals(), cellSizeFactor),
         _loadEstimator(loadEstimator),
         _dataLayoutDuringListRebuild(dataLayoutDuringListRebuild) {}
 
@@ -80,8 +80,8 @@ class VerletListsCells : public VerletListsLinkedBase<ParticleT> {
       case LoadEstimatorOption::neighborListLength: {
         return [&](const std::array<unsigned long, 3> &cellsPerDimension,
                    const std::array<unsigned long, 3> &lowerCorner, const std::array<unsigned long, 3> &upperCorner) {
-          return loadEstimators::neighborListLength<ParticleT, NeighborList>(_neighborList, cellsPerDimension,
-                                                                             lowerCorner, upperCorner);
+          return loadEstimators::neighborListLength<Particle_T, NeighborList>(_neighborList, cellsPerDimension,
+                                                                              lowerCorner, upperCorner);
         };
       }
 
@@ -112,7 +112,7 @@ class VerletListsCells : public VerletListsLinkedBase<ParticleT> {
    * @param particle
    * @return the size of the neighbor list(s) of this particle
    */
-  size_t getNumberOfPartners(const ParticleT *particle) const { return _neighborList.getNumberOfPartners(particle); }
+  size_t getNumberOfPartners(const Particle_T *particle) const { return _neighborList.getNumberOfPartners(particle); }
 
   /**
    * Special case of building the neighbor lists in c08 style where all lists that belong to one base step are stored
@@ -186,7 +186,7 @@ class VerletListsCells : public VerletListsLinkedBase<ParticleT> {
             neighbors.reserve(listLengthEstimate);
             neighbors.push_back(&p2);
           } else {
-            neighborList.emplace_back(&p1, std::vector<ParticleT *>{});
+            neighborList.emplace_back(&p1, std::vector<Particle_T *>{});
             neighborList.back().second.reserve(listLengthEstimate);
             neighborList.back().second.push_back(&p2);
           }
@@ -224,7 +224,7 @@ class VerletListsCells : public VerletListsLinkedBase<ParticleT> {
           // For any remaining particles create a new list.
           // This case can only happen if estimateNumLists can return values smaller than baseCell.size()
           for (size_t i = minCellSizeVsNumLists; i < baseCell.size(); ++i) {
-            baseCellsLists.emplace_back(&baseCell[i], std::vector<ParticleT *>{});
+            baseCellsLists.emplace_back(&baseCell[i], std::vector<Particle_T *>{});
             baseCellsLists.back().second.reserve(listLengthEstimate);
           }
 
@@ -282,7 +282,7 @@ class VerletListsCells : public VerletListsLinkedBase<ParticleT> {
     this->_verletBuiltNewton3 = traversal->getUseNewton3();
 
     // VLP needs constexpr special case because the types and thus interfaces are slightly different
-    if constexpr (std::is_same_v<NeighborList, VLCCellPairNeighborList<ParticleT>>) {
+    if constexpr (std::is_same_v<NeighborList, VLCCellPairNeighborList<Particle_T>>) {
       _neighborList.buildAoSNeighborList(this->_linkedCells, this->_verletBuiltNewton3, this->getCutoff(),
                                          this->getVerletSkin(), this->getInteractionLength(),
                                          traversal->getTraversalType(), _dataLayoutDuringListRebuild);

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
@@ -55,7 +55,7 @@ class VerletListsCells : public VerletListsLinkedBase<ParticleT> {
                    typename VerletListsCellsHelpers::VLCBuildType dataLayoutDuringListRebuild =
                        VerletListsCellsHelpers::VLCBuildType::soaBuild)
       : VerletListsLinkedBase<ParticleT>(boxMin, boxMax, cutoff, skin, rebuildFrequency,
-                                        compatibleTraversals::allVLCCompatibleTraversals(), cellSizeFactor),
+                                         compatibleTraversals::allVLCCompatibleTraversals(), cellSizeFactor),
         _loadEstimator(loadEstimator),
         _dataLayoutDuringListRebuild(dataLayoutDuringListRebuild) {}
 
@@ -81,7 +81,7 @@ class VerletListsCells : public VerletListsLinkedBase<ParticleT> {
         return [&](const std::array<unsigned long, 3> &cellsPerDimension,
                    const std::array<unsigned long, 3> &lowerCorner, const std::array<unsigned long, 3> &upperCorner) {
           return loadEstimators::neighborListLength<ParticleT, NeighborList>(_neighborList, cellsPerDimension,
-                                                                            lowerCorner, upperCorner);
+                                                                             lowerCorner, upperCorner);
         };
       }
 

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCells.h
@@ -28,13 +28,13 @@ namespace autopas {
  * It is optimized for a constant, i.e. particle independent, cutoff radius of
  * the interaction.
  * Cells are created using a cell size of at least cutoff + skin.
- * @tparam Particle
+ * @tparam ParticleT
  * @tparam NeighborList The neighbor list used by this container.
  */
 
-template <class Particle, class NeighborList>
-class VerletListsCells : public VerletListsLinkedBase<Particle> {
-  using ParticleCell = FullParticleCell<Particle>;
+template <class ParticleT, class NeighborList>
+class VerletListsCells : public VerletListsLinkedBase<ParticleT> {
+  using ParticleCell = FullParticleCell<ParticleT>;
 
  public:
   /**
@@ -54,7 +54,7 @@ class VerletListsCells : public VerletListsLinkedBase<Particle> {
                    const LoadEstimatorOption loadEstimator = LoadEstimatorOption::squaredParticlesPerCell,
                    typename VerletListsCellsHelpers::VLCBuildType dataLayoutDuringListRebuild =
                        VerletListsCellsHelpers::VLCBuildType::soaBuild)
-      : VerletListsLinkedBase<Particle>(boxMin, boxMax, cutoff, skin, rebuildFrequency,
+      : VerletListsLinkedBase<ParticleT>(boxMin, boxMax, cutoff, skin, rebuildFrequency,
                                         compatibleTraversals::allVLCCompatibleTraversals(), cellSizeFactor),
         _loadEstimator(loadEstimator),
         _dataLayoutDuringListRebuild(dataLayoutDuringListRebuild) {}
@@ -80,7 +80,7 @@ class VerletListsCells : public VerletListsLinkedBase<Particle> {
       case LoadEstimatorOption::neighborListLength: {
         return [&](const std::array<unsigned long, 3> &cellsPerDimension,
                    const std::array<unsigned long, 3> &lowerCorner, const std::array<unsigned long, 3> &upperCorner) {
-          return loadEstimators::neighborListLength<Particle, NeighborList>(_neighborList, cellsPerDimension,
+          return loadEstimators::neighborListLength<ParticleT, NeighborList>(_neighborList, cellsPerDimension,
                                                                             lowerCorner, upperCorner);
         };
       }
@@ -112,7 +112,7 @@ class VerletListsCells : public VerletListsLinkedBase<Particle> {
    * @param particle
    * @return the size of the neighbor list(s) of this particle
    */
-  size_t getNumberOfPartners(const Particle *particle) const { return _neighborList.getNumberOfPartners(particle); }
+  size_t getNumberOfPartners(const ParticleT *particle) const { return _neighborList.getNumberOfPartners(particle); }
 
   /**
    * Special case of building the neighbor lists in c08 style where all lists that belong to one base step are stored
@@ -186,7 +186,7 @@ class VerletListsCells : public VerletListsLinkedBase<Particle> {
             neighbors.reserve(listLengthEstimate);
             neighbors.push_back(&p2);
           } else {
-            neighborList.emplace_back(&p1, std::vector<Particle *>{});
+            neighborList.emplace_back(&p1, std::vector<ParticleT *>{});
             neighborList.back().second.reserve(listLengthEstimate);
             neighborList.back().second.push_back(&p2);
           }
@@ -224,7 +224,7 @@ class VerletListsCells : public VerletListsLinkedBase<Particle> {
           // For any remaining particles create a new list.
           // This case can only happen if estimateNumLists can return values smaller than baseCell.size()
           for (size_t i = minCellSizeVsNumLists; i < baseCell.size(); ++i) {
-            baseCellsLists.emplace_back(&baseCell[i], std::vector<Particle *>{});
+            baseCellsLists.emplace_back(&baseCell[i], std::vector<ParticleT *>{});
             baseCellsLists.back().second.reserve(listLengthEstimate);
           }
 
@@ -282,7 +282,7 @@ class VerletListsCells : public VerletListsLinkedBase<Particle> {
     this->_verletBuiltNewton3 = traversal->getUseNewton3();
 
     // VLP needs constexpr special case because the types and thus interfaces are slightly different
-    if constexpr (std::is_same_v<NeighborList, VLCCellPairNeighborList<Particle>>) {
+    if constexpr (std::is_same_v<NeighborList, VLCCellPairNeighborList<ParticleT>>) {
       _neighborList.buildAoSNeighborList(this->_linkedCells, this->_verletBuiltNewton3, this->getCutoff(),
                                          this->getVerletSkin(), this->getInteractionLength(),
                                          traversal->getTraversalType(), _dataLayoutDuringListRebuild);

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsHelpers.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsHelpers.h
@@ -34,7 +34,8 @@ using AllCellsNeighborListsType = std::vector<std::vector<std::pair<ParticleT *,
  * @tparam ParticleT
  */
 template <class ParticleT>
-using PairwiseNeighborListsType = std::vector<std::vector<std::vector<std::pair<ParticleT *, std::vector<ParticleT *>>>>>;
+using PairwiseNeighborListsType =
+    std::vector<std::vector<std::vector<std::pair<ParticleT *, std::vector<ParticleT *>>>>>;
 
 /**
  * Indicates which build functor should be used for the generation of the neighbor list.

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsHelpers.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsHelpers.h
@@ -17,24 +17,24 @@ namespace autopas::VerletListsCellsHelpers {
  * Cell wise verlet lists for neighbors from all adjacent cells: For every cell, a vector of pairs.
  * Each pair maps a particle to a vector of its neighbors.
  *
- * @note From a content view, this is similar to an vector<unstructured_map<Particle*, std::vector<Particle *>>>.
+ * @note From a content view, this is similar to an vector<unstructured_map<ParticleT*, std::vector<Particle *>>>.
  * However since we need to access all keys sequentially during the force computation this is faster,
  * even when the lookup of keys is slower.
  *
- * @tparam Particle
+ * @tparam ParticleT
  */
-template <class Particle>
-using AllCellsNeighborListsType = std::vector<std::vector<std::pair<Particle *, std::vector<Particle *>>>>;
+template <class ParticleT>
+using AllCellsNeighborListsType = std::vector<std::vector<std::pair<ParticleT *, std::vector<ParticleT *>>>>;
 
 /**
  * Pairwise verlet lists: For every cell a vector, for every neighboring cell a vector of particle-neighborlist pairs.
  * Each pair maps a particle to a vector of its neighbor particles.
  * Cells<NeighboringCells<Particle,NeighborParticles>>
  *
- * @tparam Particle
+ * @tparam ParticleT
  */
-template <class Particle>
-using PairwiseNeighborListsType = std::vector<std::vector<std::vector<std::pair<Particle *, std::vector<Particle *>>>>>;
+template <class ParticleT>
+using PairwiseNeighborListsType = std::vector<std::vector<std::vector<std::pair<ParticleT *, std::vector<ParticleT *>>>>>;
 
 /**
  * Indicates which build functor should be used for the generation of the neighbor list.

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsHelpers.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsHelpers.h
@@ -17,25 +17,25 @@ namespace autopas::VerletListsCellsHelpers {
  * Cell wise verlet lists for neighbors from all adjacent cells: For every cell, a vector of pairs.
  * Each pair maps a particle to a vector of its neighbors.
  *
- * @note From a content view, this is similar to an vector<unstructured_map<ParticleT*, std::vector<Particle *>>>.
+ * @note From a content view, this is similar to an vector<unstructured_map<Particle_T*, std::vector<Particle *>>>.
  * However since we need to access all keys sequentially during the force computation this is faster,
  * even when the lookup of keys is slower.
  *
- * @tparam ParticleT
+ * @tparam Particle_T
  */
-template <class ParticleT>
-using AllCellsNeighborListsType = std::vector<std::vector<std::pair<ParticleT *, std::vector<ParticleT *>>>>;
+template <class Particle_T>
+using AllCellsNeighborListsType = std::vector<std::vector<std::pair<Particle_T *, std::vector<Particle_T *>>>>;
 
 /**
  * Pairwise verlet lists: For every cell a vector, for every neighboring cell a vector of particle-neighborlist pairs.
  * Each pair maps a particle to a vector of its neighbor particles.
  * Cells<NeighboringCells<Particle,NeighborParticles>>
  *
- * @tparam ParticleT
+ * @tparam Particle_T
  */
-template <class ParticleT>
+template <class Particle_T>
 using PairwiseNeighborListsType =
-    std::vector<std::vector<std::vector<std::pair<ParticleT *, std::vector<ParticleT *>>>>>;
+    std::vector<std::vector<std::vector<std::pair<Particle_T *, std::vector<Particle_T *>>>>>;
 
 /**
  * Indicates which build functor should be used for the generation of the neighbor list.

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCAllCellsGeneratorFunctor.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCAllCellsGeneratorFunctor.h
@@ -17,11 +17,11 @@ namespace autopas {
 /**
  * This functor can generate verlet lists using the typical pairwise traversal.
  */
-template <class Particle, enum TraversalOption::Value TraversalOptionEnum>
+template <class ParticleT, enum TraversalOption::Value TraversalOptionEnum>
 class VLCAllCellsGeneratorFunctor
-    : public PairwiseFunctor<Particle, VLCAllCellsGeneratorFunctor<Particle, TraversalOptionEnum>> {
-  using NeighborListsType = typename VerletListsCellsHelpers::AllCellsNeighborListsType<Particle>;
-  using SoAArraysType = typename Particle::SoAArraysType;
+    : public PairwiseFunctor<ParticleT, VLCAllCellsGeneratorFunctor<ParticleT, TraversalOptionEnum>> {
+  using NeighborListsType = typename VerletListsCellsHelpers::AllCellsNeighborListsType<ParticleT>;
+  using SoAArraysType = typename ParticleT::SoAArraysType;
 
  public:
   /**
@@ -33,10 +33,10 @@ class VLCAllCellsGeneratorFunctor
    * @param cellsPerDim Cells per dimension of the underlying Linked Cells container (incl. Halo).
    */
   VLCAllCellsGeneratorFunctor(NeighborListsType &neighborLists,
-                              std::unordered_map<Particle *, std::pair<size_t, size_t>> &particleToCellMap,
+                              std::unordered_map<ParticleT *, std::pair<size_t, size_t>> &particleToCellMap,
                               double cutoffSkin, size_t newListAllocationSize,
                               const std::array<size_t, 3> &cellsPerDim = {})
-      : PairwiseFunctor<Particle, VLCAllCellsGeneratorFunctor<Particle, TraversalOptionEnum>>(0.),
+      : PairwiseFunctor<ParticleT, VLCAllCellsGeneratorFunctor<ParticleT, TraversalOptionEnum>>(0.),
         _neighborLists(neighborLists),
         _particleToCellMap(particleToCellMap),
         _cutoffSkinSquared(cutoffSkin * cutoffSkin),
@@ -63,12 +63,12 @@ class VLCAllCellsGeneratorFunctor
    * Set the cells pointer.
    * @param cells
    */
-  void setCells(std::vector<FullParticleCell<Particle>> *cells) { _cells = cells; }
+  void setCells(std::vector<FullParticleCell<ParticleT>> *cells) { _cells = cells; }
 
   /**
    * @copydoc PairwiseFunctor::AoSFunctor()
    */
-  void AoSFunctor(Particle &i, Particle &j, bool newton3) override {
+  void AoSFunctor(ParticleT &i, ParticleT &j, bool newton3) override {
     using namespace autopas::utils::ArrayMath::literals;
 
     if (i.isDummy() or j.isDummy()) {
@@ -104,7 +104,7 @@ class VLCAllCellsGeneratorFunctor
           // 2. If base cell is neither cellIndex1 or cellIndex2
           auto &list = _neighborLists[cellIndexI];
           auto iterIandList =
-              std::find_if(list.begin(), list.end(), [&](const std::pair<Particle *, std::vector<Particle *>> &pair) {
+              std::find_if(list.begin(), list.end(), [&](const std::pair<ParticleT *, std::vector<ParticleT *>> &pair) {
                 const auto &[particle, neighbors] = pair;
                 return particle == &i;
               });
@@ -112,7 +112,7 @@ class VLCAllCellsGeneratorFunctor
             auto &[_, neighbors] = *iterIandList;
             neighbors.push_back(&j);
           } else {
-            list.emplace_back(&i, std::vector<Particle *>{});
+            list.emplace_back(&i, std::vector<ParticleT *>{});
             list.back().second.reserve(_newListAllocationSize);
             list.back().second.push_back(&j);
           }
@@ -135,10 +135,10 @@ class VLCAllCellsGeneratorFunctor
   void SoAFunctorSingle(SoAView<SoAArraysType> soa, bool newton3) override {
     if (soa.size() == 0) return;
 
-    auto **const __restrict__ ptrPtr = soa.template begin<Particle::AttributeNames::ptr>();
-    double *const __restrict__ xPtr = soa.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict__ yPtr = soa.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict__ zPtr = soa.template begin<Particle::AttributeNames::posZ>();
+    auto **const __restrict__ ptrPtr = soa.template begin<ParticleT::AttributeNames::ptr>();
+    double *const __restrict__ xPtr = soa.template begin<ParticleT::AttributeNames::posX>();
+    double *const __restrict__ yPtr = soa.template begin<ParticleT::AttributeNames::posY>();
+    double *const __restrict__ zPtr = soa.template begin<ParticleT::AttributeNames::posZ>();
 
     // index of cellIndex is particleToCellMap of ptrPtr, same for 2
     const auto [cellIndex, _] = _particleToCellMap.at(ptrPtr[0]);
@@ -184,15 +184,15 @@ class VLCAllCellsGeneratorFunctor
   void SoAFunctorPair(SoAView<SoAArraysType> soa1, SoAView<SoAArraysType> soa2, bool /*newton3*/) override {
     if (soa1.size() == 0 or soa2.size() == 0) return;
 
-    auto **const __restrict__ ptr1Ptr = soa1.template begin<Particle::AttributeNames::ptr>();
-    double *const __restrict__ x1Ptr = soa1.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict__ y1Ptr = soa1.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict__ z1Ptr = soa1.template begin<Particle::AttributeNames::posZ>();
+    auto **const __restrict__ ptr1Ptr = soa1.template begin<ParticleT::AttributeNames::ptr>();
+    double *const __restrict__ x1Ptr = soa1.template begin<ParticleT::AttributeNames::posX>();
+    double *const __restrict__ y1Ptr = soa1.template begin<ParticleT::AttributeNames::posY>();
+    double *const __restrict__ z1Ptr = soa1.template begin<ParticleT::AttributeNames::posZ>();
 
-    auto **const __restrict__ ptr2Ptr = soa2.template begin<Particle::AttributeNames::ptr>();
-    double *const __restrict__ x2Ptr = soa2.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict__ y2Ptr = soa2.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict__ z2Ptr = soa2.template begin<Particle::AttributeNames::posZ>();
+    auto **const __restrict__ ptr2Ptr = soa2.template begin<ParticleT::AttributeNames::ptr>();
+    double *const __restrict__ x2Ptr = soa2.template begin<ParticleT::AttributeNames::posX>();
+    double *const __restrict__ y2Ptr = soa2.template begin<ParticleT::AttributeNames::posY>();
+    double *const __restrict__ z2Ptr = soa2.template begin<ParticleT::AttributeNames::posZ>();
 
     // index of cell1 is particleToCellMap of ptr1Ptr, same for 2
     const size_t cellIndex1 = _particleToCellMap.at(ptr1Ptr[0]).first;
@@ -254,7 +254,7 @@ class VLCAllCellsGeneratorFunctor
               if (iter != currentList.end()) {
                 iter->second.push_back(ptr2Ptr[j]);
               } else {
-                currentList.emplace_back(ptr1Ptr[i], std::vector<Particle *>{});
+                currentList.emplace_back(ptr1Ptr[i], std::vector<ParticleT *>{});
                 currentList.back().second.reserve(_newListAllocationSize);
                 currentList.back().second.push_back(ptr2Ptr[j]);
               }
@@ -269,31 +269,31 @@ class VLCAllCellsGeneratorFunctor
    * @copydoc Functor::getNeededAttr()
    */
   constexpr static auto getNeededAttr() {
-    return std::array<typename Particle::AttributeNames, 4>{
-        Particle::AttributeNames::ptr, Particle::AttributeNames::posX, Particle::AttributeNames::posY,
-        Particle::AttributeNames::posZ};
+    return std::array<typename ParticleT::AttributeNames, 4>{
+        ParticleT::AttributeNames::ptr, ParticleT::AttributeNames::posX, ParticleT::AttributeNames::posY,
+        ParticleT::AttributeNames::posZ};
   }
 
   /**
    * @copydoc Functor::getNeededAttr(std::false_type)
    */
   constexpr static auto getNeededAttr(std::false_type) {
-    return std::array<typename Particle::AttributeNames, 4>{
-        Particle::AttributeNames::ptr, Particle::AttributeNames::posX, Particle::AttributeNames::posY,
-        Particle::AttributeNames::posZ};
+    return std::array<typename ParticleT::AttributeNames, 4>{
+        ParticleT::AttributeNames::ptr, ParticleT::AttributeNames::posX, ParticleT::AttributeNames::posY,
+        ParticleT::AttributeNames::posZ};
   }
 
   /**
    * @copydoc Functor::getComputedAttr()
    */
-  constexpr static auto getComputedAttr() { return std::array<typename Particle::AttributeNames, 0>{}; }
+  constexpr static auto getComputedAttr() { return std::array<typename ParticleT::AttributeNames, 0>{}; }
 
  private:
   /**
    * For every cell, a vector of pairs. Each pair maps a particle to a vector of its neighbors.
    */
   NeighborListsType &_neighborLists;
-  std::unordered_map<Particle *, std::pair<size_t, size_t>> &_particleToCellMap;
+  std::unordered_map<ParticleT *, std::pair<size_t, size_t>> &_particleToCellMap;
   double _cutoffSkinSquared;
   /**
    * Cells per dimension of the underlying Linked Cells container.
@@ -301,7 +301,7 @@ class VLCAllCellsGeneratorFunctor
    */
   std::array<size_t, 3> _cellsPerDim;
 
-  std::vector<FullParticleCell<Particle>> *_cells = nullptr;
+  std::vector<FullParticleCell<ParticleT>> *_cells = nullptr;
 
   /**
    * How many fields are reserved for newly inserted neighbor lists.

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCAllCellsNeighborList.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCAllCellsNeighborList.h
@@ -26,21 +26,21 @@ namespace autopas {
 template <class ParticleCell>
 class TraversalSelector;
 
-template <class ParticleT, class NeighborList>
+template <class Particle_T, class NeighborList>
 class VLCTraversalInterface;
 
 /**
  * Neighbor list to be used with VerletListsCells container. Classic implementation of verlet lists based on linked
  * cells.
- * @tparam ParticleT Type of particle to be used for this neighbor list.
+ * @tparam Particle_T Type of particle to be used for this neighbor list.
  */
-template <class ParticleT>
-class VLCAllCellsNeighborList : public VLCNeighborListInterface<ParticleT> {
+template <class Particle_T>
+class VLCAllCellsNeighborList : public VLCNeighborListInterface<Particle_T> {
  public:
   /**
    * Type of the data structure used to save the neighbor lists.
    */
-  using ListType = typename VerletListsCellsHelpers::AllCellsNeighborListsType<ParticleT>;
+  using ListType = typename VerletListsCellsHelpers::AllCellsNeighborListsType<Particle_T>;
 
   /**
    * Helper type definition. Pair of particle and neighbor list for SoA layout.
@@ -61,7 +61,7 @@ class VLCAllCellsNeighborList : public VLCNeighborListInterface<ParticleT> {
   /**
    * @copydoc VLCNeighborListInterface::buildAoSNeighborList()
    */
-  void buildAoSNeighborList(LinkedCells<ParticleT> &linkedCells, bool useNewton3, double cutoff, double skin,
+  void buildAoSNeighborList(LinkedCells<Particle_T> &linkedCells, bool useNewton3, double cutoff, double skin,
                             double interactionLength, const TraversalOption vlcTraversalOpt,
                             typename VerletListsCellsHelpers::VLCBuildType buildType) override {
     using namespace utils::ArrayMath::literals;
@@ -137,8 +137,8 @@ class VLCAllCellsNeighborList : public VLCNeighborListInterface<ParticleT> {
       _aosNeighborList[cellIndex].reserve(estimateForNumberOfLists);
       size_t particleIndexWithinCell = 0;
       for (auto iter = cell.begin(); iter != cell.end(); ++iter, ++particleIndexWithinCell) {
-        ParticleT *particle = &*iter;
-        _aosNeighborList[cellIndex].emplace_back(particle, std::vector<ParticleT *>());
+        Particle_T *particle = &*iter;
+        _aosNeighborList[cellIndex].emplace_back(particle, std::vector<Particle_T *>());
         _aosNeighborList[cellIndex].back().second.reserve(listLengthEstimate);
         _particleToCellMap[particle] = std::make_pair(cellIndex, particleIndexWithinCell);
       }
@@ -150,8 +150,8 @@ class VLCAllCellsNeighborList : public VLCNeighborListInterface<ParticleT> {
   /**
    * @copydoc VLCNeighborListInterface::getNumberOfPartners()
    */
-  size_t getNumberOfPartners(const ParticleT *particle) const override {
-    const auto &[cellIndex, particleIndexInCell] = _particleToCellMap.at(const_cast<ParticleT *>(particle));
+  size_t getNumberOfPartners(const Particle_T *particle) const override {
+    const auto &[cellIndex, particleIndexInCell] = _particleToCellMap.at(const_cast<Particle_T *>(particle));
     return _aosNeighborList.at(cellIndex).at(particleIndexInCell).second.size();
   }
 
@@ -159,7 +159,7 @@ class VLCAllCellsNeighborList : public VLCNeighborListInterface<ParticleT> {
    * Returns the neighbor list in AoS layout.
    * @return Neighbor list in AoS layout.
    */
-  typename VerletListsCellsHelpers::AllCellsNeighborListsType<ParticleT> &getAoSNeighborList() {
+  typename VerletListsCellsHelpers::AllCellsNeighborListsType<Particle_T> &getAoSNeighborList() {
     return _aosNeighborList;
   }
 
@@ -172,11 +172,11 @@ class VLCAllCellsNeighborList : public VLCNeighborListInterface<ParticleT> {
   /**
    * @copydoc VLCNeighborListInterface::generateSoAFromAoS()
    */
-  void generateSoAFromAoS(LinkedCells<ParticleT> &linkedCells) override {
+  void generateSoAFromAoS(LinkedCells<Particle_T> &linkedCells) override {
     _soaNeighborList.clear();
 
     // particle pointer to global index of particle
-    std::unordered_map<ParticleT *, size_t> particlePtrToIndex;
+    std::unordered_map<Particle_T *, size_t> particlePtrToIndex;
     particlePtrToIndex.reserve(linkedCells.size());
     size_t i = 0;
     for (auto iter = linkedCells.begin(IteratorBehavior::ownedOrHaloOrDummy); iter.isValid(); ++iter, ++i) {
@@ -212,7 +212,7 @@ class VLCAllCellsNeighborList : public VLCNeighborListInterface<ParticleT> {
   }
 
   void setUpTraversal(TraversalInterface *traversal) override {
-    auto vTraversal = dynamic_cast<VLCTraversalInterface<ParticleT, VLCAllCellsNeighborList<ParticleT>> *>(traversal);
+    auto vTraversal = dynamic_cast<VLCTraversalInterface<Particle_T, VLCAllCellsNeighborList<Particle_T>> *>(traversal);
 
     if (vTraversal) {
       vTraversal->setVerletList(*this);
@@ -227,11 +227,11 @@ class VLCAllCellsNeighborList : public VLCNeighborListInterface<ParticleT> {
   /**
    * @copydoc VLCNeighborListInterface::applyBuildFunctor()
    */
-  void applyBuildFunctor(LinkedCells<ParticleT> &linkedCells, bool useNewton3, double cutoff, double skin,
+  void applyBuildFunctor(LinkedCells<Particle_T> &linkedCells, bool useNewton3, double cutoff, double skin,
                          double interactionLength, const TraversalOption &vlcTraversalOpt,
                          typename VerletListsCellsHelpers::VLCBuildType buildType) override {
     // Generate the build traversal with the traversal selector and apply the build functor with it.
-    TraversalSelector<FullParticleCell<ParticleT>> traversalSelector;
+    TraversalSelector<FullParticleCell<Particle_T>> traversalSelector;
     // Argument "cluster size" does not matter here.
     TraversalSelectorInfo traversalSelectorInfo(linkedCells.getCellBlock().getCellsPerDimensionWithHalo(),
                                                 interactionLength, linkedCells.getCellBlock().getCellLength(), 0);
@@ -250,7 +250,7 @@ class VLCAllCellsNeighborList : public VLCNeighborListInterface<ParticleT> {
         linkedCells.getNumberOfParticles(IteratorBehavior::ownedOrHalo), boxSizeWithHalo, interactionLength, 1.3);
 
     if (vlcTraversalOpt == TraversalOption::vlc_c08) {
-      VLCAllCellsGeneratorFunctor<ParticleT, TraversalOption::vlc_c08> f(
+      VLCAllCellsGeneratorFunctor<Particle_T, TraversalOption::vlc_c08> f(
           _aosNeighborList, _particleToCellMap, cutoff + skin, listLengthEstimate,
           linkedCells.getCellBlock().getCellsPerDimensionWithHalo());
       f.setCells(&this->_internalLinkedCells->getCells());
@@ -259,7 +259,7 @@ class VLCAllCellsNeighborList : public VLCNeighborListInterface<ParticleT> {
           lcBuildTraversalOpt, f, traversalSelectorInfo, dataLayout, useNewton3);
       linkedCells.computeInteractions(buildTraversal.get());
     } else {
-      VLCAllCellsGeneratorFunctor<ParticleT, TraversalOption::vlc_c18> f(
+      VLCAllCellsGeneratorFunctor<Particle_T, TraversalOption::vlc_c18> f(
           _aosNeighborList, _particleToCellMap, cutoff + skin, listLengthEstimate,
           linkedCells.getCellBlock().getCellsPerDimensionWithHalo());
       // Build the AoS list using the AoS or SoA functor depending on buildType
@@ -272,12 +272,12 @@ class VLCAllCellsNeighborList : public VLCNeighborListInterface<ParticleT> {
   /**
    * Internal neighbor list structure in AoS format - Verlet lists for each particle for each cell.
    */
-  typename VerletListsCellsHelpers::AllCellsNeighborListsType<ParticleT> _aosNeighborList{};
+  typename VerletListsCellsHelpers::AllCellsNeighborListsType<Particle_T> _aosNeighborList{};
 
   /**
    * Mapping of each particle to its corresponding cell and id within this cell.
    */
-  std::unordered_map<ParticleT *, std::pair<size_t, size_t>> _particleToCellMap{};
+  std::unordered_map<Particle_T *, std::pair<size_t, size_t>> _particleToCellMap{};
 
   /**
    * Internal neighbor list structure in SoA format - Verlet lists for each particle for each cell.

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCCellPairGeneratorFunctor.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCCellPairGeneratorFunctor.h
@@ -15,11 +15,11 @@ namespace autopas {
 /**
  * This functor generates pairwise verlet lists (a verlet list attached to every pair of neighboring cells).
  */
-template <class Particle>
+template <class ParticleT>
 
-class VLCCellPairGeneratorFunctor : public PairwiseFunctor<Particle, VLCCellPairGeneratorFunctor<Particle>> {
-  using PairwiseNeighborListsType = typename VerletListsCellsHelpers::PairwiseNeighborListsType<Particle>;
-  using SoAArraysType = typename Particle::SoAArraysType;
+class VLCCellPairGeneratorFunctor : public PairwiseFunctor<ParticleT, VLCCellPairGeneratorFunctor<ParticleT>> {
+  using PairwiseNeighborListsType = typename VerletListsCellsHelpers::PairwiseNeighborListsType<ParticleT>;
+  using SoAArraysType = typename ParticleT::SoAArraysType;
 
  public:
   /**
@@ -30,9 +30,9 @@ class VLCCellPairGeneratorFunctor : public PairwiseFunctor<Particle, VLCCellPair
    * @param cutoffskin cutoff + skin
    */
   VLCCellPairGeneratorFunctor(PairwiseNeighborListsType &neighborLists,
-                              std::unordered_map<Particle *, std::pair<size_t, size_t>> &particleToCellMap,
+                              std::unordered_map<ParticleT *, std::pair<size_t, size_t>> &particleToCellMap,
                               std::vector<std::unordered_map<size_t, size_t>> &globalToLocalIndex, double cutoffskin)
-      : PairwiseFunctor<Particle, VLCCellPairGeneratorFunctor<Particle>>(0.),
+      : PairwiseFunctor<ParticleT, VLCCellPairGeneratorFunctor<ParticleT>>(0.),
         _neighborLists(neighborLists),
         _particleToCellMap(particleToCellMap),
         _globalToLocalIndex(globalToLocalIndex),
@@ -57,7 +57,7 @@ class VLCCellPairGeneratorFunctor : public PairwiseFunctor<Particle, VLCCellPair
   /**
    * @copydoc PairwiseFunctor::AoSFunctor()
    */
-  void AoSFunctor(Particle &i, Particle &j, bool newton3) override {
+  void AoSFunctor(ParticleT &i, ParticleT &j, bool newton3) override {
     using namespace autopas::utils::ArrayMath::literals;
 
     if (i.isDummy() or j.isDummy()) {
@@ -92,10 +92,10 @@ class VLCCellPairGeneratorFunctor : public PairwiseFunctor<Particle, VLCCellPair
   void SoAFunctorSingle(SoAView<SoAArraysType> soa, bool newton3) override {
     if (soa.size() == 0) return;
 
-    auto **const __restrict__ ptrptr = soa.template begin<Particle::AttributeNames::ptr>();
-    double *const __restrict__ xptr = soa.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict__ yptr = soa.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict__ zptr = soa.template begin<Particle::AttributeNames::posZ>();
+    auto **const __restrict__ ptrptr = soa.template begin<ParticleT::AttributeNames::ptr>();
+    double *const __restrict__ xptr = soa.template begin<ParticleT::AttributeNames::posX>();
+    double *const __restrict__ yptr = soa.template begin<ParticleT::AttributeNames::posY>();
+    double *const __restrict__ zptr = soa.template begin<ParticleT::AttributeNames::posZ>();
 
     // index of cell1 is particleToCellMap of ptr1ptr, same for 2
     auto cell = _particleToCellMap.at(ptrptr[0]).first;
@@ -148,15 +148,15 @@ class VLCCellPairGeneratorFunctor : public PairwiseFunctor<Particle, VLCCellPair
   void SoAFunctorPair(SoAView<SoAArraysType> soa1, SoAView<SoAArraysType> soa2, bool /*newton3*/) override {
     if (soa1.size() == 0 || soa2.size() == 0) return;
 
-    auto **const __restrict__ ptr1ptr = soa1.template begin<Particle::AttributeNames::ptr>();
-    double *const __restrict__ x1ptr = soa1.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict__ y1ptr = soa1.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict__ z1ptr = soa1.template begin<Particle::AttributeNames::posZ>();
+    auto **const __restrict__ ptr1ptr = soa1.template begin<ParticleT::AttributeNames::ptr>();
+    double *const __restrict__ x1ptr = soa1.template begin<ParticleT::AttributeNames::posX>();
+    double *const __restrict__ y1ptr = soa1.template begin<ParticleT::AttributeNames::posY>();
+    double *const __restrict__ z1ptr = soa1.template begin<ParticleT::AttributeNames::posZ>();
 
-    auto **const __restrict__ ptr2ptr = soa2.template begin<Particle::AttributeNames::ptr>();
-    double *const __restrict__ x2ptr = soa2.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict__ y2ptr = soa2.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict__ z2ptr = soa2.template begin<Particle::AttributeNames::posZ>();
+    auto **const __restrict__ ptr2ptr = soa2.template begin<ParticleT::AttributeNames::ptr>();
+    double *const __restrict__ x2ptr = soa2.template begin<ParticleT::AttributeNames::posX>();
+    double *const __restrict__ y2ptr = soa2.template begin<ParticleT::AttributeNames::posY>();
+    double *const __restrict__ z2ptr = soa2.template begin<ParticleT::AttributeNames::posZ>();
 
     // index of cell1 is particleToCellMap of ptr1ptr, same for 2
     size_t cell1 = _particleToCellMap.at(ptr1ptr[0]).first;
@@ -199,24 +199,24 @@ class VLCCellPairGeneratorFunctor : public PairwiseFunctor<Particle, VLCCellPair
    * @copydoc Functor::getNeededAttr()
    */
   constexpr static auto getNeededAttr() {
-    return std::array<typename Particle::AttributeNames, 4>{
-        Particle::AttributeNames::ptr, Particle::AttributeNames::posX, Particle::AttributeNames::posY,
-        Particle::AttributeNames::posZ};
+    return std::array<typename ParticleT::AttributeNames, 4>{
+        ParticleT::AttributeNames::ptr, ParticleT::AttributeNames::posX, ParticleT::AttributeNames::posY,
+        ParticleT::AttributeNames::posZ};
   }
 
   /**
    * @copydoc Functor::getNeededAttr(std::false_type)
    */
   constexpr static auto getNeededAttr(std::false_type) {
-    return std::array<typename Particle::AttributeNames, 4>{
-        Particle::AttributeNames::ptr, Particle::AttributeNames::posX, Particle::AttributeNames::posY,
-        Particle::AttributeNames::posZ};
+    return std::array<typename ParticleT::AttributeNames, 4>{
+        ParticleT::AttributeNames::ptr, ParticleT::AttributeNames::posX, ParticleT::AttributeNames::posY,
+        ParticleT::AttributeNames::posZ};
   }
 
   /**
    * @copydoc Functor::getComputedAttr()
    */
-  constexpr static auto getComputedAttr() { return std::array<typename Particle::AttributeNames, 0>{}; }
+  constexpr static auto getComputedAttr() { return std::array<typename ParticleT::AttributeNames, 0>{}; }
 
  private:
   /**
@@ -228,7 +228,7 @@ class VLCCellPairGeneratorFunctor : public PairwiseFunctor<Particle, VLCCellPair
   /**
    * Mapping of each particle to its corresponding cell and id within this cell.
    */
-  std::unordered_map<Particle *, std::pair<size_t, size_t>> &_particleToCellMap;
+  std::unordered_map<ParticleT *, std::pair<size_t, size_t>> &_particleToCellMap;
   /**
    * For each cell1: a mapping of the "absolute" index of cell2 (in the base linked cells structure) to its "relative"
    * index in cell1's neighbors.

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCCellPairGeneratorFunctor.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCCellPairGeneratorFunctor.h
@@ -15,11 +15,11 @@ namespace autopas {
 /**
  * This functor generates pairwise verlet lists (a verlet list attached to every pair of neighboring cells).
  */
-template <class ParticleT>
+template <class Particle_T>
 
-class VLCCellPairGeneratorFunctor : public PairwiseFunctor<ParticleT, VLCCellPairGeneratorFunctor<ParticleT>> {
-  using PairwiseNeighborListsType = typename VerletListsCellsHelpers::PairwiseNeighborListsType<ParticleT>;
-  using SoAArraysType = typename ParticleT::SoAArraysType;
+class VLCCellPairGeneratorFunctor : public PairwiseFunctor<Particle_T, VLCCellPairGeneratorFunctor<Particle_T>> {
+  using PairwiseNeighborListsType = typename VerletListsCellsHelpers::PairwiseNeighborListsType<Particle_T>;
+  using SoAArraysType = typename Particle_T::SoAArraysType;
 
  public:
   /**
@@ -30,9 +30,9 @@ class VLCCellPairGeneratorFunctor : public PairwiseFunctor<ParticleT, VLCCellPai
    * @param cutoffskin cutoff + skin
    */
   VLCCellPairGeneratorFunctor(PairwiseNeighborListsType &neighborLists,
-                              std::unordered_map<ParticleT *, std::pair<size_t, size_t>> &particleToCellMap,
+                              std::unordered_map<Particle_T *, std::pair<size_t, size_t>> &particleToCellMap,
                               std::vector<std::unordered_map<size_t, size_t>> &globalToLocalIndex, double cutoffskin)
-      : PairwiseFunctor<ParticleT, VLCCellPairGeneratorFunctor<ParticleT>>(0.),
+      : PairwiseFunctor<Particle_T, VLCCellPairGeneratorFunctor<Particle_T>>(0.),
         _neighborLists(neighborLists),
         _particleToCellMap(particleToCellMap),
         _globalToLocalIndex(globalToLocalIndex),
@@ -57,7 +57,7 @@ class VLCCellPairGeneratorFunctor : public PairwiseFunctor<ParticleT, VLCCellPai
   /**
    * @copydoc PairwiseFunctor::AoSFunctor()
    */
-  void AoSFunctor(ParticleT &i, ParticleT &j, bool newton3) override {
+  void AoSFunctor(Particle_T &i, Particle_T &j, bool newton3) override {
     using namespace autopas::utils::ArrayMath::literals;
 
     if (i.isDummy() or j.isDummy()) {
@@ -92,10 +92,10 @@ class VLCCellPairGeneratorFunctor : public PairwiseFunctor<ParticleT, VLCCellPai
   void SoAFunctorSingle(SoAView<SoAArraysType> soa, bool newton3) override {
     if (soa.size() == 0) return;
 
-    auto **const __restrict__ ptrptr = soa.template begin<ParticleT::AttributeNames::ptr>();
-    double *const __restrict__ xptr = soa.template begin<ParticleT::AttributeNames::posX>();
-    double *const __restrict__ yptr = soa.template begin<ParticleT::AttributeNames::posY>();
-    double *const __restrict__ zptr = soa.template begin<ParticleT::AttributeNames::posZ>();
+    auto **const __restrict__ ptrptr = soa.template begin<Particle_T::AttributeNames::ptr>();
+    double *const __restrict__ xptr = soa.template begin<Particle_T::AttributeNames::posX>();
+    double *const __restrict__ yptr = soa.template begin<Particle_T::AttributeNames::posY>();
+    double *const __restrict__ zptr = soa.template begin<Particle_T::AttributeNames::posZ>();
 
     // index of cell1 is particleToCellMap of ptr1ptr, same for 2
     auto cell = _particleToCellMap.at(ptrptr[0]).first;
@@ -148,15 +148,15 @@ class VLCCellPairGeneratorFunctor : public PairwiseFunctor<ParticleT, VLCCellPai
   void SoAFunctorPair(SoAView<SoAArraysType> soa1, SoAView<SoAArraysType> soa2, bool /*newton3*/) override {
     if (soa1.size() == 0 || soa2.size() == 0) return;
 
-    auto **const __restrict__ ptr1ptr = soa1.template begin<ParticleT::AttributeNames::ptr>();
-    double *const __restrict__ x1ptr = soa1.template begin<ParticleT::AttributeNames::posX>();
-    double *const __restrict__ y1ptr = soa1.template begin<ParticleT::AttributeNames::posY>();
-    double *const __restrict__ z1ptr = soa1.template begin<ParticleT::AttributeNames::posZ>();
+    auto **const __restrict__ ptr1ptr = soa1.template begin<Particle_T::AttributeNames::ptr>();
+    double *const __restrict__ x1ptr = soa1.template begin<Particle_T::AttributeNames::posX>();
+    double *const __restrict__ y1ptr = soa1.template begin<Particle_T::AttributeNames::posY>();
+    double *const __restrict__ z1ptr = soa1.template begin<Particle_T::AttributeNames::posZ>();
 
-    auto **const __restrict__ ptr2ptr = soa2.template begin<ParticleT::AttributeNames::ptr>();
-    double *const __restrict__ x2ptr = soa2.template begin<ParticleT::AttributeNames::posX>();
-    double *const __restrict__ y2ptr = soa2.template begin<ParticleT::AttributeNames::posY>();
-    double *const __restrict__ z2ptr = soa2.template begin<ParticleT::AttributeNames::posZ>();
+    auto **const __restrict__ ptr2ptr = soa2.template begin<Particle_T::AttributeNames::ptr>();
+    double *const __restrict__ x2ptr = soa2.template begin<Particle_T::AttributeNames::posX>();
+    double *const __restrict__ y2ptr = soa2.template begin<Particle_T::AttributeNames::posY>();
+    double *const __restrict__ z2ptr = soa2.template begin<Particle_T::AttributeNames::posZ>();
 
     // index of cell1 is particleToCellMap of ptr1ptr, same for 2
     size_t cell1 = _particleToCellMap.at(ptr1ptr[0]).first;
@@ -199,24 +199,24 @@ class VLCCellPairGeneratorFunctor : public PairwiseFunctor<ParticleT, VLCCellPai
    * @copydoc Functor::getNeededAttr()
    */
   constexpr static auto getNeededAttr() {
-    return std::array<typename ParticleT::AttributeNames, 4>{
-        ParticleT::AttributeNames::ptr, ParticleT::AttributeNames::posX, ParticleT::AttributeNames::posY,
-        ParticleT::AttributeNames::posZ};
+    return std::array<typename Particle_T::AttributeNames, 4>{
+        Particle_T::AttributeNames::ptr, Particle_T::AttributeNames::posX, Particle_T::AttributeNames::posY,
+        Particle_T::AttributeNames::posZ};
   }
 
   /**
    * @copydoc Functor::getNeededAttr(std::false_type)
    */
   constexpr static auto getNeededAttr(std::false_type) {
-    return std::array<typename ParticleT::AttributeNames, 4>{
-        ParticleT::AttributeNames::ptr, ParticleT::AttributeNames::posX, ParticleT::AttributeNames::posY,
-        ParticleT::AttributeNames::posZ};
+    return std::array<typename Particle_T::AttributeNames, 4>{
+        Particle_T::AttributeNames::ptr, Particle_T::AttributeNames::posX, Particle_T::AttributeNames::posY,
+        Particle_T::AttributeNames::posZ};
   }
 
   /**
    * @copydoc Functor::getComputedAttr()
    */
-  constexpr static auto getComputedAttr() { return std::array<typename ParticleT::AttributeNames, 0>{}; }
+  constexpr static auto getComputedAttr() { return std::array<typename Particle_T::AttributeNames, 0>{}; }
 
  private:
   /**
@@ -228,7 +228,7 @@ class VLCCellPairGeneratorFunctor : public PairwiseFunctor<ParticleT, VLCCellPai
   /**
    * Mapping of each particle to its corresponding cell and id within this cell.
    */
-  std::unordered_map<ParticleT *, std::pair<size_t, size_t>> &_particleToCellMap;
+  std::unordered_map<Particle_T *, std::pair<size_t, size_t>> &_particleToCellMap;
   /**
    * For each cell1: a mapping of the "absolute" index of cell2 (in the base linked cells structure) to its "relative"
    * index in cell1's neighbors.

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCCellPairNeighborList.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCCellPairNeighborList.h
@@ -19,21 +19,21 @@ namespace autopas {
 template <class ParticleCell>
 class TraversalSelector;
 
-template <class Particle>
+template <class ParticleT>
 class VLCCellPairTraversalInterface;
 /**
  * Neighbor list to be used with VerletListsCells container.
  * Pairwise verlet lists iterates through each pair of neighboring cells
  * and generates a neighbor list for each particle from cell1, which consists of its (potential) partners from cell2.
- * @tparam Particle Type of particle to be used for this neighbor list.
+ * @tparam ParticleT Type of particle to be used for this neighbor list.
  */
-template <class Particle>
-class VLCCellPairNeighborList : public VLCNeighborListInterface<Particle> {
+template <class ParticleT>
+class VLCCellPairNeighborList : public VLCNeighborListInterface<ParticleT> {
  public:
   /**
    * Type of the data structure used to save the neighbor lists.
    */
-  using listType = typename VerletListsCellsHelpers::PairwiseNeighborListsType<Particle>;
+  using ListType = typename VerletListsCellsHelpers::PairwiseNeighborListsType<ParticleT>;
 
   /**
    * Helper type definition. Pair of particle and neighbor list for SoA layout.
@@ -48,9 +48,9 @@ class VLCCellPairNeighborList : public VLCNeighborListInterface<Particle> {
 
   [[nodiscard]] ContainerOption getContainerType() const override { return ContainerOption::pairwiseVerletLists; }
 
-  size_t getNumberOfPartners(const Particle *particle) const override {
+  size_t getNumberOfPartners(const ParticleT *particle) const override {
     size_t listSize = 0;
-    const auto &[firstCellIndex, particleInCellIndex] = _particleToCellMap.at(const_cast<Particle *>(particle));
+    const auto &[firstCellIndex, particleInCellIndex] = _particleToCellMap.at(const_cast<ParticleT *>(particle));
     for (auto &cellPair : _aosNeighborList[firstCellIndex]) {
       listSize += cellPair[particleInCellIndex].second.size();
     }
@@ -61,7 +61,7 @@ class VLCCellPairNeighborList : public VLCNeighborListInterface<Particle> {
    * Returns the neighbor list in AoS layout.
    * @return Neighbor list in AoS layout.
    */
-  typename VerletListsCellsHelpers::PairwiseNeighborListsType<Particle> &getAoSNeighborList() {
+  typename VerletListsCellsHelpers::PairwiseNeighborListsType<ParticleT> &getAoSNeighborList() {
     return _aosNeighborList;
   }
 
@@ -79,7 +79,7 @@ class VLCCellPairNeighborList : public VLCNeighborListInterface<Particle> {
    */
   auto &getSoANeighborList() { return _soaNeighborList; }
 
-  void buildAoSNeighborList(LinkedCells<Particle> &linkedCells, bool useNewton3, double cutoff, double skin,
+  void buildAoSNeighborList(LinkedCells<ParticleT> &linkedCells, bool useNewton3, double cutoff, double skin,
                             double interactionLength, const TraversalOption vlcTraversalOpt,
                             typename VerletListsCellsHelpers::VLCBuildType buildType) override {
     this->_internalLinkedCells = &linkedCells;
@@ -134,7 +134,7 @@ class VLCCellPairNeighborList : public VLCNeighborListInterface<Particle> {
         size_t particleIndexCurrentCell = 0;
         for (auto &particle : cells[firstCellIndex]) {
           // for each particle in cell1 make a pair of particle and neighbor list
-          cellPair.emplace_back(std::make_pair(&particle, std::vector<Particle *>()));
+          cellPair.emplace_back(std::make_pair(&particle, std::vector<ParticleT *>()));
 
           // add a pair of cell's index and particle's index in the cell
           _particleToCellMap[&particle] = std::make_pair(firstCellIndex, particleIndexCurrentCell);
@@ -147,11 +147,11 @@ class VLCCellPairNeighborList : public VLCNeighborListInterface<Particle> {
     applyBuildFunctor(linkedCells, useNewton3, cutoff, skin, interactionLength, vlcTraversalOpt, buildType);
   }
 
-  void generateSoAFromAoS(LinkedCells<Particle> &linkedCells) override {
+  void generateSoAFromAoS(LinkedCells<ParticleT> &linkedCells) override {
     _soaNeighborList.clear();
 
     // particle pointer to global index of particle
-    std::unordered_map<Particle *, size_t> particlePtrToIndex;
+    std::unordered_map<ParticleT *, size_t> particlePtrToIndex;
     particlePtrToIndex.reserve(linkedCells.size());
     size_t i = 0;
     for (auto iter = linkedCells.begin(IteratorBehavior::ownedOrHaloOrDummy); iter.isValid(); ++iter, ++i) {
@@ -194,12 +194,12 @@ class VLCCellPairNeighborList : public VLCNeighborListInterface<Particle> {
   }
 
   void setUpTraversal(TraversalInterface *traversal) override {
-    auto vTraversal = dynamic_cast<VLCCellPairTraversalInterface<Particle> *>(traversal);
+    auto vTraversal = dynamic_cast<VLCCellPairTraversalInterface<ParticleT> *>(traversal);
 
     if (vTraversal) {
       vTraversal->setVerletList(*this);
     } else {
-      auto traversal2 = dynamic_cast<VLCTraversalInterface<Particle, VLCCellPairNeighborList<Particle>> *>(traversal);
+      auto traversal2 = dynamic_cast<VLCTraversalInterface<ParticleT, VLCCellPairNeighborList<ParticleT>> *>(traversal);
       if (traversal2) {
         traversal2->setVerletList(*this);
       } else {
@@ -211,13 +211,13 @@ class VLCCellPairNeighborList : public VLCNeighborListInterface<Particle> {
   }
 
  private:
-  void applyBuildFunctor(LinkedCells<Particle> &linkedCells, bool useNewton3, double cutoff, double skin,
+  void applyBuildFunctor(LinkedCells<ParticleT> &linkedCells, bool useNewton3, double cutoff, double skin,
                          double interactionLength, const TraversalOption /*vlcTraversalOpt*/ &,
                          typename VerletListsCellsHelpers::VLCBuildType buildType) override {
-    VLCCellPairGeneratorFunctor<Particle> f(_aosNeighborList, _particleToCellMap, _globalToLocalIndex, cutoff + skin);
+    VLCCellPairGeneratorFunctor<ParticleT> f(_aosNeighborList, _particleToCellMap, _globalToLocalIndex, cutoff + skin);
 
     // Generate the build traversal with the traversal selector and apply the build functor with it.
-    TraversalSelector<FullParticleCell<Particle>> traversalSelector;
+    TraversalSelector<FullParticleCell<ParticleT>> traversalSelector;
     // Argument "cluster size" does not matter here.
     TraversalSelectorInfo traversalSelectorInfo(linkedCells.getCellBlock().getCellsPerDimensionWithHalo(),
                                                 interactionLength, linkedCells.getCellBlock().getCellLength(), 0);
@@ -235,14 +235,14 @@ class VLCCellPairNeighborList : public VLCNeighborListInterface<Particle> {
   /**
    * Internal neighbor list structure in AoS format - Verlet lists for each particle for each cell pair.
    */
-  typename VerletListsCellsHelpers::PairwiseNeighborListsType<Particle> _aosNeighborList =
-      std::vector<std::vector<std::vector<std::pair<Particle *, std::vector<Particle *>>>>>();
+  typename VerletListsCellsHelpers::PairwiseNeighborListsType<ParticleT> _aosNeighborList =
+      std::vector<std::vector<std::vector<std::pair<ParticleT *, std::vector<ParticleT *>>>>>();
 
   /**
    * Mapping of each particle to its corresponding cell and id within this cell.
    */
-  std::unordered_map<Particle *, std::pair<size_t, size_t>> _particleToCellMap =
-      std::unordered_map<Particle *, std::pair<size_t, size_t>>();
+  std::unordered_map<ParticleT *, std::pair<size_t, size_t>> _particleToCellMap =
+      std::unordered_map<ParticleT *, std::pair<size_t, size_t>>();
 
   /**
    * For each cell1: a mapping of the "absolute" index of cell2 (in the base linked cells structure) to its "relative"

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCNeighborListInterface.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCNeighborListInterface.h
@@ -13,9 +13,9 @@
 namespace autopas {
 /**
  * Interface of neighbor lists to be used with VerletListsCells container.
- * @tparam Particle Type of particle to be used for the neighbor list.
+ * @tparam ParticleT Type of particle to be used for the neighbor list.
  */
-template <class Particle>
+template <class ParticleT>
 class VLCNeighborListInterface {
  public:
   /**
@@ -33,7 +33,7 @@ class VLCNeighborListInterface {
    * @param vlcTraversalOpt Traversal for which this neighbor list is built.
    * @param buildType Type of build functor to be used for the generation of the neighbor list.
    */
-  virtual void buildAoSNeighborList(LinkedCells<Particle> &linkedCells, bool useNewton3, double cutoff, double skin,
+  virtual void buildAoSNeighborList(LinkedCells<ParticleT> &linkedCells, bool useNewton3, double cutoff, double skin,
                                     double interactionLength, const TraversalOption vlcTraversalOpt,
                                     typename VerletListsCellsHelpers::VLCBuildType buildType) = 0;
 
@@ -42,7 +42,7 @@ class VLCNeighborListInterface {
    * @param particle
    * @return the size of the neighbor list(s) of this particle
    */
-  virtual size_t getNumberOfPartners(const Particle *particle) const = 0;
+  virtual size_t getNumberOfPartners(const ParticleT *particle) const = 0;
 
   /**
    * Returns the container type of this neighbor list and the container it belongs to.
@@ -56,7 +56,7 @@ class VLCNeighborListInterface {
    * particles.
    * @param linkedCells Underlying linked cells structure.
    */
-  virtual void generateSoAFromAoS(LinkedCells<Particle> &linkedCells) = 0;
+  virtual void generateSoAFromAoS(LinkedCells<ParticleT> &linkedCells) = 0;
 
   /**
    * Loads cells into structure of arrays.
@@ -112,18 +112,18 @@ class VLCNeighborListInterface {
    * Set the Linked Cells Pointer for this List.
    * @param linkedCells
    */
-  void setLinkedCellsPointer(LinkedCells<Particle> *linkedCells) { this->_internalLinkedCells = linkedCells; }
+  void setLinkedCellsPointer(LinkedCells<ParticleT> *linkedCells) { this->_internalLinkedCells = linkedCells; }
 
  protected:
   /**
    * Internal linked cells structure. Necessary for loading and extracting SoA.
    */
-  LinkedCells<Particle> *_internalLinkedCells;
+  LinkedCells<ParticleT> *_internalLinkedCells;
 
   /**
    * Structure of arrays necessary for SoA data layout.
    */
-  SoA<typename Particle::SoAArraysType> _soa;
+  SoA<typename ParticleT::SoAArraysType> _soa;
 
   /**
    * Creates and applies a generator functor for the building of the neighbor list.
@@ -135,7 +135,7 @@ class VLCNeighborListInterface {
    * @param vlcTraversalOpt Traversal for which this neighbor list is built.
    * @param buildType Type of build functor to be used for the generation of the neighbor list.
    */
-  virtual void applyBuildFunctor(LinkedCells<Particle> &linkedCells, bool useNewton3, double cutoff, double skin,
+  virtual void applyBuildFunctor(LinkedCells<ParticleT> &linkedCells, bool useNewton3, double cutoff, double skin,
                                  double interactionLength, const TraversalOption &vlcTraversalOpt,
                                  typename VerletListsCellsHelpers::VLCBuildType buildType) = 0;
 };

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCNeighborListInterface.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCNeighborListInterface.h
@@ -13,9 +13,9 @@
 namespace autopas {
 /**
  * Interface of neighbor lists to be used with VerletListsCells container.
- * @tparam ParticleT Type of particle to be used for the neighbor list.
+ * @tparam Particle_T Type of particle to be used for the neighbor list.
  */
-template <class ParticleT>
+template <class Particle_T>
 class VLCNeighborListInterface {
  public:
   /**
@@ -33,7 +33,7 @@ class VLCNeighborListInterface {
    * @param vlcTraversalOpt Traversal for which this neighbor list is built.
    * @param buildType Type of build functor to be used for the generation of the neighbor list.
    */
-  virtual void buildAoSNeighborList(LinkedCells<ParticleT> &linkedCells, bool useNewton3, double cutoff, double skin,
+  virtual void buildAoSNeighborList(LinkedCells<Particle_T> &linkedCells, bool useNewton3, double cutoff, double skin,
                                     double interactionLength, const TraversalOption vlcTraversalOpt,
                                     typename VerletListsCellsHelpers::VLCBuildType buildType) = 0;
 
@@ -42,7 +42,7 @@ class VLCNeighborListInterface {
    * @param particle
    * @return the size of the neighbor list(s) of this particle
    */
-  virtual size_t getNumberOfPartners(const ParticleT *particle) const = 0;
+  virtual size_t getNumberOfPartners(const Particle_T *particle) const = 0;
 
   /**
    * Returns the container type of this neighbor list and the container it belongs to.
@@ -56,7 +56,7 @@ class VLCNeighborListInterface {
    * particles.
    * @param linkedCells Underlying linked cells structure.
    */
-  virtual void generateSoAFromAoS(LinkedCells<ParticleT> &linkedCells) = 0;
+  virtual void generateSoAFromAoS(LinkedCells<Particle_T> &linkedCells) = 0;
 
   /**
    * Loads cells into structure of arrays.
@@ -112,18 +112,18 @@ class VLCNeighborListInterface {
    * Set the Linked Cells Pointer for this List.
    * @param linkedCells
    */
-  void setLinkedCellsPointer(LinkedCells<ParticleT> *linkedCells) { this->_internalLinkedCells = linkedCells; }
+  void setLinkedCellsPointer(LinkedCells<Particle_T> *linkedCells) { this->_internalLinkedCells = linkedCells; }
 
  protected:
   /**
    * Internal linked cells structure. Necessary for loading and extracting SoA.
    */
-  LinkedCells<ParticleT> *_internalLinkedCells;
+  LinkedCells<Particle_T> *_internalLinkedCells;
 
   /**
    * Structure of arrays necessary for SoA data layout.
    */
-  SoA<typename ParticleT::SoAArraysType> _soa;
+  SoA<typename Particle_T::SoAArraysType> _soa;
 
   /**
    * Creates and applies a generator functor for the building of the neighbor list.
@@ -135,7 +135,7 @@ class VLCNeighborListInterface {
    * @param vlcTraversalOpt Traversal for which this neighbor list is built.
    * @param buildType Type of build functor to be used for the generation of the neighbor list.
    */
-  virtual void applyBuildFunctor(LinkedCells<ParticleT> &linkedCells, bool useNewton3, double cutoff, double skin,
+  virtual void applyBuildFunctor(LinkedCells<Particle_T> &linkedCells, bool useNewton3, double cutoff, double skin,
                                  double interactionLength, const TraversalOption &vlcTraversalOpt,
                                  typename VerletListsCellsHelpers::VLCBuildType buildType) = 0;
 };

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCCellPairTraversalInterface.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCCellPairTraversalInterface.h
@@ -10,21 +10,21 @@ namespace autopas {
  * Interface for traversals used with VLCCellPairNeighborList.
  * Allows the distinction of traversals that are only usable for VLCCellPairNeighborList
  * and not compatible with the VLCAllCellsNeighborList within the VerletListsCells container.
- * @tparam Particle type of particle
+ * @tparam ParticleT type of particle
  */
-template <class Particle>
+template <class ParticleT>
 class VLCCellPairTraversalInterface {
  public:
   /**
    * Sets the verlet list for the traversal to iterate over.
    * @param verlet The verlet list to iterate over.
    */
-  void setVerletList(VLCCellPairNeighborList<Particle> &verlet) { _cellPairVerletList = &verlet; }
+  void setVerletList(VLCCellPairNeighborList<ParticleT> &verlet) { _cellPairVerletList = &verlet; }
 
  protected:
   /**
    * The verlet list to iterate over.
    */
-  VLCCellPairNeighborList<Particle> *_cellPairVerletList;
+  VLCCellPairNeighborList<ParticleT> *_cellPairVerletList;
 };
 }  // namespace autopas

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCCellPairTraversalInterface.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCCellPairTraversalInterface.h
@@ -10,21 +10,21 @@ namespace autopas {
  * Interface for traversals used with VLCCellPairNeighborList.
  * Allows the distinction of traversals that are only usable for VLCCellPairNeighborList
  * and not compatible with the VLCAllCellsNeighborList within the VerletListsCells container.
- * @tparam ParticleT type of particle
+ * @tparam Particle_T type of particle
  */
-template <class ParticleT>
+template <class Particle_T>
 class VLCCellPairTraversalInterface {
  public:
   /**
    * Sets the verlet list for the traversal to iterate over.
    * @param verlet The verlet list to iterate over.
    */
-  void setVerletList(VLCCellPairNeighborList<ParticleT> &verlet) { _cellPairVerletList = &verlet; }
+  void setVerletList(VLCCellPairNeighborList<Particle_T> &verlet) { _cellPairVerletList = &verlet; }
 
  protected:
   /**
    * The verlet list to iterate over.
    */
-  VLCCellPairNeighborList<ParticleT> *_cellPairVerletList;
+  VLCCellPairNeighborList<Particle_T> *_cellPairVerletList;
 };
 }  // namespace autopas

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCTraversalInterface.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCTraversalInterface.h
@@ -23,7 +23,7 @@ namespace autopas {
  *
  * The container only accepts traversals in its computeInteractions() method that implement this interface.
  */
-template <class Particle, class NeighborList>
+template <class ParticleT, class NeighborList>
 class VLCTraversalInterface {
  public:
   VLCTraversalInterface() = delete;
@@ -89,7 +89,7 @@ class VLCTraversalInterface {
   /**
    * Structure of arrays to be used if the data layout is SoA.
    */
-  SoA<typename Particle::SoAArraysType> *_soa;
+  SoA<typename ParticleT::SoAArraysType> *_soa;
 
   /**
    * The type of neighbor list as an enum value.
@@ -107,14 +107,14 @@ class VLCTraversalInterface {
    * @param useNewton3
    */
   template <class PairwiseFunctor>
-  void processCellListsImpl(VLCAllCellsNeighborList<Particle> &neighborList, unsigned long cellIndex,
+  void processCellListsImpl(VLCAllCellsNeighborList<ParticleT> &neighborList, unsigned long cellIndex,
                             PairwiseFunctor *pairwiseFunctor, DataLayoutOption dataLayout, bool useNewton3) {
     if (dataLayout == DataLayoutOption::aos) {
       auto &aosList = neighborList.getAoSNeighborList();
       for (auto &[particlePtr, neighbors] : aosList[cellIndex]) {
-        Particle &particle = *particlePtr;
+        ParticleT &particle = *particlePtr;
         for (auto neighborPtr : neighbors) {
-          Particle &neighbor = *neighborPtr;
+          ParticleT &neighbor = *neighborPtr;
           pairwiseFunctor->AoSFunctor(particle, neighbor, useNewton3);
         }
       }
@@ -140,15 +140,15 @@ class VLCTraversalInterface {
    * @param useNewton3
    */
   template <class PairwiseFunctor>
-  void processCellListsImpl(VLCCellPairNeighborList<Particle> &neighborList, unsigned long cellIndex,
+  void processCellListsImpl(VLCCellPairNeighborList<ParticleT> &neighborList, unsigned long cellIndex,
                             PairwiseFunctor *pairwiseFunctor, DataLayoutOption dataLayout, bool useNewton3) {
     if (dataLayout == DataLayoutOption::aos) {
       auto &aosList = neighborList.getAoSNeighborList();
       for (auto &cellPair : aosList[cellIndex]) {
         for (auto &[particlePtr, neighbors] : cellPair) {
-          Particle &particle = *particlePtr;
+          ParticleT &particle = *particlePtr;
           for (auto neighborPtr : neighbors) {
-            Particle &neighbor = *neighborPtr;
+            ParticleT &neighbor = *neighborPtr;
             pairwiseFunctor->AoSFunctor(particle, neighbor, useNewton3);
           }
         }

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCTraversalInterface.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCTraversalInterface.h
@@ -23,7 +23,7 @@ namespace autopas {
  *
  * The container only accepts traversals in its computeInteractions() method that implement this interface.
  */
-template <class ParticleT, class NeighborList>
+template <class Particle_T, class NeighborList>
 class VLCTraversalInterface {
  public:
   VLCTraversalInterface() = delete;
@@ -89,7 +89,7 @@ class VLCTraversalInterface {
   /**
    * Structure of arrays to be used if the data layout is SoA.
    */
-  SoA<typename ParticleT::SoAArraysType> *_soa;
+  SoA<typename Particle_T::SoAArraysType> *_soa;
 
   /**
    * The type of neighbor list as an enum value.
@@ -107,14 +107,14 @@ class VLCTraversalInterface {
    * @param useNewton3
    */
   template <class PairwiseFunctor>
-  void processCellListsImpl(VLCAllCellsNeighborList<ParticleT> &neighborList, unsigned long cellIndex,
+  void processCellListsImpl(VLCAllCellsNeighborList<Particle_T> &neighborList, unsigned long cellIndex,
                             PairwiseFunctor *pairwiseFunctor, DataLayoutOption dataLayout, bool useNewton3) {
     if (dataLayout == DataLayoutOption::aos) {
       auto &aosList = neighborList.getAoSNeighborList();
       for (auto &[particlePtr, neighbors] : aosList[cellIndex]) {
-        ParticleT &particle = *particlePtr;
+        Particle_T &particle = *particlePtr;
         for (auto neighborPtr : neighbors) {
-          ParticleT &neighbor = *neighborPtr;
+          Particle_T &neighbor = *neighborPtr;
           pairwiseFunctor->AoSFunctor(particle, neighbor, useNewton3);
         }
       }
@@ -140,15 +140,15 @@ class VLCTraversalInterface {
    * @param useNewton3
    */
   template <class PairwiseFunctor>
-  void processCellListsImpl(VLCCellPairNeighborList<ParticleT> &neighborList, unsigned long cellIndex,
+  void processCellListsImpl(VLCCellPairNeighborList<Particle_T> &neighborList, unsigned long cellIndex,
                             PairwiseFunctor *pairwiseFunctor, DataLayoutOption dataLayout, bool useNewton3) {
     if (dataLayout == DataLayoutOption::aos) {
       auto &aosList = neighborList.getAoSNeighborList();
       for (auto &cellPair : aosList[cellIndex]) {
         for (auto &[particlePtr, neighbors] : cellPair) {
-          ParticleT &particle = *particlePtr;
+          Particle_T &particle = *particlePtr;
           for (auto neighborPtr : neighbors) {
-            ParticleT &neighbor = *neighborPtr;
+            Particle_T &neighbor = *neighborPtr;
             pairwiseFunctor->AoSFunctor(particle, neighbor, useNewton3);
           }
         }

--- a/src/autopas/iterators/CellIterator.h
+++ b/src/autopas/iterators/CellIterator.h
@@ -11,7 +11,7 @@
 
 /**
  * Wraps the iterator of arbitrary cells to provide a common interface.
- * @note This class is necessary because some cells store `ParticleT` and others `ParticleT *`.
+ * @note This class is necessary because some cells store `Particle_T` and others `Particle_T *`.
  * @tparam StorageType Type of the cell, used to derive the particle type.
  * @tparam modifiable If false, this is a const iterator, meaning, the underlying particle can not be modified.
  */

--- a/src/autopas/iterators/CellIterator.h
+++ b/src/autopas/iterators/CellIterator.h
@@ -11,7 +11,7 @@
 
 /**
  * Wraps the iterator of arbitrary cells to provide a common interface.
- * @note This class is necessary because some cells store `Particle` and others `Particle *`.
+ * @note This class is necessary because some cells store `ParticleT` and others `ParticleT *`.
  * @tparam StorageType Type of the cell, used to derive the particle type.
  * @tparam modifiable If false, this is a const iterator, meaning, the underlying particle can not be modified.
  */

--- a/src/autopas/iterators/ContainerIterator.h
+++ b/src/autopas/iterators/ContainerIterator.h
@@ -102,13 +102,13 @@ class ContainerIterator {
   /**
    * Type of the additional vector collection. Switch for const iterators.
    */
-  using ParticleVecType =
-      std::conditional_t<modifiable, std::vector<std::vector<ParticleT> *>, std::vector<std::vector<ParticleT> const *>>;
+  using ParticleVecType = std::conditional_t<modifiable, std::vector<std::vector<ParticleT> *>,
+                                             std::vector<std::vector<ParticleT> const *>>;
   /**
    * Type of the Particle Container type. Switch for const iterators.
    */
-  using ContainerType =
-      std::conditional_t<modifiable, ParticleContainerInterface<ParticleT>, const ParticleContainerInterface<ParticleT>>;
+  using ContainerType = std::conditional_t<modifiable, ParticleContainerInterface<ParticleT>,
+                                           const ParticleContainerInterface<ParticleT>>;
 
   /**
    * Default constructor that guarantees an invalid iterator.

--- a/src/autopas/iterators/ContainerIterator.h
+++ b/src/autopas/iterators/ContainerIterator.h
@@ -45,7 +45,7 @@ namespace containerIteratorUtils {
  * Indicates whether the particle has the correct ownership state and if this is a region iterator is in the region.
  *
  * @tparam regionIter
- * @tparam Particle
+ * @tparam ParticleT
  * @tparam Arr Template because if this is a region iterator ContainerIterator will pass an empty struct
  * @param p
  * @param behavior
@@ -53,8 +53,8 @@ namespace containerIteratorUtils {
  * @param regionMax If regionIter is true this should be a std::array<double, 3>
  * @return True iff the given particle's ownership state is compatible with the iterator behavior.
  */
-template <bool regionIter, class Particle, class Arr>
-[[nodiscard]] bool particleFulfillsIteratorRequirements(const Particle &p, IteratorBehavior behavior,
+template <bool regionIter, class ParticleT, class Arr>
+[[nodiscard]] bool particleFulfillsIteratorRequirements(const ParticleT &p, IteratorBehavior behavior,
                                                         const Arr &regionMin, const Arr &regionMax) {
   // If this is a region iterator check box condition first, otherwise race conditions can occur
   // if multiple region iterator overlap and ownership state is touched.
@@ -85,11 +85,11 @@ template <bool regionIter, class Particle, class Arr>
  * Inserting particles might invalidate the iterator.
  * There are no guarantees about the order in which particles are iterated.
  *
- * @tparam Particle
+ * @tparam ParticleT
  * @tparam modifiable If false, this is a const iterator.
  * @tparam regionIter If false, avoid any region checks and iterate the whole container.
  */
-template <class Particle, bool modifiable, bool regionIter>
+template <class ParticleT, bool modifiable, bool regionIter>
 class ContainerIterator {
   template <class T>
   friend void internal::deleteParticle(T &);
@@ -98,17 +98,17 @@ class ContainerIterator {
   /**
    * Type of the particle this iterator points to. Switch for const iterators.
    */
-  using ParticleType = std::conditional_t<modifiable, Particle, const Particle>;
+  using ParticleType = std::conditional_t<modifiable, ParticleT, const ParticleT>;
   /**
    * Type of the additional vector collection. Switch for const iterators.
    */
   using ParticleVecType =
-      std::conditional_t<modifiable, std::vector<std::vector<Particle> *>, std::vector<std::vector<Particle> const *>>;
+      std::conditional_t<modifiable, std::vector<std::vector<ParticleT> *>, std::vector<std::vector<ParticleT> const *>>;
   /**
    * Type of the Particle Container type. Switch for const iterators.
    */
   using ContainerType =
-      std::conditional_t<modifiable, ParticleContainerInterface<Particle>, const ParticleContainerInterface<Particle>>;
+      std::conditional_t<modifiable, ParticleContainerInterface<ParticleT>, const ParticleContainerInterface<ParticleT>>;
 
   /**
    * Default constructor that guarantees an invalid iterator.
@@ -149,7 +149,7 @@ class ContainerIterator {
    * Copy constructor
    * @param other
    */
-  ContainerIterator(const ContainerIterator<Particle, modifiable, regionIter> &other)
+  ContainerIterator(const ContainerIterator<ParticleT, modifiable, regionIter> &other)
       : _container(other._container),
         _currentParticleIndex(other._currentParticleIndex),
         _currentVectorIndex(other._currentVectorIndex),
@@ -166,8 +166,8 @@ class ContainerIterator {
    * @param other
    * @return
    */
-  ContainerIterator<Particle, modifiable, regionIter> &operator=(
-      const ContainerIterator<Particle, modifiable, regionIter> &other) {
+  ContainerIterator<ParticleT, modifiable, regionIter> &operator=(
+      const ContainerIterator<ParticleT, modifiable, regionIter> &other) {
     if (this != other) {
       _container = other._container;
       _currentParticleIndex = other._currentParticleIndex;
@@ -189,7 +189,7 @@ class ContainerIterator {
    * Move constructor
    * @param other
    */
-  ContainerIterator(ContainerIterator<Particle, modifiable, regionIter> &&other) noexcept
+  ContainerIterator(ContainerIterator<ParticleT, modifiable, regionIter> &&other) noexcept
       : _container(other._container),
         _currentParticleIndex(other._currentParticleIndex),
         _currentVectorIndex(other._currentVectorIndex),
@@ -206,8 +206,8 @@ class ContainerIterator {
    * @param other
    * @return
    */
-  ContainerIterator<Particle, modifiable, regionIter> &operator=(
-      ContainerIterator<Particle, modifiable, regionIter> &&other) noexcept {
+  ContainerIterator<ParticleT, modifiable, regionIter> &operator=(
+      ContainerIterator<ParticleT, modifiable, regionIter> &&other) noexcept {
     if (this != &other) {
       _container = other._container;
       _currentParticleIndex = other._currentParticleIndex;
@@ -269,7 +269,7 @@ class ContainerIterator {
    *
    * @return *this
    */
-  inline ContainerIterator<Particle, modifiable, regionIter> &operator++() {
+  inline ContainerIterator<ParticleT, modifiable, regionIter> &operator++() {
     // bump the index. If it is invalid now, the container will give us the proper one.
     ++_currentParticleIndex;
     fetchParticleAtCurrentIndex();

--- a/src/autopas/iterators/ContainerIterator.h
+++ b/src/autopas/iterators/ContainerIterator.h
@@ -45,7 +45,7 @@ namespace containerIteratorUtils {
  * Indicates whether the particle has the correct ownership state and if this is a region iterator is in the region.
  *
  * @tparam regionIter
- * @tparam ParticleT
+ * @tparam Particle_T
  * @tparam Arr Template because if this is a region iterator ContainerIterator will pass an empty struct
  * @param p
  * @param behavior
@@ -53,8 +53,8 @@ namespace containerIteratorUtils {
  * @param regionMax If regionIter is true this should be a std::array<double, 3>
  * @return True iff the given particle's ownership state is compatible with the iterator behavior.
  */
-template <bool regionIter, class ParticleT, class Arr>
-[[nodiscard]] bool particleFulfillsIteratorRequirements(const ParticleT &p, IteratorBehavior behavior,
+template <bool regionIter, class Particle_T, class Arr>
+[[nodiscard]] bool particleFulfillsIteratorRequirements(const Particle_T &p, IteratorBehavior behavior,
                                                         const Arr &regionMin, const Arr &regionMax) {
   // If this is a region iterator check box condition first, otherwise race conditions can occur
   // if multiple region iterator overlap and ownership state is touched.
@@ -85,11 +85,11 @@ template <bool regionIter, class ParticleT, class Arr>
  * Inserting particles might invalidate the iterator.
  * There are no guarantees about the order in which particles are iterated.
  *
- * @tparam ParticleT
+ * @tparam Particle_T
  * @tparam modifiable If false, this is a const iterator.
  * @tparam regionIter If false, avoid any region checks and iterate the whole container.
  */
-template <class ParticleT, bool modifiable, bool regionIter>
+template <class Particle_T, bool modifiable, bool regionIter>
 class ContainerIterator {
   template <class T>
   friend void internal::deleteParticle(T &);
@@ -98,17 +98,17 @@ class ContainerIterator {
   /**
    * Type of the particle this iterator points to. Switch for const iterators.
    */
-  using ParticleType = std::conditional_t<modifiable, ParticleT, const ParticleT>;
+  using ParticleType = std::conditional_t<modifiable, Particle_T, const Particle_T>;
   /**
    * Type of the additional vector collection. Switch for const iterators.
    */
-  using ParticleVecType = std::conditional_t<modifiable, std::vector<std::vector<ParticleT> *>,
-                                             std::vector<std::vector<ParticleT> const *>>;
+  using ParticleVecType = std::conditional_t<modifiable, std::vector<std::vector<Particle_T> *>,
+                                             std::vector<std::vector<Particle_T> const *>>;
   /**
    * Type of the Particle Container type. Switch for const iterators.
    */
-  using ContainerType = std::conditional_t<modifiable, ParticleContainerInterface<ParticleT>,
-                                           const ParticleContainerInterface<ParticleT>>;
+  using ContainerType = std::conditional_t<modifiable, ParticleContainerInterface<Particle_T>,
+                                           const ParticleContainerInterface<Particle_T>>;
 
   /**
    * Default constructor that guarantees an invalid iterator.
@@ -149,7 +149,7 @@ class ContainerIterator {
    * Copy constructor
    * @param other
    */
-  ContainerIterator(const ContainerIterator<ParticleT, modifiable, regionIter> &other)
+  ContainerIterator(const ContainerIterator<Particle_T, modifiable, regionIter> &other)
       : _container(other._container),
         _currentParticleIndex(other._currentParticleIndex),
         _currentVectorIndex(other._currentVectorIndex),
@@ -166,8 +166,8 @@ class ContainerIterator {
    * @param other
    * @return
    */
-  ContainerIterator<ParticleT, modifiable, regionIter> &operator=(
-      const ContainerIterator<ParticleT, modifiable, regionIter> &other) {
+  ContainerIterator<Particle_T, modifiable, regionIter> &operator=(
+      const ContainerIterator<Particle_T, modifiable, regionIter> &other) {
     if (this != other) {
       _container = other._container;
       _currentParticleIndex = other._currentParticleIndex;
@@ -189,7 +189,7 @@ class ContainerIterator {
    * Move constructor
    * @param other
    */
-  ContainerIterator(ContainerIterator<ParticleT, modifiable, regionIter> &&other) noexcept
+  ContainerIterator(ContainerIterator<Particle_T, modifiable, regionIter> &&other) noexcept
       : _container(other._container),
         _currentParticleIndex(other._currentParticleIndex),
         _currentVectorIndex(other._currentVectorIndex),
@@ -206,8 +206,8 @@ class ContainerIterator {
    * @param other
    * @return
    */
-  ContainerIterator<ParticleT, modifiable, regionIter> &operator=(
-      ContainerIterator<ParticleT, modifiable, regionIter> &&other) noexcept {
+  ContainerIterator<Particle_T, modifiable, regionIter> &operator=(
+      ContainerIterator<Particle_T, modifiable, regionIter> &&other) noexcept {
     if (this != &other) {
       _container = other._container;
       _currentParticleIndex = other._currentParticleIndex;
@@ -269,7 +269,7 @@ class ContainerIterator {
    *
    * @return *this
    */
-  inline ContainerIterator<ParticleT, modifiable, regionIter> &operator++() {
+  inline ContainerIterator<Particle_T, modifiable, regionIter> &operator++() {
     // bump the index. If it is invalid now, the container will give us the proper one.
     ++_currentParticleIndex;
     fetchParticleAtCurrentIndex();

--- a/src/autopas/namespaces.h
+++ b/src/autopas/namespaces.h
@@ -103,7 +103,6 @@ namespace SearchSpaceGenerators {}
 
 /**
  * Helper functions and type aliases for verlet lists cells.
- * @tparam Particle
  */
 namespace VerletListsCellsHelpers {}
 

--- a/src/autopas/particles/ParticleDefinitions.h
+++ b/src/autopas/particles/ParticleDefinitions.h
@@ -10,11 +10,6 @@
 #include "autopas/particles/ParticleBase.h"
 
 namespace autopas {
-
-/**
- * Particle with all variables in 32 bit precision
- */
-using ParticleBaseFP32 = ParticleBase<float, unsigned long>;
 /**
  * Particle with all variables in 64 bit precision
  */

--- a/src/autopas/particles/ParticleDefinitions.h
+++ b/src/autopas/particles/ParticleDefinitions.h
@@ -1,5 +1,5 @@
 /**
- * @file Particle.h
+ * @file ParticleDefinitions.h
  *
  * @date 17 Jan 2018
  * @author tchipevn

--- a/src/autopas/particles/ParticleDefinitions.h
+++ b/src/autopas/particles/ParticleDefinitions.h
@@ -14,14 +14,10 @@ namespace autopas {
 /**
  * Particle with all variables in 32 bit precision
  */
-using ParticleFP32 = ParticleBase<float, unsigned long>;
+using ParticleBaseFP32 = ParticleBase<float, unsigned long>;
 /**
  * Particle with all variables in 64 bit precision
  */
-using ParticleFP64 = ParticleBase<double, unsigned long>;
-/**
- * Alias for Particle with all variables in 64 bit precision
- */
-using Particle = ParticleFP64;
+using ParticleBaseFP64 = ParticleBase<double, unsigned long>;
 
 }  // namespace autopas

--- a/src/autopas/tuning/selectors/ContainerSelector.h
+++ b/src/autopas/tuning/selectors/ContainerSelector.h
@@ -33,10 +33,10 @@ namespace autopas {
  * The class is given a list of allowed container and traversal options to choose from.
  * This class selects the optimal container and delegates the choice of the optimal traversal down to this container.
  *
- * @tparam Particle
+ * @tparam ParticleT
  * @tparam ParticleCell
  */
-template <class Particle>
+template <class ParticleT>
 class ContainerSelector {
  public:
   /**
@@ -71,13 +71,13 @@ class ContainerSelector {
    * Getter for the optimal container. If no container is chosen yet the first allowed is selected.
    * @return Reference to the optimal container.
    */
-  inline autopas::ParticleContainerInterface<Particle> &getCurrentContainer();
+  inline autopas::ParticleContainerInterface<ParticleT> &getCurrentContainer();
 
   /**
    * Getter for the optimal container. If no container is chosen yet the first allowed is selected.
    * @return Reference to the optimal container.
    */
-  inline const autopas::ParticleContainerInterface<Particle> &getCurrentContainer() const;
+  inline const autopas::ParticleContainerInterface<ParticleT> &getCurrentContainer() const;
 
  private:
   /**
@@ -86,72 +86,72 @@ class ContainerSelector {
    * @param containerInfo additional parameter for the container
    * @return Smartpointer to new container
    */
-  std::unique_ptr<autopas::ParticleContainerInterface<Particle>> generateContainer(ContainerOption containerChoice,
+  std::unique_ptr<autopas::ParticleContainerInterface<ParticleT>> generateContainer(ContainerOption containerChoice,
                                                                                    ContainerSelectorInfo containerInfo);
 
   std::array<double, 3> _boxMin, _boxMax;
   const double _cutoff;
-  std::unique_ptr<autopas::ParticleContainerInterface<Particle>> _currentContainer;
+  std::unique_ptr<autopas::ParticleContainerInterface<ParticleT>> _currentContainer;
   ContainerSelectorInfo _currentInfo;
 };
 
-template <class Particle>
-std::unique_ptr<autopas::ParticleContainerInterface<Particle>> ContainerSelector<Particle>::generateContainer(
+template <class ParticleT>
+std::unique_ptr<autopas::ParticleContainerInterface<ParticleT>> ContainerSelector<ParticleT>::generateContainer(
     ContainerOption containerChoice, ContainerSelectorInfo containerInfo) {
-  std::unique_ptr<autopas::ParticleContainerInterface<Particle>> container;
+  std::unique_ptr<autopas::ParticleContainerInterface<ParticleT>> container;
   switch (containerChoice) {
     case ContainerOption::directSum: {
-      container = std::make_unique<DirectSum<Particle>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin,
+      container = std::make_unique<DirectSum<ParticleT>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin,
                                                         containerInfo.verletRebuildFrequency);
       break;
     }
 
     case ContainerOption::linkedCells: {
-      container = std::make_unique<LinkedCells<Particle>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin,
+      container = std::make_unique<LinkedCells<ParticleT>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin,
                                                           containerInfo.verletRebuildFrequency,
                                                           containerInfo.cellSizeFactor, containerInfo.loadEstimator);
       break;
     }
     case ContainerOption::linkedCellsReferences: {
-      container = std::make_unique<LinkedCellsReferences<Particle>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin,
+      container = std::make_unique<LinkedCellsReferences<ParticleT>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin,
                                                                     containerInfo.verletRebuildFrequency,
                                                                     containerInfo.cellSizeFactor);
       break;
     }
     case ContainerOption::verletLists: {
-      container = std::make_unique<VerletLists<Particle>>(
+      container = std::make_unique<VerletLists<ParticleT>>(
           _boxMin, _boxMax, _cutoff, containerInfo.verletSkin, containerInfo.verletRebuildFrequency,
-          VerletLists<Particle>::BuildVerletListType::VerletSoA, containerInfo.cellSizeFactor);
+          VerletLists<ParticleT>::BuildVerletListType::VerletSoA, containerInfo.cellSizeFactor);
       break;
     }
     case ContainerOption::verletListsCells: {
-      container = std::make_unique<VerletListsCells<Particle, VLCAllCellsNeighborList<Particle>>>(
+      container = std::make_unique<VerletListsCells<ParticleT, VLCAllCellsNeighborList<ParticleT>>>(
           _boxMin, _boxMax, _cutoff, containerInfo.verletSkin, containerInfo.verletRebuildFrequency,
           containerInfo.cellSizeFactor, containerInfo.loadEstimator, VerletListsCellsHelpers::VLCBuildType::soaBuild);
       break;
     }
     case ContainerOption::verletClusterLists: {
-      container = std::make_unique<VerletClusterLists<Particle>>(
+      container = std::make_unique<VerletClusterLists<ParticleT>>(
           _boxMin, _boxMax, _cutoff, containerInfo.verletSkin, containerInfo.verletRebuildFrequency,
           containerInfo.verletClusterSize, containerInfo.loadEstimator);
       break;
     }
     case ContainerOption::varVerletListsAsBuild: {
-      container = std::make_unique<VarVerletLists<Particle, VerletNeighborListAsBuild<Particle>>>(
+      container = std::make_unique<VarVerletLists<ParticleT, VerletNeighborListAsBuild<ParticleT>>>(
           _boxMin, _boxMax, _cutoff, containerInfo.verletSkin, containerInfo.verletRebuildFrequency,
           containerInfo.cellSizeFactor);
       break;
     }
 
     case ContainerOption::pairwiseVerletLists: {
-      container = std::make_unique<VerletListsCells<Particle, VLCCellPairNeighborList<Particle>>>(
+      container = std::make_unique<VerletListsCells<ParticleT, VLCCellPairNeighborList<ParticleT>>>(
           _boxMin, _boxMax, _cutoff, containerInfo.verletSkin, containerInfo.verletRebuildFrequency,
           containerInfo.cellSizeFactor, containerInfo.loadEstimator, VerletListsCellsHelpers::VLCBuildType::soaBuild);
       break;
     }
     case ContainerOption::octree: {
       container =
-          std::make_unique<Octree<Particle>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin,
+          std::make_unique<Octree<ParticleT>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin,
                                              containerInfo.verletRebuildFrequency, containerInfo.cellSizeFactor);
       break;
     }
@@ -184,8 +184,8 @@ std::unique_ptr<autopas::ParticleContainerInterface<Particle>> ContainerSelector
   return container;
 }
 
-template <class Particle>
-autopas::ParticleContainerInterface<Particle> &ContainerSelector<Particle>::getCurrentContainer() {
+template <class ParticleT>
+autopas::ParticleContainerInterface<ParticleT> &ContainerSelector<ParticleT>::getCurrentContainer() {
   if (_currentContainer == nullptr) {
     autopas::utils::ExceptionHandler::exception(
         "ContainerSelector: getCurrentContainer() called before any container was selected!");
@@ -193,8 +193,8 @@ autopas::ParticleContainerInterface<Particle> &ContainerSelector<Particle>::getC
   return *_currentContainer;
 }
 
-template <class Particle>
-const autopas::ParticleContainerInterface<Particle> &ContainerSelector<Particle>::getCurrentContainer() const {
+template <class ParticleT>
+const autopas::ParticleContainerInterface<ParticleT> &ContainerSelector<ParticleT>::getCurrentContainer() const {
   if (_currentContainer == nullptr) {
     autopas::utils::ExceptionHandler::exception(
         "ContainerSelector: getCurrentContainer() called before any container was selected!");
@@ -202,8 +202,8 @@ const autopas::ParticleContainerInterface<Particle> &ContainerSelector<Particle>
   return *_currentContainer;
 }
 
-template <class Particle>
-void ContainerSelector<Particle>::selectContainer(ContainerOption containerOption,
+template <class ParticleT>
+void ContainerSelector<ParticleT>::selectContainer(ContainerOption containerOption,
                                                   ContainerSelectorInfo containerInfo) {
   // Only do something if we have no container, a new type is required, or the info changed
   if (_currentContainer == nullptr or _currentContainer->getContainerType() != containerOption or

--- a/src/autopas/tuning/selectors/ContainerSelector.h
+++ b/src/autopas/tuning/selectors/ContainerSelector.h
@@ -33,10 +33,10 @@ namespace autopas {
  * The class is given a list of allowed container and traversal options to choose from.
  * This class selects the optimal container and delegates the choice of the optimal traversal down to this container.
  *
- * @tparam ParticleT
+ * @tparam Particle_T
  * @tparam ParticleCell
  */
-template <class ParticleT>
+template <class Particle_T>
 class ContainerSelector {
  public:
   /**
@@ -71,13 +71,13 @@ class ContainerSelector {
    * Getter for the optimal container. If no container is chosen yet the first allowed is selected.
    * @return Reference to the optimal container.
    */
-  inline autopas::ParticleContainerInterface<ParticleT> &getCurrentContainer();
+  inline autopas::ParticleContainerInterface<Particle_T> &getCurrentContainer();
 
   /**
    * Getter for the optimal container. If no container is chosen yet the first allowed is selected.
    * @return Reference to the optimal container.
    */
-  inline const autopas::ParticleContainerInterface<ParticleT> &getCurrentContainer() const;
+  inline const autopas::ParticleContainerInterface<Particle_T> &getCurrentContainer() const;
 
  private:
   /**
@@ -86,73 +86,73 @@ class ContainerSelector {
    * @param containerInfo additional parameter for the container
    * @return Smartpointer to new container
    */
-  std::unique_ptr<autopas::ParticleContainerInterface<ParticleT>> generateContainer(
+  std::unique_ptr<autopas::ParticleContainerInterface<Particle_T>> generateContainer(
       ContainerOption containerChoice, ContainerSelectorInfo containerInfo);
 
   std::array<double, 3> _boxMin, _boxMax;
   const double _cutoff;
-  std::unique_ptr<autopas::ParticleContainerInterface<ParticleT>> _currentContainer;
+  std::unique_ptr<autopas::ParticleContainerInterface<Particle_T>> _currentContainer;
   ContainerSelectorInfo _currentInfo;
 };
 
-template <class ParticleT>
-std::unique_ptr<autopas::ParticleContainerInterface<ParticleT>> ContainerSelector<ParticleT>::generateContainer(
+template <class Particle_T>
+std::unique_ptr<autopas::ParticleContainerInterface<Particle_T>> ContainerSelector<Particle_T>::generateContainer(
     ContainerOption containerChoice, ContainerSelectorInfo containerInfo) {
-  std::unique_ptr<autopas::ParticleContainerInterface<ParticleT>> container;
+  std::unique_ptr<autopas::ParticleContainerInterface<Particle_T>> container;
   switch (containerChoice) {
     case ContainerOption::directSum: {
-      container = std::make_unique<DirectSum<ParticleT>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin,
-                                                         containerInfo.verletRebuildFrequency);
+      container = std::make_unique<DirectSum<Particle_T>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin,
+                                                          containerInfo.verletRebuildFrequency);
       break;
     }
 
     case ContainerOption::linkedCells: {
-      container = std::make_unique<LinkedCells<ParticleT>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin,
-                                                           containerInfo.verletRebuildFrequency,
-                                                           containerInfo.cellSizeFactor, containerInfo.loadEstimator);
+      container = std::make_unique<LinkedCells<Particle_T>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin,
+                                                            containerInfo.verletRebuildFrequency,
+                                                            containerInfo.cellSizeFactor, containerInfo.loadEstimator);
       break;
     }
     case ContainerOption::linkedCellsReferences: {
-      container = std::make_unique<LinkedCellsReferences<ParticleT>>(
+      container = std::make_unique<LinkedCellsReferences<Particle_T>>(
           _boxMin, _boxMax, _cutoff, containerInfo.verletSkin, containerInfo.verletRebuildFrequency,
           containerInfo.cellSizeFactor);
       break;
     }
     case ContainerOption::verletLists: {
-      container = std::make_unique<VerletLists<ParticleT>>(
+      container = std::make_unique<VerletLists<Particle_T>>(
           _boxMin, _boxMax, _cutoff, containerInfo.verletSkin, containerInfo.verletRebuildFrequency,
-          VerletLists<ParticleT>::BuildVerletListType::VerletSoA, containerInfo.cellSizeFactor);
+          VerletLists<Particle_T>::BuildVerletListType::VerletSoA, containerInfo.cellSizeFactor);
       break;
     }
     case ContainerOption::verletListsCells: {
-      container = std::make_unique<VerletListsCells<ParticleT, VLCAllCellsNeighborList<ParticleT>>>(
+      container = std::make_unique<VerletListsCells<Particle_T, VLCAllCellsNeighborList<Particle_T>>>(
           _boxMin, _boxMax, _cutoff, containerInfo.verletSkin, containerInfo.verletRebuildFrequency,
           containerInfo.cellSizeFactor, containerInfo.loadEstimator, VerletListsCellsHelpers::VLCBuildType::soaBuild);
       break;
     }
     case ContainerOption::verletClusterLists: {
-      container = std::make_unique<VerletClusterLists<ParticleT>>(
+      container = std::make_unique<VerletClusterLists<Particle_T>>(
           _boxMin, _boxMax, _cutoff, containerInfo.verletSkin, containerInfo.verletRebuildFrequency,
           containerInfo.verletClusterSize, containerInfo.loadEstimator);
       break;
     }
     case ContainerOption::varVerletListsAsBuild: {
-      container = std::make_unique<VarVerletLists<ParticleT, VerletNeighborListAsBuild<ParticleT>>>(
+      container = std::make_unique<VarVerletLists<Particle_T, VerletNeighborListAsBuild<Particle_T>>>(
           _boxMin, _boxMax, _cutoff, containerInfo.verletSkin, containerInfo.verletRebuildFrequency,
           containerInfo.cellSizeFactor);
       break;
     }
 
     case ContainerOption::pairwiseVerletLists: {
-      container = std::make_unique<VerletListsCells<ParticleT, VLCCellPairNeighborList<ParticleT>>>(
+      container = std::make_unique<VerletListsCells<Particle_T, VLCCellPairNeighborList<Particle_T>>>(
           _boxMin, _boxMax, _cutoff, containerInfo.verletSkin, containerInfo.verletRebuildFrequency,
           containerInfo.cellSizeFactor, containerInfo.loadEstimator, VerletListsCellsHelpers::VLCBuildType::soaBuild);
       break;
     }
     case ContainerOption::octree: {
       container =
-          std::make_unique<Octree<ParticleT>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin,
-                                              containerInfo.verletRebuildFrequency, containerInfo.cellSizeFactor);
+          std::make_unique<Octree<Particle_T>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin,
+                                               containerInfo.verletRebuildFrequency, containerInfo.cellSizeFactor);
       break;
     }
     default: {
@@ -184,8 +184,8 @@ std::unique_ptr<autopas::ParticleContainerInterface<ParticleT>> ContainerSelecto
   return container;
 }
 
-template <class ParticleT>
-autopas::ParticleContainerInterface<ParticleT> &ContainerSelector<ParticleT>::getCurrentContainer() {
+template <class Particle_T>
+autopas::ParticleContainerInterface<Particle_T> &ContainerSelector<Particle_T>::getCurrentContainer() {
   if (_currentContainer == nullptr) {
     autopas::utils::ExceptionHandler::exception(
         "ContainerSelector: getCurrentContainer() called before any container was selected!");
@@ -193,8 +193,8 @@ autopas::ParticleContainerInterface<ParticleT> &ContainerSelector<ParticleT>::ge
   return *_currentContainer;
 }
 
-template <class ParticleT>
-const autopas::ParticleContainerInterface<ParticleT> &ContainerSelector<ParticleT>::getCurrentContainer() const {
+template <class Particle_T>
+const autopas::ParticleContainerInterface<Particle_T> &ContainerSelector<Particle_T>::getCurrentContainer() const {
   if (_currentContainer == nullptr) {
     autopas::utils::ExceptionHandler::exception(
         "ContainerSelector: getCurrentContainer() called before any container was selected!");
@@ -202,9 +202,9 @@ const autopas::ParticleContainerInterface<ParticleT> &ContainerSelector<Particle
   return *_currentContainer;
 }
 
-template <class ParticleT>
-void ContainerSelector<ParticleT>::selectContainer(ContainerOption containerOption,
-                                                   ContainerSelectorInfo containerInfo) {
+template <class Particle_T>
+void ContainerSelector<Particle_T>::selectContainer(ContainerOption containerOption,
+                                                    ContainerSelectorInfo containerInfo) {
   // Only do something if we have no container, a new type is required, or the info changed
   if (_currentContainer == nullptr or _currentContainer->getContainerType() != containerOption or
       _currentInfo != containerInfo) {

--- a/src/autopas/tuning/selectors/ContainerSelector.h
+++ b/src/autopas/tuning/selectors/ContainerSelector.h
@@ -86,8 +86,8 @@ class ContainerSelector {
    * @param containerInfo additional parameter for the container
    * @return Smartpointer to new container
    */
-  std::unique_ptr<autopas::ParticleContainerInterface<ParticleT>> generateContainer(ContainerOption containerChoice,
-                                                                                   ContainerSelectorInfo containerInfo);
+  std::unique_ptr<autopas::ParticleContainerInterface<ParticleT>> generateContainer(
+      ContainerOption containerChoice, ContainerSelectorInfo containerInfo);
 
   std::array<double, 3> _boxMin, _boxMax;
   const double _cutoff;
@@ -102,20 +102,20 @@ std::unique_ptr<autopas::ParticleContainerInterface<ParticleT>> ContainerSelecto
   switch (containerChoice) {
     case ContainerOption::directSum: {
       container = std::make_unique<DirectSum<ParticleT>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin,
-                                                        containerInfo.verletRebuildFrequency);
+                                                         containerInfo.verletRebuildFrequency);
       break;
     }
 
     case ContainerOption::linkedCells: {
       container = std::make_unique<LinkedCells<ParticleT>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin,
-                                                          containerInfo.verletRebuildFrequency,
-                                                          containerInfo.cellSizeFactor, containerInfo.loadEstimator);
+                                                           containerInfo.verletRebuildFrequency,
+                                                           containerInfo.cellSizeFactor, containerInfo.loadEstimator);
       break;
     }
     case ContainerOption::linkedCellsReferences: {
-      container = std::make_unique<LinkedCellsReferences<ParticleT>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin,
-                                                                    containerInfo.verletRebuildFrequency,
-                                                                    containerInfo.cellSizeFactor);
+      container = std::make_unique<LinkedCellsReferences<ParticleT>>(
+          _boxMin, _boxMax, _cutoff, containerInfo.verletSkin, containerInfo.verletRebuildFrequency,
+          containerInfo.cellSizeFactor);
       break;
     }
     case ContainerOption::verletLists: {
@@ -152,7 +152,7 @@ std::unique_ptr<autopas::ParticleContainerInterface<ParticleT>> ContainerSelecto
     case ContainerOption::octree: {
       container =
           std::make_unique<Octree<ParticleT>>(_boxMin, _boxMax, _cutoff, containerInfo.verletSkin,
-                                             containerInfo.verletRebuildFrequency, containerInfo.cellSizeFactor);
+                                              containerInfo.verletRebuildFrequency, containerInfo.cellSizeFactor);
       break;
     }
     default: {
@@ -204,7 +204,7 @@ const autopas::ParticleContainerInterface<ParticleT> &ContainerSelector<Particle
 
 template <class ParticleT>
 void ContainerSelector<ParticleT>::selectContainer(ContainerOption containerOption,
-                                                  ContainerSelectorInfo containerInfo) {
+                                                   ContainerSelectorInfo containerInfo) {
   // Only do something if we have no container, a new type is required, or the info changed
   if (_currentContainer == nullptr or _currentContainer->getContainerType() != containerOption or
       _currentInfo != containerInfo) {

--- a/src/autopas/tuning/tuningStrategy/LiveInfo.h
+++ b/src/autopas/tuning/tuningStrategy/LiveInfo.h
@@ -71,14 +71,14 @@ class LiveInfo {
    * - threadCount: The number of threads that can be used.
    * - rebuildFrequency: The current verlet-rebuild-frequency of the simulation.
    *
-   * @tparam ParticleT The type of particle the container stores.
+   * @tparam Particle_T The type of particle the container stores.
    * @tparam PairwiseFunctor The type of functor.
    * @param container The container to gather the infos from.
    * @param functor The functor to gather the infos from.
    * @param rebuildFrequency The current verlet rebuild frequency that is used in the simulation.
    */
-  template <class ParticleT, class PairwiseFunctor>
-  void gather(const autopas::ParticleContainerInterface<ParticleT> &container, const PairwiseFunctor &functor,
+  template <class Particle_T, class PairwiseFunctor>
+  void gather(const autopas::ParticleContainerInterface<Particle_T> &container, const PairwiseFunctor &functor,
               unsigned int rebuildFrequency) {
     using namespace autopas::utils::ArrayMath::literals;
     using autopas::utils::ArrayMath::ceilToInt;
@@ -101,7 +101,7 @@ class LiveInfo {
     infos["domainSizeY"] = domainSize[1];
     infos["domainSizeZ"] = domainSize[2];
 
-    infos["particleSize"] = sizeof(ParticleT);
+    infos["particleSize"] = sizeof(Particle_T);
 
     // Calculate number of cells for a linked cells container, assuming cell size factor == 1
     const auto cellsPerDim = ceilToInt(domainSize * cutoffInv);
@@ -116,7 +116,7 @@ class LiveInfo {
     std::vector<size_t> particleBinsBlurred;
     particleBinsBlurred.resize(27);
     const auto blurredCellDimsReciproc = std::array<double, 3>{3.0, 3.0, 3.0} / domainSize;
-    for (const ParticleT &particle : container) {
+    for (const Particle_T &particle : container) {
       if (utils::inBox(particle.getR(), boxMin, boxMax)) {
         // find the actual cell
         const auto offsetIntoBox = particle.getR() - boxMin;
@@ -211,7 +211,7 @@ class LiveInfo {
 
     infos["threadCount"] = static_cast<size_t>(autopas::autopas_get_max_threads());
 
-    constexpr size_t particleSizeNeededByFunctor = calculateParticleSizeNeededByFunctor<ParticleT, PairwiseFunctor>(
+    constexpr size_t particleSizeNeededByFunctor = calculateParticleSizeNeededByFunctor<Particle_T, PairwiseFunctor>(
         std::make_index_sequence<PairwiseFunctor::getNeededAttr().size()>());
     infos["particleSizeNeededByFunctor"] = particleSizeNeededByFunctor;
   }
@@ -331,16 +331,16 @@ class LiveInfo {
   /**
    * Private helper to calculate the particle size needed by a functor. This is the sum of the size of the type of all
    * needed attributes.
-   * @tparam ParticleT The type of the Particle
+   * @tparam Particle_T The type of the Particle
    * @tparam PairwiseFunctor The Functor
    * @tparam Idx An index sequence for all elements of PairwiseFunctor::getNeededAttr() elements.
    * @return The number of bytes needed by the information of a particle the functor needs.
    */
-  template <class ParticleT, class PairwiseFunctor, size_t... Idx>
+  template <class Particle_T, class PairwiseFunctor, size_t... Idx>
   constexpr static auto calculateParticleSizeNeededByFunctor(std::index_sequence<Idx...>) {
     return (0 + ... +
             sizeof(typename std::tuple_element<PairwiseFunctor::getNeededAttr()[Idx],
-                                               typename ParticleT::SoAArraysType>::type::value_type));
+                                               typename Particle_T::SoAArraysType>::type::value_type));
   }
 
   /**

--- a/src/autopas/tuning/tuningStrategy/LiveInfo.h
+++ b/src/autopas/tuning/tuningStrategy/LiveInfo.h
@@ -71,14 +71,14 @@ class LiveInfo {
    * - threadCount: The number of threads that can be used.
    * - rebuildFrequency: The current verlet-rebuild-frequency of the simulation.
    *
-   * @tparam Particle The type of particle the container stores.
+   * @tparam ParticleT The type of particle the container stores.
    * @tparam PairwiseFunctor The type of functor.
    * @param container The container to gather the infos from.
    * @param functor The functor to gather the infos from.
    * @param rebuildFrequency The current verlet rebuild frequency that is used in the simulation.
    */
-  template <class Particle, class PairwiseFunctor>
-  void gather(const autopas::ParticleContainerInterface<Particle> &container, const PairwiseFunctor &functor,
+  template <class ParticleT, class PairwiseFunctor>
+  void gather(const autopas::ParticleContainerInterface<ParticleT> &container, const PairwiseFunctor &functor,
               unsigned int rebuildFrequency) {
     using namespace autopas::utils::ArrayMath::literals;
     using autopas::utils::ArrayMath::ceilToInt;
@@ -101,7 +101,7 @@ class LiveInfo {
     infos["domainSizeY"] = domainSize[1];
     infos["domainSizeZ"] = domainSize[2];
 
-    infos["particleSize"] = sizeof(Particle);
+    infos["particleSize"] = sizeof(ParticleT);
 
     // Calculate number of cells for a linked cells container, assuming cell size factor == 1
     const auto cellsPerDim = ceilToInt(domainSize * cutoffInv);
@@ -116,7 +116,7 @@ class LiveInfo {
     std::vector<size_t> particleBinsBlurred;
     particleBinsBlurred.resize(27);
     const auto blurredCellDimsReciproc = std::array<double, 3>{3.0, 3.0, 3.0} / domainSize;
-    for (const Particle &particle : container) {
+    for (const ParticleT &particle : container) {
       if (utils::inBox(particle.getR(), boxMin, boxMax)) {
         // find the actual cell
         const auto offsetIntoBox = particle.getR() - boxMin;
@@ -211,7 +211,7 @@ class LiveInfo {
 
     infos["threadCount"] = static_cast<size_t>(autopas::autopas_get_max_threads());
 
-    constexpr size_t particleSizeNeededByFunctor = calculateParticleSizeNeededByFunctor<Particle, PairwiseFunctor>(
+    constexpr size_t particleSizeNeededByFunctor = calculateParticleSizeNeededByFunctor<ParticleT, PairwiseFunctor>(
         std::make_index_sequence<PairwiseFunctor::getNeededAttr().size()>());
     infos["particleSizeNeededByFunctor"] = particleSizeNeededByFunctor;
   }
@@ -331,16 +331,16 @@ class LiveInfo {
   /**
    * Private helper to calculate the particle size needed by a functor. This is the sum of the size of the type of all
    * needed attributes.
-   * @tparam Particle The type of the Particle
+   * @tparam ParticleT The type of the Particle
    * @tparam PairwiseFunctor The Functor
    * @tparam Idx An index sequence for all elements of PairwiseFunctor::getNeededAttr() elements.
    * @return The number of bytes needed by the information of a particle the functor needs.
    */
-  template <class Particle, class PairwiseFunctor, size_t... Idx>
+  template <class ParticleT, class PairwiseFunctor, size_t... Idx>
   constexpr static auto calculateParticleSizeNeededByFunctor(std::index_sequence<Idx...>) {
     return (0 + ... +
             sizeof(typename std::tuple_element<PairwiseFunctor::getNeededAttr()[Idx],
-                                               typename Particle::SoAArraysType>::type::value_type));
+                                               typename ParticleT::SoAArraysType>::type::value_type));
   }
 
   /**

--- a/src/autopas/utils/ParticleTypeTrait.h
+++ b/src/autopas/utils/ParticleTypeTrait.h
@@ -6,7 +6,7 @@
 
 #pragma once
 namespace autopas {
-template <class Particle>
+template <class ParticleT>
 class AutoPas;
 namespace utils {
 
@@ -38,15 +38,15 @@ struct ParticleTypeTrait<std::vector<ParticleCell>> {
 
 /**
  * Specialization for the AutoPas class.
- * @tparam Particle
+ * @tparam ParticleT
  * @tparam ParticleCell
  */
-template <class Particle>
-struct ParticleTypeTrait<autopas::AutoPas<Particle>> {
+template <class ParticleT>
+struct ParticleTypeTrait<autopas::AutoPas<ParticleT>> {
   /**
    * The Particle Type.
    */
-  using value = Particle;
+  using value = ParticleT;
 };
 }  // namespace utils
 }  // namespace autopas

--- a/src/autopas/utils/ParticleTypeTrait.h
+++ b/src/autopas/utils/ParticleTypeTrait.h
@@ -6,7 +6,7 @@
 
 #pragma once
 namespace autopas {
-template <class ParticleT>
+template <class Particle_T>
 class AutoPas;
 namespace utils {
 
@@ -38,15 +38,15 @@ struct ParticleTypeTrait<std::vector<ParticleCell>> {
 
 /**
  * Specialization for the AutoPas class.
- * @tparam ParticleT
+ * @tparam Particle_T
  * @tparam ParticleCell
  */
-template <class ParticleT>
-struct ParticleTypeTrait<autopas::AutoPas<ParticleT>> {
+template <class Particle_T>
+struct ParticleTypeTrait<autopas::AutoPas<Particle_T>> {
   /**
    * The Particle Type.
    */
-  using value = ParticleT;
+  using value = Particle_T;
 };
 }  // namespace utils
 }  // namespace autopas

--- a/src/autopas/utils/StaticContainerSelector.h
+++ b/src/autopas/utils/StaticContainerSelector.h
@@ -21,7 +21,7 @@ namespace autopas {
 /**
  * Will execute the passed function body with the static container type of container.
  *
- * @tparam ParticleT
+ * @tparam Particle_T
  * @tparam ParticleCell
  * @tparam FunctionType
  * @param container The container to be used.
@@ -29,31 +29,31 @@ namespace autopas {
  * E.g: [&](auto &container){container->doSth();}  // The & is optional here. The auto is necessary!
  * @return Returns whatever function returns.
  */
-template <typename ParticleT, typename FunctionType>
-decltype(auto) withStaticContainerType(autopas::ParticleContainerInterface<ParticleT> &container,
+template <typename Particle_T, typename FunctionType>
+decltype(auto) withStaticContainerType(autopas::ParticleContainerInterface<Particle_T> &container,
                                        FunctionType &&function) {
   switch (container.getContainerType()) {
     case ContainerOption::directSum:
-      return function(dynamic_cast<autopas::DirectSum<ParticleT> &>(container));
+      return function(dynamic_cast<autopas::DirectSum<Particle_T> &>(container));
     case ContainerOption::linkedCells:
-      return function(dynamic_cast<autopas::LinkedCells<ParticleT> &>(container));
+      return function(dynamic_cast<autopas::LinkedCells<Particle_T> &>(container));
     case ContainerOption::linkedCellsReferences:
-      return function(dynamic_cast<autopas::LinkedCellsReferences<ParticleT> &>(container));
+      return function(dynamic_cast<autopas::LinkedCellsReferences<Particle_T> &>(container));
     case ContainerOption::verletLists:
-      return function(dynamic_cast<autopas::VerletLists<ParticleT> &>(container));
+      return function(dynamic_cast<autopas::VerletLists<Particle_T> &>(container));
     case ContainerOption::verletListsCells:
       return function(
-          dynamic_cast<autopas::VerletListsCells<ParticleT, VLCAllCellsNeighborList<ParticleT>> &>(container));
+          dynamic_cast<autopas::VerletListsCells<Particle_T, VLCAllCellsNeighborList<Particle_T>> &>(container));
     case ContainerOption::verletClusterLists:
-      return function(dynamic_cast<autopas::VerletClusterLists<ParticleT> &>(container));
+      return function(dynamic_cast<autopas::VerletClusterLists<Particle_T> &>(container));
     case ContainerOption::pairwiseVerletLists:
       return function(
-          dynamic_cast<autopas::VerletListsCells<ParticleT, VLCCellPairNeighborList<ParticleT>> &>(container));
+          dynamic_cast<autopas::VerletListsCells<Particle_T, VLCCellPairNeighborList<Particle_T>> &>(container));
     case ContainerOption::varVerletListsAsBuild:
       return function(
-          dynamic_cast<autopas::VarVerletLists<ParticleT, VerletNeighborListAsBuild<ParticleT>> &>(container));
+          dynamic_cast<autopas::VarVerletLists<Particle_T, VerletNeighborListAsBuild<Particle_T>> &>(container));
     case ContainerOption::octree:
-      return function(dynamic_cast<autopas::Octree<ParticleT> &>(container));
+      return function(dynamic_cast<autopas::Octree<Particle_T> &>(container));
   }
   autopas::utils::ExceptionHandler::exception("Unknown type of container in StaticContainerSelector.h. Type: {}",
                                               container.getContainerType());

--- a/src/autopas/utils/StaticContainerSelector.h
+++ b/src/autopas/utils/StaticContainerSelector.h
@@ -21,7 +21,7 @@ namespace autopas {
 /**
  * Will execute the passed function body with the static container type of container.
  *
- * @tparam Particle
+ * @tparam ParticleT
  * @tparam ParticleCell
  * @tparam FunctionType
  * @param container The container to be used.
@@ -29,31 +29,31 @@ namespace autopas {
  * E.g: [&](auto &container){container->doSth();}  // The & is optional here. The auto is necessary!
  * @return Returns whatever function returns.
  */
-template <typename Particle, typename FunctionType>
-decltype(auto) withStaticContainerType(autopas::ParticleContainerInterface<Particle> &container,
+template <typename ParticleT, typename FunctionType>
+decltype(auto) withStaticContainerType(autopas::ParticleContainerInterface<ParticleT> &container,
                                        FunctionType &&function) {
   switch (container.getContainerType()) {
     case ContainerOption::directSum:
-      return function(dynamic_cast<autopas::DirectSum<Particle> &>(container));
+      return function(dynamic_cast<autopas::DirectSum<ParticleT> &>(container));
     case ContainerOption::linkedCells:
-      return function(dynamic_cast<autopas::LinkedCells<Particle> &>(container));
+      return function(dynamic_cast<autopas::LinkedCells<ParticleT> &>(container));
     case ContainerOption::linkedCellsReferences:
-      return function(dynamic_cast<autopas::LinkedCellsReferences<Particle> &>(container));
+      return function(dynamic_cast<autopas::LinkedCellsReferences<ParticleT> &>(container));
     case ContainerOption::verletLists:
-      return function(dynamic_cast<autopas::VerletLists<Particle> &>(container));
+      return function(dynamic_cast<autopas::VerletLists<ParticleT> &>(container));
     case ContainerOption::verletListsCells:
       return function(
-          dynamic_cast<autopas::VerletListsCells<Particle, VLCAllCellsNeighborList<Particle>> &>(container));
+          dynamic_cast<autopas::VerletListsCells<ParticleT, VLCAllCellsNeighborList<ParticleT>> &>(container));
     case ContainerOption::verletClusterLists:
-      return function(dynamic_cast<autopas::VerletClusterLists<Particle> &>(container));
+      return function(dynamic_cast<autopas::VerletClusterLists<ParticleT> &>(container));
     case ContainerOption::pairwiseVerletLists:
       return function(
-          dynamic_cast<autopas::VerletListsCells<Particle, VLCCellPairNeighborList<Particle>> &>(container));
+          dynamic_cast<autopas::VerletListsCells<ParticleT, VLCCellPairNeighborList<ParticleT>> &>(container));
     case ContainerOption::varVerletListsAsBuild:
       return function(
-          dynamic_cast<autopas::VarVerletLists<Particle, VerletNeighborListAsBuild<Particle>> &>(container));
+          dynamic_cast<autopas::VarVerletLists<ParticleT, VerletNeighborListAsBuild<ParticleT>> &>(container));
     case ContainerOption::octree:
-      return function(dynamic_cast<autopas::Octree<Particle> &>(container));
+      return function(dynamic_cast<autopas::Octree<ParticleT> &>(container));
   }
   autopas::utils::ExceptionHandler::exception("Unknown type of container in StaticContainerSelector.h. Type: {}",
                                               container.getContainerType());

--- a/src/autopas/utils/checkFunctorType.h
+++ b/src/autopas/utils/checkFunctorType.h
@@ -18,12 +18,12 @@ namespace {
 std::false_type isPairwiseFunctorImpl(...);
 /**
  * Return true for a PairwiseFunctor type
- * @tparam ParticleT
+ * @tparam Particle_T
  * @tparam FunctorT
  * @return true
  */
-template <typename ParticleT, typename FunctorT>
-std::true_type isPairwiseFunctorImpl(const autopas::PairwiseFunctor<ParticleT, FunctorT> &);
+template <typename Particle_T, typename FunctorT>
+std::true_type isPairwiseFunctorImpl(const autopas::PairwiseFunctor<Particle_T, FunctorT> &);
 
 /**
  * Returns false for any types that are not a TriwiseFunctor
@@ -32,12 +32,12 @@ std::true_type isPairwiseFunctorImpl(const autopas::PairwiseFunctor<ParticleT, F
 std::false_type isTriwiseFunctorImpl(...);
 /**
  * Return true for a TriwiseFunctor type
- * @tparam ParticleT
+ * @tparam Particle_T
  * @tparam FunctorT
  * @return true
  */
-template <typename ParticleT, typename FunctorT>
-std::true_type isTriwiseFunctorImpl(const autopas::TriwiseFunctor<ParticleT, FunctorT> &);
+template <typename Particle_T, typename FunctorT>
+std::true_type isTriwiseFunctorImpl(const autopas::TriwiseFunctor<Particle_T, FunctorT> &);
 }  // namespace
 
 namespace autopas::utils {

--- a/src/autopas/utils/logging/OctreeLogger.h
+++ b/src/autopas/utils/logging/OctreeLogger.h
@@ -19,9 +19,9 @@
 namespace autopas {
 /**
  * Log an octree to a .vtk file
- * @tparam ParticleT The enclosed particle type
+ * @tparam Particle_T The enclosed particle type
  */
-template <typename ParticleT>
+template <typename Particle_T>
 class OctreeLogger {
  public:
   /**
@@ -38,13 +38,13 @@ class OctreeLogger {
    * Write the octree below the wrapper to a .vtk file
    * @param wrapper A pointer to the octree node wrapper
    */
-  void logTree(OctreeNodeWrapper<ParticleT> *wrapper) { logTree(wrapper->getRaw()); }
+  void logTree(OctreeNodeWrapper<Particle_T> *wrapper) { logTree(wrapper->getRaw()); }
 
   /**
    * This function writes the octree to a .vtk file
    * @param root A pointer to the octree root node
    */
-  void logTree(OctreeNodeInterface<ParticleT> *root) {
+  void logTree(OctreeNodeInterface<Particle_T> *root) {
     // Load the leaf boxes
     using Position = std::array<double, 3>;
     using Box = std::pair<Position, Position>;
@@ -148,7 +148,7 @@ class OctreeLogger {
    * @param leaves A list of octree leaves that are echoed into the JSON file
    * @return The FILE pointer is just passed through
    */
-  static FILE *leavesToJSON(FILE *out, std::vector<OctreeLeafNode<ParticleT> *> &leaves) {
+  static FILE *leavesToJSON(FILE *out, std::vector<OctreeLeafNode<Particle_T> *> &leaves) {
     if (out) {
       fprintf(out, "[\n");
       for (int leafIndex = 0; leafIndex < leaves.size(); ++leafIndex) {
@@ -270,19 +270,19 @@ class OctreeLogger {
    * @param root The root from which the particles should be obtained
    * @return The file pointer
    */
-  static FILE *particlesToJSON(FILE *out, OctreeNodeInterface<ParticleT> *root) {
+  static FILE *particlesToJSON(FILE *out, OctreeNodeInterface<Particle_T> *root) {
     if (out) {
       // Get all leaves
-      std::vector<OctreeLeafNode<ParticleT> *> leaves;
+      std::vector<OctreeLeafNode<Particle_T> *> leaves;
       root->appendAllLeaves(leaves);
 
       fprintf(out, "[");
       for (int leafIndex = 0; leafIndex < leaves.size(); ++leafIndex) {
-        OctreeLeafNode<ParticleT> *leaf = leaves[leafIndex];
+        OctreeLeafNode<Particle_T> *leaf = leaves[leafIndex];
 
         auto n = leaf->size();
         for (int particleIndex = 0; particleIndex < n; ++particleIndex) {
-          ParticleT &particle = leaf->at(particleIndex);
+          Particle_T &particle = leaf->at(particleIndex);
           auto p = particle.getR();
           fputc('[', out);
           out3(out, p[0], p[1], p[2]);
@@ -307,9 +307,9 @@ class OctreeLogger {
    * @param ownedLeaves A list of leaf nodes from the owned octree
    * @param haloLeaves A list of leaf nodes from the halo octree
    */
-  static void octreeToJSON(OctreeNodeInterface<ParticleT> *owned, OctreeNodeInterface<ParticleT> *halo,
-                           std::vector<OctreeLeafNode<ParticleT> *> &ownedLeaves,
-                           std::vector<OctreeLeafNode<ParticleT> *> &haloLeaves) {
+  static void octreeToJSON(OctreeNodeInterface<Particle_T> *owned, OctreeNodeInterface<Particle_T> *halo,
+                           std::vector<OctreeLeafNode<Particle_T> *> &ownedLeaves,
+                           std::vector<OctreeLeafNode<Particle_T> *> &haloLeaves) {
 #if AUTOPAS_LOG_OCTREE
     // Log all owned leaves for this octree
     fclose(OctreeLogger::leavesToJSON(fopen("owned.json", "w"), ownedLeaves));
@@ -355,7 +355,7 @@ class OctreeLogger {
    * @param out The FILE pointer
    * @param node An octree node to obtain the box minimum and maximum coordinates from
    */
-  static void outBoxCoordinatesJSON(FILE *out, OctreeNodeInterface<ParticleT> *node) {
+  static void outBoxCoordinatesJSON(FILE *out, OctreeNodeInterface<Particle_T> *node) {
     const auto min = node->getBoxMin();
     const auto max = node->getBoxMax();
     outLocationArrayJSON(out, min, max);

--- a/src/autopas/utils/logging/OctreeLogger.h
+++ b/src/autopas/utils/logging/OctreeLogger.h
@@ -19,9 +19,9 @@
 namespace autopas {
 /**
  * Log an octree to a .vtk file
- * @tparam Particle The enclosed particle type
+ * @tparam ParticleT The enclosed particle type
  */
-template <typename Particle>
+template <typename ParticleT>
 class OctreeLogger {
  public:
   /**
@@ -38,13 +38,13 @@ class OctreeLogger {
    * Write the octree below the wrapper to a .vtk file
    * @param wrapper A pointer to the octree node wrapper
    */
-  void logTree(OctreeNodeWrapper<Particle> *wrapper) { logTree(wrapper->getRaw()); }
+  void logTree(OctreeNodeWrapper<ParticleT> *wrapper) { logTree(wrapper->getRaw()); }
 
   /**
    * This function writes the octree to a .vtk file
    * @param root A pointer to the octree root node
    */
-  void logTree(OctreeNodeInterface<Particle> *root) {
+  void logTree(OctreeNodeInterface<ParticleT> *root) {
     // Load the leaf boxes
     using Position = std::array<double, 3>;
     using Box = std::pair<Position, Position>;
@@ -148,7 +148,7 @@ class OctreeLogger {
    * @param leaves A list of octree leaves that are echoed into the JSON file
    * @return The FILE pointer is just passed through
    */
-  static FILE *leavesToJSON(FILE *out, std::vector<OctreeLeafNode<Particle> *> &leaves) {
+  static FILE *leavesToJSON(FILE *out, std::vector<OctreeLeafNode<ParticleT> *> &leaves) {
     if (out) {
       fprintf(out, "[\n");
       for (int leafIndex = 0; leafIndex < leaves.size(); ++leafIndex) {
@@ -270,19 +270,19 @@ class OctreeLogger {
    * @param root The root from which the particles should be obtained
    * @return The file pointer
    */
-  static FILE *particlesToJSON(FILE *out, OctreeNodeInterface<Particle> *root) {
+  static FILE *particlesToJSON(FILE *out, OctreeNodeInterface<ParticleT> *root) {
     if (out) {
       // Get all leaves
-      std::vector<OctreeLeafNode<Particle> *> leaves;
+      std::vector<OctreeLeafNode<ParticleT> *> leaves;
       root->appendAllLeaves(leaves);
 
       fprintf(out, "[");
       for (int leafIndex = 0; leafIndex < leaves.size(); ++leafIndex) {
-        OctreeLeafNode<Particle> *leaf = leaves[leafIndex];
+        OctreeLeafNode<ParticleT> *leaf = leaves[leafIndex];
 
         auto n = leaf->size();
         for (int particleIndex = 0; particleIndex < n; ++particleIndex) {
-          Particle &particle = leaf->at(particleIndex);
+          ParticleT &particle = leaf->at(particleIndex);
           auto p = particle.getR();
           fputc('[', out);
           out3(out, p[0], p[1], p[2]);
@@ -307,9 +307,9 @@ class OctreeLogger {
    * @param ownedLeaves A list of leaf nodes from the owned octree
    * @param haloLeaves A list of leaf nodes from the halo octree
    */
-  static void octreeToJSON(OctreeNodeInterface<Particle> *owned, OctreeNodeInterface<Particle> *halo,
-                           std::vector<OctreeLeafNode<Particle> *> &ownedLeaves,
-                           std::vector<OctreeLeafNode<Particle> *> &haloLeaves) {
+  static void octreeToJSON(OctreeNodeInterface<ParticleT> *owned, OctreeNodeInterface<ParticleT> *halo,
+                           std::vector<OctreeLeafNode<ParticleT> *> &ownedLeaves,
+                           std::vector<OctreeLeafNode<ParticleT> *> &haloLeaves) {
 #if AUTOPAS_LOG_OCTREE
     // Log all owned leaves for this octree
     fclose(OctreeLogger::leavesToJSON(fopen("owned.json", "w"), ownedLeaves));
@@ -355,7 +355,7 @@ class OctreeLogger {
    * @param out The FILE pointer
    * @param node An octree node to obtain the box minimum and maximum coordinates from
    */
-  static void outBoxCoordinatesJSON(FILE *out, OctreeNodeInterface<Particle> *node) {
+  static void outBoxCoordinatesJSON(FILE *out, OctreeNodeInterface<ParticleT> *node) {
     const auto min = node->getBoxMin();
     const auto max = node->getBoxMax();
     outLocationArrayJSON(out, min, max);

--- a/src/autopas/utils/markParticleAsDeleted.h
+++ b/src/autopas/utils/markParticleAsDeleted.h
@@ -12,15 +12,15 @@ namespace autopas::internal {
  * Marks a particle as deleted.
  *
  * This function is able to call the private markAsDeleted() function of the particle via a friend declaration.
- * The reason for this is that it should be as hard as possible to call ParticleT::markAsDeleted() from outside of
+ * The reason for this is that it should be as hard as possible to call Particle_T::markAsDeleted() from outside of
  * AutoPas, hence this free function is in the namespace internal.
  *
- * @tparam ParticleT
+ * @tparam Particle_T
  * @param p
  * @note: This function should not be used from outside of AutoPas. Instead, use AutoPas::deleteParticle(iterator).
  */
-template <typename ParticleT>
-void markParticleAsDeleted(ParticleT &p) {
+template <typename Particle_T>
+void markParticleAsDeleted(Particle_T &p) {
   p.markAsDeleted();
 }
 

--- a/src/autopas/utils/markParticleAsDeleted.h
+++ b/src/autopas/utils/markParticleAsDeleted.h
@@ -12,15 +12,15 @@ namespace autopas::internal {
  * Marks a particle as deleted.
  *
  * This function is able to call the private markAsDeleted() function of the particle via a friend declaration.
- * The reason for this is that it should be as hard as possible to call Particle::markAsDeleted() from outside of
+ * The reason for this is that it should be as hard as possible to call ParticleT::markAsDeleted() from outside of
  * AutoPas, hence this free function is in the namespace internal.
  *
- * @tparam Particle
+ * @tparam ParticleT
  * @param p
  * @note: This function should not be used from outside of AutoPas. Instead, use AutoPas::deleteParticle(iterator).
  */
-template <typename Particle>
-void markParticleAsDeleted(Particle &p) {
+template <typename ParticleT>
+void markParticleAsDeleted(ParticleT &p) {
   p.markAsDeleted();
 }
 

--- a/tests/testAutopas/mocks/MockPairwiseFunctor.h
+++ b/tests/testAutopas/mocks/MockPairwiseFunctor.h
@@ -13,44 +13,44 @@
 #include "autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h"
 #include "autopas/options/DataLayoutOption.h"
 
-template <class Particle>
-class MockPairwiseFunctor : public autopas::PairwiseFunctor<Particle, MockPairwiseFunctor<Particle>> {
+template <class ParticleT>
+class MockPairwiseFunctor : public autopas::PairwiseFunctor<ParticleT, MockPairwiseFunctor<ParticleT>> {
  public:
-  MockPairwiseFunctor() : autopas::PairwiseFunctor<Particle, MockPairwiseFunctor<Particle>>(0.){};
-  // virtual void AoSFunctor(Particle &i, Particle &j, bool newton3)
-  MOCK_METHOD(void, AoSFunctor, (Particle & i, Particle &j, bool newton3), (override));
+  MockPairwiseFunctor() : autopas::PairwiseFunctor<ParticleT, MockPairwiseFunctor<ParticleT>>(0.){};
+  // virtual void AoSFunctor(ParticleT &i, ParticleT &j, bool newton3)
+  MOCK_METHOD(void, AoSFunctor, (ParticleT & i, ParticleT &j, bool newton3), (override));
 
   // virtual void SoAFunctorSingle(SoAView &soa, bool newton3)
-  MOCK_METHOD(void, SoAFunctorSingle, (autopas::SoAView<typename Particle::SoAArraysType> soa, bool newton3),
+  MOCK_METHOD(void, SoAFunctorSingle, (autopas::SoAView<typename ParticleT::SoAArraysType> soa, bool newton3),
               (override));
 
   // virtual void SoAFunctorPair(SoAView &soa1, SoAView &soa2, bool newton3)
   MOCK_METHOD(void, SoAFunctorPair,
-              (autopas::SoAView<typename Particle::SoAArraysType> soa,
-               autopas::SoAView<typename Particle::SoAArraysType> soa2, bool newton3),
+              (autopas::SoAView<typename ParticleT::SoAArraysType> soa,
+               autopas::SoAView<typename ParticleT::SoAArraysType> soa2, bool newton3),
               (override));
 
   // virtual void SoAFunctorVerlet(SoAView &soa, const std::vector, (override)<std::vector<size_t,
   // AlignedAllocator<size_t>>> &neighborList, size_t iFrom, size_t iTo, bool newton3)
   MOCK_METHOD(void, SoAFunctorVerlet,
-              (autopas::SoAView<typename Particle::SoAArraysType> soa, size_t indexFirst,
+              (autopas::SoAView<typename ParticleT::SoAArraysType> soa, size_t indexFirst,
                (const std::vector<size_t, autopas::AlignedAllocator<size_t>> &), bool newton3),
               (override));
 
   MOCK_METHOD(void, SoALoader,
-              (autopas::FullParticleCell<Particle> & cell, autopas::SoA<typename Particle::SoAArraysType> &soa,
+              (autopas::FullParticleCell<ParticleT> & cell, autopas::SoA<typename ParticleT::SoAArraysType> &soa,
                size_t offset, bool skipSoAResize));
 
   MOCK_METHOD(void, SoALoader,
-              (autopas::ReferenceParticleCell<Particle> & cell, autopas::SoA<typename Particle::SoAArraysType> &soa,
+              (autopas::ReferenceParticleCell<ParticleT> & cell, autopas::SoA<typename ParticleT::SoAArraysType> &soa,
                size_t offset, bool skipSoAResize));
 
   MOCK_METHOD(void, SoAExtractor,
-              (autopas::FullParticleCell<Particle> & cell, autopas::SoA<typename Particle::SoAArraysType> &soa,
+              (autopas::FullParticleCell<ParticleT> & cell, autopas::SoA<typename ParticleT::SoAArraysType> &soa,
                size_t offset));
 
   MOCK_METHOD(void, SoAExtractor,
-              (autopas::ReferenceParticleCell<Particle> & cell, autopas::SoA<typename Particle::SoAArraysType> &soa,
+              (autopas::ReferenceParticleCell<ParticleT> & cell, autopas::SoA<typename ParticleT::SoAArraysType> &soa,
                size_t offset));
 
   // virtual bool allowsNewton3() { return true; }

--- a/tests/testAutopas/mocks/MockPairwiseFunctor.h
+++ b/tests/testAutopas/mocks/MockPairwiseFunctor.h
@@ -13,44 +13,44 @@
 #include "autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h"
 #include "autopas/options/DataLayoutOption.h"
 
-template <class ParticleT>
-class MockPairwiseFunctor : public autopas::PairwiseFunctor<ParticleT, MockPairwiseFunctor<ParticleT>> {
+template <class Particle_T>
+class MockPairwiseFunctor : public autopas::PairwiseFunctor<Particle_T, MockPairwiseFunctor<Particle_T>> {
  public:
-  MockPairwiseFunctor() : autopas::PairwiseFunctor<ParticleT, MockPairwiseFunctor<ParticleT>>(0.){};
-  // virtual void AoSFunctor(ParticleT &i, ParticleT &j, bool newton3)
-  MOCK_METHOD(void, AoSFunctor, (ParticleT & i, ParticleT &j, bool newton3), (override));
+  MockPairwiseFunctor() : autopas::PairwiseFunctor<Particle_T, MockPairwiseFunctor<Particle_T>>(0.){};
+  // virtual void AoSFunctor(Particle_T &i, Particle_T &j, bool newton3)
+  MOCK_METHOD(void, AoSFunctor, (Particle_T & i, Particle_T &j, bool newton3), (override));
 
   // virtual void SoAFunctorSingle(SoAView &soa, bool newton3)
-  MOCK_METHOD(void, SoAFunctorSingle, (autopas::SoAView<typename ParticleT::SoAArraysType> soa, bool newton3),
+  MOCK_METHOD(void, SoAFunctorSingle, (autopas::SoAView<typename Particle_T::SoAArraysType> soa, bool newton3),
               (override));
 
   // virtual void SoAFunctorPair(SoAView &soa1, SoAView &soa2, bool newton3)
   MOCK_METHOD(void, SoAFunctorPair,
-              (autopas::SoAView<typename ParticleT::SoAArraysType> soa,
-               autopas::SoAView<typename ParticleT::SoAArraysType> soa2, bool newton3),
+              (autopas::SoAView<typename Particle_T::SoAArraysType> soa,
+               autopas::SoAView<typename Particle_T::SoAArraysType> soa2, bool newton3),
               (override));
 
   // virtual void SoAFunctorVerlet(SoAView &soa, const std::vector, (override)<std::vector<size_t,
   // AlignedAllocator<size_t>>> &neighborList, size_t iFrom, size_t iTo, bool newton3)
   MOCK_METHOD(void, SoAFunctorVerlet,
-              (autopas::SoAView<typename ParticleT::SoAArraysType> soa, size_t indexFirst,
+              (autopas::SoAView<typename Particle_T::SoAArraysType> soa, size_t indexFirst,
                (const std::vector<size_t, autopas::AlignedAllocator<size_t>> &), bool newton3),
               (override));
 
   MOCK_METHOD(void, SoALoader,
-              (autopas::FullParticleCell<ParticleT> & cell, autopas::SoA<typename ParticleT::SoAArraysType> &soa,
+              (autopas::FullParticleCell<Particle_T> & cell, autopas::SoA<typename Particle_T::SoAArraysType> &soa,
                size_t offset, bool skipSoAResize));
 
   MOCK_METHOD(void, SoALoader,
-              (autopas::ReferenceParticleCell<ParticleT> & cell, autopas::SoA<typename ParticleT::SoAArraysType> &soa,
+              (autopas::ReferenceParticleCell<Particle_T> & cell, autopas::SoA<typename Particle_T::SoAArraysType> &soa,
                size_t offset, bool skipSoAResize));
 
   MOCK_METHOD(void, SoAExtractor,
-              (autopas::FullParticleCell<ParticleT> & cell, autopas::SoA<typename ParticleT::SoAArraysType> &soa,
+              (autopas::FullParticleCell<Particle_T> & cell, autopas::SoA<typename Particle_T::SoAArraysType> &soa,
                size_t offset));
 
   MOCK_METHOD(void, SoAExtractor,
-              (autopas::ReferenceParticleCell<ParticleT> & cell, autopas::SoA<typename ParticleT::SoAArraysType> &soa,
+              (autopas::ReferenceParticleCell<Particle_T> & cell, autopas::SoA<typename Particle_T::SoAArraysType> &soa,
                size_t offset));
 
   // virtual bool allowsNewton3() { return true; }

--- a/tests/testAutopas/mocks/MockTriwiseFunctor.h
+++ b/tests/testAutopas/mocks/MockTriwiseFunctor.h
@@ -13,51 +13,51 @@
 #include "autopas/cells/ReferenceParticleCell.h"
 #include "autopas/options/DataLayoutOption.h"
 
-template <class ParticleT>
-class MockTriwiseFunctor : public autopas::TriwiseFunctor<ParticleT, MockTriwiseFunctor<ParticleT>> {
+template <class Particle_T>
+class MockTriwiseFunctor : public autopas::TriwiseFunctor<Particle_T, MockTriwiseFunctor<Particle_T>> {
  public:
-  MockTriwiseFunctor() : autopas::TriwiseFunctor<ParticleT, MockTriwiseFunctor<ParticleT>>(0.){};
-  // virtual void AoSFunctor(ParticleT &i, ParticleT &j, bool newton3)
-  MOCK_METHOD(void, AoSFunctor, (ParticleT & i, ParticleT &j, ParticleT &k, bool newton3), (override));
+  MockTriwiseFunctor() : autopas::TriwiseFunctor<Particle_T, MockTriwiseFunctor<Particle_T>>(0.){};
+  // virtual void AoSFunctor(Particle_T &i, Particle_T &j, bool newton3)
+  MOCK_METHOD(void, AoSFunctor, (Particle_T & i, Particle_T &j, Particle_T &k, bool newton3), (override));
 
   // virtual void SoAFunctorSingle(SoAView &soa, bool newton3)
-  MOCK_METHOD(void, SoAFunctorSingle, (autopas::SoAView<typename ParticleT::SoAArraysType> soa, bool newton3),
+  MOCK_METHOD(void, SoAFunctorSingle, (autopas::SoAView<typename Particle_T::SoAArraysType> soa, bool newton3),
               (override));
 
   // virtual void SoAFunctorPair(SoAView &soa1, SoAView &soa2, bool newton3)
   MOCK_METHOD(void, SoAFunctorPair,
-              (autopas::SoAView<typename ParticleT::SoAArraysType> soa1,
-               autopas::SoAView<typename ParticleT::SoAArraysType> soa2, bool newton3),
+              (autopas::SoAView<typename Particle_T::SoAArraysType> soa1,
+               autopas::SoAView<typename Particle_T::SoAArraysType> soa2, bool newton3),
               (override));
 
   // virtual void SoAFunctorPair(SoAView &soa1, SoAView &soa2, bool newton3)
   MOCK_METHOD(void, SoAFunctorTriple,
-              (autopas::SoAView<typename ParticleT::SoAArraysType> soa1,
-               autopas::SoAView<typename ParticleT::SoAArraysType> soa2,
-               autopas::SoAView<typename ParticleT::SoAArraysType> soa3, bool newton3),
+              (autopas::SoAView<typename Particle_T::SoAArraysType> soa1,
+               autopas::SoAView<typename Particle_T::SoAArraysType> soa2,
+               autopas::SoAView<typename Particle_T::SoAArraysType> soa3, bool newton3),
               (override));
 
   // virtual void SoAFunctorVerlet(SoAView &soa, const std::vector, (override)<std::vector<size_t,
   // AlignedAllocator<size_t>>> &neighborList, size_t iFrom, size_t iTo, bool newton3)
   MOCK_METHOD(void, SoAFunctorVerlet,
-              (autopas::SoAView<typename ParticleT::SoAArraysType> soa, size_t indexFirst,
+              (autopas::SoAView<typename Particle_T::SoAArraysType> soa, size_t indexFirst,
                (const std::vector<size_t, autopas::AlignedAllocator<size_t>> &), bool newton3),
               (override));
 
   MOCK_METHOD(void, SoALoader,
-              (autopas::FullParticleCell<ParticleT> & cell, autopas::SoA<typename ParticleT::SoAArraysType> &soa,
+              (autopas::FullParticleCell<Particle_T> & cell, autopas::SoA<typename Particle_T::SoAArraysType> &soa,
                size_t offset, bool skipSoAResize));
 
   MOCK_METHOD(void, SoALoader,
-              (autopas::ReferenceParticleCell<ParticleT> & cell, autopas::SoA<typename ParticleT::SoAArraysType> &soa,
+              (autopas::ReferenceParticleCell<Particle_T> & cell, autopas::SoA<typename Particle_T::SoAArraysType> &soa,
                size_t offset, bool skipSoAResize));
 
   MOCK_METHOD(void, SoAExtractor,
-              (autopas::FullParticleCell<ParticleT> & cell, autopas::SoA<typename ParticleT::SoAArraysType> &soa,
+              (autopas::FullParticleCell<Particle_T> & cell, autopas::SoA<typename Particle_T::SoAArraysType> &soa,
                size_t offset));
 
   MOCK_METHOD(void, SoAExtractor,
-              (autopas::ReferenceParticleCell<ParticleT> & cell, autopas::SoA<typename ParticleT::SoAArraysType> &soa,
+              (autopas::ReferenceParticleCell<Particle_T> & cell, autopas::SoA<typename Particle_T::SoAArraysType> &soa,
                size_t offset));
 
   // virtual bool allowsNewton3() { return true; }

--- a/tests/testAutopas/mocks/MockTriwiseFunctor.h
+++ b/tests/testAutopas/mocks/MockTriwiseFunctor.h
@@ -11,54 +11,53 @@
 #include "autopas/baseFunctors/TriwiseFunctor.h"
 #include "autopas/cells/FullParticleCell.h"
 #include "autopas/cells/ReferenceParticleCell.h"
-//#include "autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h"
 #include "autopas/options/DataLayoutOption.h"
 
-template <class Particle>
-class MockTriwiseFunctor : public autopas::TriwiseFunctor<Particle, MockTriwiseFunctor<Particle>> {
+template <class ParticleT>
+class MockTriwiseFunctor : public autopas::TriwiseFunctor<ParticleT, MockTriwiseFunctor<ParticleT>> {
  public:
-  MockTriwiseFunctor() : autopas::TriwiseFunctor<Particle, MockTriwiseFunctor<Particle>>(0.){};
-  // virtual void AoSFunctor(Particle &i, Particle &j, bool newton3)
-  MOCK_METHOD(void, AoSFunctor, (Particle & i, Particle &j, Particle &k, bool newton3), (override));
+  MockTriwiseFunctor() : autopas::TriwiseFunctor<ParticleT, MockTriwiseFunctor<ParticleT>>(0.){};
+  // virtual void AoSFunctor(ParticleT &i, ParticleT &j, bool newton3)
+  MOCK_METHOD(void, AoSFunctor, (ParticleT & i, ParticleT &j, ParticleT &k, bool newton3), (override));
 
   // virtual void SoAFunctorSingle(SoAView &soa, bool newton3)
-  MOCK_METHOD(void, SoAFunctorSingle, (autopas::SoAView<typename Particle::SoAArraysType> soa, bool newton3),
+  MOCK_METHOD(void, SoAFunctorSingle, (autopas::SoAView<typename ParticleT::SoAArraysType> soa, bool newton3),
               (override));
 
   // virtual void SoAFunctorPair(SoAView &soa1, SoAView &soa2, bool newton3)
   MOCK_METHOD(void, SoAFunctorPair,
-              (autopas::SoAView<typename Particle::SoAArraysType> soa1,
-               autopas::SoAView<typename Particle::SoAArraysType> soa2, bool newton3),
+              (autopas::SoAView<typename ParticleT::SoAArraysType> soa1,
+               autopas::SoAView<typename ParticleT::SoAArraysType> soa2, bool newton3),
               (override));
 
   // virtual void SoAFunctorPair(SoAView &soa1, SoAView &soa2, bool newton3)
   MOCK_METHOD(void, SoAFunctorTriple,
-              (autopas::SoAView<typename Particle::SoAArraysType> soa1,
-               autopas::SoAView<typename Particle::SoAArraysType> soa2,
-               autopas::SoAView<typename Particle::SoAArraysType> soa3, bool newton3),
+              (autopas::SoAView<typename ParticleT::SoAArraysType> soa1,
+               autopas::SoAView<typename ParticleT::SoAArraysType> soa2,
+               autopas::SoAView<typename ParticleT::SoAArraysType> soa3, bool newton3),
               (override));
 
   // virtual void SoAFunctorVerlet(SoAView &soa, const std::vector, (override)<std::vector<size_t,
   // AlignedAllocator<size_t>>> &neighborList, size_t iFrom, size_t iTo, bool newton3)
   MOCK_METHOD(void, SoAFunctorVerlet,
-              (autopas::SoAView<typename Particle::SoAArraysType> soa, size_t indexFirst,
+              (autopas::SoAView<typename ParticleT::SoAArraysType> soa, size_t indexFirst,
                (const std::vector<size_t, autopas::AlignedAllocator<size_t>> &), bool newton3),
               (override));
 
   MOCK_METHOD(void, SoALoader,
-              (autopas::FullParticleCell<Particle> & cell, autopas::SoA<typename Particle::SoAArraysType> &soa,
+              (autopas::FullParticleCell<ParticleT> & cell, autopas::SoA<typename ParticleT::SoAArraysType> &soa,
                size_t offset, bool skipSoAResize));
 
   MOCK_METHOD(void, SoALoader,
-              (autopas::ReferenceParticleCell<Particle> & cell, autopas::SoA<typename Particle::SoAArraysType> &soa,
+              (autopas::ReferenceParticleCell<ParticleT> & cell, autopas::SoA<typename ParticleT::SoAArraysType> &soa,
                size_t offset, bool skipSoAResize));
 
   MOCK_METHOD(void, SoAExtractor,
-              (autopas::FullParticleCell<Particle> & cell, autopas::SoA<typename Particle::SoAArraysType> &soa,
+              (autopas::FullParticleCell<ParticleT> & cell, autopas::SoA<typename ParticleT::SoAArraysType> &soa,
                size_t offset));
 
   MOCK_METHOD(void, SoAExtractor,
-              (autopas::ReferenceParticleCell<Particle> & cell, autopas::SoA<typename Particle::SoAArraysType> &soa,
+              (autopas::ReferenceParticleCell<ParticleT> & cell, autopas::SoA<typename ParticleT::SoAArraysType> &soa,
                size_t offset));
 
   // virtual bool allowsNewton3() { return true; }

--- a/tests/testAutopas/testingHelpers/EmptyPairwiseFunctor.h
+++ b/tests/testAutopas/testingHelpers/EmptyPairwiseFunctor.h
@@ -15,29 +15,29 @@
  * Empty Functor, this functor is empty and can be used for testing purposes.
  * It returns that it is applicable for everything.
  */
-template <class ParticleT>
-class EmptyPairwiseFunctor : public autopas::PairwiseFunctor<ParticleT, EmptyPairwiseFunctor<ParticleT>> {
+template <class Particle_T>
+class EmptyPairwiseFunctor : public autopas::PairwiseFunctor<Particle_T, EmptyPairwiseFunctor<Particle_T>> {
  private:
  public:
   /**
    * Structure of the SoAs defined by the particle.
    */
-  using SoAArraysType = typename ParticleT::SoAArraysType;
+  using SoAArraysType = typename Particle_T::SoAArraysType;
 
   /**
    * Default constructor.
    */
-  EmptyPairwiseFunctor() : autopas::PairwiseFunctor<ParticleT, EmptyPairwiseFunctor<ParticleT>>(0.){};
+  EmptyPairwiseFunctor() : autopas::PairwiseFunctor<Particle_T, EmptyPairwiseFunctor<Particle_T>>(0.){};
 
   /**
    * @copydoc autopas::PairwiseFunctor::AoSFunctor()
    */
-  void AoSFunctor(ParticleT &i, ParticleT &j, bool newton3) override {}
+  void AoSFunctor(Particle_T &i, Particle_T &j, bool newton3) override {}
 
   /**
    * @copydoc autopas::PairwiseFunctor::SoAFunctorSingle()
    */
-  void SoAFunctorSingle(autopas::SoAView<typename ParticleT::SoAArraysType> soa, bool newton3) override {}
+  void SoAFunctorSingle(autopas::SoAView<typename Particle_T::SoAArraysType> soa, bool newton3) override {}
 
   /**
    * SoAFunctor for a pair of SoAs.
@@ -45,13 +45,13 @@ class EmptyPairwiseFunctor : public autopas::PairwiseFunctor<ParticleT, EmptyPai
    * @param soa2 A second autopas::SoAView for the Functor
    * @param newton3 A boolean to indicate whether to allow newton3
    */
-  void SoAFunctorPair(autopas::SoAView<typename ParticleT::SoAArraysType> soa1,
-                      autopas::SoAView<typename ParticleT::SoAArraysType> soa2, bool newton3) override {}
+  void SoAFunctorPair(autopas::SoAView<typename Particle_T::SoAArraysType> soa1,
+                      autopas::SoAView<typename Particle_T::SoAArraysType> soa2, bool newton3) override {}
 
   /**
    * @copydoc autopas::PairwiseFunctor::SoAFunctorVerlet()
    */
-  void SoAFunctorVerlet(autopas::SoAView<typename ParticleT::SoAArraysType> soa, size_t indexFirst,
+  void SoAFunctorVerlet(autopas::SoAView<typename Particle_T::SoAArraysType> soa, size_t indexFirst,
                         const std::vector<size_t, autopas::AlignedAllocator<size_t>> &neighborList,
                         bool newton3) override{};
 

--- a/tests/testAutopas/testingHelpers/EmptyPairwiseFunctor.h
+++ b/tests/testAutopas/testingHelpers/EmptyPairwiseFunctor.h
@@ -15,29 +15,29 @@
  * Empty Functor, this functor is empty and can be used for testing purposes.
  * It returns that it is applicable for everything.
  */
-template <class Particle>
-class EmptyPairwiseFunctor : public autopas::PairwiseFunctor<Particle, EmptyPairwiseFunctor<Particle>> {
+template <class ParticleT>
+class EmptyPairwiseFunctor : public autopas::PairwiseFunctor<ParticleT, EmptyPairwiseFunctor<ParticleT>> {
  private:
  public:
   /**
    * Structure of the SoAs defined by the particle.
    */
-  using SoAArraysType = typename Particle::SoAArraysType;
+  using SoAArraysType = typename ParticleT::SoAArraysType;
 
   /**
    * Default constructor.
    */
-  EmptyPairwiseFunctor() : autopas::PairwiseFunctor<Particle, EmptyPairwiseFunctor<Particle>>(0.){};
+  EmptyPairwiseFunctor() : autopas::PairwiseFunctor<ParticleT, EmptyPairwiseFunctor<ParticleT>>(0.){};
 
   /**
    * @copydoc autopas::PairwiseFunctor::AoSFunctor()
    */
-  void AoSFunctor(Particle &i, Particle &j, bool newton3) override {}
+  void AoSFunctor(ParticleT &i, ParticleT &j, bool newton3) override {}
 
   /**
    * @copydoc autopas::PairwiseFunctor::SoAFunctorSingle()
    */
-  void SoAFunctorSingle(autopas::SoAView<typename Particle::SoAArraysType> soa, bool newton3) override {}
+  void SoAFunctorSingle(autopas::SoAView<typename ParticleT::SoAArraysType> soa, bool newton3) override {}
 
   /**
    * SoAFunctor for a pair of SoAs.
@@ -45,13 +45,13 @@ class EmptyPairwiseFunctor : public autopas::PairwiseFunctor<Particle, EmptyPair
    * @param soa2 A second autopas::SoAView for the Functor
    * @param newton3 A boolean to indicate whether to allow newton3
    */
-  void SoAFunctorPair(autopas::SoAView<typename Particle::SoAArraysType> soa1,
-                      autopas::SoAView<typename Particle::SoAArraysType> soa2, bool newton3) override {}
+  void SoAFunctorPair(autopas::SoAView<typename ParticleT::SoAArraysType> soa1,
+                      autopas::SoAView<typename ParticleT::SoAArraysType> soa2, bool newton3) override {}
 
   /**
    * @copydoc autopas::PairwiseFunctor::SoAFunctorVerlet()
    */
-  void SoAFunctorVerlet(autopas::SoAView<typename Particle::SoAArraysType> soa, size_t indexFirst,
+  void SoAFunctorVerlet(autopas::SoAView<typename ParticleT::SoAArraysType> soa, size_t indexFirst,
                         const std::vector<size_t, autopas::AlignedAllocator<size_t>> &neighborList,
                         bool newton3) override{};
 

--- a/tests/testAutopas/testingHelpers/NonConstructibleParticle.h
+++ b/tests/testAutopas/testingHelpers/NonConstructibleParticle.h
@@ -6,12 +6,12 @@
 
 #pragma once
 
-#include "autopas/particles/Particle.h"
+#include "autopas/particles/ParticleDefinitions.h"
 
 /**
  * A particle class without an actual constructor (only copy, etc.).
  */
-class NonConstructibleParticle : public autopas::Particle {
+class NonConstructibleParticle : public autopas::ParticleBaseFP64 {
  public:
   /**
    * Default constructor is deleted.

--- a/tests/testAutopas/testingHelpers/commonTypedefs.h
+++ b/tests/testAutopas/testingHelpers/commonTypedefs.h
@@ -7,22 +7,22 @@
 #pragma once
 
 #include "autopas/cells/FullParticleCell.h"
-#include "autopas/particles/Particle.h"
+#include "autopas/particles/ParticleDefinitions.h"
 #include "mocks/MockPairwiseFunctor.h"
 #include "mocks/MockTriwiseFunctor.h"
 #include "molecularDynamicsLibrary/LJFunctor.h"
 #include "molecularDynamicsLibrary/MoleculeLJ.h"
 
-// a place for usings that are commonly used in tests
+// a place for aliases that are commonly used in tests
 
 /**
- * Short for AutoPas Particle
+ * Short for AutoPas ParticleBaseFP64
  */
-using Particle = autopas::Particle;
+using ParticleFP64 = autopas::ParticleBaseFP64;
 /**
- * Short for a FullParticle Cell with the AutoPas Particle
+ * Short for a FullParticle Cell with the AutoPas ParticleFP64
  */
-using FPCell = autopas::FullParticleCell<autopas::Particle>;
+using FPCell = autopas::FullParticleCell<ParticleFP64>;
 
 /**
  * Short for the AutoPas single site Lennard-Jones molecule
@@ -37,11 +37,11 @@ using FMCell = autopas::FullParticleCell<Molecule>;
 /**
  * Short for Mock Pairwise Functor
  */
-using MPairwiseFunctor = MockPairwiseFunctor<autopas::Particle>;
+using MPairwiseFunctor = MockPairwiseFunctor<ParticleFP64>;
 /**
  * Short for Mock Triwise Functor
  */
-using MTriwiseFunctor = MockTriwiseFunctor<autopas::Particle>;
+using MTriwiseFunctor = MockTriwiseFunctor<ParticleFP64>;
 
 /**
  * Helper alias for LJFunctor, with more defaults geared towards testing.

--- a/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.h
+++ b/tests/testAutopas/tests/autopasInterface/AutoPasInterfaceTest.h
@@ -78,11 +78,11 @@ static inline auto getTestableContainerOptions() { return autopas::ContainerOpti
  * @return Vector of added particles
  */
 template <class Container>
-std::vector<typename Container::Particle_t> addParticlesMinMidMax(Container &container) {
+std::vector<typename Container::ParticleType> addParticlesMinMidMax(Container &container) {
   using namespace autopas::utils::ArrayMath::literals;
 
   constexpr size_t numParticles = 3;
-  std::vector<typename Container::Particle_t> addedParticles;
+  std::vector<typename Container::ParticleType> addedParticles;
   addedParticles.reserve(numParticles);
 
   // helper for Positions
@@ -100,7 +100,7 @@ std::vector<typename Container::Particle_t> addParticlesMinMidMax(Container &con
     constexpr double scalingFactor = 1. / (numParticles - 1);
     // boxMin + i/scalingFactor * boxMax
     auto pos = nearBoxMin + (nearBoxLength * (i * scalingFactor));
-    typename Container::Particle_t particle(pos, {0., 0., 0.}, 1);
+    typename Container::ParticleType particle(pos, {0., 0., 0.}, 1);
     container.addParticle(particle);
     addedParticles.push_back(particle);
   }

--- a/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
@@ -82,9 +82,10 @@ INSTANTIATE_TEST_SUITE_P(
                 configOk = autopas::utils::withStaticCellType<ParticleFP64>(
                     container.getParticleCellTypeEnum(), [&](auto particleCellDummy) {
                       auto traversalSelector = autopas::TraversalSelector<decltype(particleCellDummy)>();
-                      auto traversalWithN3 = traversalSelector.template generateTraversal<MockTriwiseFunctor<ParticleFP64>>(
-                          traversalOption, functor, container.getTraversalSelectorInfo(), dataLayoutOption,
-                          autopas::Newton3Option::enabled);
+                      auto traversalWithN3 =
+                          traversalSelector.template generateTraversal<MockTriwiseFunctor<ParticleFP64>>(
+                              traversalOption, functor, container.getTraversalSelectorInfo(), dataLayoutOption,
+                              autopas::Newton3Option::enabled);
                       auto traversalWithoutN3 =
                           traversalSelector.template generateTraversal<MockTriwiseFunctor<ParticleFP64>>(
                               traversalOption, functor, container.getTraversalSelectorInfo(), dataLayoutOption,

--- a/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/Newton3OnOffTest.cpp
@@ -41,7 +41,7 @@ INSTANTIATE_TEST_SUITE_P(
           applicableCombinations;
 
       // container factory
-      autopas::ContainerSelector<Particle> containerSelector(
+      autopas::ContainerSelector<autopas::ParticleBaseFP64> containerSelector(
           Newton3OnOffTest::getBoxMin(), Newton3OnOffTest::getBoxMax(), Newton3OnOffTest::getCutoff());
       autopas::ContainerSelectorInfo containerInfo(
           Newton3OnOffTest::getCellSizeFactor(), Newton3OnOffTest::getVerletSkin(),
@@ -51,7 +51,7 @@ INSTANTIATE_TEST_SUITE_P(
       // generate for all containers
       for (auto containerOption : autopas::ContainerOption::getAllOptions()) {
         containerSelector.selectContainer(containerOption, containerInfo);
-        autopas::ParticleContainerInterface<Particle> &container = containerSelector.getCurrentContainer();
+        autopas::ParticleContainerInterface<ParticleFP64> &container = containerSelector.getCurrentContainer();
 
         for (auto dataLayoutOption : autopas::DataLayoutOption::getAllOptions()) {
           for (auto interactionType : autopas::InteractionTypeOption::getMostOptions()) {
@@ -60,33 +60,33 @@ INSTANTIATE_TEST_SUITE_P(
               bool configOk = false;
 
               if (interactionType == autopas::InteractionTypeOption::pairwise) {
-                MockPairwiseFunctor<Particle> functor;
+                MockPairwiseFunctor<ParticleFP64> functor;
                 // generate both newton3 versions of the same traversal and check that both are applicable
-                configOk = autopas::utils::withStaticCellType<Particle>(
+                configOk = autopas::utils::withStaticCellType<ParticleFP64>(
                     container.getParticleCellTypeEnum(), [&](auto particleCellDummy) {
                       auto traversalSelector = autopas::TraversalSelector<decltype(particleCellDummy)>();
                       auto traversalWithN3 =
-                          traversalSelector.template generateTraversal<MockPairwiseFunctor<Particle>>(
+                          traversalSelector.template generateTraversal<MockPairwiseFunctor<ParticleFP64>>(
                               traversalOption, functor, container.getTraversalSelectorInfo(), dataLayoutOption,
                               autopas::Newton3Option::enabled);
                       auto traversalWithoutN3 =
-                          traversalSelector.template generateTraversal<MockPairwiseFunctor<Particle>>(
+                          traversalSelector.template generateTraversal<MockPairwiseFunctor<ParticleFP64>>(
                               traversalOption, functor, container.getTraversalSelectorInfo(), dataLayoutOption,
                               autopas::Newton3Option::disabled);
 
                       return traversalWithN3->isApplicable() and traversalWithoutN3->isApplicable();
                     });
               } else if (interactionType == autopas::InteractionTypeOption::triwise) {
-                MockTriwiseFunctor<Particle> functor;
+                MockTriwiseFunctor<ParticleFP64> functor;
                 // generate both newton3 versions of the same traversal and check that both are applicable
-                configOk = autopas::utils::withStaticCellType<Particle>(
+                configOk = autopas::utils::withStaticCellType<ParticleFP64>(
                     container.getParticleCellTypeEnum(), [&](auto particleCellDummy) {
                       auto traversalSelector = autopas::TraversalSelector<decltype(particleCellDummy)>();
-                      auto traversalWithN3 = traversalSelector.template generateTraversal<MockTriwiseFunctor<Particle>>(
+                      auto traversalWithN3 = traversalSelector.template generateTraversal<MockTriwiseFunctor<ParticleFP64>>(
                           traversalOption, functor, container.getTraversalSelectorInfo(), dataLayoutOption,
                           autopas::Newton3Option::enabled);
                       auto traversalWithoutN3 =
-                          traversalSelector.template generateTraversal<MockTriwiseFunctor<Particle>>(
+                          traversalSelector.template generateTraversal<MockTriwiseFunctor<ParticleFP64>>(
                               traversalOption, functor, container.getTraversalSelectorInfo(), dataLayoutOption,
                               autopas::Newton3Option::disabled);
 
@@ -117,13 +117,13 @@ void Newton3OnOffTest::countFunctorCalls(autopas::ContainerOption containerOptio
   if (containerOption == autopas::ContainerOption::directSum and dataLayout == autopas::DataLayoutOption::soa) {
     return;
   }
-  autopas::ContainerSelector<Particle> containerSelector(getBoxMin(), getBoxMax(), getCutoff());
+  autopas::ContainerSelector<ParticleFP64> containerSelector(getBoxMin(), getBoxMax(), getCutoff());
   const autopas::ContainerSelectorInfo containerInfo(getCellSizeFactor(), getVerletSkin(), getRebuildFrequency(),
                                                      getClusterSize(), autopas::LoadEstimatorOption::none);
 
   containerSelector.selectContainer(containerOption, containerInfo);
 
-  autopas::ParticleContainerInterface<Particle> &container = containerSelector.getCurrentContainer();
+  autopas::ParticleContainerInterface<ParticleFP64> &container = containerSelector.getCurrentContainer();
 
   const Molecule defaultParticle{};
   autopasTools::generators::UniformGenerator::fillWithParticles(container, defaultParticle, container.getBoxMin(),
@@ -142,7 +142,7 @@ void Newton3OnOffTest::countFunctorCalls(autopas::ContainerOption containerOptio
 
   if (dataLayout == autopas::DataLayoutOption::soa) {
     // loader and extractor will be called, we don't care how often.
-    autopas::utils::withStaticCellType<Particle>(container.getParticleCellTypeEnum(), [&](auto particleCellDummy) {
+    autopas::utils::withStaticCellType<ParticleFP64>(container.getParticleCellTypeEnum(), [&](auto particleCellDummy) {
       auto *expectation =
           &EXPECT_CALL(mockFunctor, SoALoader(::testing::Matcher<decltype(particleCellDummy) &>(_), _, _, _))
                .Times(testing::AtLeast(1));
@@ -298,7 +298,7 @@ std::tuple<size_t, size_t, size_t> Newton3OnOffTest::eval(autopas::DataLayoutOpt
 
   auto traversalSelectorInfo = container.getTraversalSelectorInfo();
   // simulate iteration
-  autopas::utils::withStaticCellType<Particle>(container.getParticleCellTypeEnum(), [&](auto particleCellDummy) {
+  autopas::utils::withStaticCellType<ParticleFP64>(container.getParticleCellTypeEnum(), [&](auto particleCellDummy) {
     iterate(container,
             autopas::TraversalSelector<decltype(particleCellDummy)>::template generateTraversal<Functor>(
                 traversalOption, mockFunctor, traversalSelectorInfo, dataLayout, n3Option),

--- a/tests/testAutopas/tests/cells/FullParticleCellTest.cpp
+++ b/tests/testAutopas/tests/cells/FullParticleCellTest.cpp
@@ -9,17 +9,17 @@
 #include "testingHelpers/commonTypedefs.h"
 
 TEST_F(FullParticleCellTest, testRangeBasedLoop) {
-  autopas::FullParticleCell<Particle> cell({1., 1., 1.});
+  autopas::FullParticleCell<ParticleFP64> cell({1., 1., 1.});
 
-  Particle p({.1, .2, .3}, {0., 0., 0.}, 0);
+  ParticleFP64 p({.1, .2, .3}, {0., 0., 0.}, 0);
   cell.addParticle(p);
 
-  Particle p2({.5, .2, .2}, {0., 0., 0.}, 1);
+  ParticleFP64 p2({.5, .2, .2}, {0., 0., 0.}, 1);
   cell.addParticle(p2);
 
   EXPECT_EQ(cell.size(), 2);
 
-  for (Particle &particle : cell) {
+  for (ParticleFP64 &particle : cell) {
     particle.setF({42., 42., 42.});
   }
 

--- a/tests/testAutopas/tests/cells/SortedCellViewTest.cpp
+++ b/tests/testAutopas/tests/cells/SortedCellViewTest.cpp
@@ -11,10 +11,10 @@
 #include "testingHelpers/commonTypedefs.h"
 
 TEST_F(SortedCellViewTest, testParticleAccess) {
-  auto fpc = autopas::FullParticleCell<Particle>();
-  Particle p1 = Particle();
+  auto fpc = autopas::FullParticleCell<ParticleFP64>();
+  ParticleFP64 p1 = ParticleFP64();
   fpc.addParticle(p1);
-  auto fspc = autopas::SortedCellView<autopas::FullParticleCell<Particle>>(fpc, {1., 0., 0.});
+  auto fspc = autopas::SortedCellView<autopas::FullParticleCell<ParticleFP64>>(fpc, {1., 0., 0.});
   EXPECT_EQ(fspc._particles.size(), 1);
   std::array<double, 3> force{3.1416, 2.7183, 9.8067};
   fspc._particles.front().second->addF(force);
@@ -22,20 +22,20 @@ TEST_F(SortedCellViewTest, testParticleAccess) {
 }
 
 TEST_F(SortedCellViewTest, testParticleSorting) {
-  auto fpc = autopas::FullParticleCell<Particle>();
-  Particle p1 = Particle({0., 3., 0.}, {0., 0., 0.}, 0);
+  auto fpc = autopas::FullParticleCell<ParticleFP64>();
+  ParticleFP64 p1 = ParticleFP64({0., 3., 0.}, {0., 0., 0.}, 0);
   fpc.addParticle(p1);
-  Particle p2 = Particle({2., 1., 2.}, {0., 0., 0.}, 2);
+  ParticleFP64 p2 = ParticleFP64({2., 1., 2.}, {0., 0., 0.}, 2);
   fpc.addParticle(p2);
-  Particle p3 = Particle({1., 2., 1.}, {0., 0., 0.}, 1);
+  ParticleFP64 p3 = ParticleFP64({1., 2., 1.}, {0., 0., 0.}, 1);
   fpc.addParticle(p3);
-  Particle p4 = Particle({3., 0., 3.}, {0., 0., 0.}, 3);
+  ParticleFP64 p4 = ParticleFP64({3., 0., 3.}, {0., 0., 0.}, 3);
   fpc.addParticle(p4);
 
   unsigned int id = 0u;
 
   {
-    auto fspc = autopas::SortedCellView<autopas::FullParticleCell<Particle>>(fpc, {1., 0., 0.});
+    auto fspc = autopas::SortedCellView<autopas::FullParticleCell<ParticleFP64>>(fpc, {1., 0., 0.});
     EXPECT_EQ(fspc.size(), 4);
 
     for (auto &p : fspc._particles) {
@@ -45,7 +45,7 @@ TEST_F(SortedCellViewTest, testParticleSorting) {
     }
   }
   {
-    auto fspc = autopas::SortedCellView<autopas::FullParticleCell<Particle>>(fpc, {0., 1., 0.});
+    auto fspc = autopas::SortedCellView<autopas::FullParticleCell<ParticleFP64>>(fpc, {0., 1., 0.});
     EXPECT_EQ(fspc.size(), 4);
 
     for (auto &p : fspc._particles) {

--- a/tests/testAutopas/tests/containers/AllContainersTests.cpp
+++ b/tests/testAutopas/tests/containers/AllContainersTests.cpp
@@ -69,7 +69,7 @@ TEST_P(AllContainersTests, testParticleAdding) {
       for (double z : {boxMin[2] - 1.5, boxMin[2] - .5, boxMin[2], boxMin[2] + 5., boxMax[2] - 0.001, boxMax[2],
                        boxMax[2] + .5, boxMax[2] + 1.5}) {
         autopas::ParticleBaseFP64 p({x, y, z}, {0., 0., 0.},
-                            id++);  // not const as updating ownership (as containers no longer handle this)
+                                    id++);  // not const as updating ownership (as containers no longer handle this)
         if (x == -1.5 or y == -1.5 or z == -1.5 or x == 11.5 or y == 11.5 or z == 11.5) {
           EXPECT_ANY_THROW(container.addParticle(p));  // outside, therefore not ok!
           p.setOwnershipState(autopas::OwnershipState::halo);
@@ -142,7 +142,7 @@ TEST_P(AllContainersTests, testDeleteHaloParticles) {
 TEST_P(AllContainersTestsBothUpdates, testUpdateContainerHalo) {
   auto &container = getInitializedContainer(std::get<0>(GetParam()));
   const autopas::ParticleBaseFP64 p({boxMin[0] - 0.5, boxMin[1] - 0.5, boxMin[2] - 0.5}, {0, 0, 0}, 42,
-                            autopas::OwnershipState::halo);
+                                    autopas::OwnershipState::halo);
   container.addHaloParticle(p);
 
   EXPECT_EQ(container.size(), 1);

--- a/tests/testAutopas/tests/containers/AllContainersTests.cpp
+++ b/tests/testAutopas/tests/containers/AllContainersTests.cpp
@@ -25,12 +25,12 @@ TEST_P(AllContainersTests, testGetNumberOfParticles) {
   EXPECT_EQ(container.size(), 0);
 
   const std::array<double, 3> r = {2, 2, 2};
-  const Particle p(r, {0., 0., 0.}, 0);
+  const ParticleFP64 p(r, {0., 0., 0.}, 0);
   container.addParticle(p);
   EXPECT_EQ(container.size(), 1);
 
   const std::array<double, 3> r2 = {1.5, 2, 2};
-  const Particle p2(r2, {0., 0., 0.}, 1);
+  const ParticleFP64 p2(r2, {0., 0., 0.}, 1);
   container.addParticle(p2);
   EXPECT_EQ(container.size(), 2);
 }
@@ -43,11 +43,11 @@ TEST_P(AllContainersTests, testDeleteAllParticles) {
   EXPECT_EQ(container.size(), 0);
 
   const std::array<double, 3> r = {2, 2, 2};
-  const Particle p(r, {0., 0., 0.}, 0);
+  const ParticleFP64 p(r, {0., 0., 0.}, 0);
   container.addParticle(p);
 
   const std::array<double, 3> r2 = {1.5, 2, 2};
-  const Particle p2(r2, {0., 0., 0.}, 1);
+  const ParticleFP64 p2(r2, {0., 0., 0.}, 1);
   container.addParticle(p2);
   EXPECT_EQ(container.size(), 2);
 
@@ -68,7 +68,7 @@ TEST_P(AllContainersTests, testParticleAdding) {
                      boxMax[1] + .5, boxMax[1] + 1.5}) {
       for (double z : {boxMin[2] - 1.5, boxMin[2] - .5, boxMin[2], boxMin[2] + 5., boxMax[2] - 0.001, boxMax[2],
                        boxMax[2] + .5, boxMax[2] + 1.5}) {
-        autopas::Particle p({x, y, z}, {0., 0., 0.},
+        autopas::ParticleBaseFP64 p({x, y, z}, {0., 0., 0.},
                             id++);  // not const as updating ownership (as containers no longer handle this)
         if (x == -1.5 or y == -1.5 or z == -1.5 or x == 11.5 or y == 11.5 or z == 11.5) {
           EXPECT_ANY_THROW(container.addParticle(p));  // outside, therefore not ok!
@@ -122,7 +122,7 @@ TEST_P(AllContainersTests, testDeleteHaloParticles) {
         }
         auto pos = domainCenter + std::array<double, 3>{distCenterToMidHalo[0] * x, distCenterToMidHalo[1] * y,
                                                         distCenterToMidHalo[2] * z};
-        const Particle p{pos, zeros, numParticles++, autopas::OwnershipState::halo};
+        const ParticleFP64 p{pos, zeros, numParticles++, autopas::OwnershipState::halo};
         container.addHaloParticle(p);
       }
     }
@@ -141,7 +141,7 @@ TEST_P(AllContainersTests, testDeleteHaloParticles) {
  */
 TEST_P(AllContainersTestsBothUpdates, testUpdateContainerHalo) {
   auto &container = getInitializedContainer(std::get<0>(GetParam()));
-  const autopas::Particle p({boxMin[0] - 0.5, boxMin[1] - 0.5, boxMin[2] - 0.5}, {0, 0, 0}, 42,
+  const autopas::ParticleBaseFP64 p({boxMin[0] - 0.5, boxMin[1] - 0.5, boxMin[2] - 0.5}, {0, 0, 0}, 42,
                             autopas::OwnershipState::halo);
   container.addHaloParticle(p);
 
@@ -165,12 +165,12 @@ TEST_P(AllContainersTestsBothUpdates, testUpdateContainerHalo) {
 void AllContainersTestsBothUpdates::testUpdateContainerDeletesDummy(bool previouslyOwned) {
   static std::atomic<unsigned long> numParticles = 0;
 
-  class TestParticle : public autopas::Particle {
+  class TestParticle : public autopas::ParticleBaseFP64 {
    public:
-    TestParticle(std::array<double, 3> r, std::array<double, 3> v, unsigned long id) : Particle(r, v, id) {
+    TestParticle(std::array<double, 3> r, std::array<double, 3> v, unsigned long id) : ParticleFP64(r, v, id) {
       ++numParticles;
     }
-    TestParticle(const TestParticle &testParticle) : Particle(testParticle) { ++numParticles; }
+    TestParticle(const TestParticle &testParticle) : ParticleFP64(testParticle) { ++numParticles; }
     ~TestParticle() override { --numParticles; }
   };
 
@@ -237,24 +237,24 @@ TEST_P(AllContainersTests, testUpdateContainerKeepsNeighborListsValidIfSpecified
   auto &container = getInitializedContainer(std::get<0>(GetParam()));
 
   {
-    const Particle p({-.1, -.1, -.1}, {0., 0., 0.}, 0, autopas::OwnershipState::halo);
+    const ParticleFP64 p({-.1, -.1, -.1}, {0., 0., 0.}, 0, autopas::OwnershipState::halo);
     container.addHaloParticle(p);
   }
 
   {
-    const Particle p({.02, .1, .1}, {0., 0., 0.}, 1);
+    const ParticleFP64 p({.02, .1, .1}, {0., 0., 0.}, 1);
     container.addParticle(p);
   }
 
   {
-    const Particle p({1.23, .1, .1}, {0., 0., 0.}, 2);
+    const ParticleFP64 p({1.23, .1, .1}, {0., 0., 0.}, 2);
     container.addParticle(p);
   }
   struct Values {
     unsigned long id;
     int occurrences;
   };
-  std::map<Particle *, Values> previous_particles;
+  std::map<ParticleFP64 *, Values> previous_particles;
   for (auto &&p : container) {
     // Iterates over owned and halo particles!
     previous_particles[&p] = {p.getID(), 0};

--- a/tests/testAutopas/tests/containers/AllContainersTests.h
+++ b/tests/testAutopas/tests/containers/AllContainersTests.h
@@ -15,9 +15,9 @@ class AllContainersTestsBase : public AutoPasTestBase {
   std::array<double, 3> boxMin = {0, 0, 0};
   std::array<double, 3> boxMax = {10, 10, 10};
   double cutoff = 1;
-  autopas::ContainerSelector<Particle> selector{boxMin, boxMax, cutoff};
+  autopas::ContainerSelector<ParticleFP64> selector{boxMin, boxMax, cutoff};
 
-  template <class ParticleType = autopas::Particle>
+  template <class ParticleType = ParticleFP64>
   auto &getInitializedContainer(autopas::ContainerOption containerOptionToTest) {
     const double skin = 0.2;
     const unsigned int rebuildFrequency = 20;

--- a/tests/testAutopas/tests/containers/directSum/DSSequentialTraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/directSum/DSSequentialTraversalTest.cpp
@@ -21,7 +21,7 @@ TEST_F(DSSequentialTraversalTest, testTraversalTriwiseAoS) { testTraversalTriwis
 TEST_F(DSSequentialTraversalTest, testTraversalTriwiseSoA) { testTraversalTriwise(true); }
 
 std::vector<FPCell> DSSequentialTraversalTest::fillParticleCells(size_t numParticles, size_t numHaloParticlesPerCell) {
-  autopas::Particle particle;
+  autopas::ParticleBaseFP64 particle;
   std::vector<FPCell> cells(7);
   std::mt19937 generator(42);
 

--- a/tests/testAutopas/tests/containers/directSum/DirectSumContainerTest.cpp
+++ b/tests/testAutopas/tests/containers/directSum/DirectSumContainerTest.cpp
@@ -9,12 +9,12 @@
 INSTANTIATE_TEST_SUITE_P(Generated, DirectSumContainerTest, testing::Bool());
 
 TEST_P(DirectSumContainerTest, testUpdateContainerCloseToBoundary) {
-  autopas::DirectSum<autopas::Particle> directSum({0., 0., 0.}, {10., 10., 10.}, 1., 0., 0);
+  autopas::DirectSum<autopas::ParticleBaseFP64> directSum({0., 0., 0.}, {10., 10., 10.}, 1., 0., 0);
   int id = 1;
   for (double x : {0., 5., 9.999}) {
     for (double y : {0., 5., 9.999}) {
       for (double z : {0., 5., 9.999}) {
-        autopas::Particle p({x, y, z}, {0., 0., 0.}, id++);
+        autopas::ParticleBaseFP64 p({x, y, z}, {0., 0., 0.}, id++);
         EXPECT_NO_THROW(directSum.addParticle(p));  // inside, therefore ok!
       }
     }

--- a/tests/testAutopas/tests/containers/directSum/DirectSumContainerTest.h
+++ b/tests/testAutopas/tests/containers/directSum/DirectSumContainerTest.h
@@ -9,7 +9,7 @@
 #include "AutoPasTestBase.h"
 #include "autopas/cells/FullParticleCell.h"
 #include "autopas/containers/directSum/DirectSum.h"
-#include "autopas/particles/Particle.h"
+#include "autopas/particles/ParticleDefinitions.h"
 #include "testingHelpers/commonTypedefs.h"
 
 using ParamType = bool;

--- a/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.cpp
@@ -24,7 +24,7 @@ TYPED_TEST_P(LinkedCellsTest, testUpdateContainer) {
   typename TestFixture::LinkedCellsType linkedCells(boxMin, boxMax, cutoff, skin, rebuildFrequency);
 
   // create owned particles
-  const std::vector<autopas::Particle> ownedParticles{
+  const std::vector<ParticleFP64> ownedParticles{
       // clang-format off
       {{0.5, 0.5, 0.5}, zero, 0},
       {{1.5, 1.5, 1.5}, zero, 1},
@@ -35,7 +35,7 @@ TYPED_TEST_P(LinkedCellsTest, testUpdateContainer) {
   };
 
   // These are going to be halo particles
-  const std::vector<autopas::Particle> haloParticles{
+  const std::vector<ParticleFP64> haloParticles{
       {{-0.5, +1.5, +1.5}, zero, 5, autopas::OwnershipState::halo},
       {{+5.0, +1.5, +1.5}, zero, 6, autopas::OwnershipState::halo},
       {{+1.5, -0.5, +1.5}, zero, 7, autopas::OwnershipState::halo},
@@ -84,7 +84,7 @@ TYPED_TEST_P(LinkedCellsTest, testUpdateContainer) {
   linkedCells.getCells()[particleIdToCellIdMap[3]].begin()->addR({+0.2, +0.0, -1.0});  // move to {5.0, 1.5, 0.5}
   linkedCells.getCells()[particleIdToCellIdMap[4]].begin()->addR({-0.9, -2.0, -2.0});  // move to {1.6, 0.5, 0.5}
 
-  std::vector<Particle> invalidParticles;
+  std::vector<ParticleFP64> invalidParticles;
   EXPECT_NO_THROW(invalidParticles = linkedCells.updateContainer(this->_keepListsValid));
   EXPECT_EQ(invalidParticles.size(), 1);
   EXPECT_EQ(invalidParticles[0].getID(), 3);
@@ -132,7 +132,7 @@ TYPED_TEST_P(LinkedCellsTest, testUpdateContainerCloseToBoundary) {
   for (const double x : {0., 5., 9.999}) {
     for (const double y : {0., 5., 9.999}) {
       for (const double z : {0., 5., 9.999}) {
-        const autopas::Particle p({x, y, z}, {0., 0., 0.}, id++);
+        const ParticleFP64 p({x, y, z}, {0., 0., 0.}, id++);
         EXPECT_NO_THROW(linkedCells.addParticle(p));  // inside, therefore ok!
       }
     }
@@ -188,18 +188,18 @@ struct two_values {
 };
 
 // defines the types of linkedCells and _keepListsValid
-struct LC_KeepListsValid : two_values<autopas::LinkedCells<Particle>, std::true_type> {};
-struct LC_DontKeepListsValid : two_values<autopas::LinkedCells<Particle>, std::false_type> {};
-struct LCRef_KeepListsValid : two_values<autopas::LinkedCellsReferences<Particle>, std::true_type> {};
-struct LCRef_DontKeepListsValid : two_values<autopas::LinkedCellsReferences<Particle>, std::false_type> {};
+struct LC_KeepListsValid : two_values<autopas::LinkedCells<ParticleFP64>, std::true_type> {};
+struct LC_DontKeepListsValid : two_values<autopas::LinkedCells<ParticleFP64>, std::false_type> {};
+struct LCRef_KeepListsValid : two_values<autopas::LinkedCellsReferences<ParticleFP64>, std::true_type> {};
+struct LCRef_DontKeepListsValid : two_values<autopas::LinkedCellsReferences<ParticleFP64>, std::false_type> {};
 
 using MyTypes =
     ::testing::Types<LC_KeepListsValid, LC_DontKeepListsValid, LCRef_KeepListsValid, LCRef_DontKeepListsValid>;
 
 /// @todo c++20: replace with:
-// using MyTypes = ::testing::Types<std::tuple<autopas::LinkedCells<Particle>, std::true_type>,
-//                                  std::tuple<autopas::LinkedCells<Particle>, std::false_type>,
-//                                  std::tuple<autopas::LinkedCellsReferences<Particle>, std::true_type>,
-//                                  std::tuple<autopas::LinkedCellsReferences<Particle>, std::false_type> >;
+// using MyTypes = ::testing::Types<std::tuple<autopas::LinkedCells<ParticleFP64>, std::true_type>,
+//                                  std::tuple<autopas::LinkedCells<ParticleFP64>, std::false_type>,
+//                                  std::tuple<autopas::LinkedCellsReferences<ParticleFP64>, std::true_type>,
+//                                  std::tuple<autopas::LinkedCellsReferences<ParticleFP64>, std::false_type> >;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(GeneratedTyped, LinkedCellsTest, MyTypes);

--- a/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/LinkedCellsTest.h
@@ -11,7 +11,7 @@
 #include "autopas/cells/ReferenceParticleCell.h"
 #include "autopas/containers/linkedCells/LinkedCells.h"
 #include "autopas/containers/linkedCells/LinkedCellsReferences.h"
-#include "autopas/particles/Particle.h"
+#include "autopas/particles/ParticleDefinitions.h"
 #include "testingHelpers/commonTypedefs.h"
 
 template <class TestingType>

--- a/tests/testAutopas/tests/containers/linkedCells/ParticleVectorTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/ParticleVectorTest.cpp
@@ -12,7 +12,7 @@
 ParticleVectorTest::ParticleVectorTest() = default;
 
 TEST_F(ParticleVectorTest, testdirtySizeAfterMarkAsClean) {
-  auto particleVector = ParticleVector<autopas::ParticleBaseFP64 >();
+  auto particleVector = ParticleVector<autopas::ParticleBaseFP64>();
 
   autopas::ParticleBaseFP64 p1({0.5, 0.5, 0.5}, {0, 0, 0}, 0);
   autopas::ParticleBaseFP64 p2({1.5, 1.5, 1.5}, {0, 0, 0}, 1);

--- a/tests/testAutopas/tests/containers/linkedCells/ParticleVectorTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/ParticleVectorTest.cpp
@@ -12,15 +12,15 @@
 ParticleVectorTest::ParticleVectorTest() = default;
 
 TEST_F(ParticleVectorTest, testdirtySizeAfterMarkAsClean) {
-  auto particleVector = ParticleVector<autopas::Particle>();
+  auto particleVector = ParticleVector<autopas::ParticleBaseFP64 >();
 
-  autopas::Particle p1({0.5, 0.5, 0.5}, {0, 0, 0}, 0);
-  autopas::Particle p2({1.5, 1.5, 1.5}, {0, 0, 0}, 1);
-  autopas::Particle p3({1.6, 1.5, 1.5}, {0, 0, 0}, 2);
-  autopas::Particle p4({2.5, 1.5, 1.5}, {0, 0, 0}, 3);
-  autopas::Particle p5({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
-  autopas::Particle p6({2.5, 1.5, 1.5}, {0, 0, 0}, 3);
-  autopas::Particle p7({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
+  autopas::ParticleBaseFP64 p1({0.5, 0.5, 0.5}, {0, 0, 0}, 0);
+  autopas::ParticleBaseFP64 p2({1.5, 1.5, 1.5}, {0, 0, 0}, 1);
+  autopas::ParticleBaseFP64 p3({1.6, 1.5, 1.5}, {0, 0, 0}, 2);
+  autopas::ParticleBaseFP64 p4({2.5, 1.5, 1.5}, {0, 0, 0}, 3);
+  autopas::ParticleBaseFP64 p5({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
+  autopas::ParticleBaseFP64 p6({2.5, 1.5, 1.5}, {0, 0, 0}, 3);
+  autopas::ParticleBaseFP64 p7({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
 
   particleVector.push_back(p1);
   particleVector.push_back(p2);
@@ -40,17 +40,17 @@ TEST_F(ParticleVectorTest, testdirtySizeAfterMarkAsClean) {
 }
 
 TEST_F(ParticleVectorTest, testDirtySizeAfterImplicitResize) {
-  auto particleVector = ParticleVector<autopas::Particle>();
+  auto particleVector = ParticleVector<autopas::ParticleBaseFP64>();
 
-  autopas::Particle p1({0.5, 0.5, 0.5}, {0, 0, 0}, 0);
-  autopas::Particle p2({1.5, 1.5, 1.5}, {0, 0, 0}, 1);
-  autopas::Particle p3({1.6, 1.5, 1.5}, {0, 0, 0}, 2);
-  autopas::Particle p4({2.5, 1.5, 1.5}, {0, 0, 0}, 3);
-  autopas::Particle p5({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
-  autopas::Particle p6({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
-  autopas::Particle p7({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
-  autopas::Particle p8({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
-  autopas::Particle p9({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
+  autopas::ParticleBaseFP64 p1({0.5, 0.5, 0.5}, {0, 0, 0}, 0);
+  autopas::ParticleBaseFP64 p2({1.5, 1.5, 1.5}, {0, 0, 0}, 1);
+  autopas::ParticleBaseFP64 p3({1.6, 1.5, 1.5}, {0, 0, 0}, 2);
+  autopas::ParticleBaseFP64 p4({2.5, 1.5, 1.5}, {0, 0, 0}, 3);
+  autopas::ParticleBaseFP64 p5({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
+  autopas::ParticleBaseFP64 p6({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
+  autopas::ParticleBaseFP64 p7({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
+  autopas::ParticleBaseFP64 p8({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
+  autopas::ParticleBaseFP64 p9({2.5, 2.5, 2.5}, {0, 0, 0}, 4);
 
   particleVector.push_back(p1);
   particleVector.push_back(p2);

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.cpp
@@ -28,7 +28,7 @@ void testTraversal(autopas::TraversalOption traversalOption, autopas::LoadEstima
   const std::array<double, 3> linkedCellsBoxMin = {0., 0., 0.};
 
   TraversalTest::CountFunctor functor(cutoff);
-  autopas::LinkedCells<Particle> linkedCells(linkedCellsBoxMin, linkedCellsBoxMax, cutoff, 0.0, 1, 1.0 / cutoff,
+  autopas::LinkedCells<ParticleFP64> linkedCells(linkedCellsBoxMin, linkedCellsBoxMax, cutoff, 0.0, 1, 1.0 / cutoff,
                                              loadEstimatorOption);
 
   autopasTools::generators::GridGenerator::fillWithParticles(linkedCells, edgeLength);

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.cpp
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.cpp
@@ -29,7 +29,7 @@ void testTraversal(autopas::TraversalOption traversalOption, autopas::LoadEstima
 
   TraversalTest::CountFunctor functor(cutoff);
   autopas::LinkedCells<ParticleFP64> linkedCells(linkedCellsBoxMin, linkedCellsBoxMax, cutoff, 0.0, 1, 1.0 / cutoff,
-                                             loadEstimatorOption);
+                                                 loadEstimatorOption);
 
   autopasTools::generators::GridGenerator::fillWithParticles(linkedCells, edgeLength);
   ASSERT_EQ(linkedCells.size(), edgeLength[0] * edgeLength[1] * edgeLength[2]);

--- a/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.h
+++ b/tests/testAutopas/tests/containers/linkedCells/traversals/TraversalTest.h
@@ -41,14 +41,14 @@ class TraversalTest
     }
   };
 
-  class CountFunctor : public autopas::PairwiseFunctor<Particle, CountFunctor> {
+  class CountFunctor : public autopas::PairwiseFunctor<ParticleFP64, CountFunctor> {
    public:
-    using SoAArraysType = Particle::SoAArraysType;
+    using SoAArraysType = ParticleFP64::SoAArraysType;
     using ParticleCell = FPCell;
     using floatType = double;
 
     CountFunctor(floatType cutoff)
-        : autopas::PairwiseFunctor<Particle, CountFunctor>(cutoff), _cutoffSquare(cutoff * cutoff){};
+        : autopas::PairwiseFunctor<ParticleFP64, CountFunctor>(cutoff), _cutoffSquare(cutoff * cutoff){};
 
     std::string getName() override { return "TraversalTestCountFunctor"; }
 
@@ -58,7 +58,7 @@ class TraversalTest
 
     bool allowsNonNewton3() override { return true; }
 
-    void AoSFunctor(Particle &i, Particle &j, bool newton3) override {
+    void AoSFunctor(ParticleFP64 &i, ParticleFP64 &j, bool newton3) override {
       using namespace autopas::utils::ArrayMath::literals;
 
       if (i.isDummy() or j.isDummy()) {

--- a/tests/testAutopas/tests/containers/octree/OctreeTests.cpp
+++ b/tests/testAutopas/tests/containers/octree/OctreeTests.cpp
@@ -211,9 +211,9 @@ TEST_F(OctreeTest, testChildIndexing) {
   ASSERT_EQ(ruf->getBoxMax(), max);
 }
 
-template <typename ParticleT>
-static void verifyFaceNeighbor(autopas::octree::Face face, autopas::OctreeNodeInterface<ParticleT> *node,
-                               autopas::OctreeNodeInterface<ParticleT> *neighbor) {
+template <typename Particle_T>
+static void verifyFaceNeighbor(autopas::octree::Face face, autopas::OctreeNodeInterface<Particle_T> *node,
+                               autopas::OctreeNodeInterface<Particle_T> *neighbor) {
   using namespace autopas;
 
   int touchAxis = getAxis(face);

--- a/tests/testAutopas/tests/containers/octree/OctreeTests.cpp
+++ b/tests/testAutopas/tests/containers/octree/OctreeTests.cpp
@@ -16,7 +16,7 @@
 #include "autopas/containers/octree/OctreeDirection.h"
 #include "autopas/containers/octree/OctreeNodeInterface.h"
 #include "autopas/options/Newton3Option.h"
-#include "autopas/particles/Particle.h"
+#include "autopas/particles/ParticleDefinitions.h"
 #include "autopas/tuning/selectors/ContainerSelector.h"
 #include "autopas/utils/StaticCellSelector.h"
 #include "molecularDynamicsLibrary/LJFunctor.h"
@@ -211,9 +211,9 @@ TEST_F(OctreeTest, testChildIndexing) {
   ASSERT_EQ(ruf->getBoxMax(), max);
 }
 
-template <typename Particle>
-static void verifyFaceNeighbor(autopas::octree::Face face, autopas::OctreeNodeInterface<Particle> *node,
-                               autopas::OctreeNodeInterface<Particle> *neighbor) {
+template <typename ParticleT>
+static void verifyFaceNeighbor(autopas::octree::Face face, autopas::OctreeNodeInterface<ParticleT> *node,
+                               autopas::OctreeNodeInterface<ParticleT> *neighbor) {
   using namespace autopas;
 
   int touchAxis = getAxis(face);
@@ -266,9 +266,9 @@ static std::array<double, 3> random3D(std::array<double, 3> min, std::array<doub
  * @param max The maximum coordinate of the cube from which the position is sampled
  * @return A particle with no speed and id 0
  */
-static autopas::ParticleFP64 getRandomlyDistributedParticle(std::array<double, 3> min, std::array<double, 3> max) {
+static autopas::ParticleBaseFP64 getRandomlyDistributedParticle(std::array<double, 3> min, std::array<double, 3> max) {
   auto randomPosition = random3D(min, max);
-  return autopas::ParticleFP64(randomPosition, {0, 0, 0}, 0);
+  return autopas::ParticleBaseFP64(randomPosition, {0, 0, 0}, 0);
 }
 
 /**
@@ -278,10 +278,10 @@ static autopas::ParticleFP64 getRandomlyDistributedParticle(std::array<double, 3
  * @param max The maximum coordinate of the octree's bounding box
  * @param randomParticleCount How many particles should be spawned
  */
-static std::unique_ptr<autopas::OctreeNodeInterface<autopas::ParticleFP64>> createRandomOctree(
+static std::unique_ptr<autopas::OctreeNodeInterface<autopas::ParticleBaseFP64>> createRandomOctree(
     std::array<double, 3> min, std::array<double, 3> max, int randomParticleCount, int treeSplitThreshold = 16) {
   using namespace autopas;
-  std::unique_ptr<OctreeNodeInterface<autopas::ParticleFP64>> root =
+  std::unique_ptr<OctreeNodeInterface<autopas::ParticleBaseFP64>> root =
       std::make_unique<OctreeLeafNode<ParticleFP64>>(min, max, nullptr, treeSplitThreshold, 1, 1.0);
   for (int particleIndex = 0; particleIndex < randomParticleCount; ++particleIndex) {
     auto randomParticle = getRandomlyDistributedParticle(min, max);

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
@@ -22,7 +22,7 @@ TEST_F(VerletClusterListsTest, VerletListConstructor) {
   const double skin = 0.2;
   const unsigned int rebuildFrequency = 20;
   const size_t clusterSize = 4;
-  const autopas::VerletClusterLists<Particle> verletLists(boxMin, boxMax, cutoff, skin, rebuildFrequency, clusterSize);
+  const autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, rebuildFrequency, clusterSize);
 }
 
 TEST_F(VerletClusterListsTest, testVerletListBuild) {
@@ -32,16 +32,16 @@ TEST_F(VerletClusterListsTest, testVerletListBuild) {
   const double skin = 0.2;
   const unsigned int rebuildFrequency = 20;
   const size_t clusterSize = 4;
-  autopas::VerletClusterLists<Particle> verletLists(boxMin, boxMax, cutoff, skin, rebuildFrequency, clusterSize);
+  autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, rebuildFrequency, clusterSize);
 
   const std::array<double, 3> r = {2, 2, 2};
-  const Particle p(r, {0., 0., 0.}, 0);
+  const ParticleFP64 p(r, {0., 0., 0.}, 0);
   verletLists.addParticle(p);
   const std::array<double, 3> r2 = {1.5, 2, 2};
-  const Particle p2(r2, {0., 0., 0.}, 1);
+  const ParticleFP64 p2(r2, {0., 0., 0.}, 1);
   verletLists.addParticle(p2);
 
-  MockPairwiseFunctor<Particle> emptyFunctor;
+  MockPairwiseFunctor<ParticleFP64> emptyFunctor;
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, _)).Times(AtLeast(1));
   autopas::VCLClusterIterationTraversal<FPCell, MPairwiseFunctor> verletTraversal(
       &emptyFunctor, clusterSize, autopas::DataLayoutOption::aos, false);
@@ -57,10 +57,10 @@ TEST_F(VerletClusterListsTest, testAddParticlesAndBuildTwice) {
   const unsigned int rebuildFrequency = 20;
   const unsigned long numParticles = 271;
   const size_t clusterSize = 4;
-  autopas::VerletClusterLists<Particle> verletLists(boxMin, boxMax, cutoff, skin, rebuildFrequency, clusterSize);
+  autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, rebuildFrequency, clusterSize);
 
   autopasTools::generators::UniformGenerator::fillWithParticles(
-      verletLists, autopas::Particle{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
+      verletLists, ParticleFP64{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
 
   MPairwiseFunctor emptyFunctor;
   autopas::VCLClusterIterationTraversal<FPCell, MPairwiseFunctor> verletTraversal(
@@ -79,12 +79,12 @@ TEST_F(VerletClusterListsTest, testIterator) {
   const unsigned int rebuildFrequency = 20;
   const unsigned long numParticles = 271;
   const size_t clusterSize = 4;
-  autopas::VerletClusterLists<Particle> verletLists(boxMin, boxMax, cutoff, skin, rebuildFrequency, clusterSize);
+  autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, rebuildFrequency, clusterSize);
 
   autopasTools::generators::UniformGenerator::fillWithParticles(
-      verletLists, autopas::Particle{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
+      verletLists, ParticleFP64{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
 
-  MockPairwiseFunctor<Particle> emptyFunctor;
+  MockPairwiseFunctor<ParticleFP64> emptyFunctor;
   autopas::VCLClusterIterationTraversal<FPCell, MPairwiseFunctor> verletTraversal(
       &emptyFunctor, clusterSize, autopas::DataLayoutOption::aos, false);
   verletLists.rebuildNeighborLists(&verletTraversal);
@@ -98,10 +98,10 @@ TEST_F(VerletClusterListsTest, testIterator) {
   EXPECT_EQ(numParticlesInIterator, numParticles);
 }
 
-auto calculateValidPairs(const std::vector<autopas::Particle *> &particles, double cutoffSqr) {
+auto calculateValidPairs(const std::vector<ParticleFP64 *> &particles, double cutoffSqr) {
   using namespace autopas::utils::ArrayMath::literals;
 
-  std::vector<std::pair<autopas::Particle *, autopas::Particle *>> particlePairs;
+  std::vector<std::pair<ParticleFP64 *, ParticleFP64 *>> particlePairs;
   particlePairs.reserve(particlePairs.size() * (particlePairs.size() / 2));
   for (auto *particlePtr : particles) {
     for (auto *neighborPtr : particles) {
@@ -116,8 +116,8 @@ auto calculateValidPairs(const std::vector<autopas::Particle *> &particles, doub
   return particlePairs;
 }
 
-void compareParticlePairs(const std::vector<std::pair<autopas::Particle *, autopas::Particle *>> &expected,
-                          const std::vector<std::pair<autopas::Particle *, autopas::Particle *>> &actual,
+void compareParticlePairs(const std::vector<std::pair<ParticleFP64 *, ParticleFP64 *>> &expected,
+                          const std::vector<std::pair<ParticleFP64 *, ParticleFP64 *>> &actual,
                           const std::string &errMsg) {
   using autopas::utils::ArrayUtils::operator<<;
   EXPECT_EQ(expected.size(), actual.size()) << errMsg << "\n"
@@ -140,18 +140,18 @@ TEST_F(VerletClusterListsTest, testNeighborListsValidAfterMovingLessThanHalfSkin
   const unsigned int rebuildFrequency = 20;
   const unsigned long numParticles = 30;
   const size_t clusterSize = 4;
-  autopas::VerletClusterLists<Particle> verletLists(boxMin, boxMax, cutoff, skin, rebuildFrequency, clusterSize);
+  autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, rebuildFrequency, clusterSize);
 
   // Fill the container with random particles and build neighbor lists
   autopasTools::generators::UniformGenerator::fillWithParticles(
-      verletLists, autopas::Particle{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
+      verletLists, ParticleFP64{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
   CollectParticlePairsFunctor functor{cutoff, boxMin, boxMax};
   autopas::VCLClusterIterationTraversal<FPCell, CollectParticlePairsFunctor> verletTraversal(
       &functor, clusterSize, autopas::DataLayoutOption::aos, false);
   verletLists.rebuildNeighborLists(&verletTraversal);
 
   // copy all generated particles
-  std::vector<autopas::Particle *> particles;
+  std::vector<ParticleFP64 *> particles;
   for (auto it = verletLists.begin(); it.isValid(); ++it) {
     particles.push_back(&(*it));
   }
@@ -198,7 +198,7 @@ TEST_F(VerletClusterListsTest, testNeighborListsValidAfterMovingLessThanHalfSkin
   compareParticlePairs(referenceParticlePairsAfterMove, calculatedParticlePairsAfterMove, "After random movement");
 }
 
-auto getClusterNeighbors(autopas::VerletClusterLists<Particle> &verletLists) {
+auto getClusterNeighbors(autopas::VerletClusterLists<ParticleFP64> &verletLists) {
   std::unordered_map<size_t, std::vector<size_t>> neighbors;
   verletLists.traverseClusters<false>([&neighbors](auto &cluster) {
     auto idFirstParticleInCluster = cluster[0].getID();
@@ -229,12 +229,12 @@ TEST_F(VerletClusterListsTest, testNewton3NeighborList) {
   std::unordered_map<size_t, std::vector<size_t>> neighborsNoN3{}, neighborsN3{};
 
   for (bool newton3 : {true, false}) {
-    autopas::VerletClusterLists<Particle> verletLists(boxMin, boxMax, cutoff, skin, rebuildFrequency, clusterSize);
+    autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, rebuildFrequency, clusterSize);
 
     autopasTools::generators::UniformGenerator::fillWithParticles(
-        verletLists, autopas::Particle{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
+        verletLists, ParticleFP64{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
 
-    MockPairwiseFunctor<Particle> functor;
+    MockPairwiseFunctor<ParticleFP64> functor;
     if (newton3) {
       autopas::VCLC06Traversal<FPCell, MPairwiseFunctor> traversalNoN3(&functor, clusterSize,
                                                                        autopas::DataLayoutOption::aos, false);
@@ -271,26 +271,26 @@ TEST_F(VerletClusterListsTest, testGridAlignment) {
   const double skin{0.5};
   const size_t rebuildFreq{10};
   const size_t clusterSize{4};
-  autopas::VerletClusterLists<Particle> verletLists(boxMin, boxMax, cutoff, skin / rebuildFreq, rebuildFreq,
+  autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin / rebuildFreq, rebuildFreq,
                                                     clusterSize);
   size_t numParticles{0};
   // lower corner of the inner box, thus in the first inner tower
-  const Particle p0{boxMin, {0., 0., 0.}, numParticles++};
+  const ParticleFP64 p0{boxMin, {0., 0., 0.}, numParticles++};
   verletLists.addParticle(p0);
   // just outside the lower corner, thus in the halo
-  const Particle p1{boxMin - 0.1, {0., 0., 0.}, numParticles++};
+  const ParticleFP64 p1{boxMin - 0.1, {0., 0., 0.}, numParticles++};
   verletLists.addHaloParticle(p1);
   // just inside the upper corner, thus in the last inner tower
-  const Particle p2{boxMax - 0.1, {0., 0., 0.}, numParticles++};
+  const ParticleFP64 p2{boxMax - 0.1, {0., 0., 0.}, numParticles++};
   verletLists.addParticle(p2);
   // just outside the upper corner, thus in the halo
-  const Particle p3{boxMax, {0., 0., 0.}, numParticles++};
+  const ParticleFP64 p3{boxMax, {0., 0., 0.}, numParticles++};
   verletLists.addHaloParticle(p3);
 
   // we need 256 to 500 Particles for a 5x5 grid of towers with side length 2
   // so we add as many as we are missing
   for (; numParticles < 257;) {
-    const Particle pDummy{(boxMax - boxMin) / 2., {0., 0., 0.}, numParticles++};
+    const ParticleFP64 pDummy{(boxMax - boxMin) / 2., {0., 0., 0.}, numParticles++};
     verletLists.addParticle(pDummy);
   }
 
@@ -324,9 +324,9 @@ TEST_F(VerletClusterListsTest, testVerletListColoringTraversalNewton3NoDataRace)
   const unsigned int rebuildFrequency = 10;
   const int numParticles = 5000;
   const size_t clusterSize = 4;
-  autopas::VerletClusterLists<Particle> verletLists(boxMin, boxMax, cutoff, skin, rebuildFrequency, clusterSize);
+  autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, rebuildFrequency, clusterSize);
 
-  autopasTools::generators::UniformGenerator::fillWithParticles(verletLists, autopas::Particle{}, boxMin, boxMax,
+  autopasTools::generators::UniformGenerator::fillWithParticles(verletLists, ParticleFP64{}, boxMin, boxMax,
                                                                 numParticles);
 
   CollectParticlesPerThreadFunctor functor;

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
@@ -22,7 +22,8 @@ TEST_F(VerletClusterListsTest, VerletListConstructor) {
   const double skin = 0.2;
   const unsigned int rebuildFrequency = 20;
   const size_t clusterSize = 4;
-  const autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, rebuildFrequency, clusterSize);
+  const autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, rebuildFrequency,
+                                                              clusterSize);
 }
 
 TEST_F(VerletClusterListsTest, testVerletListBuild) {
@@ -59,8 +60,8 @@ TEST_F(VerletClusterListsTest, testAddParticlesAndBuildTwice) {
   const size_t clusterSize = 4;
   autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, rebuildFrequency, clusterSize);
 
-  autopasTools::generators::UniformGenerator::fillWithParticles(
-      verletLists, ParticleFP64{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
+  autopasTools::generators::UniformGenerator::fillWithParticles(verletLists, ParticleFP64{}, verletLists.getBoxMin(),
+                                                                verletLists.getBoxMax(), numParticles);
 
   MPairwiseFunctor emptyFunctor;
   autopas::VCLClusterIterationTraversal<FPCell, MPairwiseFunctor> verletTraversal(
@@ -81,8 +82,8 @@ TEST_F(VerletClusterListsTest, testIterator) {
   const size_t clusterSize = 4;
   autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, rebuildFrequency, clusterSize);
 
-  autopasTools::generators::UniformGenerator::fillWithParticles(
-      verletLists, ParticleFP64{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
+  autopasTools::generators::UniformGenerator::fillWithParticles(verletLists, ParticleFP64{}, verletLists.getBoxMin(),
+                                                                verletLists.getBoxMax(), numParticles);
 
   MockPairwiseFunctor<ParticleFP64> emptyFunctor;
   autopas::VCLClusterIterationTraversal<FPCell, MPairwiseFunctor> verletTraversal(
@@ -143,8 +144,8 @@ TEST_F(VerletClusterListsTest, testNeighborListsValidAfterMovingLessThanHalfSkin
   autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, rebuildFrequency, clusterSize);
 
   // Fill the container with random particles and build neighbor lists
-  autopasTools::generators::UniformGenerator::fillWithParticles(
-      verletLists, ParticleFP64{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
+  autopasTools::generators::UniformGenerator::fillWithParticles(verletLists, ParticleFP64{}, verletLists.getBoxMin(),
+                                                                verletLists.getBoxMax(), numParticles);
   CollectParticlePairsFunctor functor{cutoff, boxMin, boxMax};
   autopas::VCLClusterIterationTraversal<FPCell, CollectParticlePairsFunctor> verletTraversal(
       &functor, clusterSize, autopas::DataLayoutOption::aos, false);
@@ -231,8 +232,8 @@ TEST_F(VerletClusterListsTest, testNewton3NeighborList) {
   for (bool newton3 : {true, false}) {
     autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, rebuildFrequency, clusterSize);
 
-    autopasTools::generators::UniformGenerator::fillWithParticles(
-        verletLists, ParticleFP64{}, verletLists.getBoxMin(), verletLists.getBoxMax(), numParticles);
+    autopasTools::generators::UniformGenerator::fillWithParticles(verletLists, ParticleFP64{}, verletLists.getBoxMin(),
+                                                                  verletLists.getBoxMax(), numParticles);
 
     MockPairwiseFunctor<ParticleFP64> functor;
     if (newton3) {
@@ -272,7 +273,7 @@ TEST_F(VerletClusterListsTest, testGridAlignment) {
   const size_t rebuildFreq{10};
   const size_t clusterSize{4};
   autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin / rebuildFreq, rebuildFreq,
-                                                    clusterSize);
+                                                        clusterSize);
   size_t numParticles{0};
   // lower corner of the inner box, thus in the first inner tower
   const ParticleFP64 p0{boxMin, {0., 0., 0.}, numParticles++};

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.h
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.h
@@ -11,7 +11,7 @@
 #include "AutoPasTestBase.h"
 #include "autopas/cells/FullParticleCell.h"
 #include "autopas/containers/verletClusterLists/traversals/VCLC06Traversal.h"
-#include "autopas/particles/Particle.h"
+#include "autopas/particles/ParticleDefinitions.h"
 #include "autopas/utils/WrapOpenMP.h"
 #include "autopasTools/generators/UniformGenerator.h"
 #include "mocks/MockPairwiseFunctor.h"
@@ -19,9 +19,9 @@
 
 class VerletClusterListsTest : public AutoPasTestBase {};
 
-class CollectParticlePairsFunctor : public autopas::PairwiseFunctor<autopas::Particle, CollectParticlePairsFunctor> {
+class CollectParticlePairsFunctor : public autopas::PairwiseFunctor<ParticleFP64, CollectParticlePairsFunctor> {
  public:
-  std::vector<std::pair<Particle *, Particle *>> _pairs{};
+  std::vector<std::pair<ParticleFP64 *, ParticleFP64 *>> _pairs{};
   std::array<double, 3> _min;
   std::array<double, 3> _max;
 
@@ -30,7 +30,7 @@ class CollectParticlePairsFunctor : public autopas::PairwiseFunctor<autopas::Par
 
   void initTraversal() override { _pairs.clear(); }
 
-  void AoSFunctor(Particle &i, Particle &j, bool newton3) override {
+  void AoSFunctor(ParticleFP64 &i, ParticleFP64 &j, bool newton3) override {
     using namespace autopas::utils::ArrayMath::literals;
 
     auto dist = i.getR() - j.getR();
@@ -56,11 +56,11 @@ class CollectParticlePairsFunctor : public autopas::PairwiseFunctor<autopas::Par
 
 #if defined(AUTOPAS_USE_OPENMP)
 class CollectParticlesPerThreadFunctor
-    : public autopas::PairwiseFunctor<autopas::Particle, CollectParticlesPerThreadFunctor> {
+    : public autopas::PairwiseFunctor<ParticleFP64, CollectParticlesPerThreadFunctor> {
  public:
   int _currentColor{};
 
-  std::array<std::vector<std::set<Particle *>>, 8> _particlesPerThreadPerColor;
+  std::array<std::vector<std::set<ParticleFP64 *>>, 8> _particlesPerThreadPerColor;
 
  public:
   CollectParticlesPerThreadFunctor() : PairwiseFunctor(0) {}
@@ -71,7 +71,7 @@ class CollectParticlesPerThreadFunctor
     }
   }
 
-  void AoSFunctor(Particle &i, Particle &j, bool newton3) override {
+  void AoSFunctor(ParticleFP64 &i, ParticleFP64 &j, bool newton3) override {
     if (i.isDummy() or j.isDummy()) {
       return;
     }

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterTowerTest.cpp
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterTowerTest.cpp
@@ -9,13 +9,13 @@
 #include "autopas/containers/verletClusterLists/ClusterTower.h"
 #include "testingHelpers/commonTypedefs.h"
 
-template <class Particle>
-using ClusterTower = autopas::internal::ClusterTower<Particle>;
+template <class ParticleT>
+using ClusterTower = autopas::internal::ClusterTower<ParticleT>;
 
 TEST_F(VerletClusterTowerTest, testAddParticle) {
-  ClusterTower<Particle> tower(4);
-  Particle p1;
-  Particle p2;
+  ClusterTower<ParticleFP64> tower(4);
+  ParticleFP64 p1;
+  ParticleFP64 p2;
 
   tower.addParticle(p1);
   tower.addParticle(p2);
@@ -26,10 +26,10 @@ TEST_F(VerletClusterTowerTest, testAddParticle) {
 static void testClusterGenerationAndDummies(size_t clusterSize) {
   // Test for different number of particles
   for (size_t numParticles : {29, 64, 1, 2, 4, 0}) {
-    ClusterTower<Particle> tower(clusterSize);
+    ClusterTower<ParticleFP64> tower(clusterSize);
 
     for (size_t i = 0; i < numParticles; i++) {
-      tower.addParticle(Particle{{0.0, 0.0, (double)i}, {0, 0, 0}, i});
+      tower.addParticle(ParticleFP64{{0.0, 0.0, (double)i}, {0, 0, 0}, i});
     }
     EXPECT_EQ(tower.getNumActualParticles(), numParticles);
 
@@ -74,7 +74,7 @@ TEST_F(VerletClusterTowerTest, testClusterGenerationAndDummies) {
 }
 
 TEST_F(VerletClusterTowerTest, testCollectAllActualParticles) {
-  ClusterTower<Particle> tower(4);
+  ClusterTower<ParticleFP64> tower(4);
   constexpr size_t numParticles = 21;
 
   for (size_t i = 0; i < numParticles; i++) {
@@ -94,7 +94,7 @@ TEST_F(VerletClusterTowerTest, testCollectAllActualParticles) {
 
 TEST_F(VerletClusterTowerTest, testIterator) {
   constexpr size_t clusterSize = 4;
-  ClusterTower<Particle> tower(clusterSize);
+  ClusterTower<ParticleFP64> tower(clusterSize);
   constexpr size_t numParticles = 21;
   constexpr size_t numDummies = clusterSize - (numParticles % clusterSize);
   static_assert(numDummies != 0, "Without dummies this test is boring. Adapt parameters!");

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterTowerTest.cpp
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterTowerTest.cpp
@@ -9,8 +9,8 @@
 #include "autopas/containers/verletClusterLists/ClusterTower.h"
 #include "testingHelpers/commonTypedefs.h"
 
-template <class ParticleT>
-using ClusterTower = autopas::internal::ClusterTower<ParticleT>;
+template <class Particle_T>
+using ClusterTower = autopas::internal::ClusterTower<Particle_T>;
 
 TEST_F(VerletClusterTowerTest, testAddParticle) {
   ClusterTower<ParticleFP64> tower(4);

--- a/tests/testAutopas/tests/containers/verletListsCellBased/varVerletLists/VarVerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/varVerletLists/VarVerletListsTest.cpp
@@ -26,7 +26,7 @@ TEST_F(VarVerletListsTest, VerletListConstructor) {
   double cutoff = 1.;
   double skin = 0.2;
   unsigned int rebuildFrequency = 20;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skin,
+  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(min, max, cutoff, skin,
                                                                                               rebuildFrequency);
 }
 
@@ -36,17 +36,17 @@ TEST_F(VarVerletListsTest, testAddParticleNumParticle) {
   double cutoff = 1.;
   double skin = 0.2;
   unsigned int rebuildFrequency = 20;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skin,
+  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(min, max, cutoff, skin,
                                                                                               rebuildFrequency);
   EXPECT_EQ(verletLists.size(), 0);
 
   std::array<double, 3> r = {2, 2, 2};
-  Particle p(r, {0., 0., 0.}, 0);
+  ParticleFP64 p(r, {0., 0., 0.}, 0);
   verletLists.addParticle(p);
   EXPECT_EQ(verletLists.size(), 1);
 
   std::array<double, 3> r2 = {1.5, 2, 2};
-  Particle p2(r2, {0., 0., 0.}, 1);
+  ParticleFP64 p2(r2, {0., 0., 0.}, 1);
   verletLists.addParticle(p2);
   EXPECT_EQ(verletLists.size(), 2);
 }
@@ -57,16 +57,16 @@ TEST_F(VarVerletListsTest, testDeleteAllParticles) {
   double cutoff = 1.;
   double skin = 0.2;
   unsigned int rebuildFrequency = 20;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skin,
+  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(min, max, cutoff, skin,
                                                                                               rebuildFrequency);
   EXPECT_EQ(verletLists.size(), 0);
 
   std::array<double, 3> r = {2, 2, 2};
-  Particle p(r, {0., 0., 0.}, 0);
+  ParticleFP64 p(r, {0., 0., 0.}, 0);
   verletLists.addParticle(p);
 
   std::array<double, 3> r2 = {1.5, 2, 2};
-  Particle p2(r2, {0., 0., 0.}, 1);
+  ParticleFP64 p2(r2, {0., 0., 0.}, 1);
   verletLists.addParticle(p2);
   EXPECT_EQ(verletLists.size(), 2);
 
@@ -80,20 +80,20 @@ TEST_F(VarVerletListsTest, testVerletListBuild) {
   double cutoff = 1.;
   double skin = 0.2;
   unsigned int rebuildFrequency = 20;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skin,
+  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(min, max, cutoff, skin,
                                                                                               rebuildFrequency);
 
   std::array<double, 3> r = {2, 2, 2};
-  Particle p(r, {0., 0., 0.}, 0);
+  ParticleFP64 p(r, {0., 0., 0.}, 0);
   verletLists.addParticle(p);
   std::array<double, 3> r2 = {1.5, 2, 2};
-  Particle p2(r2, {0., 0., 0.}, 1);
+  ParticleFP64 p2(r2, {0., 0., 0.}, 1);
   verletLists.addParticle(p2);
 
-  MockPairwiseFunctor<Particle> emptyFunctor;
+  MockPairwiseFunctor<ParticleFP64> emptyFunctor;
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, true)).Times(AtLeast(1));
 
-  autopas::VVLAsBuildTraversal<FPCell, autopas::Particle, MPairwiseFunctor> dummyTraversal(
+  autopas::VVLAsBuildTraversal<FPCell, ParticleFP64, MPairwiseFunctor> dummyTraversal(
       &emptyFunctor, autopas::DataLayoutOption::aos, true);
 
   verletLists.rebuildNeighborLists(&dummyTraversal);
@@ -108,21 +108,21 @@ TEST_F(VarVerletListsTest, testVerletList) {
   double cutoff = 1.;
   double skin = 0.2;
   unsigned int rebuildFrequency = 20;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skin,
+  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(min, max, cutoff, skin,
                                                                                               rebuildFrequency);
 
   std::array<double, 3> r = {2, 2, 2};
-  Particle p(r, {0., 0., 0.}, 0);
+  ParticleFP64 p(r, {0., 0., 0.}, 0);
   verletLists.addParticle(p);
   std::array<double, 3> r2 = {1.5, 2, 2};
-  Particle p2(r2, {0., 0., 0.}, 1);
+  ParticleFP64 p2(r2, {0., 0., 0.}, 1);
   verletLists.addParticle(p2);
 
-  MockPairwiseFunctor<Particle> mockFunctor;
+  MockPairwiseFunctor<ParticleFP64> mockFunctor;
   using ::testing::_;  // anything is ok
   EXPECT_CALL(mockFunctor, AoSFunctor(_, _, true));
 
-  autopas::VVLAsBuildTraversal<FPCell, autopas::Particle, MPairwiseFunctor> dummyTraversal(
+  autopas::VVLAsBuildTraversal<FPCell, ParticleFP64, MPairwiseFunctor> dummyTraversal(
       &mockFunctor, autopas::DataLayoutOption::aos, true);
   verletLists.rebuildNeighborLists(&dummyTraversal);
   verletLists.computeInteractions(&dummyTraversal);
@@ -136,21 +136,21 @@ TEST_F(VarVerletListsTest, testVerletListInSkin) {
   double cutoff = 1.;
   double skin = 0.2;
   unsigned int rebuildFrequency = 20;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skin,
+  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(min, max, cutoff, skin,
                                                                                               rebuildFrequency);
 
   std::array<double, 3> r = {1.4, 2, 2};
-  Particle p(r, {0., 0., 0.}, 0);
+  ParticleFP64 p(r, {0., 0., 0.}, 0);
   verletLists.addParticle(p);
   std::array<double, 3> r2 = {2.5, 2, 2};
-  Particle p2(r2, {0., 0., 0.}, 1);
+  ParticleFP64 p2(r2, {0., 0., 0.}, 1);
   verletLists.addParticle(p2);
 
-  MockPairwiseFunctor<Particle> mockFunctor;
+  MockPairwiseFunctor<ParticleFP64> mockFunctor;
   using ::testing::_;  // anything is ok
   EXPECT_CALL(mockFunctor, AoSFunctor(_, _, true));
 
-  autopas::VVLAsBuildTraversal<FPCell, autopas::Particle, MPairwiseFunctor> dummyTraversal(
+  autopas::VVLAsBuildTraversal<FPCell, ParticleFP64, MPairwiseFunctor> dummyTraversal(
       &mockFunctor, autopas::DataLayoutOption::aos, true);
 
   verletLists.rebuildNeighborLists(&dummyTraversal);
@@ -165,20 +165,20 @@ TEST_F(VarVerletListsTest, testVerletListBuildTwice) {
   double cutoff = 1.;
   double skin = 0.2;
   unsigned int rebuildFrequency = 20;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skin,
+  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(min, max, cutoff, skin,
                                                                                               rebuildFrequency);
 
   std::array<double, 3> r = {2, 2, 2};
-  Particle p(r, {0., 0., 0.}, 0);
+  ParticleFP64 p(r, {0., 0., 0.}, 0);
   verletLists.addParticle(p);
   std::array<double, 3> r2 = {1.5, 2, 2};
-  Particle p2(r2, {0., 0., 0.}, 1);
+  ParticleFP64 p2(r2, {0., 0., 0.}, 1);
   verletLists.addParticle(p2);
 
-  MockPairwiseFunctor<Particle> emptyFunctor;
+  MockPairwiseFunctor<ParticleFP64> emptyFunctor;
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, true)).Times(AtLeast(1));
 
-  autopas::VVLAsBuildTraversal<FPCell, autopas::Particle, MPairwiseFunctor> dummyTraversal(
+  autopas::VVLAsBuildTraversal<FPCell, ParticleFP64, MPairwiseFunctor> dummyTraversal(
       &emptyFunctor, autopas::DataLayoutOption::aos, true);
 
   verletLists.rebuildNeighborLists(&dummyTraversal);
@@ -195,24 +195,24 @@ TEST_F(VarVerletListsTest, testVerletListBuildFarAway) {
   double cutoff = 1.;
   double skin = 0.2;
   unsigned int rebuildFrequency = 20;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skin,
+  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(min, max, cutoff, skin,
                                                                                               rebuildFrequency);
 
   std::array<double, 3> r = {2, 2, 2};
-  Particle p(r, {0., 0., 0.}, 0);
+  ParticleFP64 p(r, {0., 0., 0.}, 0);
   verletLists.addParticle(p);
 
   std::array<double, 3> r2 = {1.5, 2, 2};
-  Particle p2(r2, {0., 0., 0.}, 1);
+  ParticleFP64 p2(r2, {0., 0., 0.}, 1);
   verletLists.addParticle(p2);
 
   std::array<double, 3> r3 = {4.5, 4.5, 4.5};
-  Particle p3(r3, {0., 0., 0.}, 2);
+  ParticleFP64 p3(r3, {0., 0., 0.}, 2);
   verletLists.addParticle(p3);
 
-  MockPairwiseFunctor<Particle> emptyFunctor;
+  MockPairwiseFunctor<ParticleFP64> emptyFunctor;
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, true)).Times(AtLeast(1));
-  autopas::VVLAsBuildTraversal<FPCell, autopas::Particle, MPairwiseFunctor> dummyTraversal(
+  autopas::VVLAsBuildTraversal<FPCell, ParticleFP64, MPairwiseFunctor> dummyTraversal(
       &emptyFunctor, autopas::DataLayoutOption::aos, true);
   verletLists.rebuildNeighborLists(&dummyTraversal);
   verletLists.computeInteractions(&dummyTraversal);
@@ -226,20 +226,20 @@ TEST_F(VarVerletListsTest, testVerletListBuildHalo) {
   double cutoff = 1.;
   double skin = 0.2;
   unsigned int rebuildFrequency = 20;
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(min, max, cutoff, skin,
+  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(min, max, cutoff, skin,
                                                                                               rebuildFrequency);
 
   std::array<double, 3> r = {0.9, 0.9, 0.9};
-  Particle p(r, {0., 0., 0.}, 0, autopas::OwnershipState::halo);
+  ParticleFP64 p(r, {0., 0., 0.}, 0, autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p);
   std::array<double, 3> r2 = {1.1, 1.1, 1.1};
-  Particle p2(r2, {0., 0., 0.}, 1);
+  ParticleFP64 p2(r2, {0., 0., 0.}, 1);
   verletLists.addParticle(p2);
 
-  MockPairwiseFunctor<Particle> emptyFunctor;
+  MockPairwiseFunctor<ParticleFP64> emptyFunctor;
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, true)).Times(AtLeast(1));
 
-  autopas::VVLAsBuildTraversal<FPCell, autopas::Particle, MPairwiseFunctor> dummyTraversal(
+  autopas::VVLAsBuildTraversal<FPCell, ParticleFP64, MPairwiseFunctor> dummyTraversal(
       &emptyFunctor, autopas::DataLayoutOption::aos, true);
 
   verletLists.rebuildNeighborLists(&dummyTraversal);
@@ -250,8 +250,8 @@ TEST_F(VarVerletListsTest, testVerletListBuildHalo) {
   EXPECT_EQ(verletLists.getNumberOfNeighborPairs(), 1);
 }
 
-template <class Container, class Particle>
-bool moveUpdateAndExpectEqual(Container &container, Particle &particle, std::array<double, 3> newPosition) {
+template <class Container, class ParticleFP64>
+bool moveUpdateAndExpectEqual(Container &container, ParticleFP64 &particle, std::array<double, 3> newPosition) {
   particle.setR(newPosition);
   /// @todo: uncomment
   bool updated = container.updateHaloParticle(particle);
@@ -264,10 +264,10 @@ bool moveUpdateAndExpectEqual(Container &container, Particle &particle, std::arr
 }
 
 TEST_F(VarVerletListsTest, testUpdateHaloParticle) {
-  autopas::VarVerletLists<Particle, autopas::VerletNeighborListAsBuild<Particle>> verletLists(
+  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(
       {0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 1);
 
-  Particle p({-.1, 10.1, -.1}, {0., 0., 0.}, 1, autopas::OwnershipState::halo);
+  ParticleFP64 p({-.1, 10.1, -.1}, {0., 0., 0.}, 1, autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p);
 
   // test same position, change velocity
@@ -294,20 +294,20 @@ TEST_F(VarVerletListsTest, testUpdateHaloParticle) {
   EXPECT_TRUE(moveUpdateAndExpectEqual(verletLists, p, {.05, 9.95, .05}));
 
   // check for particle with wrong id
-  Particle p2({-.1, -.1, -.1}, {0., 0., 0.}, 2, autopas::OwnershipState::halo);
+  ParticleFP64 p2({-.1, -.1, -.1}, {0., 0., 0.}, 2, autopas::OwnershipState::halo);
   EXPECT_FALSE(verletLists.updateHaloParticle(p2));
 
   // test move far, expect throw
   EXPECT_FALSE(moveUpdateAndExpectEqual(verletLists, p, {3, 3, 3}));
 
   // test particles at intermediate positions (not at corners)
-  Particle p3({-1., 4., 2.}, {0., 0., 0.}, 3, autopas::OwnershipState::halo);
+  ParticleFP64 p3({-1., 4., 2.}, {0., 0., 0.}, 3, autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p3);
   EXPECT_TRUE(verletLists.updateHaloParticle(p3));
-  Particle p4({4., 10.2, 2.}, {0., 0., 0.}, 4, autopas::OwnershipState::halo);
+  ParticleFP64 p4({4., 10.2, 2.}, {0., 0., 0.}, 4, autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p4);
   EXPECT_TRUE(verletLists.updateHaloParticle(p4));
-  Particle p5({5., 4., 10.2}, {0., 0., 0.}, 3, autopas::OwnershipState::halo);
+  ParticleFP64 p5({5., 4., 10.2}, {0., 0., 0.}, 3, autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p5);
   EXPECT_TRUE(verletLists.updateHaloParticle(p5));
 }

--- a/tests/testAutopas/tests/containers/verletListsCellBased/varVerletLists/VarVerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/varVerletLists/VarVerletListsTest.cpp
@@ -26,8 +26,8 @@ TEST_F(VarVerletListsTest, VerletListConstructor) {
   double cutoff = 1.;
   double skin = 0.2;
   unsigned int rebuildFrequency = 20;
-  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(min, max, cutoff, skin,
-                                                                                              rebuildFrequency);
+  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(
+      min, max, cutoff, skin, rebuildFrequency);
 }
 
 TEST_F(VarVerletListsTest, testAddParticleNumParticle) {
@@ -36,8 +36,8 @@ TEST_F(VarVerletListsTest, testAddParticleNumParticle) {
   double cutoff = 1.;
   double skin = 0.2;
   unsigned int rebuildFrequency = 20;
-  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(min, max, cutoff, skin,
-                                                                                              rebuildFrequency);
+  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(
+      min, max, cutoff, skin, rebuildFrequency);
   EXPECT_EQ(verletLists.size(), 0);
 
   std::array<double, 3> r = {2, 2, 2};
@@ -57,8 +57,8 @@ TEST_F(VarVerletListsTest, testDeleteAllParticles) {
   double cutoff = 1.;
   double skin = 0.2;
   unsigned int rebuildFrequency = 20;
-  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(min, max, cutoff, skin,
-                                                                                              rebuildFrequency);
+  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(
+      min, max, cutoff, skin, rebuildFrequency);
   EXPECT_EQ(verletLists.size(), 0);
 
   std::array<double, 3> r = {2, 2, 2};
@@ -80,8 +80,8 @@ TEST_F(VarVerletListsTest, testVerletListBuild) {
   double cutoff = 1.;
   double skin = 0.2;
   unsigned int rebuildFrequency = 20;
-  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(min, max, cutoff, skin,
-                                                                                              rebuildFrequency);
+  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(
+      min, max, cutoff, skin, rebuildFrequency);
 
   std::array<double, 3> r = {2, 2, 2};
   ParticleFP64 p(r, {0., 0., 0.}, 0);
@@ -108,8 +108,8 @@ TEST_F(VarVerletListsTest, testVerletList) {
   double cutoff = 1.;
   double skin = 0.2;
   unsigned int rebuildFrequency = 20;
-  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(min, max, cutoff, skin,
-                                                                                              rebuildFrequency);
+  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(
+      min, max, cutoff, skin, rebuildFrequency);
 
   std::array<double, 3> r = {2, 2, 2};
   ParticleFP64 p(r, {0., 0., 0.}, 0);
@@ -136,8 +136,8 @@ TEST_F(VarVerletListsTest, testVerletListInSkin) {
   double cutoff = 1.;
   double skin = 0.2;
   unsigned int rebuildFrequency = 20;
-  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(min, max, cutoff, skin,
-                                                                                              rebuildFrequency);
+  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(
+      min, max, cutoff, skin, rebuildFrequency);
 
   std::array<double, 3> r = {1.4, 2, 2};
   ParticleFP64 p(r, {0., 0., 0.}, 0);
@@ -165,8 +165,8 @@ TEST_F(VarVerletListsTest, testVerletListBuildTwice) {
   double cutoff = 1.;
   double skin = 0.2;
   unsigned int rebuildFrequency = 20;
-  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(min, max, cutoff, skin,
-                                                                                              rebuildFrequency);
+  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(
+      min, max, cutoff, skin, rebuildFrequency);
 
   std::array<double, 3> r = {2, 2, 2};
   ParticleFP64 p(r, {0., 0., 0.}, 0);
@@ -195,8 +195,8 @@ TEST_F(VarVerletListsTest, testVerletListBuildFarAway) {
   double cutoff = 1.;
   double skin = 0.2;
   unsigned int rebuildFrequency = 20;
-  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(min, max, cutoff, skin,
-                                                                                              rebuildFrequency);
+  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(
+      min, max, cutoff, skin, rebuildFrequency);
 
   std::array<double, 3> r = {2, 2, 2};
   ParticleFP64 p(r, {0., 0., 0.}, 0);
@@ -226,8 +226,8 @@ TEST_F(VarVerletListsTest, testVerletListBuildHalo) {
   double cutoff = 1.;
   double skin = 0.2;
   unsigned int rebuildFrequency = 20;
-  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(min, max, cutoff, skin,
-                                                                                              rebuildFrequency);
+  autopas::VarVerletLists<ParticleFP64, autopas::VerletNeighborListAsBuild<ParticleFP64>> verletLists(
+      min, max, cutoff, skin, rebuildFrequency);
 
   std::array<double, 3> r = {0.9, 0.9, 0.9};
   ParticleFP64 p(r, {0., 0., 0.}, 0, autopas::OwnershipState::halo);

--- a/tests/testAutopas/tests/containers/verletListsCellBased/varVerletLists/VarVerletListsTest.h
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/varVerletLists/VarVerletListsTest.h
@@ -10,7 +10,7 @@
 
 #include "AutoPasTestBase.h"
 #include "autopas/cells/FullParticleCell.h"
-#include "autopas/particles/Particle.h"
+#include "autopas/particles/ParticleDefinitions.h"
 #include "autopasTools/generators/UniformGenerator.h"
 #include "mocks/MockPairwiseFunctor.h"
 #include "testingHelpers/commonTypedefs.h"

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.cpp
@@ -206,8 +206,8 @@ TEST_P(VerletListsTest, testVerletListBuildHalo) {
   ASSERT_EQ(partners, 1);
 }
 
-template <class Container, class ParticleT>
-bool moveUpdateAndExpectEqual(Container &container, ParticleT &particle, const std::array<double, 3> &newPosition) {
+template <class Container, class Particle_T>
+bool moveUpdateAndExpectEqual(Container &container, Particle_T &particle, const std::array<double, 3> &newPosition) {
   particle.setR(newPosition);
   bool updated = container.updateHaloParticle(particle);
   if (updated) {

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.cpp
@@ -26,8 +26,8 @@ TEST_P(VerletListsTest, testVerletListBuildAndIterate) {
   unsigned int rebuildFrequency = 20;
   const double cellSizeFactor = GetParam();
   autopas::VerletLists<ParticleFP64> verletLists(min, max, cutoff, skin, rebuildFrequency,
-                                             autopas::VerletLists<ParticleFP64>::BuildVerletListType::VerletSoA,
-                                             cellSizeFactor);
+                                                 autopas::VerletLists<ParticleFP64>::BuildVerletListType::VerletSoA,
+                                                 cellSizeFactor);
 
   std::array<double, 3> r = {2, 2, 2};
   ParticleFP64 p(r, {0., 0., 0.}, 0);
@@ -62,8 +62,8 @@ TEST_P(VerletListsTest, testVerletListInSkin) {
   unsigned int rebuildFrequency = 20;
   const double cellSizeFactor = GetParam();
   autopas::VerletLists<ParticleFP64> verletLists(min, max, cutoff, skin, rebuildFrequency,
-                                             autopas::VerletLists<ParticleFP64>::BuildVerletListType::VerletSoA,
-                                             cellSizeFactor);
+                                                 autopas::VerletLists<ParticleFP64>::BuildVerletListType::VerletSoA,
+                                                 cellSizeFactor);
 
   std::array<double, 3> r = {1.4, 2, 2};
   ParticleFP64 p(r, {0., 0., 0.}, 0);
@@ -98,8 +98,8 @@ TEST_P(VerletListsTest, testVerletListBuildTwice) {
   unsigned int rebuildFrequency = 20;
   const double cellSizeFactor = GetParam();
   autopas::VerletLists<ParticleFP64> verletLists(min, max, cutoff, skin, rebuildFrequency,
-                                             autopas::VerletLists<ParticleFP64>::BuildVerletListType::VerletSoA,
-                                             cellSizeFactor);
+                                                 autopas::VerletLists<ParticleFP64>::BuildVerletListType::VerletSoA,
+                                                 cellSizeFactor);
 
   std::array<double, 3> r = {2, 2, 2};
   ParticleFP64 p(r, {0., 0., 0.}, 0);
@@ -135,8 +135,8 @@ TEST_P(VerletListsTest, testVerletListBuildFarAway) {
   unsigned int rebuildFrequency = 20;
   const double cellSizeFactor = GetParam();
   autopas::VerletLists<ParticleFP64> verletLists(min, max, cutoff, skin, rebuildFrequency,
-                                             autopas::VerletLists<ParticleFP64>::BuildVerletListType::VerletSoA,
-                                             cellSizeFactor);
+                                                 autopas::VerletLists<ParticleFP64>::BuildVerletListType::VerletSoA,
+                                                 cellSizeFactor);
 
   std::array<double, 3> r = {2, 2, 2};
   ParticleFP64 p(r, {0., 0., 0.}, 0);
@@ -176,8 +176,8 @@ TEST_P(VerletListsTest, testVerletListBuildHalo) {
   unsigned int rebuildFrequency = 20;
   const double cellSizeFactor = GetParam();
   autopas::VerletLists<ParticleFP64> verletLists(min, max, cutoff, skin, rebuildFrequency,
-                                             autopas::VerletLists<ParticleFP64>::BuildVerletListType::VerletSoA,
-                                             cellSizeFactor);
+                                                 autopas::VerletLists<ParticleFP64>::BuildVerletListType::VerletSoA,
+                                                 cellSizeFactor);
 
   std::array<double, 3> r = {0.9, 0.9, 0.9};
   ParticleFP64 p(r, {0., 0., 0.}, 0, autopas::OwnershipState::halo);
@@ -221,8 +221,8 @@ bool moveUpdateAndExpectEqual(Container &container, ParticleT &particle, const s
 TEST_P(VerletListsTest, testUpdateHaloParticle) {
   const double cellSizeFactor = GetParam();
   autopas::VerletLists<ParticleFP64> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 30,
-                                             autopas::VerletLists<ParticleFP64>::BuildVerletListType::VerletSoA,
-                                             cellSizeFactor);
+                                                 autopas::VerletLists<ParticleFP64>::BuildVerletListType::VerletSoA,
+                                                 cellSizeFactor);
 
   ParticleFP64 p({-.1, 10.1, -.1}, {0., 0., 0.}, 1, autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p);
@@ -275,8 +275,8 @@ TEST_P(VerletListsTest, LoadExtractSoA) {
   unsigned int rebuildFrequency = 30;
   const double cellSizeFactor = GetParam();
   autopas::VerletLists<ParticleFP64> verletLists({0., 0., 0.}, {10., 10., 10.}, cutoff, skin, rebuildFrequency,
-                                             autopas::VerletLists<ParticleFP64>::BuildVerletListType::VerletSoA,
-                                             cellSizeFactor);
+                                                 autopas::VerletLists<ParticleFP64>::BuildVerletListType::VerletSoA,
+                                                 cellSizeFactor);
 
   ParticleFP64 p({-.1, 10.1, -.1}, {0., 0., 0.}, 1, autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p);
@@ -287,8 +287,10 @@ TEST_P(VerletListsTest, LoadExtractSoA) {
                                                                               autopas::DataLayoutOption::soa, false);
   const size_t dimWithHalo = 10 / ((cutoff + skin) * cellSizeFactor) + 2ul;
   const size_t numCells = dimWithHalo * dimWithHalo * dimWithHalo;
-  EXPECT_CALL(mockFunctor, SoALoader(testing::An<autopas::FullParticleCell<ParticleFP64> &>(), _, _, _)).Times(numCells);
-  EXPECT_CALL(mockFunctor, SoAExtractor(testing::An<autopas::FullParticleCell<ParticleFP64> &>(), _, _)).Times(numCells);
+  EXPECT_CALL(mockFunctor, SoALoader(testing::An<autopas::FullParticleCell<ParticleFP64> &>(), _, _, _))
+      .Times(numCells);
+  EXPECT_CALL(mockFunctor, SoAExtractor(testing::An<autopas::FullParticleCell<ParticleFP64> &>(), _, _))
+      .Times(numCells);
   EXPECT_CALL(mockFunctor, SoAFunctorVerlet(_, _, _, _)).Times(1);
 
   verletLists.rebuildNeighborLists(&verletTraversal);

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.cpp
@@ -25,18 +25,18 @@ TEST_P(VerletListsTest, testVerletListBuildAndIterate) {
   double skin = 0.2;
   unsigned int rebuildFrequency = 20;
   const double cellSizeFactor = GetParam();
-  autopas::VerletLists<Particle> verletLists(min, max, cutoff, skin, rebuildFrequency,
-                                             autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA,
+  autopas::VerletLists<ParticleFP64> verletLists(min, max, cutoff, skin, rebuildFrequency,
+                                             autopas::VerletLists<ParticleFP64>::BuildVerletListType::VerletSoA,
                                              cellSizeFactor);
 
   std::array<double, 3> r = {2, 2, 2};
-  Particle p(r, {0., 0., 0.}, 0);
+  ParticleFP64 p(r, {0., 0., 0.}, 0);
   verletLists.addParticle(p);
   std::array<double, 3> r2 = {1.5, 2, 2};
-  Particle p2(r2, {0., 0., 0.}, 1);
+  ParticleFP64 p2(r2, {0., 0., 0.}, 1);
   verletLists.addParticle(p2);
 
-  MockPairwiseFunctor<Particle> emptyFunctor;
+  MockPairwiseFunctor<ParticleFP64> emptyFunctor;
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, true)).Times(1);
 
   autopas::VLListIterationTraversal<FPCell, MPairwiseFunctor> verletTraversal(&emptyFunctor,
@@ -61,18 +61,18 @@ TEST_P(VerletListsTest, testVerletListInSkin) {
   double skin = 0.2;
   unsigned int rebuildFrequency = 20;
   const double cellSizeFactor = GetParam();
-  autopas::VerletLists<Particle> verletLists(min, max, cutoff, skin, rebuildFrequency,
-                                             autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA,
+  autopas::VerletLists<ParticleFP64> verletLists(min, max, cutoff, skin, rebuildFrequency,
+                                             autopas::VerletLists<ParticleFP64>::BuildVerletListType::VerletSoA,
                                              cellSizeFactor);
 
   std::array<double, 3> r = {1.4, 2, 2};
-  Particle p(r, {0., 0., 0.}, 0);
+  ParticleFP64 p(r, {0., 0., 0.}, 0);
   verletLists.addParticle(p);
   std::array<double, 3> r2 = {2.5, 2, 2};
-  Particle p2(r2, {0., 0., 0.}, 1);
+  ParticleFP64 p2(r2, {0., 0., 0.}, 1);
   verletLists.addParticle(p2);
 
-  MockPairwiseFunctor<Particle> mockFunctor;
+  MockPairwiseFunctor<ParticleFP64> mockFunctor;
   EXPECT_CALL(mockFunctor, AoSFunctor(_, _, true));
 
   autopas::VLListIterationTraversal<FPCell, MPairwiseFunctor> verletTraversal(&mockFunctor,
@@ -97,18 +97,18 @@ TEST_P(VerletListsTest, testVerletListBuildTwice) {
   double skin = 0.2;
   unsigned int rebuildFrequency = 20;
   const double cellSizeFactor = GetParam();
-  autopas::VerletLists<Particle> verletLists(min, max, cutoff, skin, rebuildFrequency,
-                                             autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA,
+  autopas::VerletLists<ParticleFP64> verletLists(min, max, cutoff, skin, rebuildFrequency,
+                                             autopas::VerletLists<ParticleFP64>::BuildVerletListType::VerletSoA,
                                              cellSizeFactor);
 
   std::array<double, 3> r = {2, 2, 2};
-  Particle p(r, {0., 0., 0.}, 0);
+  ParticleFP64 p(r, {0., 0., 0.}, 0);
   verletLists.addParticle(p);
   std::array<double, 3> r2 = {1.5, 2, 2};
-  Particle p2(r2, {0., 0., 0.}, 1);
+  ParticleFP64 p2(r2, {0., 0., 0.}, 1);
   verletLists.addParticle(p2);
 
-  MockPairwiseFunctor<Particle> emptyFunctor;
+  MockPairwiseFunctor<ParticleFP64> emptyFunctor;
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, true)).Times(AtLeast(1));
 
   autopas::VLListIterationTraversal<FPCell, MPairwiseFunctor> verletTraversal(&emptyFunctor,
@@ -134,23 +134,23 @@ TEST_P(VerletListsTest, testVerletListBuildFarAway) {
   double skin = 0.2;
   unsigned int rebuildFrequency = 20;
   const double cellSizeFactor = GetParam();
-  autopas::VerletLists<Particle> verletLists(min, max, cutoff, skin, rebuildFrequency,
-                                             autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA,
+  autopas::VerletLists<ParticleFP64> verletLists(min, max, cutoff, skin, rebuildFrequency,
+                                             autopas::VerletLists<ParticleFP64>::BuildVerletListType::VerletSoA,
                                              cellSizeFactor);
 
   std::array<double, 3> r = {2, 2, 2};
-  Particle p(r, {0., 0., 0.}, 0);
+  ParticleFP64 p(r, {0., 0., 0.}, 0);
   verletLists.addParticle(p);
 
   std::array<double, 3> r2 = {1.5, 2, 2};
-  Particle p2(r2, {0., 0., 0.}, 1);
+  ParticleFP64 p2(r2, {0., 0., 0.}, 1);
   verletLists.addParticle(p2);
 
   std::array<double, 3> r3 = {4.5, 4.5, 4.5};
-  Particle p3(r3, {0., 0., 0.}, 2);
+  ParticleFP64 p3(r3, {0., 0., 0.}, 2);
   verletLists.addParticle(p3);
 
-  MockPairwiseFunctor<Particle> emptyFunctor;
+  MockPairwiseFunctor<ParticleFP64> emptyFunctor;
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, true)).Times(AtLeast(1));
 
   autopas::VLListIterationTraversal<FPCell, MPairwiseFunctor> verletTraversal(&emptyFunctor,
@@ -175,18 +175,18 @@ TEST_P(VerletListsTest, testVerletListBuildHalo) {
   double skin = 0.2;
   unsigned int rebuildFrequency = 20;
   const double cellSizeFactor = GetParam();
-  autopas::VerletLists<Particle> verletLists(min, max, cutoff, skin, rebuildFrequency,
-                                             autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA,
+  autopas::VerletLists<ParticleFP64> verletLists(min, max, cutoff, skin, rebuildFrequency,
+                                             autopas::VerletLists<ParticleFP64>::BuildVerletListType::VerletSoA,
                                              cellSizeFactor);
 
   std::array<double, 3> r = {0.9, 0.9, 0.9};
-  Particle p(r, {0., 0., 0.}, 0, autopas::OwnershipState::halo);
+  ParticleFP64 p(r, {0., 0., 0.}, 0, autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p);
   std::array<double, 3> r2 = {1.1, 1.1, 1.1};
-  Particle p2(r2, {0., 0., 0.}, 1);
+  ParticleFP64 p2(r2, {0., 0., 0.}, 1);
   verletLists.addParticle(p2);
 
-  MockPairwiseFunctor<Particle> emptyFunctor;
+  MockPairwiseFunctor<ParticleFP64> emptyFunctor;
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, true)).Times(AtLeast(1));
 
   autopas::VLListIterationTraversal<FPCell, MPairwiseFunctor> verletTraversal(&emptyFunctor,
@@ -206,8 +206,8 @@ TEST_P(VerletListsTest, testVerletListBuildHalo) {
   ASSERT_EQ(partners, 1);
 }
 
-template <class Container, class Particle>
-bool moveUpdateAndExpectEqual(Container &container, Particle &particle, const std::array<double, 3> &newPosition) {
+template <class Container, class ParticleT>
+bool moveUpdateAndExpectEqual(Container &container, ParticleT &particle, const std::array<double, 3> &newPosition) {
   particle.setR(newPosition);
   bool updated = container.updateHaloParticle(particle);
   if (updated) {
@@ -220,11 +220,11 @@ bool moveUpdateAndExpectEqual(Container &container, Particle &particle, const st
 
 TEST_P(VerletListsTest, testUpdateHaloParticle) {
   const double cellSizeFactor = GetParam();
-  autopas::VerletLists<Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 30,
-                                             autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA,
+  autopas::VerletLists<ParticleFP64> verletLists({0., 0., 0.}, {10., 10., 10.}, 2., 0.3, 30,
+                                             autopas::VerletLists<ParticleFP64>::BuildVerletListType::VerletSoA,
                                              cellSizeFactor);
 
-  Particle p({-.1, 10.1, -.1}, {0., 0., 0.}, 1, autopas::OwnershipState::halo);
+  ParticleFP64 p({-.1, 10.1, -.1}, {0., 0., 0.}, 1, autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p);
 
   // test same position, change velocity
@@ -251,20 +251,20 @@ TEST_P(VerletListsTest, testUpdateHaloParticle) {
   EXPECT_TRUE(moveUpdateAndExpectEqual(verletLists, p, {.05, 9.95, .05}));
 
   // check for particle with wrong id
-  Particle p2({-.1, -.1, -.1}, {0., 0., 0.}, 2, autopas::OwnershipState::halo);
+  ParticleFP64 p2({-.1, -.1, -.1}, {0., 0., 0.}, 2, autopas::OwnershipState::halo);
   EXPECT_FALSE(verletLists.updateHaloParticle(p2));
 
   // test move far, expect throw
   EXPECT_FALSE(moveUpdateAndExpectEqual(verletLists, p, {3, 3, 3}));
 
   // test particles at intermediate positions (not at corners)
-  Particle p3({-1., 4., 2.}, {0., 0., 0.}, 3, autopas::OwnershipState::halo);
+  ParticleFP64 p3({-1., 4., 2.}, {0., 0., 0.}, 3, autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p3);
   EXPECT_TRUE(verletLists.updateHaloParticle(p3));
-  Particle p4({4., 10.2, 2.}, {0., 0., 0.}, 4, autopas::OwnershipState::halo);
+  ParticleFP64 p4({4., 10.2, 2.}, {0., 0., 0.}, 4, autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p4);
   EXPECT_TRUE(verletLists.updateHaloParticle(p4));
-  Particle p5({5., 4., 10.2}, {0., 0., 0.}, 3, autopas::OwnershipState::halo);
+  ParticleFP64 p5({5., 4., 10.2}, {0., 0., 0.}, 3, autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p5);
   EXPECT_TRUE(verletLists.updateHaloParticle(p5));
 }
@@ -274,21 +274,21 @@ TEST_P(VerletListsTest, LoadExtractSoA) {
   double skin = 0.3;
   unsigned int rebuildFrequency = 30;
   const double cellSizeFactor = GetParam();
-  autopas::VerletLists<Particle> verletLists({0., 0., 0.}, {10., 10., 10.}, cutoff, skin, rebuildFrequency,
-                                             autopas::VerletLists<Particle>::BuildVerletListType::VerletSoA,
+  autopas::VerletLists<ParticleFP64> verletLists({0., 0., 0.}, {10., 10., 10.}, cutoff, skin, rebuildFrequency,
+                                             autopas::VerletLists<ParticleFP64>::BuildVerletListType::VerletSoA,
                                              cellSizeFactor);
 
-  Particle p({-.1, 10.1, -.1}, {0., 0., 0.}, 1, autopas::OwnershipState::halo);
+  ParticleFP64 p({-.1, 10.1, -.1}, {0., 0., 0.}, 1, autopas::OwnershipState::halo);
   verletLists.addHaloParticle(p);
 
-  MockPairwiseFunctor<Particle> mockFunctor;
+  MockPairwiseFunctor<ParticleFP64> mockFunctor;
 
   autopas::VLListIterationTraversal<FPCell, MPairwiseFunctor> verletTraversal(&mockFunctor,
                                                                               autopas::DataLayoutOption::soa, false);
   const size_t dimWithHalo = 10 / ((cutoff + skin) * cellSizeFactor) + 2ul;
   const size_t numCells = dimWithHalo * dimWithHalo * dimWithHalo;
-  EXPECT_CALL(mockFunctor, SoALoader(testing::An<autopas::FullParticleCell<Particle> &>(), _, _, _)).Times(numCells);
-  EXPECT_CALL(mockFunctor, SoAExtractor(testing::An<autopas::FullParticleCell<Particle> &>(), _, _)).Times(numCells);
+  EXPECT_CALL(mockFunctor, SoALoader(testing::An<autopas::FullParticleCell<ParticleFP64> &>(), _, _, _)).Times(numCells);
+  EXPECT_CALL(mockFunctor, SoAExtractor(testing::An<autopas::FullParticleCell<ParticleFP64> &>(), _, _)).Times(numCells);
   EXPECT_CALL(mockFunctor, SoAFunctorVerlet(_, _, _, _)).Times(1);
 
   verletLists.rebuildNeighborLists(&verletTraversal);

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.h
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletLists/VerletListsTest.h
@@ -10,7 +10,7 @@
 
 #include "AutoPasTestBase.h"
 #include "autopas/cells/FullParticleCell.h"
-#include "autopas/particles/Particle.h"
+#include "autopas/particles/ParticleDefinitions.h"
 #include "autopasTools/generators/UniformGenerator.h"
 #include "mocks/MockPairwiseFunctor.h"
 #include "molecularDynamicsLibrary/ParticlePropertiesLibrary.h"

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/PairwiseVerletListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/PairwiseVerletListsTest.cpp
@@ -17,7 +17,7 @@ using ::testing::Values;
  * This scenario is an interaction between two particles and the result should be 1.
  */
 TEST_P(PairwiseVerletListsTest, testTwoParticles) {
-  MockPairwiseFunctor<Particle> emptyFunctor;
+  MockPairwiseFunctor<ParticleFP64> emptyFunctor;
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {3, 3, 3};
   double cutoff = 1.;
@@ -29,17 +29,17 @@ TEST_P(PairwiseVerletListsTest, testTwoParticles) {
   auto buildType = std::get<2>(params);
   const autopas::LoadEstimatorOption loadEstimator = autopas::LoadEstimatorOption::none;
   EXPECT_CALL(emptyFunctor, AoSFunctor(_, _, useNewton3)).Times(AtLeast(1));
-  autopas::VerletListsCells<Particle, autopas::VLCCellPairNeighborList<Particle>> verletLists(
+  autopas::VerletListsCells<ParticleFP64, autopas::VLCCellPairNeighborList<ParticleFP64>> verletLists(
       min, max, cutoff, skin, rebuildFrequency, cellSizeFactor, loadEstimator, buildType);
 
   std::array<double, 3> r = {2, 2, 2};
-  Particle p(r, {0., 0., 0.}, 0);
+  ParticleFP64 p(r, {0., 0., 0.}, 0);
   verletLists.addParticle(p);
   std::array<double, 3> r2 = {1.5, 2, 2};
-  Particle p2(r2, {0., 0., 0.}, 1);
+  ParticleFP64 p2(r2, {0., 0., 0.}, 1);
   verletLists.addParticle(p2);
 
-  autopas::VLCC18Traversal<FPCell, MPairwiseFunctor, autopas::VLCCellPairNeighborList<Particle>> traversal(
+  autopas::VLCC18Traversal<FPCell, MPairwiseFunctor, autopas::VLCCellPairNeighborList<ParticleFP64>> traversal(
       verletLists.getCellsPerDimension(), &emptyFunctor, verletLists.getInteractionLength(),
       verletLists.getCellLength(), autopas::DataLayoutOption::aos, useNewton3,
       autopas::ContainerOption::pairwiseVerletLists);
@@ -47,7 +47,7 @@ TEST_P(PairwiseVerletListsTest, testTwoParticles) {
   verletLists.rebuildNeighborLists(&traversal);
   verletLists.computeInteractions(&traversal);
 
-  std::vector<Particle *> list;
+  std::vector<ParticleFP64 *> list;
   for (auto iter = verletLists.begin(); iter.isValid(); ++iter) list.push_back(&*iter);
 
   size_t partners = 0;
@@ -71,7 +71,7 @@ TEST_P(PairwiseVerletListsTest, testTwoParticles) {
  * The result should be 2.
  */
 TEST_P(PairwiseVerletListsTest, testThreeParticlesOneFar) {
-  MockPairwiseFunctor<Particle> emptyFunctorOther;
+  MockPairwiseFunctor<ParticleFP64> emptyFunctorOther;
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {5, 5, 5};
   double cutoff = 1.;
@@ -85,20 +85,20 @@ TEST_P(PairwiseVerletListsTest, testThreeParticlesOneFar) {
 
   EXPECT_CALL(emptyFunctorOther, AoSFunctor(_, _, useNewton3)).Times(AtLeast(1));
 
-  autopas::VerletListsCells<Particle, autopas::VLCCellPairNeighborList<Particle>> verletLists(
+  autopas::VerletListsCells<ParticleFP64, autopas::VLCCellPairNeighborList<ParticleFP64>> verletLists(
       min, max, cutoff, skin, rebuildFrequency, cellSizeFactor, loadEstimator, buildType);
 
   std::array<double, 3> r = {2.5, 2.5, 2.5};
-  Particle p(r, {0., 0., 0.}, 0);
+  ParticleFP64 p(r, {0., 0., 0.}, 0);
   verletLists.addParticle(p);
   std::array<double, 3> r2 = {2.5, 2.5, 3.5};
-  Particle p2(r2, {0., 0., 0.}, 1);
+  ParticleFP64 p2(r2, {0., 0., 0.}, 1);
   verletLists.addParticle(p2);
   std::array<double, 3> r3 = {3, 3, 3.5};
-  Particle p3(r3, {0., 0., 0.}, 1);
+  ParticleFP64 p3(r3, {0., 0., 0.}, 1);
   verletLists.addParticle(p3);
 
-  autopas::VLCC18Traversal<FPCell, MPairwiseFunctor, autopas::VLCCellPairNeighborList<Particle>> traversal(
+  autopas::VLCC18Traversal<FPCell, MPairwiseFunctor, autopas::VLCCellPairNeighborList<ParticleFP64>> traversal(
       verletLists.getCellsPerDimension(), &emptyFunctorOther, verletLists.getInteractionLength(),
       verletLists.getCellLength(), autopas::DataLayoutOption::aos, useNewton3,
       autopas::ContainerOption::pairwiseVerletLists);
@@ -106,7 +106,7 @@ TEST_P(PairwiseVerletListsTest, testThreeParticlesOneFar) {
   verletLists.rebuildNeighborLists(&traversal);
   verletLists.computeInteractions(&traversal);
 
-  std::vector<Particle *> list;
+  std::vector<ParticleFP64 *> list;
   for (auto iter = verletLists.begin(); iter.isValid(); ++iter) list.push_back(&*iter);
 
   size_t partners = 0;
@@ -131,7 +131,7 @@ TEST_P(PairwiseVerletListsTest, testThreeParticlesOneFar) {
  * This scenario includes three particles interacting with each other and the result should be 3.
  */
 TEST_P(PairwiseVerletListsTest, testThreeParticlesClose) {
-  MockPairwiseFunctor<Particle> mock;
+  MockPairwiseFunctor<ParticleFP64> mock;
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {5, 5, 5};
   double cutoff = 1.;
@@ -144,27 +144,27 @@ TEST_P(PairwiseVerletListsTest, testThreeParticlesClose) {
   const autopas::LoadEstimatorOption loadEstimator = autopas::LoadEstimatorOption::none;
 
   EXPECT_CALL(mock, AoSFunctor(_, _, useNewton3)).Times(AtLeast(1));
-  autopas::VerletListsCells<Particle, autopas::VLCCellPairNeighborList<Particle>> verletLists(
+  autopas::VerletListsCells<ParticleFP64, autopas::VLCCellPairNeighborList<ParticleFP64>> verletLists(
       min, max, cutoff, skin, rebuildFrequency, cellSizeFactor, loadEstimator, buildType);
 
   std::array<double, 3> r = {2.5, 2.5, 2.5};
-  Particle p(r, {0., 0., 0.}, 0);
+  ParticleFP64 p(r, {0., 0., 0.}, 0);
   verletLists.addParticle(p);
   std::array<double, 3> r2 = {2.5, 2.5, 3.5};
-  Particle p2(r2, {0., 0., 0.}, 1);
+  ParticleFP64 p2(r2, {0., 0., 0.}, 1);
   verletLists.addParticle(p2);
   std::array<double, 3> r3 = {2, 2, 3};
-  Particle p3(r3, {0., 0., 0.}, 1);
+  ParticleFP64 p3(r3, {0., 0., 0.}, 1);
   verletLists.addParticle(p3);
 
-  autopas::VLCC18Traversal<FPCell, MPairwiseFunctor, autopas::VLCCellPairNeighborList<Particle>> traversal(
+  autopas::VLCC18Traversal<FPCell, MPairwiseFunctor, autopas::VLCCellPairNeighborList<ParticleFP64>> traversal(
       verletLists.getCellsPerDimension(), &mock, verletLists.getInteractionLength(), verletLists.getCellLength(),
       autopas::DataLayoutOption::aos, useNewton3, autopas::ContainerOption::pairwiseVerletLists);
 
   verletLists.rebuildNeighborLists(&traversal);
   verletLists.computeInteractions(&traversal);
 
-  std::vector<Particle *> list;
+  std::vector<ParticleFP64 *> list;
   for (auto iter = verletLists.begin(); iter.isValid(); ++iter) list.push_back(&*iter);
 
   size_t partners = 0;
@@ -189,7 +189,7 @@ TEST_P(PairwiseVerletListsTest, testThreeParticlesClose) {
  * This scenario includes a single particle and the result should be 0.
  */
 TEST_P(PairwiseVerletListsTest, testOneParticle) {
-  MockPairwiseFunctor<Particle> mock;
+  MockPairwiseFunctor<ParticleFP64> mock;
   // EXPECT_CALL(mock, AoSFunctor(_, _, true)); ?????
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {5, 5, 5};
@@ -201,21 +201,21 @@ TEST_P(PairwiseVerletListsTest, testOneParticle) {
   bool useNewton3 = std::get<1>(params);
   auto buildType = std::get<2>(params);
   const autopas::LoadEstimatorOption loadEstimator = autopas::LoadEstimatorOption::none;
-  autopas::VerletListsCells<Particle, autopas::VLCCellPairNeighborList<Particle>> verletLists(
+  autopas::VerletListsCells<ParticleFP64, autopas::VLCCellPairNeighborList<ParticleFP64>> verletLists(
       min, max, cutoff, skin, rebuildFrequency, cellSizeFactor, loadEstimator, buildType);
 
   std::array<double, 3> r = {2.5, 2.5, 2.5};
-  Particle p(r, {0., 0., 0.}, 0);
+  ParticleFP64 p(r, {0., 0., 0.}, 0);
   verletLists.addParticle(p);
 
-  autopas::VLCC18Traversal<FPCell, MPairwiseFunctor, autopas::VLCCellPairNeighborList<Particle>> traversal(
+  autopas::VLCC18Traversal<FPCell, MPairwiseFunctor, autopas::VLCCellPairNeighborList<ParticleFP64>> traversal(
       verletLists.getCellsPerDimension(), &mock, verletLists.getInteractionLength(), verletLists.getCellLength(),
       autopas::DataLayoutOption::aos, useNewton3, autopas::ContainerOption::pairwiseVerletLists);
 
   verletLists.rebuildNeighborLists(&traversal);
   verletLists.computeInteractions(&traversal);
 
-  std::vector<Particle *> list;
+  std::vector<ParticleFP64 *> list;
   for (auto iter = verletLists.begin(); iter.isValid(); ++iter) list.push_back(&*iter);
 
   size_t partners = 0;

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/PairwiseVerletListsTest.h
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/PairwiseVerletListsTest.h
@@ -11,7 +11,7 @@
 #include "AutoPasTestBase.h"
 #include "autopas/cells/FullParticleCell.h"
 #include "autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsHelpers.h"
-#include "autopas/particles/Particle.h"
+#include "autopas/particles/ParticleDefinitions.h"
 #include "autopasTools/generators/UniformGenerator.h"
 #include "mocks/MockPairwiseFunctor.h"
 #include "molecularDynamicsLibrary/LJFunctor.h"

--- a/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/VerletListsCellsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletListsCellBased/verletListsCells/VerletListsCellsTest.cpp
@@ -10,7 +10,7 @@
 #include "autopas/containers/verletListsCellBased/verletListsCells/VerletListsCellsHelpers.h"
 #include "autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCAllCellsNeighborList.h"
 #include "autopas/containers/verletListsCellBased/verletListsCells/traversals/VLCC18Traversal.h"
-#include "autopas/particles/Particle.h"
+#include "autopas/particles/ParticleDefinitions.h"
 #include "autopasTools/generators/UniformGenerator.h"
 #include "mocks/MockPairwiseFunctor.h"
 #include "molecularDynamicsLibrary/LJFunctor.h"
@@ -19,7 +19,7 @@
 using ::testing::_;
 using ::testing::AtLeast;
 
-void applyFunctor(MockPairwiseFunctor<Particle> &functor, const double cellSizefactor,
+void applyFunctor(MockPairwiseFunctor<ParticleFP64> &functor, const double cellSizefactor,
                   autopas::VerletListsCellsHelpers::VLCBuildType buildType) {
   std::array<double, 3> min = {1, 1, 1};
   std::array<double, 3> max = {3, 3, 3};
@@ -27,24 +27,24 @@ void applyFunctor(MockPairwiseFunctor<Particle> &functor, const double cellSizef
   double skin = 0.2;
   unsigned int rebuildFrequency = 20;
   const autopas::LoadEstimatorOption loadEstimator = autopas::LoadEstimatorOption::none;
-  autopas::VerletListsCells<Particle, autopas::VLCAllCellsNeighborList<Particle>> verletLists(
+  autopas::VerletListsCells<ParticleFP64, autopas::VLCAllCellsNeighborList<ParticleFP64>> verletLists(
       min, max, cutoff, skin, rebuildFrequency, cellSizefactor, loadEstimator, buildType);
 
   std::array<double, 3> r = {2, 2, 2};
-  Particle p(r, {0., 0., 0.}, 0);
+  ParticleFP64 p(r, {0., 0., 0.}, 0);
   verletLists.addParticle(p);
   std::array<double, 3> r2 = {1.5, 2, 2};
-  Particle p2(r2, {0., 0., 0.}, 1);
+  ParticleFP64 p2(r2, {0., 0., 0.}, 1);
   verletLists.addParticle(p2);
 
-  autopas::VLCC18Traversal<FPCell, MPairwiseFunctor, autopas::VLCAllCellsNeighborList<Particle>> traversal(
+  autopas::VLCC18Traversal<FPCell, MPairwiseFunctor, autopas::VLCAllCellsNeighborList<ParticleFP64>> traversal(
       verletLists.getCellsPerDimension(), &functor, verletLists.getInteractionLength(), verletLists.getCellLength(),
       autopas::DataLayoutOption::aos, true, autopas::ContainerOption::verletListsCells);
 
   verletLists.rebuildNeighborLists(&traversal);
   verletLists.computeInteractions(&traversal);
 
-  std::vector<Particle *> list;
+  std::vector<ParticleFP64 *> list;
   for (auto iter = verletLists.begin(autopas::IteratorBehavior::ownedOrHalo); iter.isValid(); ++iter) {
     list.push_back(&*iter);
   }
@@ -112,22 +112,22 @@ void soaTest(const double cellSizeFactor, autopas::VerletListsCellsHelpers::VLCB
 }
 
 TEST_F(VerletListsCellsTest, testVerletListBuild) {
-  MockPairwiseFunctor<Particle> emptyFunctorAoSBuild;
+  MockPairwiseFunctor<ParticleFP64> emptyFunctorAoSBuild;
   EXPECT_CALL(emptyFunctorAoSBuild, AoSFunctor(_, _, true)).Times(1);
 
   applyFunctor(emptyFunctorAoSBuild, 1.0, autopas::VerletListsCellsHelpers::VLCBuildType::aosBuild);
 
-  MockPairwiseFunctor<Particle> emptyFunctorSoABuild;
+  MockPairwiseFunctor<ParticleFP64> emptyFunctorSoABuild;
   EXPECT_CALL(emptyFunctorSoABuild, AoSFunctor(_, _, true)).Times(1);
 
   applyFunctor(emptyFunctorSoABuild, 1.0, autopas::VerletListsCellsHelpers::VLCBuildType::soaBuild);
 
-  MockPairwiseFunctor<Particle> emptyFunctorAoSBuild_cs2;
+  MockPairwiseFunctor<ParticleFP64> emptyFunctorAoSBuild_cs2;
   EXPECT_CALL(emptyFunctorAoSBuild_cs2, AoSFunctor(_, _, true)).Times(1);
 
   applyFunctor(emptyFunctorAoSBuild_cs2, 2.0, autopas::VerletListsCellsHelpers::VLCBuildType::aosBuild);
 
-  MockPairwiseFunctor<Particle> emptyFunctorSoABuild_cs2;
+  MockPairwiseFunctor<ParticleFP64> emptyFunctorSoABuild_cs2;
   EXPECT_CALL(emptyFunctorSoABuild_cs2, AoSFunctor(_, _, true)).Times(1);
 
   applyFunctor(emptyFunctorSoABuild_cs2, 2.0, autopas::VerletListsCellsHelpers::VLCBuildType::soaBuild);

--- a/tests/testAutopas/tests/particles/MyMoleculeTest.cpp
+++ b/tests/testAutopas/tests/particles/MyMoleculeTest.cpp
@@ -6,16 +6,16 @@
 
 #include <gtest/gtest.h>
 
-#include "autopas/particles/Particle.h"
+#include "autopas/particles/ParticleDefinitions.h"
 #include "tests/autopasInterface/AutoPasTest.h"
 
 using namespace autopas;
 
-class MyMolecule : public Particle {
+class MyMolecule : public ParticleFP64 {
  public:
-  MyMolecule() : Particle(), _myvar(0) {}
+  MyMolecule() : ParticleFP64(), _myvar(0) {}
   MyMolecule(const std::array<double, 3> &r, const std::array<double, 3> &v, unsigned long i, int myvar)
-      : Particle(r, v, i), _myvar(myvar) {}
+      : ParticleFP64(r, v, i), _myvar(myvar) {}
   void print() {
     std::cout << "Molecule with position: ";
     for (auto &r : getR()) {

--- a/tests/testAutopas/tests/tuning/selectors/ContainerSelectorTest.cpp
+++ b/tests/testAutopas/tests/tuning/selectors/ContainerSelectorTest.cpp
@@ -7,7 +7,7 @@
 #include "ContainerSelectorTest.h"
 
 TEST_F(ContainerSelectorTest, testSelectAndGetCurrentContainer) {
-  autopas::ContainerSelector<Particle> containerSelector(bBoxMin, bBoxMax, cutoff);
+  autopas::ContainerSelector<ParticleFP64> containerSelector(bBoxMin, bBoxMax, cutoff);
   autopas::ContainerSelectorInfo containerInfo(cellSizeFactor, verletSkin, verletRebuildFrequency, 64,
                                                autopas::LoadEstimatorOption::none);
 

--- a/tests/testAutopas/tests/tuning/selectors/ContainerSelectorTestFromTo.cpp
+++ b/tests/testAutopas/tests/tuning/selectors/ContainerSelectorTestFromTo.cpp
@@ -24,8 +24,8 @@ using ::testing::ValuesIn;
  * @param ListHaloOutsideCutoff All particles in the halo.
  */
 void getStatus(const std::array<double, 3> &bBoxMin, const std::array<double, 3> &bBoxMax, const double cutoff,
-               autopas::ContainerSelector<Particle> &containerSelector, std::vector<Particle> &ListInner,
-               std::vector<Particle> &ListHaloWithinCutoff, std::vector<Particle> &ListHaloOutsideCutoff) {
+               autopas::ContainerSelector<ParticleFP64> &containerSelector, std::vector<ParticleFP64> &ListInner,
+               std::vector<ParticleFP64> &ListHaloWithinCutoff, std::vector<ParticleFP64> &ListHaloOutsideCutoff) {
   using namespace autopas::utils::ArrayMath::literals;
 
   for (auto iter = containerSelector.getCurrentContainer().begin(autopas::IteratorBehavior::owned); iter.isValid();
@@ -47,7 +47,7 @@ void getStatus(const std::array<double, 3> &bBoxMin, const std::array<double, 3>
 TEST_P(ContainerSelectorTestFromTo, testContainerConversion) {
   const auto &[from, to] = GetParam();
 
-  autopas::ContainerSelector<Particle> containerSelector(bBoxMin, bBoxMax, cutoff);
+  autopas::ContainerSelector<ParticleFP64> containerSelector(bBoxMin, bBoxMax, cutoff);
   autopas::ContainerSelectorInfo containerInfo(cellSizeFactor, verletSkin, verletRebuildFrequency, 64,
                                                autopas::LoadEstimatorOption::none);
 
@@ -67,7 +67,7 @@ TEST_P(ContainerSelectorTestFromTo, testContainerConversion) {
       for (auto y : getPossible1DPositions(bBoxMin[1], bBoxMax[1])) {
         for (auto z : getPossible1DPositions(bBoxMin[2], bBoxMax[2])) {
           const std::array<double, 3> pos{x, y, z};
-          Particle p(pos, {0., 0., 0.}, id);
+          ParticleFP64 p(pos, {0., 0., 0.}, id);
           if (autopas::utils::inBox(pos, bBoxMin, bBoxMax)) {
             container.addParticle(p);
           } else {
@@ -80,7 +80,7 @@ TEST_P(ContainerSelectorTestFromTo, testContainerConversion) {
     }
   }
 
-  std::vector<Particle> beforeListInner, beforeListHaloWithinCutoff,
+  std::vector<ParticleFP64> beforeListInner, beforeListHaloWithinCutoff,
       beforeListHaloOutsideCutoff /*for particles only in verlet containers*/;
 
   getStatus(bBoxMin, bBoxMax, cutoff, containerSelector, beforeListInner, beforeListHaloWithinCutoff,
@@ -89,7 +89,7 @@ TEST_P(ContainerSelectorTestFromTo, testContainerConversion) {
   // select container to which we want to convert to
   containerSelector.selectContainer(to, containerInfo);
 
-  std::vector<Particle> afterListInner, afterListHaloWithinCutoff, afterListHaloOutsideCutoff;
+  std::vector<ParticleFP64> afterListInner, afterListHaloWithinCutoff, afterListHaloOutsideCutoff;
 
   getStatus(bBoxMin, bBoxMax, cutoff, containerSelector, afterListInner, afterListHaloWithinCutoff,
             afterListHaloOutsideCutoff);

--- a/tests/testAutopas/tests/tuning/selectors/TraversalSelectorTest.h
+++ b/tests/testAutopas/tests/tuning/selectors/TraversalSelectorTest.h
@@ -9,7 +9,7 @@
 #include <gtest/gtest.h>
 
 #include "AutoPasTestBase.h"
-#include "autopas/particles/Particle.h"
+#include "autopas/particles/ParticleDefinitions.h"
 #include "autopas/tuning/selectors/TraversalSelector.h"
 #include "mocks/MockPairwiseFunctor.h"
 #include "testingHelpers/commonTypedefs.h"

--- a/tests/testAutopas/tests/utils/SoATest.cpp
+++ b/tests/testAutopas/tests/utils/SoATest.cpp
@@ -211,8 +211,8 @@ TEST_F(SoATest, SoATestMultiWriteRead) {
 
   EXPECT_EQ(soa.size(), 1);
 
-  soa.writeMultiple<ParticleBaseFP64::AttributeNames::posX, ParticleBaseFP64::AttributeNames::posY, ParticleBaseFP64::AttributeNames::posZ>(
-      0, {4., 5., 6.});
+  soa.writeMultiple<ParticleBaseFP64::AttributeNames::posX, ParticleBaseFP64::AttributeNames::posY,
+                    ParticleBaseFP64::AttributeNames::posZ>(0, {4., 5., 6.});
 
   std::array<double, 3> f = {7., 8., 9.};
   soa.writeMultiple<ParticleBaseFP64::AttributeNames::forceX, ParticleBaseFP64::AttributeNames::forceY,
@@ -332,8 +332,8 @@ TEST_F(SoATest, SoATestComplicatedAccess) {
 
   EXPECT_EQ(soa.size(), 1);
 
-  soa.writeMultiple<ParticleBaseFP64::AttributeNames::posX, ParticleBaseFP64::AttributeNames::posY, ParticleBaseFP64::AttributeNames::posZ>(
-      0, {4., 5., 6.});
+  soa.writeMultiple<ParticleBaseFP64::AttributeNames::posX, ParticleBaseFP64::AttributeNames::posY,
+                    ParticleBaseFP64::AttributeNames::posZ>(0, {4., 5., 6.});
 
   std::array<double, 3> f = {7., 8., 9.};
   soa.writeMultiple<ParticleBaseFP64::AttributeNames::forceX, ParticleBaseFP64::AttributeNames::forceY,

--- a/tests/testAutopas/tests/utils/SoATest.cpp
+++ b/tests/testAutopas/tests/utils/SoATest.cpp
@@ -6,7 +6,7 @@
 
 #include "SoATest.h"
 
-TEST_F(SoATest, testInitialization) { autopas::SoA<autopas::Particle::SoAArraysType> soa; }
+TEST_F(SoATest, testInitialization) { autopas::SoA<autopas::ParticleBaseFP64::SoAArraysType> soa; }
 
 TEST_F(SoATest, SoATypeTest) {
   static_assert(std::is_same<autopas::utils::SoAType<size_t, double, double, double>::Type,
@@ -84,43 +84,43 @@ TEST_F(SoATest, SoAStorageTestApply) {
 }
 
 TEST_F(SoATest, SoATestPush) {
-  // default soa using autopas::Particle
-  using autopas::Particle;
-  autopas::SoA<Particle::SoAArraysType> soa;
+  // default soa using autopas::ParticleBaseFP64
+  using autopas::ParticleBaseFP64;
+  autopas::SoA<ParticleBaseFP64::SoAArraysType> soa;
 
   EXPECT_EQ(soa.size(), 0);
 
-  soa.push<Particle::AttributeNames::id>(2);
-  soa.push<Particle::AttributeNames::posX>(0.3);
-  soa.push<Particle::AttributeNames::posY>(0.1);
-  soa.push<Particle::AttributeNames::posZ>(0.5);
-  soa.push<Particle::AttributeNames::forceX>(-0.2);
-  soa.push<Particle::AttributeNames::forceY>(0.7);
-  soa.push<Particle::AttributeNames::forceZ>(0.07);
+  soa.push<ParticleBaseFP64::AttributeNames::id>(2);
+  soa.push<ParticleBaseFP64::AttributeNames::posX>(0.3);
+  soa.push<ParticleBaseFP64::AttributeNames::posY>(0.1);
+  soa.push<ParticleBaseFP64::AttributeNames::posZ>(0.5);
+  soa.push<ParticleBaseFP64::AttributeNames::forceX>(-0.2);
+  soa.push<ParticleBaseFP64::AttributeNames::forceY>(0.7);
+  soa.push<ParticleBaseFP64::AttributeNames::forceZ>(0.07);
 
   EXPECT_EQ(soa.size(), 1);
 
-  EXPECT_EQ(soa.read<Particle::AttributeNames::id>(0), 2);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posX>(0), 0.3);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posY>(0), 0.1);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posZ>(0), 0.5);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceX>(0), -0.2);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceY>(0), 0.7);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceZ>(0), 0.07);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::id>(0), 2);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posX>(0), 0.3);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posY>(0), 0.1);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posZ>(0), 0.5);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceX>(0), -0.2);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceY>(0), 0.7);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceZ>(0), 0.07);
 }
 
 TEST_F(SoATest, SoATestAppend) {
-  // default soa using autopas::Particle
-  using autopas::Particle;
-  std::array<autopas::SoA<Particle::SoAArraysType>, 2> soaBuffer;
+  // default soa using autopas::ParticleBaseFP64
+  using autopas::ParticleBaseFP64;
+  std::array<autopas::SoA<ParticleBaseFP64::SoAArraysType>, 2> soaBuffer;
 
-  soaBuffer[0].push<Particle::AttributeNames::id>(2);
-  soaBuffer[0].push<Particle::AttributeNames::posX>(0.3);
-  soaBuffer[0].push<Particle::AttributeNames::posY>(0.1);
-  soaBuffer[0].push<Particle::AttributeNames::posZ>(0.5);
-  soaBuffer[0].push<Particle::AttributeNames::forceX>(-0.2);
-  soaBuffer[0].push<Particle::AttributeNames::forceY>(0.7);
-  soaBuffer[0].push<Particle::AttributeNames::forceZ>(0.07);
+  soaBuffer[0].push<ParticleBaseFP64::AttributeNames::id>(2);
+  soaBuffer[0].push<ParticleBaseFP64::AttributeNames::posX>(0.3);
+  soaBuffer[0].push<ParticleBaseFP64::AttributeNames::posY>(0.1);
+  soaBuffer[0].push<ParticleBaseFP64::AttributeNames::posZ>(0.5);
+  soaBuffer[0].push<ParticleBaseFP64::AttributeNames::forceX>(-0.2);
+  soaBuffer[0].push<ParticleBaseFP64::AttributeNames::forceY>(0.7);
+  soaBuffer[0].push<ParticleBaseFP64::AttributeNames::forceZ>(0.07);
 
   EXPECT_EQ(soaBuffer[0].size(), 1);
   EXPECT_EQ(soaBuffer[1].size(), 0);
@@ -129,13 +129,13 @@ TEST_F(SoATest, SoATestAppend) {
   EXPECT_EQ(soaBuffer[0].size(), 1);
   EXPECT_EQ(soaBuffer[1].size(), 1);
 
-  EXPECT_EQ(soaBuffer[1].read<Particle::AttributeNames::id>(0), 2);
-  EXPECT_EQ(soaBuffer[1].read<Particle::AttributeNames::posX>(0), 0.3);
-  EXPECT_EQ(soaBuffer[1].read<Particle::AttributeNames::posY>(0), 0.1);
-  EXPECT_EQ(soaBuffer[1].read<Particle::AttributeNames::posZ>(0), 0.5);
-  EXPECT_EQ(soaBuffer[1].read<Particle::AttributeNames::forceX>(0), -0.2);
-  EXPECT_EQ(soaBuffer[1].read<Particle::AttributeNames::forceY>(0), 0.7);
-  EXPECT_EQ(soaBuffer[1].read<Particle::AttributeNames::forceZ>(0), 0.07);
+  EXPECT_EQ(soaBuffer[1].read<ParticleBaseFP64::AttributeNames::id>(0), 2);
+  EXPECT_EQ(soaBuffer[1].read<ParticleBaseFP64::AttributeNames::posX>(0), 0.3);
+  EXPECT_EQ(soaBuffer[1].read<ParticleBaseFP64::AttributeNames::posY>(0), 0.1);
+  EXPECT_EQ(soaBuffer[1].read<ParticleBaseFP64::AttributeNames::posZ>(0), 0.5);
+  EXPECT_EQ(soaBuffer[1].read<ParticleBaseFP64::AttributeNames::forceX>(0), -0.2);
+  EXPECT_EQ(soaBuffer[1].read<ParticleBaseFP64::AttributeNames::forceY>(0), 0.7);
+  EXPECT_EQ(soaBuffer[1].read<ParticleBaseFP64::AttributeNames::forceZ>(0), 0.07);
   // Append to filled buffer
   soaBuffer[0].append(soaBuffer[1]);
   EXPECT_EQ(soaBuffer[0].size(), 2);
@@ -143,91 +143,91 @@ TEST_F(SoATest, SoATestAppend) {
 }
 
 TEST_F(SoATest, SoATestSwap) {
-  // default soa using autopas::Particle
-  using autopas::Particle;
-  autopas::SoA<Particle::SoAArraysType> soa;
+  // default soa using autopas::ParticleBaseFP64
+  using autopas::ParticleBaseFP64;
+  autopas::SoA<ParticleBaseFP64::SoAArraysType> soa;
 
   soa.resizeArrays(2);
 
-  soa.begin<Particle::AttributeNames::id>()[0] = 3;
-  soa.begin<Particle::AttributeNames::posX>()[0] = 1.3;
-  soa.begin<Particle::AttributeNames::posY>()[0] = 1.1;
-  soa.begin<Particle::AttributeNames::posZ>()[0] = 1.5;
-  soa.begin<Particle::AttributeNames::forceX>()[0] = -1.2;
-  soa.begin<Particle::AttributeNames::forceY>()[0] = 1.7;
-  soa.begin<Particle::AttributeNames::forceZ>()[0] = 1.07;
+  soa.begin<ParticleBaseFP64::AttributeNames::id>()[0] = 3;
+  soa.begin<ParticleBaseFP64::AttributeNames::posX>()[0] = 1.3;
+  soa.begin<ParticleBaseFP64::AttributeNames::posY>()[0] = 1.1;
+  soa.begin<ParticleBaseFP64::AttributeNames::posZ>()[0] = 1.5;
+  soa.begin<ParticleBaseFP64::AttributeNames::forceX>()[0] = -1.2;
+  soa.begin<ParticleBaseFP64::AttributeNames::forceY>()[0] = 1.7;
+  soa.begin<ParticleBaseFP64::AttributeNames::forceZ>()[0] = 1.07;
 
-  soa.begin<Particle::AttributeNames::id>()[1] = 1;
-  soa.begin<Particle::AttributeNames::posX>()[1] = 10.3;
-  soa.begin<Particle::AttributeNames::posY>()[1] = 10.1;
-  soa.begin<Particle::AttributeNames::posZ>()[1] = 10.5;
-  soa.begin<Particle::AttributeNames::forceX>()[1] = -10.2;
-  soa.begin<Particle::AttributeNames::forceY>()[1] = 10.7;
-  soa.begin<Particle::AttributeNames::forceZ>()[1] = 10.07;
+  soa.begin<ParticleBaseFP64::AttributeNames::id>()[1] = 1;
+  soa.begin<ParticleBaseFP64::AttributeNames::posX>()[1] = 10.3;
+  soa.begin<ParticleBaseFP64::AttributeNames::posY>()[1] = 10.1;
+  soa.begin<ParticleBaseFP64::AttributeNames::posZ>()[1] = 10.5;
+  soa.begin<ParticleBaseFP64::AttributeNames::forceX>()[1] = -10.2;
+  soa.begin<ParticleBaseFP64::AttributeNames::forceY>()[1] = 10.7;
+  soa.begin<ParticleBaseFP64::AttributeNames::forceZ>()[1] = 10.07;
 
-  EXPECT_EQ(soa.read<Particle::AttributeNames::id>(0), 3);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posX>(0), 1.3);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posY>(0), 1.1);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posZ>(0), 1.5);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceX>(0), -1.2);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceY>(0), 1.7);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceZ>(0), 1.07);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::id>(0), 3);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posX>(0), 1.3);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posY>(0), 1.1);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posZ>(0), 1.5);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceX>(0), -1.2);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceY>(0), 1.7);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceZ>(0), 1.07);
 
-  EXPECT_EQ(soa.read<Particle::AttributeNames::id>(1), 1);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posX>(1), 10.3);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posY>(1), 10.1);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posZ>(1), 10.5);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceX>(1), -10.2);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceY>(1), 10.7);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceZ>(1), 10.07);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::id>(1), 1);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posX>(1), 10.3);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posY>(1), 10.1);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posZ>(1), 10.5);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceX>(1), -10.2);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceY>(1), 10.7);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceZ>(1), 10.07);
 
   soa.swap(0, 1);
 
-  EXPECT_EQ(soa.read<Particle::AttributeNames::id>(1), 3);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posX>(1), 1.3);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posY>(1), 1.1);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posZ>(1), 1.5);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceX>(1), -1.2);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceY>(1), 1.7);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceZ>(1), 1.07);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::id>(1), 3);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posX>(1), 1.3);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posY>(1), 1.1);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posZ>(1), 1.5);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceX>(1), -1.2);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceY>(1), 1.7);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceZ>(1), 1.07);
 
-  EXPECT_EQ(soa.read<Particle::AttributeNames::id>(0), 1);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posX>(0), 10.3);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posY>(0), 10.1);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posZ>(0), 10.5);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceX>(0), -10.2);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceY>(0), 10.7);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceZ>(0), 10.07);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::id>(0), 1);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posX>(0), 10.3);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posY>(0), 10.1);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posZ>(0), 10.5);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceX>(0), -10.2);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceY>(0), 10.7);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceZ>(0), 10.07);
 }
 
 TEST_F(SoATest, SoATestMultiWriteRead) {
-  // default soa using autopas::Particle
-  using autopas::Particle;
-  autopas::SoA<Particle::SoAArraysType> soa;
+  // default soa using autopas::ParticleBaseFP64
+  using autopas::ParticleBaseFP64;
+  autopas::SoA<ParticleBaseFP64::SoAArraysType> soa;
 
   soa.resizeArrays(1);
 
-  soa.begin<Particle::AttributeNames::id>()[0] = 1;
+  soa.begin<ParticleBaseFP64::AttributeNames::id>()[0] = 1;
 
   EXPECT_EQ(soa.size(), 1);
 
-  soa.writeMultiple<Particle::AttributeNames::posX, Particle::AttributeNames::posY, Particle::AttributeNames::posZ>(
+  soa.writeMultiple<ParticleBaseFP64::AttributeNames::posX, ParticleBaseFP64::AttributeNames::posY, ParticleBaseFP64::AttributeNames::posZ>(
       0, {4., 5., 6.});
 
   std::array<double, 3> f = {7., 8., 9.};
-  soa.writeMultiple<Particle::AttributeNames::forceX, Particle::AttributeNames::forceY,
-                    Particle::AttributeNames::forceZ>(0, f);
+  soa.writeMultiple<ParticleBaseFP64::AttributeNames::forceX, ParticleBaseFP64::AttributeNames::forceY,
+                    ParticleBaseFP64::AttributeNames::forceZ>(0, f);
 
-  EXPECT_EQ(soa.read<Particle::AttributeNames::id>(0), 1);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posX>(0), 4.);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posY>(0), 5.);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posZ>(0), 6.);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceX>(0), 7.);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceY>(0), 8.);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceZ>(0), 9.);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::id>(0), 1);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posX>(0), 4.);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posY>(0), 5.);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posZ>(0), 6.);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceX>(0), 7.);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceY>(0), 8.);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceZ>(0), 9.);
 
-  auto res = soa.readMultiple<Particle::AttributeNames::forceX, Particle::AttributeNames::forceY,
-                              Particle::AttributeNames::forceZ>(0);
+  auto res = soa.readMultiple<ParticleBaseFP64::AttributeNames::forceX, ParticleBaseFP64::AttributeNames::forceY,
+                              ParticleBaseFP64::AttributeNames::forceZ>(0);
 
   static_assert(std::is_same<decltype(res), std::array<double, 3>>::value, "id type must be proper(size_t)");
 
@@ -238,117 +238,117 @@ TEST_F(SoATest, SoATestMultiWriteRead) {
 
 // this test makes certain that methods don't destroy the inner state of the test
 TEST_F(SoATest, SoATestComplicatedAccess) {
-  // default soa using autopas::Particle
-  using autopas::Particle;
-  autopas::SoA<Particle::SoAArraysType> soa;
+  // default soa using autopas::ParticleBaseFP64
+  using autopas::ParticleBaseFP64;
+  autopas::SoA<ParticleBaseFP64::SoAArraysType> soa;
 
   EXPECT_EQ(soa.size(), 0);
 
-  soa.push<Particle::AttributeNames::id>(2);
-  soa.push<Particle::AttributeNames::posX>(0.3);
-  soa.push<Particle::AttributeNames::posY>(0.1);
-  soa.push<Particle::AttributeNames::posZ>(0.5);
-  soa.push<Particle::AttributeNames::forceX>(-0.2);
-  soa.push<Particle::AttributeNames::forceY>(0.7);
-  soa.push<Particle::AttributeNames::forceZ>(0.07);
+  soa.push<ParticleBaseFP64::AttributeNames::id>(2);
+  soa.push<ParticleBaseFP64::AttributeNames::posX>(0.3);
+  soa.push<ParticleBaseFP64::AttributeNames::posY>(0.1);
+  soa.push<ParticleBaseFP64::AttributeNames::posZ>(0.5);
+  soa.push<ParticleBaseFP64::AttributeNames::forceX>(-0.2);
+  soa.push<ParticleBaseFP64::AttributeNames::forceY>(0.7);
+  soa.push<ParticleBaseFP64::AttributeNames::forceZ>(0.07);
 
   EXPECT_EQ(soa.size(), 1);
 
-  EXPECT_EQ(soa.read<Particle::AttributeNames::id>(0), 2);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posX>(0), 0.3);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posY>(0), 0.1);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posZ>(0), 0.5);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceX>(0), -0.2);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceY>(0), 0.7);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceZ>(0), 0.07);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::id>(0), 2);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posX>(0), 0.3);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posY>(0), 0.1);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posZ>(0), 0.5);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceX>(0), -0.2);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceY>(0), 0.7);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceZ>(0), 0.07);
 
   soa.clear();
 
   EXPECT_EQ(soa.size(), 0);
 
-  soa.push<Particle::AttributeNames::id>(3);
-  soa.push<Particle::AttributeNames::posX>(1.3);
-  soa.push<Particle::AttributeNames::posY>(1.1);
-  soa.push<Particle::AttributeNames::posZ>(1.5);
-  soa.push<Particle::AttributeNames::forceX>(-1.2);
-  soa.push<Particle::AttributeNames::forceY>(1.7);
-  soa.push<Particle::AttributeNames::forceZ>(1.07);
+  soa.push<ParticleBaseFP64::AttributeNames::id>(3);
+  soa.push<ParticleBaseFP64::AttributeNames::posX>(1.3);
+  soa.push<ParticleBaseFP64::AttributeNames::posY>(1.1);
+  soa.push<ParticleBaseFP64::AttributeNames::posZ>(1.5);
+  soa.push<ParticleBaseFP64::AttributeNames::forceX>(-1.2);
+  soa.push<ParticleBaseFP64::AttributeNames::forceY>(1.7);
+  soa.push<ParticleBaseFP64::AttributeNames::forceZ>(1.07);
 
   EXPECT_EQ(soa.size(), 1);
 
-  EXPECT_EQ(soa.read<Particle::AttributeNames::id>(0), 3);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posX>(0), 1.3);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posY>(0), 1.1);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posZ>(0), 1.5);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceX>(0), -1.2);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceY>(0), 1.7);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceZ>(0), 1.07);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::id>(0), 3);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posX>(0), 1.3);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posY>(0), 1.1);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posZ>(0), 1.5);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceX>(0), -1.2);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceY>(0), 1.7);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceZ>(0), 1.07);
 
   soa.resizeArrays(2);
 
-  soa.begin<Particle::AttributeNames::id>()[1] = 1;
-  soa.begin<Particle::AttributeNames::posX>()[1] = 10.3;
-  soa.begin<Particle::AttributeNames::posY>()[1] = 10.1;
-  soa.begin<Particle::AttributeNames::posZ>()[1] = 10.5;
-  soa.begin<Particle::AttributeNames::forceX>()[1] = -10.2;
-  soa.begin<Particle::AttributeNames::forceY>()[1] = 10.7;
-  soa.begin<Particle::AttributeNames::forceZ>()[1] = 10.07;
+  soa.begin<ParticleBaseFP64::AttributeNames::id>()[1] = 1;
+  soa.begin<ParticleBaseFP64::AttributeNames::posX>()[1] = 10.3;
+  soa.begin<ParticleBaseFP64::AttributeNames::posY>()[1] = 10.1;
+  soa.begin<ParticleBaseFP64::AttributeNames::posZ>()[1] = 10.5;
+  soa.begin<ParticleBaseFP64::AttributeNames::forceX>()[1] = -10.2;
+  soa.begin<ParticleBaseFP64::AttributeNames::forceY>()[1] = 10.7;
+  soa.begin<ParticleBaseFP64::AttributeNames::forceZ>()[1] = 10.07;
 
-  EXPECT_EQ(soa.read<Particle::AttributeNames::id>(0), 3);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posX>(0), 1.3);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posY>(0), 1.1);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posZ>(0), 1.5);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceX>(0), -1.2);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceY>(0), 1.7);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceZ>(0), 1.07);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::id>(0), 3);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posX>(0), 1.3);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posY>(0), 1.1);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posZ>(0), 1.5);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceX>(0), -1.2);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceY>(0), 1.7);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceZ>(0), 1.07);
 
-  EXPECT_EQ(soa.read<Particle::AttributeNames::id>(1), 1);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posX>(1), 10.3);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posY>(1), 10.1);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posZ>(1), 10.5);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceX>(1), -10.2);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceY>(1), 10.7);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceZ>(1), 10.07);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::id>(1), 1);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posX>(1), 10.3);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posY>(1), 10.1);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posZ>(1), 10.5);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceX>(1), -10.2);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceY>(1), 10.7);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceZ>(1), 10.07);
 
   soa.swap(0, 1);
 
-  EXPECT_EQ(soa.read<Particle::AttributeNames::id>(1), 3);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posX>(1), 1.3);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posY>(1), 1.1);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posZ>(1), 1.5);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceX>(1), -1.2);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceY>(1), 1.7);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceZ>(1), 1.07);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::id>(1), 3);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posX>(1), 1.3);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posY>(1), 1.1);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posZ>(1), 1.5);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceX>(1), -1.2);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceY>(1), 1.7);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceZ>(1), 1.07);
 
-  EXPECT_EQ(soa.read<Particle::AttributeNames::id>(0), 1);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posX>(0), 10.3);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posY>(0), 10.1);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posZ>(0), 10.5);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceX>(0), -10.2);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceY>(0), 10.7);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceZ>(0), 10.07);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::id>(0), 1);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posX>(0), 10.3);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posY>(0), 10.1);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posZ>(0), 10.5);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceX>(0), -10.2);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceY>(0), 10.7);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceZ>(0), 10.07);
 
   soa.pop_back();
 
   EXPECT_EQ(soa.size(), 1);
 
-  soa.writeMultiple<Particle::AttributeNames::posX, Particle::AttributeNames::posY, Particle::AttributeNames::posZ>(
+  soa.writeMultiple<ParticleBaseFP64::AttributeNames::posX, ParticleBaseFP64::AttributeNames::posY, ParticleBaseFP64::AttributeNames::posZ>(
       0, {4., 5., 6.});
 
   std::array<double, 3> f = {7., 8., 9.};
-  soa.writeMultiple<Particle::AttributeNames::forceX, Particle::AttributeNames::forceY,
-                    Particle::AttributeNames::forceZ>(0, f);
+  soa.writeMultiple<ParticleBaseFP64::AttributeNames::forceX, ParticleBaseFP64::AttributeNames::forceY,
+                    ParticleBaseFP64::AttributeNames::forceZ>(0, f);
 
-  EXPECT_EQ(soa.read<Particle::AttributeNames::id>(0), 1);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posX>(0), 4.);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posY>(0), 5.);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::posZ>(0), 6.);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceX>(0), 7.);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceY>(0), 8.);
-  EXPECT_EQ(soa.read<Particle::AttributeNames::forceZ>(0), 9.);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::id>(0), 1);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posX>(0), 4.);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posY>(0), 5.);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::posZ>(0), 6.);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceX>(0), 7.);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceY>(0), 8.);
+  EXPECT_EQ(soa.read<ParticleBaseFP64::AttributeNames::forceZ>(0), 9.);
 
-  auto res = soa.readMultiple<Particle::AttributeNames::forceX, Particle::AttributeNames::forceY,
-                              Particle::AttributeNames::forceZ>(0);
+  auto res = soa.readMultiple<ParticleBaseFP64::AttributeNames::forceX, ParticleBaseFP64::AttributeNames::forceY,
+                              ParticleBaseFP64::AttributeNames::forceZ>(0);
 
   static_assert(std::is_same<decltype(res), std::array<double, 3>>::value, "id type must be proper(size_t)");
 

--- a/tests/testAutopas/tests/utils/SoATest.h
+++ b/tests/testAutopas/tests/utils/SoATest.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "AutoPasTestBase.h"
-#include "autopas/particles/Particle.h"
+#include "autopas/particles/ParticleDefinitions.h"
 #include "autopas/utils/SoA.h"
 #include "autopas/utils/SoAType.h"
 

--- a/tests/testAutopas/tests/utils/checkFunctorTypeTest.cpp
+++ b/tests/testAutopas/tests/utils/checkFunctorTypeTest.cpp
@@ -12,7 +12,7 @@
 using namespace autopas;
 
 // Define different kind of Functors for testing
-class PairwiseTestFunctor : public PairwiseFunctor<Particle, PairwiseTestFunctor> {
+class PairwiseTestFunctor : public PairwiseFunctor<ParticleFP64, PairwiseTestFunctor> {
  public:
   PairwiseTestFunctor() : PairwiseFunctor(1.0){};
   std::string getName() override { return "PairwiseTestFunctor"; };
@@ -20,7 +20,7 @@ class PairwiseTestFunctor : public PairwiseFunctor<Particle, PairwiseTestFunctor
   bool allowsNonNewton3() override { return true; };
   bool isRelevantForTuning() override { return true; };
 };
-class TriwiseTestFunctor : public TriwiseFunctor<Particle, TriwiseTestFunctor> {
+class TriwiseTestFunctor : public TriwiseFunctor<ParticleFP64, TriwiseTestFunctor> {
  public:
   TriwiseTestFunctor() : TriwiseFunctor(1.0){};
   std::string getName() override { return "TriwiseTestFunctor"; };
@@ -31,7 +31,7 @@ class TriwiseTestFunctor : public TriwiseFunctor<Particle, TriwiseTestFunctor> {
 
 class ChildPairwiseTestFunctor : public PairwiseTestFunctor {};
 class ChildTriwiseTestFunctor : public PairwiseTestFunctor {};
-class BaseTestFunctor : public Functor<Particle, BaseTestFunctor> {};
+class BaseTestFunctor : public Functor<ParticleFP64, BaseTestFunctor> {};
 class InvalidFunctor {};
 
 // Test that only a pairwise functor is recognized as PairwiseFunctor


### PR DESCRIPTION
# Description

"`Particle`" is used in AutoPas both as a template parameter (i.e. the particle type AutoPas is templated with) and an alias for `ParticleBase` with double precision. This could easily lead to name conflicts like suspected in #1006. 

In this PR we deal with this in two ways:

- The `Particle` alias is removed as it is too generic a name for what is really a base particle. Instead, the alias `ParticleFP64` (renamed to `ParticleBaseFP64`) is used as it is more verbose. In the tests, the alias `Particle` is replaced with `ParticleFP64` (Why not `ParticleBaseFP64`? No strong reason, other than it is used in the tests as a generic FP64 Particle whereas the AutoPas alias is used as an alias for the base particle class - in short, the emphasis in the tests is not really that it is the base class)
- Template parameters `Particle` are renamed `ParticleT`. The contributing guidelines state that all template parameter `typename`s/`class`es should have a `T` postfix. I do not change this for all template parameters and this task would be simply an issue for the future.

After making these changes, I am not totally sure about if the postfix `T` is necessary - the key issue really was that the `Particle` alias shouldn't have existed - and it could be perceived as ugly. Changing all the template parameters to `T` would be a real pain. I would be interested in your opinions.


## Resolved Issues

- [x] fixes #1006

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] CI
- [x] Running `CTest` on ARM cluster
- [x] Checking that this fixes #1006 
