### PR TITLE
Renamed `_dimsPerLength` to `_dimsSortedByLength` in SlicedBasedTraversal

### DIFF
--- a/src/autopas/containers/cellTraversals/SlicedBalancedBasedTraversal.h
+++ b/src/autopas/containers/cellTraversals/SlicedBalancedBasedTraversal.h
@@ -51,8 +51,8 @@ class SlicedBalancedBasedTraversal : public SlicedLockBasedTraversal<ParticleCel
     this->_sliceThickness.clear();
 
     // estimate loads along longest axis
-    auto maxDimension = this->_dimsPerLength[0];
-    auto maxDimensionLength = this->_cellsPerDimension[this->_dimsPerLength[0]];
+    auto maxDimension = this->_dimsSortedByLength[0];
+    auto maxDimensionLength = this->_cellsPerDimension[this->_dimsSortedByLength[0]];
 
     std::vector<unsigned long> loads;
     utils::Timer timer;

--- a/src/autopas/containers/cellTraversals/SlicedBasedTraversal.h
+++ b/src/autopas/containers/cellTraversals/SlicedBasedTraversal.h
@@ -47,7 +47,7 @@ class SlicedBasedTraversal : public CellTraversal<ParticleCell>, public Traversa
       : CellTraversal<ParticleCell>(dims),
         TraversalInterface(dataLayout, useNewton3),
         _overlap{},
-        _dimsPerLength{},
+        _dimsSortedByLength{},
         _interactionLength(interactionLength),
         _cellLength(cellLength),
         _overlapLongestAxis(0),
@@ -63,7 +63,7 @@ class SlicedBasedTraversal : public CellTraversal<ParticleCell>, public Traversa
    */
   [[nodiscard]] bool isApplicable() const override {
     auto minSliceThickness = _overlapLongestAxis + 1;
-    auto maxNumSlices = this->_cellsPerDimension[_dimsPerLength[0]] / minSliceThickness;
+    auto maxNumSlices = this->_cellsPerDimension[_dimsSortedByLength[0]] / minSliceThickness;
     return maxNumSlices > 0;
   }
 
