### PR TITLE
Make AutoPas use C++20

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Please keep in mind the following notes while working.
 
 ## C++
 ### General Notes
-* Cpp standard: C++17. If there is a piece of code, which could be done better using a newer standard, please add a comment like `@todo C++20` including the alternative version of the code.
+* Cpp standard: C++20. If there is a piece of code, which could be done better using a newer standard, please add a comment like `@todo C++23` including the alternative version of the code.
 * Pointers: Always use smart pointers when you are managing memory. Don't use `new` or `delete`.
 * OpenMP: Use AutoPas wrapper functions and macros for OpenMP from [`WrapOpenMP.h`](/src/autopas/utils/WrapOpenMP.h) instead of native OpenMP to allow clean building without OpenMP.
 * `#pragma once` instead of header guards.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ if (CMAKE_VERSION VERSION_LESS 3.17)
             STATUS
             "Setting CMAKE_CXX_STANDARD globally because cmake < 3.17 is used."
     )
-    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD 20)
 endif ()
 
 if (NOT CYGWIN)

--- a/cmake/modules/autopas_all.cmake
+++ b/cmake/modules/autopas_all.cmake
@@ -9,8 +9,8 @@ if (MD_FLEXIBLE_ENABLE_ALLLBL)
   include(FetchContent)
   FetchContent_Declare(
     allfetch
-    URL ${AUTOPAS_SOURCE_DIR}/libs/ALL_20210930.zip
-    URL_HASH MD5=841b87748f82da1666bdc26f2038a3a1
+    URL ${AUTOPAS_SOURCE_DIR}/libs/ALL-0.9.3.zip
+    URL_HASH MD5=aa30549b3decce8df1ee82e90b198b04
   )
   
   # Get ALL source and binary directories from CMake project

--- a/cmake/modules/autopas_other-compileroptions.cmake
+++ b/cmake/modules/autopas_other-compileroptions.cmake
@@ -13,10 +13,10 @@ option(
     AUTOPAS_COMPILE_TIME_PROFILING "Sets clang's -ftime-trace or gcc's -ftime-report" OFF
 )
 
-# autopas requires c++17. If cmake < 3.17 is used this is set globally in the top level
+# autopas requires c++20. If cmake < 3.17 is used this is set globally in the top level
 # CMakeLists.txt
 if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
-    target_compile_features(autopas PUBLIC cxx_std_17)
+    target_compile_features(autopas PUBLIC cxx_std_20)
 endif ()
 
 target_compile_options(

--- a/docs/userdoc/Building.md
+++ b/docs/userdoc/Building.md
@@ -3,7 +3,7 @@
 ## Requirements
 * CMake 3.14 or newer
 * a CMake generator target (`make` is tested)
-* a C++17 compiler (gcc11, clang13, and ~~icpc 2019~~ are tested)
+* a C++20 compiler (gcc11, clang13, and ~~icpc 2019~~ are tested)
 * OpenMP (comes with GCC, for Clang you need `libomp`)
 
 Optional:

--- a/src/autopas/containers/linkedCells/ParticleVector.h
+++ b/src/autopas/containers/linkedCells/ParticleVector.h
@@ -21,7 +21,7 @@
 template <class Particle_T>
 class ParticleVector {
  public:
-  ParticleVector<Particle_T>() = default;
+  ParticleVector() = default;
 
   /**
    * Returns the dirty flag, indicating whether Particles exist in the vector that are not stored in a cell yet.

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -179,12 +179,12 @@ class VerletClusterLists : public ParticleContainerInterface<Particle_T>, public
    * @param p The particle to add.
    */
   void addParticleImpl(const Particle_T &p) override {
-    _isValid.store(ValidityState::invalid, std::memory_order::memory_order_relaxed);
+    _isValid.store(ValidityState::invalid, std::memory_order_relaxed);
     _particlesToAdd[autopas_get_thread_num()].push_back(p);
   }
 
   void addHaloParticleImpl(const Particle_T &haloParticle) override {
-    _isValid.store(ValidityState::invalid, std::memory_order::memory_order_relaxed);
+    _isValid.store(ValidityState::invalid, std::memory_order_relaxed);
     _particlesToAdd[autopas_get_thread_num()].push_back(haloParticle);
   }
 
@@ -247,7 +247,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle_T>, public
       }
     }
     if (deletedSomething) {
-      _isValid.store(ValidityState::invalid, std::memory_order::memory_order_relaxed);
+      _isValid.store(ValidityState::invalid, std::memory_order_relaxed);
     }
   }
 
@@ -382,7 +382,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle_T>, public
         }
       }
     }
-    _isValid.store(ValidityState::invalid, std::memory_order::memory_order_relaxed);
+    _isValid.store(ValidityState::invalid, std::memory_order_relaxed);
     return invalidParticles;
   }
 
