### PR TITLE
Verlet Cluster List fix: min distance between bounding boxes

### DIFF
--- a/src/autopas/utils/ArrayMath.h
+++ b/src/autopas/utils/ArrayMath.h
@@ -690,6 +690,6 @@ double boxDistanceSquared(const std::array<T, SIZE> &aMin, const std::array<T, S
   const auto aToB = max(std::array<T, SIZE>{}, aMin - bMax);
   const auto bToA = max(std::array<T, SIZE>{}, bMin - aMax);
 
-  return dot(aToB, aToB) + dot(bToA, bToA);
+  return std::min(dot(aToB, aToB), dot(bToA, bToA));
 }
 }  // namespace autopas::utils::ArrayMath


### PR DESCRIPTION
# Description

While reviewing our VCL neighbour list rebuilding and comparing it with GROMACS, I noticed a small mistake (please correct me if I'm wrong and have misunderstood). In the current implementation, we take the square of the minimum distance between the bounding boxes and the largest distance and then add them together. This value is compared to the square of the Interaction length [here](https://github.com/AutoPas/AutoPas/blob/master/src/autopas/containers/verletClusterLists/VerletClusterListsRebuilder.h#L402). Shouldn't this just be the smallest distance between the bounding boxes?

In GROMACS (code below), they use `max(difference0, difference1)` because they are looking at absolute values, and the larger value would always be negative in their code. Refer to the hand-drawn figure below (cluster A is the reference in both cases). In AutoPas, however, we directly compare the square of distances, so we just need to take the `min()` of the two distances. Also, we don't need to compare with zero, as the value will always be greater than zero.

[Gromacs code snippet](https://github.com/gromacs/gromacs/blob/347ad68ebc0c6bd2ecadea7f4bcff714f2229fdb/src/gromacs/nbnxm/boundingboxdistance.h#L106)
<img width="969" height="646" alt="image" src="https://github.com/user-attachments/assets/125f1139-99c2-4bde-bd42-6a5a8408e273" />

Explanation of why Gromacs uses `max()` function
![PXL_20250930_070124103 MP~2](https://github.com/user-attachments/assets/9990b271-82f3-4b2a-bbe1-3b4e9444182e)


## Resolved Issues

There were cases where VCL was not working. I couldn't find them, but I would be happy to try them out and see how this change affects them.

- [ ] fixes #Issue

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

If you believe this needs further verification, please let me know. Additionally, it would be helpful if you could suggest some examples of how to test this.

- [x] Ran example simulations, and they seem to work fine. 
- [x] ~~The coverage report shows all relevant lines are tested.~~ Not a new function.