@@ -72,14 +72,14 @@ class SlicedBasedTraversal : public CellTraversal<ParticleCell>, public Traversa
    * @param minSliceThickness
    */
   virtual void initSliceThickness(unsigned long minSliceThickness) {
-    auto numSlices = this->_cellsPerDimension[_dimsPerLength[0]] / minSliceThickness;
+    auto numSlices = this->_cellsPerDimension[_dimsSortedByLength[0]] / minSliceThickness;
     _sliceThickness.clear();
 
     // abort if domain is too small -> cleared _sliceThickness array indicates non applicability
     if (numSlices < 1) return;
 
     _sliceThickness.insert(_sliceThickness.begin(), numSlices, minSliceThickness);
-    auto rest = this->_cellsPerDimension[_dimsPerLength[0]] - _sliceThickness[0] * numSlices;
+    auto rest = this->_cellsPerDimension[_dimsSortedByLength[0]] - _sliceThickness[0] * numSlices;
     // remaining slices to distribute the remaining layers on
     auto remSlices = std::min(rest, numSlices);
     for (size_t i = 0; i < remSlices; ++i) {
@@ -142,9 +142,9 @@ class SlicedBasedTraversal : public CellTraversal<ParticleCell>, public Traversa
   std::array<unsigned long, 3> _overlap;
 
   /**
-   * Store ids of dimensions ordered by number of cells per dimensions.
+   * Store ids of dimensions (0, 1, 2 = x, y, z) sorted by in decreasing order of number of cells in that dimension.
    */
-  std::array<int, 3> _dimsPerLength;
+  std::array<int, 3> _dimsSortedByLength;
 
   /**
    * Overlap of interacting cells along the longest axis.
@@ -190,11 +190,11 @@ inline void SlicedBasedTraversal<ParticleCell, Functor>::init(const std::array<u
 
   // find longest dimension
   auto minMaxElem = std::minmax_element(this->_cellsPerDimension.begin(), this->_cellsPerDimension.end());
-  _dimsPerLength[0] = (int)std::distance(this->_cellsPerDimension.begin(), minMaxElem.second);
-  _dimsPerLength[2] = (int)std::distance(this->_cellsPerDimension.begin(), minMaxElem.first);
-  _dimsPerLength[1] = 3 - (_dimsPerLength[0] + _dimsPerLength[2]);
+  _dimsSortedByLength[0] = (int)std::distance(this->_cellsPerDimension.begin(), minMaxElem.second);
+  _dimsSortedByLength[2] = (int)std::distance(this->_cellsPerDimension.begin(), minMaxElem.first);
+  _dimsSortedByLength[1] = 3 - (_dimsSortedByLength[0] + _dimsSortedByLength[2]);
 
-  _overlapLongestAxis = _overlap[_dimsPerLength[0]];
+  _overlapLongestAxis = _overlap[_dimsSortedByLength[0]];
 }
 
 }  // namespace autopas

--- a/src/autopas/containers/cellTraversals/SlicedC02BasedTraversal.h
+++ b/src/autopas/containers/cellTraversals/SlicedC02BasedTraversal.h
@@ -57,7 +57,7 @@ class SlicedC02BasedTraversal : public SlicedBasedTraversal<ParticleCell, Functo
    * @return true iff the traversal can be applied.
    */
   [[nodiscard]] bool isApplicable() const override {
-    return this->_cellsPerDimension[this->_dimsPerLength[0]] >= this->_overlapLongestAxis;
+    return this->_cellsPerDimension[this->_dimsSortedByLength[0]] >= this->_overlapLongestAxis;
   }
 
   /**
@@ -79,7 +79,7 @@ void SlicedC02BasedTraversal<ParticleCell, Functor>::cSlicedTraversal(LoopBody &
   auto numSlices = this->_sliceThickness.size();
   // check if applicable
 
-  std::array<size_t, 2> overLapps23{this->_overlap[this->_dimsPerLength[1]], this->_overlap[this->_dimsPerLength[2]]};
+  std::array<size_t, 2> overLapps23{this->_overlap[this->_dimsSortedByLength[1]], this->_overlap[this->_dimsSortedByLength[2]]};
 
   if (not this->_spaciallyForward) {
     overLapps23 = {0ul, 0ul};
@@ -91,19 +91,19 @@ void SlicedC02BasedTraversal<ParticleCell, Functor>::cSlicedTraversal(LoopBody &
     for (size_t slice = offset; slice < numSlices; slice += 2) {
       array<unsigned long, 3> myStartArray{0, 0, 0};
       for (size_t i = 0; i < slice; ++i) {
-        myStartArray[this->_dimsPerLength[0]] += this->_sliceThickness[i];
+        myStartArray[this->_dimsSortedByLength[0]] += this->_sliceThickness[i];
       }
 
-      const auto lastLayer = myStartArray[this->_dimsPerLength[0]] + this->_sliceThickness[slice];
-      for (unsigned long dimSlice = myStartArray[this->_dimsPerLength[0]]; dimSlice < lastLayer; ++dimSlice) {
+      const auto lastLayer = myStartArray[this->_dimsSortedByLength[0]] + this->_sliceThickness[slice];
+      for (unsigned long dimSlice = myStartArray[this->_dimsSortedByLength[0]]; dimSlice < lastLayer; ++dimSlice) {
         for (unsigned long dimMedium = 0;
-             dimMedium < this->_cellsPerDimension[this->_dimsPerLength[1]] - overLapps23[0]; ++dimMedium) {
+             dimMedium < this->_cellsPerDimension[this->_dimsSortedByLength[1]] - overLapps23[0]; ++dimMedium) {
           for (unsigned long dimShort = 0;
-               dimShort < this->_cellsPerDimension[this->_dimsPerLength[2]] - overLapps23[1]; ++dimShort) {
+               dimShort < this->_cellsPerDimension[this->_dimsSortedByLength[2]] - overLapps23[1]; ++dimShort) {
             array<unsigned long, 3> idArray = {};
-            idArray[this->_dimsPerLength[0]] = dimSlice;
-            idArray[this->_dimsPerLength[1]] = dimMedium;
-            idArray[this->_dimsPerLength[2]] = dimShort;
+            idArray[this->_dimsSortedByLength[0]] = dimSlice;
+            idArray[this->_dimsSortedByLength[1]] = dimMedium;
+            idArray[this->_dimsSortedByLength[2]] = dimShort;
             loopBody(idArray[0], idArray[1], idArray[2]);
           }
         }

--- a/src/autopas/containers/cellTraversals/SlicedLockBasedTraversal.h
+++ b/src/autopas/containers/cellTraversals/SlicedLockBasedTraversal.h
@@ -69,7 +69,7 @@ void SlicedLockBasedTraversal<ParticleCell, Functor>::slicedTraversal(LoopBody &
   // 0) check if applicable
   const auto overLapps23 = [&]() -> std::array<size_t, 2> {
     if (this->_spaciallyForward) {
-      return {this->_overlap[this->_dimsPerLength[1]], this->_overlap[this->_dimsPerLength[2]]};
+      return {this->_overlap[this->_dimsSortedByLength[1]], this->_overlap[this->_dimsSortedByLength[2]]};
     } else {
       return {0ul, 0ul};
     }
@@ -93,7 +93,7 @@ void SlicedLockBasedTraversal<ParticleCell, Functor>::slicedTraversal(LoopBody &
     timers[slice].start();
     array<unsigned long, 3> myStartArray{0, 0, 0};
     for (size_t i = 0; i < slice; ++i) {
-      myStartArray[this->_dimsPerLength[0]] += this->_sliceThickness[i];
+      myStartArray[this->_dimsSortedByLength[0]] += this->_sliceThickness[i];
     }
 
     // all but the first slice need to lock their starting layers.
@@ -103,28 +103,28 @@ void SlicedLockBasedTraversal<ParticleCell, Functor>::slicedTraversal(LoopBody &
         locks[lockBaseIndex + i].lock();
       }
     }
-    const auto lastLayer = myStartArray[this->_dimsPerLength[0]] + this->_sliceThickness[slice];
+    const auto lastLayer = myStartArray[this->_dimsSortedByLength[0]] + this->_sliceThickness[slice];
     for (unsigned long sliceOffset = 0ul; sliceOffset < this->_sliceThickness[slice]; ++sliceOffset) {
-      const auto dimSlice = myStartArray[this->_dimsPerLength[0]] + sliceOffset;
+      const auto dimSlice = myStartArray[this->_dimsSortedByLength[0]] + sliceOffset;
       // at the last layers request lock for the starting layer of the next
       // slice. Does not apply for the last slice.
       if (slice != numSlices - 1 and dimSlice >= lastLayer - this->_overlapLongestAxis) {
         locks[((slice + 1) * this->_overlapLongestAxis) - (lastLayer - dimSlice)].lock();
       }
-      for (unsigned long dimMedium = 0; dimMedium < this->_cellsPerDimension[this->_dimsPerLength[1]] - overLapps23[0];
+      for (unsigned long dimMedium = 0; dimMedium < this->_cellsPerDimension[this->_dimsSortedByLength[1]] - overLapps23[0];
            ++dimMedium) {
-        for (unsigned long dimShort = 0; dimShort < this->_cellsPerDimension[this->_dimsPerLength[2]] - overLapps23[1];
+        for (unsigned long dimShort = 0; dimShort < this->_cellsPerDimension[this->_dimsSortedByLength[2]] - overLapps23[1];
              ++dimShort) {
           array<unsigned long, 3> idArray = {};
-          idArray[this->_dimsPerLength[0]] = dimSlice;
-          idArray[this->_dimsPerLength[1]] = dimMedium;
-          idArray[this->_dimsPerLength[2]] = dimShort;
+          idArray[this->_dimsSortedByLength[0]] = dimSlice;
+          idArray[this->_dimsSortedByLength[1]] = dimMedium;
+          idArray[this->_dimsSortedByLength[2]] = dimShort;
 
           loopBody(idArray[0], idArray[1], idArray[2]);
         }
       }
       // at the end of the first layers release the lock
-      if (slice > 0 and dimSlice < myStartArray[this->_dimsPerLength[0]] + this->_overlapLongestAxis) {
+      if (slice > 0 and dimSlice < myStartArray[this->_dimsSortedByLength[0]] + this->_overlapLongestAxis) {
         locks[lockBaseIndex + sliceOffset].unlock();
         // if lastLayer is reached within overlap area, unlock all following locks
         // this should never be the case if slice thicknesses are set up properly; thickness should always be


### PR DESCRIPTION
# Description

Whilst reviewing #1022, I got a little confused by a member variable of `SlicedBasedTraversal` (nothing to do with the PR). So I changed the name and documentation to something I felt was clearer.


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] CI