@@ -964,7 +964,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle_T>, public
   [[nodiscard]] double getInteractionLength() const override { return _cutoff + this->getVerletSkin(); }
 
   void deleteAllParticles() override {
-    _isValid.store(ValidityState::invalid, std::memory_order::memory_order_relaxed);
+    _isValid.store(ValidityState::invalid, std::memory_order_relaxed);
     std::for_each(_particlesToAdd.begin(), _particlesToAdd.end(), [](auto &buffer) { buffer.clear(); });
     std::for_each(_towerBlock.begin(), _towerBlock.end(), [](auto &tower) { tower.clear(); });
   }
@@ -1001,7 +1001,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle_T>, public
 
     _numClusters = _builder->rebuildTowersAndClusters();
 
-    _isValid.store(ValidityState::cellsValidListsInvalid, std::memory_order::memory_order_relaxed);
+    _isValid.store(ValidityState::cellsValidListsInvalid, std::memory_order_relaxed);
     for (auto &tower : _towerBlock) {
       tower.setParticleDeletionObserver(this);
     }
@@ -1156,7 +1156,7 @@ class VerletClusterLists : public ParticleContainerInterface<Particle_T>, public
    */
   void notifyParticleDeleted() override {
     // this is potentially called from a threaded environment, so we have to make this atomic here!
-    _isValid.store(ValidityState::invalid, std::memory_order::memory_order_relaxed);
+    _isValid.store(ValidityState::invalid, std::memory_order_relaxed);
   }
 
  private:

--- a/src/autopas/utils/ExceptionHandler.h
+++ b/src/autopas/utils/ExceptionHandler.h
@@ -155,7 +155,7 @@ void ExceptionHandler::exception(const char *const e);  // NOLINT
 
 template <typename First, typename... Args>
 void ExceptionHandler::exception(std::string exceptionString, First first, Args... args) {
-  std::string s = fmt::format(exceptionString, first, args...);
+  std::string s = fmt::format(fmt::runtime(exceptionString), first, args...);
   exception(s);
 }
 

--- a/src/autopas/utils/logging/IterationLogger.cpp
+++ b/src/autopas/utils/logging/IterationLogger.cpp
@@ -38,7 +38,7 @@ autopas::IterationLogger::IterationLogger(const std::string &outputSuffix, bool 
         "energyJoules[J],"
         "energyDeltaT[s]");
   }
-  headerLogger->info(csvHeader, Configuration().getCSVHeader());
+  headerLogger->info(fmt::runtime(csvHeader), Configuration().getCSVHeader());
   spdlog::drop(headerLoggerName);
   // End of workaround
 

--- a/tests/testAutopas/tests/containers/octree/OctreeTests.cpp
+++ b/tests/testAutopas/tests/containers/octree/OctreeTests.cpp
@@ -19,7 +19,7 @@
 #include "autopas/particles/ParticleDefinitions.h"
 #include "autopas/tuning/selectors/ContainerSelector.h"
 #include "autopas/utils/StaticCellSelector.h"
-#include "molecularDynamicsLibrary/LJFunctor.h"
+#include "mocks/MockPairwiseFunctor.h"
 
 using ::testing::_;
 
@@ -736,7 +736,7 @@ TEST_F(OctreeTest, testLeafIDs) {
   // Get leaves
   std::vector<OctreeLeafNode<ParticleFP64> *> leaves;
   root->appendAllLeaves(leaves);
-  OTC18Traversal<ParticleFP64, mdLib::LJFunctor<ParticleFP64>>::assignIDs(leaves);
+  OTC18Traversal<ParticleFP64, MockPairwiseFunctor<ParticleFP64>>::assignIDs(leaves);
 
   std::vector<int> ids, expected;
   for (int i = 0; i < leaves.size(); ++i) {


### PR DESCRIPTION
# Description

As part of an internal collaboration with Sam, we decided that it would be a good idea to bump the C++ standard version used by AutoPas from C++17 to C++20. This PR contains the minimum set of changes to make that happen. In particular, I have updated the documentation to indicate that C++20 is used by default and fixed, with the help of Sam, some minor bugs that were causing compilation errors. 

As a side note, inside the project, there are several `@todo c++20` that are low-hanging fruit, but I would recommend that those be addressed in separate pull requests. 

## Related Pull Requests

- None so far

## Resolved Issues

- Not any I could find

# How Has This Been Tested?

So far, I only checked that it compiled and that several tests from the CI are passing locally. I tried to run a ctest on my Mac, but (1) there are too many tests to make a full local check viable, and (2) some of them are timing out both on master and on this branch, so I prefer to check what your CI produces.

If you provide a subset of tests I should run locally, I would of course be happy to do so 😉.
