### PR TITLE
Fix MacOS Pipeline

### DIFF
--- a/.github/workflows/TestSuites.yaml
+++ b/.github/workflows/TestSuites.yaml
@@ -182,7 +182,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install requirements
         run: |
-          brew install libomp gcc@14 cmake ninja
+          brew install libomp gcc@14 ninja
       - name: Configure and Build md-flexible
         run: |
           mkdir build && cd build


### PR DESCRIPTION
# Changelog

Seems like the new GitHub Runner Images for macOS come with a sufficiently recent CMake. We don't need to manually install it anymore.

Resolves #1033