### PR TITLE
Fix clang compilation with omp and address sanitizer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,10 +81,11 @@ if (AUTOPAS_FORMATTING_TARGETS)
     include(autopas_format)
 endif ()
 
+
 include(autopas_ccache)
+include(autopas_OpenMP) # Add omp before sanitizers
 include(autopas_clang-sanitizers)
 include(autopas_clang-tidy)
-include(autopas_OpenMP)
 include(autopas_mpi)
 
 include(version.cmake)

--- a/cmake/modules/autopas_pmt.cmake
+++ b/cmake/modules/autopas_pmt.cmake
@@ -41,6 +41,22 @@ if (AUTOPAS_ENABLE_ENERGY_MEASUREMENTS)
 
     FetchContent_MakeAvailable(pmt)
 
+    # Disable sanitizers for PMT only as there are issues with Clang 16
+    target_compile_options(pmt PRIVATE
+            -fno-sanitize=all
+            -fno-sanitize=address
+            -fno-sanitize=undefined
+            -fno-sanitize=leak
+            -fno-sanitize=thread
+    )
+    target_link_options(pmt PRIVATE
+            -fno-sanitize=all
+            -fno-sanitize=address
+            -fno-sanitize=undefined
+            -fno-sanitize=leak
+            -fno-sanitize=thread
+    )
+
     # sensors available in pmt that are not currently required in AutoPas
     mark_as_advanced(
             PMT_BUILD_CRAY

--- a/docs/userdoc/Building.md
+++ b/docs/userdoc/Building.md
@@ -3,7 +3,7 @@
 ## Requirements
 * CMake 3.14 or newer
 * a CMake generator target (`make` is tested)
-* a C++20 compiler (gcc11, clang13, and ~~icpc 2019~~ are tested)
+* a C++20 compiler (gcc11, clang14, and ~~icpc 2019~~ are tested)
 * OpenMP (comes with GCC, for Clang you need `libomp`)
 
 Optional:


### PR DESCRIPTION
# Description

I bumped the clang compiler version in our Docker image to clang-14, which enables more C++ 20 support.

For some reasons, the newer Clang version(s) have problems with the address sanitizer enabled, as it cannot find the correct OpenMP library for C++, after the initialization of the sanitizer.

The easy fix for this is placing the omp module before the sanitizers module in `CMakeLists.txt`
