### PR TITLE
Feature/mixed precision reintegration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ venv/
 # benchmark output folder
 *testTuning_*/
 *measurePerf_*/
-runBenchmark.sh
 
 # sourcetrail stuff
 *.srctrlbm

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ venv/
 # benchmark output folder
 *testTuning_*/
 *measurePerf_*/
+runBenchmark.sh
 
 # sourcetrail stuff
 *.srctrlbm

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/AxilrodTellerFunctor.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/AxilrodTellerFunctor.h
@@ -106,7 +106,7 @@ class AxilrodTellerFunctor
   /**
    * Precision of SoA entries.
    */
-  using SoAFloatPrecision = typename Particle::ParticleSoAFloatPrecision;
+  using SoAFloatPrecision = typename Particle::ParticleCalcPrecision;
 
  public:
   /**

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/AxilrodTellerFunctor.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/AxilrodTellerFunctor.h
@@ -106,7 +106,7 @@ class AxilrodTellerFunctor
   /**
    * Precision of SoA entries.
    */
-  using SoAFloatPrecision = typename Particle::ParticleCalcPrecision;
+  using SoAFloatPrecision = typename Particle::ParticleCalcType;
 
  public:
   /**

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctor.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctor.h
@@ -40,14 +40,19 @@ class LJFunctor
     : public autopas::PairwiseFunctor<Particle, LJFunctor<Particle, applyShift, useMixing, useNewton3, calculateGlobals,
                                                           countFLOPs, relevantForTuning>> {
   /**
+   * FloatType used for calculations
+   */
+  using CalcPrecision = typename Particle::ParticleCalcPrecision;
+
+  /**
+   * FloatType used for accumulations or more relevant calculations
+   */
+  using AccuPrecision = typename Particle::ParticleAccuPrecision;
+
+  /**
    * Structure of the SoAs defined by the particle.
    */
   using SoAArraysType = typename Particle::SoAArraysType;
-
-  /**
-   * Precision of SoA entries.
-   */
-  using SoAFloatPrecision = typename Particle::ParticleCalcPrecision;
 
  public:
   /**
@@ -61,7 +66,7 @@ class LJFunctor
    * @param cutoff
    * @note param dummy is unused, only there to make the signature different from the public constructor.
    */
-  explicit LJFunctor(double cutoff, void * /*dummy*/)
+  explicit LJFunctor(CalcPrecision cutoff, void * /*dummy*/)
       : autopas::PairwiseFunctor<Particle, LJFunctor<Particle, applyShift, useMixing, useNewton3, calculateGlobals,
                                                      countFLOPs, relevantForTuning>>(cutoff),
         _cutoffSquared{cutoff * cutoff},
@@ -85,7 +90,7 @@ class LJFunctor
    *
    * @param cutoff
    */
-  explicit LJFunctor(double cutoff) : LJFunctor(cutoff, nullptr) {
+  explicit LJFunctor(CalcPrecision cutoff) : LJFunctor(cutoff, nullptr) {
     static_assert(not useMixing,
                   "Mixing without a ParticlePropertiesLibrary is not possible! Use a different constructor or set "
                   "mixing to false.");
@@ -97,7 +102,7 @@ class LJFunctor
    * @param cutoff
    * @param particlePropertiesLibrary
    */
-  explicit LJFunctor(double cutoff, ParticlePropertiesLibrary<double, size_t> &particlePropertiesLibrary)
+  explicit LJFunctor(CalcPrecision cutoff, ParticlePropertiesLibrary<CalcPrecision, size_t> &particlePropertiesLibrary)
       : LJFunctor(cutoff, nullptr) {
     static_assert(useMixing,
                   "Not using Mixing but using a ParticlePropertiesLibrary is not allowed! Use a different constructor "
@@ -130,9 +135,9 @@ class LJFunctor
       ++_aosThreadDataFLOPs[threadnum].numDistCalls;
     }
 
-    auto sigmaSquared = _sigmaSquared;
-    auto epsilon24 = _epsilon24;
-    auto shift6 = _shift6;
+    CalcPrecision sigmaSquared = _sigmaSquared;
+    CalcPrecision epsilon24 = _epsilon24;
+    CalcPrecision shift6 = _shift6;
     if constexpr (useMixing) {
       sigmaSquared = _PPLibrary->getMixingSigmaSquared(i.getTypeId(), j.getTypeId());
       epsilon24 = _PPLibrary->getMixing24Epsilon(i.getTypeId(), j.getTypeId());
@@ -140,24 +145,32 @@ class LJFunctor
         shift6 = _PPLibrary->getMixingShift6(i.getTypeId(), j.getTypeId());
       }
     }
-    auto dr = i.getR() - j.getR();
-    double dr2 = autopas::utils::ArrayMath::dot(dr, dr);
+    std::array<CalcPrecision, 3> dr = i.getR() - j.getR();
+    CalcPrecision dr2 = autopas::utils::ArrayMath::dot(dr, dr);
 
     if (dr2 > _cutoffSquared) {
       return;
     }
 
-    double invdr2 = 1. / dr2;
-    double lj6 = sigmaSquared * invdr2;
+    CalcPrecision invdr2 = static_cast<CalcPrecision>(1.) / dr2;
+    CalcPrecision lj6 = sigmaSquared * invdr2;
     lj6 = lj6 * lj6 * lj6;
-    double lj12 = lj6 * lj6;
-    double lj12m6 = lj12 - lj6;
-    double fac = epsilon24 * (lj12 + lj12m6) * invdr2;
-    auto f = dr * fac;
-    i.addF(f);
+    CalcPrecision lj12 = lj6 * lj6;
+    CalcPrecision lj12m6 = lj12 - lj6;
+    CalcPrecision fac = epsilon24 * (lj12 + lj12m6) * invdr2;
+    std::array<CalcPrecision, 3> f = dr * fac;
+    std::array<AccuPrecision, 3> convertedF;
+
+    if constexpr (std::is_same_v<CalcPrecision, AccuPrecision>) {
+      convertedF = f;
+    } else {
+      convertedF = autopas::utils::ArrayUtils::static_cast_copy_array<>(f);
+    }
+
+    i.addF(convertedF);
     if (newton3) {
       // only if we use newton 3 here, we want to
-      j.subF(f);
+      j.subF(convertedF);
     }
 
     if constexpr (countFLOPs) {
@@ -173,7 +186,8 @@ class LJFunctor
       // Potential energy has an additional factor of 6, which is also handled in endTraversal().
 
       auto virial = dr * f;
-      double potentialEnergy6 = epsilon24 * lj12m6 + shift6;
+      double potentialEnergy6 = static_cast<AccuPrecision>(epsilon24) * static_cast<AccuPrecision>(lj12m6) +
+                                static_cast<AccuPrecision>(shift6);
 
       if (i.isOwned()) {
         _aosThreadDataGlobals[threadnum].potentialEnergySum += potentialEnergy6;
@@ -209,27 +223,27 @@ class LJFunctor
     const auto *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
     const auto *const __restrict ownedStatePtr = soa.template begin<Particle::AttributeNames::ownershipState>();
 
-    SoAFloatPrecision *const __restrict fxptr = soa.template begin<Particle::AttributeNames::forceX>();
-    SoAFloatPrecision *const __restrict fyptr = soa.template begin<Particle::AttributeNames::forceY>();
-    SoAFloatPrecision *const __restrict fzptr = soa.template begin<Particle::AttributeNames::forceZ>();
+    AccuPrecision *const __restrict fxptr = soa.template begin<Particle::AttributeNames::forceX>();
+    AccuPrecision *const __restrict fyptr = soa.template begin<Particle::AttributeNames::forceY>();
+    AccuPrecision *const __restrict fzptr = soa.template begin<Particle::AttributeNames::forceZ>();
 
     [[maybe_unused]] auto *const __restrict typeptr = soa.template begin<Particle::AttributeNames::typeId>();
-    // the local redeclaration of the following values helps the SoAFloatPrecision-generation of various compilers.
-    const SoAFloatPrecision cutoffSquared = _cutoffSquared;
+    // the local redeclaration of the following values helps the CalcPrecision-generation of various compilers.
+    const CalcPrecision cutoffSquared = _cutoffSquared;
 
-    SoAFloatPrecision potentialEnergySum = 0.;  // Note: This is not the potential energy but some fixed multiple of it.
-    SoAFloatPrecision virialSumX = 0.;
-    SoAFloatPrecision virialSumY = 0.;
-    SoAFloatPrecision virialSumZ = 0.;
+    AccuPrecision potentialEnergySum = 0.;  // Note: This is not the potential energy but some fixed multiple of it.
+    AccuPrecision virialSumX = 0.;
+    AccuPrecision virialSumY = 0.;
+    AccuPrecision virialSumZ = 0.;
 
     size_t numDistanceCalculationSum = 0;
     size_t numKernelCallsN3Sum = 0;
     size_t numKernelCallsNoN3Sum = 0;
     size_t numGlobalCalcsSum = 0;
 
-    std::vector<SoAFloatPrecision, autopas::AlignedAllocator<SoAFloatPrecision>> sigmaSquareds;
-    std::vector<SoAFloatPrecision, autopas::AlignedAllocator<SoAFloatPrecision>> epsilon24s;
-    std::vector<SoAFloatPrecision, autopas::AlignedAllocator<SoAFloatPrecision>> shift6s;
+    std::vector<CalcPrecision, autopas::AlignedAllocator<CalcPrecision>> sigmaSquareds;
+    std::vector<CalcPrecision, autopas::AlignedAllocator<CalcPrecision>> epsilon24s;
+    std::vector<CalcPrecision, autopas::AlignedAllocator<CalcPrecision>> shift6s;
     if constexpr (useMixing) {
       // Preload all sigma and epsilons for next vectorized region.
       // Not preloading and directly using the values, will produce worse results.
@@ -241,9 +255,9 @@ class LJFunctor
       }
     }
 
-    const SoAFloatPrecision const_shift6 = _shift6;
-    const SoAFloatPrecision const_sigmaSquared = _sigmaSquared;
-    const SoAFloatPrecision const_epsilon24 = _epsilon24;
+    const CalcPrecision const_shift6 = _shift6;
+    const CalcPrecision const_sigmaSquared = _sigmaSquared;
+    const CalcPrecision const_epsilon24 = _epsilon24;
 
     for (unsigned int i = 0; i < soa.size(); ++i) {
       const auto ownedStateI = ownedStatePtr[i];
@@ -251,9 +265,9 @@ class LJFunctor
         continue;
       }
 
-      SoAFloatPrecision fxacc = 0.;
-      SoAFloatPrecision fyacc = 0.;
-      SoAFloatPrecision fzacc = 0.;
+      AccuPrecision fxacc = 0.;
+      AccuPrecision fyacc = 0.;
+      AccuPrecision fzacc = 0.;
 
       if constexpr (useMixing) {
         for (unsigned int j = 0; j < soa.size(); ++j) {
@@ -270,9 +284,9 @@ class LJFunctor
 // g++ only with -ffast-math or -funsafe-math-optimizations
 #pragma omp simd reduction(+ : fxacc, fyacc, fzacc, potentialEnergySum, virialSumX, virialSumY, virialSumZ, numDistanceCalculationSum, numKernelCallsN3Sum, numKernelCallsNoN3Sum, numGlobalCalcsSum)
       for (unsigned int j = i + 1; j < soa.size(); ++j) {
-        SoAFloatPrecision shift6 = const_shift6;
-        SoAFloatPrecision sigmaSquared = const_sigmaSquared;
-        SoAFloatPrecision epsilon24 = const_epsilon24;
+        CalcPrecision shift6 = const_shift6;
+        CalcPrecision sigmaSquared = const_sigmaSquared;
+        CalcPrecision epsilon24 = const_epsilon24;
         if constexpr (useMixing) {
           sigmaSquared = sigmaSquareds[j];
           epsilon24 = epsilon24s[j];
@@ -283,31 +297,32 @@ class LJFunctor
 
         const auto ownedStateJ = ownedStatePtr[j];
 
-        const SoAFloatPrecision drx = xptr[i] - xptr[j];
-        const SoAFloatPrecision dry = yptr[i] - yptr[j];
-        const SoAFloatPrecision drz = zptr[i] - zptr[j];
+        const CalcPrecision drx = xptr[i] - xptr[j];
+        const CalcPrecision dry = yptr[i] - yptr[j];
+        const CalcPrecision drz = zptr[i] - zptr[j];
 
-        const SoAFloatPrecision drx2 = drx * drx;
-        const SoAFloatPrecision dry2 = dry * dry;
-        const SoAFloatPrecision drz2 = drz * drz;
+        const CalcPrecision drx2 = drx * drx;
+        const CalcPrecision dry2 = dry * dry;
+        const CalcPrecision drz2 = drz * drz;
 
-        const SoAFloatPrecision dr2 = drx2 + dry2 + drz2;
+        const CalcPrecision dr2 = drx2 + dry2 + drz2;
 
         // Mask away if distance is too large or any particle is a dummy.
         // Particle ownedStateI was already checked previously.
         const bool mask = dr2 <= cutoffSquared and ownedStateJ != autopas::OwnershipState::dummy;
 
-        const SoAFloatPrecision invdr2 = 1. / dr2;
-        const SoAFloatPrecision lj2 = sigmaSquared * invdr2;
-        const SoAFloatPrecision lj6 = lj2 * lj2 * lj2;
-        const SoAFloatPrecision lj12 = lj6 * lj6;
-        const SoAFloatPrecision lj12m6 = lj12 - lj6;
-        const SoAFloatPrecision fac = mask * epsilon24 * (lj12 + lj12m6) * invdr2;
+        const CalcPrecision invdr2 = static_cast<CalcPrecision>(1.) / dr2;
+        const CalcPrecision lj2 = sigmaSquared * invdr2;
+        const CalcPrecision lj6 = lj2 * lj2 * lj2;
+        const CalcPrecision lj12 = lj6 * lj6;
+        const CalcPrecision lj12m6 = lj12 - lj6;
+        const CalcPrecision fac = mask * epsilon24 * (lj12 + lj12m6) * invdr2;
 
-        const SoAFloatPrecision fx = drx * fac;
-        const SoAFloatPrecision fy = dry * fac;
-        const SoAFloatPrecision fz = drz * fac;
+        const CalcPrecision fx = drx * fac;
+        const CalcPrecision fy = dry * fac;
+        const CalcPrecision fz = drz * fac;
 
+        // (potential) implicit cast to different precision
         fxacc += fx;
         fyacc += fy;
         fzacc += fz;
@@ -323,16 +338,16 @@ class LJFunctor
         }
 
         if (calculateGlobals) {
-          const SoAFloatPrecision virialx = drx * fx;
-          const SoAFloatPrecision virialy = dry * fy;
-          const SoAFloatPrecision virialz = drz * fz;
-          const SoAFloatPrecision potentialEnergy6 = mask * (epsilon24 * lj12m6 + shift6);
+          const CalcPrecision virialx = drx * fx;
+          const CalcPrecision virialy = dry * fy;
+          const CalcPrecision virialz = drz * fz;
+          const CalcPrecision potentialEnergy6 = mask * (epsilon24 * lj12m6 + shift6);
 
           // We add 6 times the potential energy for each owned particle. The total sum is corrected in endTraversal().
-          SoAFloatPrecision energyFactor = (ownedStateI == autopas::OwnershipState::owned ? 1. : 0.) +
-                                           (ownedStateJ == autopas::OwnershipState::owned ? 1. : 0.);
+          CalcPrecision energyFactor = (ownedStateI == autopas::OwnershipState::owned ? 1. : 0.) +
+                                       (ownedStateJ == autopas::OwnershipState::owned ? 1. : 0.);
           potentialEnergySum += potentialEnergy6 * energyFactor;
-
+          // (potential) implicit cast to different precision above and below
           virialSumX += virialx * energyFactor;
           virialSumY += virialy * energyFactor;
           virialSumZ += virialz * energyFactor;
@@ -408,10 +423,10 @@ class LJFunctor
     [[maybe_unused]] auto *const __restrict typeptr2 = soa2.template begin<Particle::AttributeNames::typeId>();
 
     // Checks whether the cells are halo cells.
-    SoAFloatPrecision potentialEnergySum = 0.;
-    SoAFloatPrecision virialSumX = 0.;
-    SoAFloatPrecision virialSumY = 0.;
-    SoAFloatPrecision virialSumZ = 0.;
+    AccuPrecision potentialEnergySum = 0.;
+    AccuPrecision virialSumX = 0.;
+    AccuPrecision virialSumY = 0.;
+    AccuPrecision virialSumZ = 0.;
 
     size_t numDistanceCalculationSum = 0;
     size_t numKernelCallsN3Sum = 0;
@@ -419,15 +434,15 @@ class LJFunctor
     size_t numGlobalCalcsN3Sum = 0;
     size_t numGlobalCalcsNoN3Sum = 0;
 
-    const SoAFloatPrecision cutoffSquared = _cutoffSquared;
-    SoAFloatPrecision shift6 = _shift6;
-    SoAFloatPrecision sigmaSquared = _sigmaSquared;
-    SoAFloatPrecision epsilon24 = _epsilon24;
+    const CalcPrecision cutoffSquared = _cutoffSquared;
+    CalcPrecision shift6 = _shift6;
+    CalcPrecision sigmaSquared = _sigmaSquared;
+    CalcPrecision epsilon24 = _epsilon24;
 
     // preload all sigma and epsilons for next vectorized region
-    std::vector<SoAFloatPrecision, autopas::AlignedAllocator<SoAFloatPrecision>> sigmaSquareds;
-    std::vector<SoAFloatPrecision, autopas::AlignedAllocator<SoAFloatPrecision>> epsilon24s;
-    std::vector<SoAFloatPrecision, autopas::AlignedAllocator<SoAFloatPrecision>> shift6s;
+    std::vector<CalcPrecision, autopas::AlignedAllocator<CalcPrecision>> sigmaSquareds;
+    std::vector<CalcPrecision, autopas::AlignedAllocator<CalcPrecision>> epsilon24s;
+    std::vector<CalcPrecision, autopas::AlignedAllocator<CalcPrecision>> shift6s;
     if constexpr (useMixing) {
       sigmaSquareds.resize(soa2.size());
       epsilon24s.resize(soa2.size());
@@ -438,9 +453,9 @@ class LJFunctor
     }
 
     for (unsigned int i = 0; i < soa1.size(); ++i) {
-      SoAFloatPrecision fxacc = 0;
-      SoAFloatPrecision fyacc = 0;
-      SoAFloatPrecision fzacc = 0;
+      AccuPrecision fxacc = 0;
+      AccuPrecision fyacc = 0;
+      AccuPrecision fzacc = 0;
 
       const auto ownedStateI = ownedStatePtr1[i];
       if (ownedStateI == autopas::OwnershipState::dummy) {
@@ -472,34 +487,36 @@ class LJFunctor
 
         const auto ownedStateJ = ownedStatePtr2[j];
 
-        const SoAFloatPrecision drx = x1ptr[i] - x2ptr[j];
-        const SoAFloatPrecision dry = y1ptr[i] - y2ptr[j];
-        const SoAFloatPrecision drz = z1ptr[i] - z2ptr[j];
+        const CalcPrecision drx = x1ptr[i] - x2ptr[j];
+        const CalcPrecision dry = y1ptr[i] - y2ptr[j];
+        const CalcPrecision drz = z1ptr[i] - z2ptr[j];
 
-        const SoAFloatPrecision drx2 = drx * drx;
-        const SoAFloatPrecision dry2 = dry * dry;
-        const SoAFloatPrecision drz2 = drz * drz;
+        const CalcPrecision drx2 = drx * drx;
+        const CalcPrecision dry2 = dry * dry;
+        const CalcPrecision drz2 = drz * drz;
 
-        const SoAFloatPrecision dr2 = drx2 + dry2 + drz2;
+        const CalcPrecision dr2 = drx2 + dry2 + drz2;
 
         // Mask away if distance is too large or any particle is a dummy.
         // Particle ownedStateI was already checked previously.
         const bool mask = dr2 <= cutoffSquared and ownedStateJ != autopas::OwnershipState::dummy;
 
-        const SoAFloatPrecision invdr2 = 1. / dr2;
-        const SoAFloatPrecision lj2 = sigmaSquared * invdr2;
-        const SoAFloatPrecision lj6 = lj2 * lj2 * lj2;
-        const SoAFloatPrecision lj12 = lj6 * lj6;
-        const SoAFloatPrecision lj12m6 = lj12 - lj6;
-        const SoAFloatPrecision fac = mask * epsilon24 * (lj12 + lj12m6) * invdr2;
+        const CalcPrecision invdr2 = static_cast<CalcPrecision>(1.) / dr2;
+        const CalcPrecision lj2 = sigmaSquared * invdr2;
+        const CalcPrecision lj6 = lj2 * lj2 * lj2;
+        const CalcPrecision lj12 = lj6 * lj6;
+        const CalcPrecision lj12m6 = lj12 - lj6;
+        const CalcPrecision fac = mask * epsilon24 * (lj12 + lj12m6) * invdr2;
 
-        const SoAFloatPrecision fx = drx * fac;
-        const SoAFloatPrecision fy = dry * fac;
-        const SoAFloatPrecision fz = drz * fac;
+        const CalcPrecision fx = drx * fac;
+        const CalcPrecision fy = dry * fac;
+        const CalcPrecision fz = drz * fac;
 
+        // (potential) implicit cast to different precision
         fxacc += fx;
         fyacc += fy;
         fzacc += fz;
+
         if (newton3) {
           fx2ptr[j] -= fx;
           fy2ptr[j] -= fy;
@@ -516,15 +533,14 @@ class LJFunctor
         }
 
         if constexpr (calculateGlobals) {
-          SoAFloatPrecision virialx = drx * fx;
-          SoAFloatPrecision virialy = dry * fy;
-          SoAFloatPrecision virialz = drz * fz;
-          SoAFloatPrecision potentialEnergy6 = mask * (epsilon24 * lj12m6 + shift6);
+          CalcPrecision virialx = drx * fx;
+          CalcPrecision virialy = dry * fy;
+          CalcPrecision virialz = drz * fz;
+          CalcPrecision potentialEnergy6 = mask * (epsilon24 * lj12m6 + shift6);
 
           // We add 6 times the potential energy for each owned particle. The total sum is corrected in endTraversal().
-          const SoAFloatPrecision energyFactor =
-              (ownedStateI == autopas::OwnershipState::owned ? 1. : 0.) +
-              (newton3 ? (ownedStateJ == autopas::OwnershipState::owned ? 1. : 0.) : 0.);
+          const CalcPrecision energyFactor = (ownedStateI == autopas::OwnershipState::owned ? 1. : 0.) +
+                                             (newton3 ? (ownedStateJ == autopas::OwnershipState::owned ? 1. : 0.) : 0.);
           potentialEnergySum += potentialEnergy6 * energyFactor;
           virialSumX += virialx * energyFactor;
           virialSumY += virialy * energyFactor;
@@ -585,11 +601,11 @@ class LJFunctor
    * @param epsilon24
    * @param sigmaSquared
    */
-  void setParticleProperties(SoAFloatPrecision epsilon24, SoAFloatPrecision sigmaSquared) {
+  void setParticleProperties(CalcPrecision epsilon24, CalcPrecision sigmaSquared) {
     _epsilon24 = epsilon24;
     _sigmaSquared = sigmaSquared;
     if (applyShift) {
-      _shift6 = ParticlePropertiesLibrary<double, size_t>::calcShift6(_epsilon24, _sigmaSquared, _cutoffSquared);
+      _shift6 = ParticlePropertiesLibrary<CalcPrecision, size_t>::calcShift6(_epsilon24, _sigmaSquared, _cutoffSquared);
     } else {
       _shift6 = 0.;
     }
@@ -818,15 +834,15 @@ class LJFunctor
 
     const auto *const __restrict ownedStatePtr = soa.template begin<Particle::AttributeNames::ownershipState>();
 
-    const SoAFloatPrecision cutoffSquared = _cutoffSquared;
-    SoAFloatPrecision shift6 = _shift6;
-    SoAFloatPrecision sigmaSquared = _sigmaSquared;
-    SoAFloatPrecision epsilon24 = _epsilon24;
+    const CalcPrecision cutoffSquared = _cutoffSquared;
+    CalcPrecision shift6 = _shift6;
+    CalcPrecision sigmaSquared = _sigmaSquared;
+    CalcPrecision epsilon24 = _epsilon24;
 
-    SoAFloatPrecision potentialEnergySum = 0.;
-    SoAFloatPrecision virialSumX = 0.;
-    SoAFloatPrecision virialSumY = 0.;
-    SoAFloatPrecision virialSumZ = 0.;
+    AccuPrecision potentialEnergySum = 0.;
+    AccuPrecision virialSumX = 0.;
+    AccuPrecision virialSumY = 0.;
+    AccuPrecision virialSumZ = 0.;
 
     // Counters for when countFLOPs is activated
     size_t numDistanceCalculationSum = 0;
@@ -835,9 +851,9 @@ class LJFunctor
     size_t numGlobalCalcsN3Sum = 0;
     size_t numGlobalCalcsNoN3Sum = 0;
 
-    SoAFloatPrecision fxacc = 0;
-    SoAFloatPrecision fyacc = 0;
-    SoAFloatPrecision fzacc = 0;
+    AccuPrecision fxacc = 0;
+    AccuPrecision fyacc = 0;
+    AccuPrecision fzacc = 0;
     const size_t neighborListSize = neighborList.size();
     const size_t *const __restrict neighborListPtr = neighborList.data();
 
@@ -868,7 +884,7 @@ class LJFunctor
     // if the size of the verlet list is larger than the given size vecsize,
     // we will use a vectorized version.
     if (neighborListSize >= vecsize) {
-      alignas(64) std::array<SoAFloatPrecision, vecsize> xtmp, ytmp, ztmp, xArr, yArr, zArr, fxArr, fyArr, fzArr;
+      alignas(64) std::array<CalcPrecision, vecsize> xtmp, ytmp, ztmp, xArr, yArr, zArr, fxArr, fyArr, fzArr;
       alignas(64) std::array<autopas::OwnershipState, vecsize> ownedStateArr{};
       // broadcast of the position of particle i
       for (size_t tmpj = 0; tmpj < vecsize; tmpj++) {
@@ -882,9 +898,9 @@ class LJFunctor
         // vecsize particles in the neighborlist of particle i starting at
         // particle joff
 
-        [[maybe_unused]] alignas(autopas::DEFAULT_CACHE_LINE_SIZE) std::array<SoAFloatPrecision, vecsize> sigmaSquareds;
-        [[maybe_unused]] alignas(autopas::DEFAULT_CACHE_LINE_SIZE) std::array<SoAFloatPrecision, vecsize> epsilon24s;
-        [[maybe_unused]] alignas(autopas::DEFAULT_CACHE_LINE_SIZE) std::array<SoAFloatPrecision, vecsize> shift6s;
+        [[maybe_unused]] alignas(autopas::DEFAULT_CACHE_LINE_SIZE) std::array<CalcPrecision, vecsize> sigmaSquareds;
+        [[maybe_unused]] alignas(autopas::DEFAULT_CACHE_LINE_SIZE) std::array<CalcPrecision, vecsize> epsilon24s;
+        [[maybe_unused]] alignas(autopas::DEFAULT_CACHE_LINE_SIZE) std::array<CalcPrecision, vecsize> shift6s;
         if constexpr (useMixing) {
           for (size_t j = 0; j < vecsize; j++) {
             sigmaSquareds[j] =
@@ -918,34 +934,36 @@ class LJFunctor
 
           const auto ownedStateJ = ownedStateArr[j];
 
-          const SoAFloatPrecision drx = xtmp[j] - xArr[j];
-          const SoAFloatPrecision dry = ytmp[j] - yArr[j];
-          const SoAFloatPrecision drz = ztmp[j] - zArr[j];
+          const CalcPrecision drx = xtmp[j] - xArr[j];
+          const CalcPrecision dry = ytmp[j] - yArr[j];
+          const CalcPrecision drz = ztmp[j] - zArr[j];
 
-          const SoAFloatPrecision drx2 = drx * drx;
-          const SoAFloatPrecision dry2 = dry * dry;
-          const SoAFloatPrecision drz2 = drz * drz;
+          const CalcPrecision drx2 = drx * drx;
+          const CalcPrecision dry2 = dry * dry;
+          const CalcPrecision drz2 = drz * drz;
 
-          const SoAFloatPrecision dr2 = drx2 + dry2 + drz2;
+          const CalcPrecision dr2 = drx2 + dry2 + drz2;
 
           // Mask away if distance is too large or any particle is a dummy.
           // Particle ownedStateI was already checked previously.
           const bool mask = dr2 <= cutoffSquared and ownedStateJ != autopas::OwnershipState::dummy;
 
-          const SoAFloatPrecision invdr2 = 1. / dr2;
-          const SoAFloatPrecision lj2 = sigmaSquared * invdr2;
-          const SoAFloatPrecision lj6 = lj2 * lj2 * lj2;
-          const SoAFloatPrecision lj12 = lj6 * lj6;
-          const SoAFloatPrecision lj12m6 = lj12 - lj6;
-          const SoAFloatPrecision fac = mask * epsilon24 * (lj12 + lj12m6) * invdr2;
+          const CalcPrecision invdr2 = 1. / dr2;
+          const CalcPrecision lj2 = sigmaSquared * invdr2;
+          const CalcPrecision lj6 = lj2 * lj2 * lj2;
+          const CalcPrecision lj12 = lj6 * lj6;
+          const CalcPrecision lj12m6 = lj12 - lj6;
+          const CalcPrecision fac = mask * epsilon24 * (lj12 + lj12m6) * invdr2;
 
-          const SoAFloatPrecision fx = drx * fac;
-          const SoAFloatPrecision fy = dry * fac;
-          const SoAFloatPrecision fz = drz * fac;
+          const CalcPrecision fx = drx * fac;
+          const CalcPrecision fy = dry * fac;
+          const CalcPrecision fz = drz * fac;
 
+          // (potential) implicit cast to different precision
           fxacc += fx;
           fyacc += fy;
           fzacc += fz;
+
           if (newton3) {
             fxArr[j] = fx;
             fyArr[j] = fy;
@@ -962,17 +980,18 @@ class LJFunctor
           }
 
           if (calculateGlobals) {
-            SoAFloatPrecision virialx = drx * fx;
-            SoAFloatPrecision virialy = dry * fy;
-            SoAFloatPrecision virialz = drz * fz;
-            SoAFloatPrecision potentialEnergy6 = mask * (epsilon24 * lj12m6 + shift6);
+            CalcPrecision virialx = drx * fx;
+            CalcPrecision virialy = dry * fy;
+            CalcPrecision virialz = drz * fz;
+            CalcPrecision potentialEnergy6 = mask * (epsilon24 * lj12m6 + shift6);
 
             // We add 6 times the potential energy for each owned particle. The total sum is corrected in
             // endTraversal().
-            const SoAFloatPrecision energyFactor =
+            const CalcPrecision energyFactor =
                 (ownedStateI == autopas::OwnershipState::owned ? 1. : 0.) +
                 (newton3 ? (ownedStateJ == autopas::OwnershipState::owned ? 1. : 0.) : 0.);
             potentialEnergySum += potentialEnergy6 * energyFactor;
+            // (potential) implicit cast to different precision above and below
             virialSumX += virialx * energyFactor;
             virialSumY += virialy * energyFactor;
             virialSumZ += virialz * energyFactor;
@@ -1015,15 +1034,15 @@ class LJFunctor
         continue;
       }
 
-      const SoAFloatPrecision drx = xptr[indexFirst] - xptr[j];
-      const SoAFloatPrecision dry = yptr[indexFirst] - yptr[j];
-      const SoAFloatPrecision drz = zptr[indexFirst] - zptr[j];
+      const CalcPrecision drx = xptr[indexFirst] - xptr[j];
+      const CalcPrecision dry = yptr[indexFirst] - yptr[j];
+      const CalcPrecision drz = zptr[indexFirst] - zptr[j];
 
-      const SoAFloatPrecision drx2 = drx * drx;
-      const SoAFloatPrecision dry2 = dry * dry;
-      const SoAFloatPrecision drz2 = drz * drz;
+      const CalcPrecision drx2 = drx * drx;
+      const CalcPrecision dry2 = dry * dry;
+      const CalcPrecision drz2 = drz * drz;
 
-      const SoAFloatPrecision dr2 = drx2 + dry2 + drz2;
+      const CalcPrecision dr2 = drx2 + dry2 + drz2;
 
       if constexpr (countFLOPs) {
         numDistanceCalculationSum += 1;
@@ -1033,20 +1052,21 @@ class LJFunctor
         continue;
       }
 
-      const SoAFloatPrecision invdr2 = 1. / dr2;
-      const SoAFloatPrecision lj2 = sigmaSquared * invdr2;
-      const SoAFloatPrecision lj6 = lj2 * lj2 * lj2;
-      const SoAFloatPrecision lj12 = lj6 * lj6;
-      const SoAFloatPrecision lj12m6 = lj12 - lj6;
-      const SoAFloatPrecision fac = epsilon24 * (lj12 + lj12m6) * invdr2;
+      const CalcPrecision invdr2 = 1. / dr2;
+      const CalcPrecision lj2 = sigmaSquared * invdr2;
+      const CalcPrecision lj6 = lj2 * lj2 * lj2;
+      const CalcPrecision lj12 = lj6 * lj6;
+      const CalcPrecision lj12m6 = lj12 - lj6;
+      const CalcPrecision fac = epsilon24 * (lj12 + lj12m6) * invdr2;
 
-      const SoAFloatPrecision fx = drx * fac;
-      const SoAFloatPrecision fy = dry * fac;
-      const SoAFloatPrecision fz = drz * fac;
+      const CalcPrecision fx = drx * fac;
+      const CalcPrecision fy = dry * fac;
+      const CalcPrecision fz = drz * fac;
 
       fxacc += fx;
       fyacc += fy;
       fzacc += fz;
+      // (potential) implicit cast to different precision
       if (newton3) {
         fxptr[j] -= fx;
         fyptr[j] -= fy;
@@ -1062,16 +1082,16 @@ class LJFunctor
       }
 
       if (calculateGlobals) {
-        SoAFloatPrecision virialx = drx * fx;
-        SoAFloatPrecision virialy = dry * fy;
-        SoAFloatPrecision virialz = drz * fz;
-        SoAFloatPrecision potentialEnergy6 = (epsilon24 * lj12m6 + shift6);
+        CalcPrecision virialx = drx * fx;
+        CalcPrecision virialy = dry * fy;
+        CalcPrecision virialz = drz * fz;
+        CalcPrecision potentialEnergy6 = (epsilon24 * lj12m6 + shift6);
 
         // We add 6 times the potential energy for each owned particle. The total sum is corrected in endTraversal().
-        const SoAFloatPrecision energyFactor =
-            (ownedStateI == autopas::OwnershipState::owned ? 1. : 0.) +
-            (newton3 ? (ownedStateJ == autopas::OwnershipState::owned ? 1. : 0.) : 0.);
+        const CalcPrecision energyFactor = (ownedStateI == autopas::OwnershipState::owned ? 1. : 0.) +
+                                           (newton3 ? (ownedStateJ == autopas::OwnershipState::owned ? 1. : 0.) : 0.);
         potentialEnergySum += potentialEnergy6 * energyFactor;
+        // (potential) implicit cast to different precision above and below
         virialSumX += virialx * energyFactor;
         virialSumY += virialy * energyFactor;
         virialSumZ += virialz * energyFactor;
@@ -1121,12 +1141,12 @@ class LJFunctor
     }
 
     // variables
-    std::array<double, 3> virialSum;
-    double potentialEnergySum;
+    std::array<AccuPrecision, 3> virialSum;
+    AccuPrecision potentialEnergySum;
 
    private:
     // dummy parameter to get the right size (64 bytes)
-    double __remainingTo64[(64 - 4 * sizeof(double)) / sizeof(double)];
+    double __remainingTo64[(64 - 4 * sizeof(AccuPrecision)) / sizeof(double)];
   };
 
   /**
@@ -1192,17 +1212,17 @@ class LJFunctor
   static_assert(sizeof(AoSThreadDataGlobals) % 64 == 0, "AoSThreadDataGlobals has wrong size");
   static_assert(sizeof(AoSThreadDataFLOPs) % 64 == 0, "AoSThreadDataFLOPs has wrong size");
 
-  const double _cutoffSquared;
+  const CalcPrecision _cutoffSquared;
   // not const because they might be reset through PPL
-  double _epsilon24, _sigmaSquared, _shift6 = 0;
+  CalcPrecision _epsilon24, _sigmaSquared, _shift6 = 0;
 
-  ParticlePropertiesLibrary<SoAFloatPrecision, size_t> *_PPLibrary = nullptr;
+  ParticlePropertiesLibrary<CalcPrecision, size_t> *_PPLibrary = nullptr;
 
   // sum of the potential energy, only calculated if calculateGlobals is true
-  double _potentialEnergySum;
+  AccuPrecision _potentialEnergySum;
 
   // sum of the virial, only calculated if calculateGlobals is true
-  std::array<double, 3> _virialSum;
+  std::array<AccuPrecision, 3> _virialSum;
 
   // thread buffer for aos
   std::vector<AoSThreadDataGlobals> _aosThreadDataGlobals{};

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctor.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctor.h
@@ -678,11 +678,11 @@ class LJFunctor
       }
       // For each interaction, we added the full contribution for both particles. Divide by 2 here, so that each
       // contribution is only counted once per pair.
-      _potentialEnergySum *= 0.5;
-      _virialSum *= 0.5;
+      _potentialEnergySum *= static_cast<AccuType>(0.5);
+      _virialSum *= static_cast<AccuType>(0.5);
 
       // We have always calculated 6*potentialEnergy, so we divide by 6 here!
-      _potentialEnergySum /= 6.;
+      _potentialEnergySum /= static_cast<AccuType>(6.0);
       _postProcessed = true;
 
       AutoPasLog(DEBUG, "Final potential energy {}", _potentialEnergySum);

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctor.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctor.h
@@ -47,7 +47,7 @@ class LJFunctor
   /**
    * Precision of SoA entries.
    */
-  using SoAFloatPrecision = typename Particle::ParticleSoAFloatPrecision;
+  using SoAFloatPrecision = typename Particle::ParticleCalcPrecision;
 
  public:
   /**

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorAVX.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorAVX.h
@@ -55,18 +55,7 @@ class LJFunctorAVX
    */
   using AccuType = typename Particle_T::ParticleAccuType;
 
-  /** SIMD type used for *calculations*.
-   It must match the precision mode blocks below:
-   - SPSP and SPDP use float AVX intrinsics (__m256)
-   - DPDP uses double AVX intrinsics (__m256d)
-   */
-#if AUTOPAS_PRECISION_MODE == SPSP || AUTOPAS_PRECISION_MODE == SPDP
-  using SIMDCalcType = __m256;
-#else
-  using SIMDCalcType = __m256d;
-#endif
-
-  // SIMD type used for *accumulations*, which depends on AccuType.
+  using SIMDCalcType = typename std::conditional_t<std::is_same<CalcType, float>::value, __m256, __m256d>;
   using SIMDAccuType = typename std::conditional_t<std::is_same<AccuType, float>::value, __m256, __m256d>;
 
   using SoAArraysType = typename Particle_T::SoAArraysType;

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorAVX.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorAVX.h
@@ -1469,12 +1469,6 @@ class LJFunctorAVX
       _mm256_set_epi32(0, 0, 0, 0, 0, -1, -1, -1),    _mm256_set_epi32(0, 0, 0, 0, -1, -1, -1, -1),
       _mm256_set_epi32(0, 0, 0, -1, -1, -1, -1, -1),  _mm256_set_epi32(0, 0, -1, -1, -1, -1, -1, -1),
       _mm256_set_epi32(0, -1, -1, -1, -1, -1, -1, -1)};
-  const __m256i _masksHalf[3]{
-      _mm256_set_epi64x(0, 0, 0, -1),
-      _mm256_set_epi64x(0, 0, -1, -1),
-      _mm256_set_epi64x(0, -1, -1, -1),
-  };
-
   const __m256i _ownedStateDummyMM256i{0x0};
   const __m256i _ownedStateOwnedMM256i{_mm256_set1_epi32(static_cast<int32_t>(autopas::OwnershipState::owned))};
   const __m256 _cutoffSquared{};

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorAVX.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorAVX.h
@@ -1374,7 +1374,7 @@ class LJFunctorAVX
       _virialSum *= static_cast<AccuType>(0.5);
 
       // We have always calculated 6*potentialEnergy, so we divide by 6 here!
-      _potentialEnergySum /= 6.;
+      _potentialEnergySum /= static_cast<AccuType>(6.);
       _postProcessed = true;
 
       AutoPasLog(DEBUG, "Final potential energy {}", _potentialEnergySum);
@@ -1386,7 +1386,7 @@ class LJFunctorAVX
    * Get the potential Energy
    * @return the potential Energy
    */
-  double getPotentialEnergy() {
+  AccuType getPotentialEnergy() {
     if (not calculateGlobals) {
       throw autopas::utils::ExceptionHandler::AutoPasException(
           "Trying to get potential energy even though calculateGlobals is false. If you want this functor to "
@@ -1405,7 +1405,7 @@ class LJFunctorAVX
    * Get the virial
    * @return the virial
    */
-  double getVirial() {
+  AccuType getVirial() {
     if (not calculateGlobals) {
       throw autopas::utils::ExceptionHandler::AutoPasException(
           "Trying to get virial even though calculateGlobals is false. If you want this functor to calculate global "

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorAVX.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorAVX.h
@@ -76,10 +76,10 @@ class LJFunctorAVX
 #ifdef __AVX__
       : autopas::PairwiseFunctor<Particle, LJFunctorAVX<Particle, applyShift, useMixing, useNewton3, calculateGlobals,
                                                         countFLOPs, relevantForTuning>>(cutoff),
-#if AUTOPAS_PRECISION_MODE == DPDP
-        _cutoffSquared{_mm256_set1_pd(cutoff * cutoff)},
-#else
+#if AUTOPAS_PRECISION_MODE == SPSP || AUTOPAS_PRECISION_MODE == SPDP
         _cutoffSquared{_mm256_set1_ps(cutoff * cutoff)},
+#else
+        _cutoffSquared{_mm256_set1_pd(cutoff * cutoff)},
 #endif
         _cutoffSquaredAoS(cutoff * cutoff),
         _potentialEnergySum{0.},
@@ -1097,7 +1097,6 @@ class LJFunctorAVX
     // _mm256_set1_epi32 broadcasts a 32-bit integer, we use this instruction to have 8 values!
     __m256i ownedStateI = _mm256_set1_epi32(static_cast<autopas::OwnershipType>(ownedStatePtr[indexFirst]));
 
-    // TODO MP does this alignment need to change for SPXP?
     alignas(64) std::array<CalcType, vecLength> x2tmp{};
     alignas(64) std::array<CalcType, vecLength> y2tmp{};
     alignas(64) std::array<CalcType, vecLength> z2tmp{};

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorAVX.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorAVX.h
@@ -947,7 +947,7 @@ class LJFunctorAVX
           _mm256_cmp_ps(_mm256_castsi256_ps(ownedStateI), _mm256_castsi256_ps(_ownedStateOwnedMM256i), _CMP_EQ_UQ);
       __m256 energyFactor = _mm256_blendv_ps(_zero, _one, ownedMaskI);
       if constexpr (newton3) {
-        __m256d ownedMaskJ =
+        __m256 ownedMaskJ =
             _mm256_cmp_ps(_mm256_castsi256_ps(ownedStateJ), _mm256_castsi256_ps(_ownedStateOwnedMM256i), _CMP_EQ_UQ);
         energyFactor = _mm256_add_ps(energyFactor, _mm256_blendv_ps(_zero, _one, ownedMaskJ));
       }

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorAVX.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorAVX.h
@@ -129,7 +129,7 @@ class LJFunctorAVX
    * @param cutoff
    * @param particlePropertiesLibrary
    */
-  explicit LJFunctorAVX(CalcType cutoff, ParticlePropertiesLibrary<double, size_t> &particlePropertiesLibrary)
+  explicit LJFunctorAVX(CalcType cutoff, ParticlePropertiesLibrary<CalcType, size_t> &particlePropertiesLibrary)
       : LJFunctorAVX(cutoff, nullptr) {
     static_assert(useMixing,
                   "Not using Mixing but using a ParticlePropertiesLibrary is not allowed! Use a different constructor "
@@ -1625,7 +1625,7 @@ class LJFunctorAVX
   const CalcType _cutoffSquaredAoS = 0;
   CalcType _epsilon24AoS, _sigmaSquaredAoS, _shift6AoS = 0;
 
-  ParticlePropertiesLibrary<double, size_t> *_PPLibrary = nullptr;
+  ParticlePropertiesLibrary<CalcType, size_t> *_PPLibrary = nullptr;
 
   // sum of the potential energy, only calculated if calculateGlobals is true
   AccuType _potentialEnergySum;

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorAVX.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorAVX.h
@@ -954,15 +954,15 @@ class LJFunctorAVX
       const __m256d energyFactorLow = _mm256_cvtps_pd(_mm256_extractf128_ps(energyFactor, 0));
       const __m256d energyFactorHigh = _mm256_cvtps_pd(_mm256_extractf128_ps(energyFactor, 1));
       *potentialEnergySum = wrapperFMA(
-          energyFactorLow, _mm256_cvtps_pd(_mm256_extractf128_ps(potentialEnergyMasked, 0), *potentialEnergySum));
+          energyFactorLow, _mm256_cvtps_pd(_mm256_extractf128_ps(potentialEnergyMasked, 0)), *potentialEnergySum);
       *potentialEnergySum = wrapperFMA(
-          energyFactorHigh, _mm256_cvtps_pd(_mm256_extractf128_ps(potentialEnergyMasked, 1), *potentialEnergySum));
-      *virialSumX = wrapperFMA(energyFactorLow, _mm256_cvtps_pd(_mm256_extractf128_ps(virialX, 0), *virialSumX));
-      *virialSumX = wrapperFMA(energyFactorHigh, _mm256_cvtps_pd(_mm256_extractf128_ps(virialX, 1), *virialSumX));
-      *virialSumY = wrapperFMA(energyFactorLow, _mm256_cvtps_pd(_mm256_extractf128_ps(virialY, 0), *virialSumY));
-      *virialSumY = wrapperFMA(energyFactorHigh, _mm256_cvtps_pd(_mm256_extractf128_ps(virialY, 1), *virialSumY));
-      *virialSumZ = wrapperFMA(energyFactorLow, _mm256_cvtps_pd(_mm256_extractf128_ps(virialZ, 0), *virialSumZ));
-      *virialSumZ = wrapperFMA(energyFactorHigh, _mm256_cvtps_pd(_mm256_extractf128_ps(virialZ, 1), *virialSumZ));
+          energyFactorHigh, _mm256_cvtps_pd(_mm256_extractf128_ps(potentialEnergyMasked, 1)), *potentialEnergySum);
+      *virialSumX = wrapperFMA(energyFactorLow, _mm256_cvtps_pd(_mm256_extractf128_ps(virialX, 0)), *virialSumX);
+      *virialSumX = wrapperFMA(energyFactorHigh, _mm256_cvtps_pd(_mm256_extractf128_ps(virialX, 1)), *virialSumX);
+      *virialSumY = wrapperFMA(energyFactorLow, _mm256_cvtps_pd(_mm256_extractf128_ps(virialY, 0)), *virialSumY);
+      *virialSumY = wrapperFMA(energyFactorHigh, _mm256_cvtps_pd(_mm256_extractf128_ps(virialY, 1)), *virialSumY);
+      *virialSumZ = wrapperFMA(energyFactorLow, _mm256_cvtps_pd(_mm256_extractf128_ps(virialZ, 0)), *virialSumZ);
+      *virialSumZ = wrapperFMA(energyFactorHigh, _mm256_cvtps_pd(_mm256_extractf128_ps(virialZ, 1)), *virialSumZ);
     }
 #else
     // double precision
@@ -1377,8 +1377,8 @@ class LJFunctorAVX
       _potentialEnergySum /= static_cast<AccuType>(6.);
       _postProcessed = true;
 
-      AutoPasLog(DEBUG, "Final potential energy {}", _potentialEnergySum);
-      AutoPasLog(DEBUG, "Final virial           {}", _virialSum[0] + _virialSum[1] + _virialSum[2]);
+      AutoPasLog(INFO, "Final potential energy {}", _potentialEnergySum);
+      AutoPasLog(INFO, "Final virial           {}", _virialSum[0] + _virialSum[1] + _virialSum[2]);
     }
   }
 

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorAVX.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorAVX.h
@@ -1478,6 +1478,25 @@ class LJFunctorAVX
     return __m256d();
 #endif
   }
+
+  /**
+   * Wrapper function for FMA. If FMA is not supported it first executes the multiplication then the addition.
+   * @param factorA
+   * @param factorB
+   * @param summandC
+   * @return A * B + C
+   */
+  inline __m256 wrapperFMA(const __m256 &factorA, const __m256 &factorB, const __m256 &summandC) {
+#ifdef __FMA__
+    return _mm256_fmadd_ps(factorA, factorB, summandC);
+#elif __AVX__
+    const __m256 tmp = _mm256_mul_ps(factorA, factorB);
+    return _mm256_add_ps(summandC, tmp);
+#else
+    // dummy return. If no vectorization is available this whole class is pointless anyways.
+    return __m256();
+#endif
+  }
 #endif
 
   /**

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorAVX.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJFunctorAVX.h
@@ -55,7 +55,18 @@ class LJFunctorAVX
    */
   using AccuType = typename Particle_T::ParticleAccuType;
 
-  using SIMDCalcType = typename std::conditional_t<std::is_same<CalcType, float>::value, __m256, __m256d>;
+  /** SIMD type used for *calculations*.
+   It must match the precision mode blocks below:
+   - SPSP and SPDP use float AVX intrinsics (__m256)
+   - DPDP uses double AVX intrinsics (__m256d)
+   */
+#if AUTOPAS_PRECISION_MODE == SPSP || AUTOPAS_PRECISION_MODE == SPDP
+  using SIMDCalcType = __m256;
+#else
+  using SIMDCalcType = __m256d;
+#endif
+
+  // SIMD type used for *accumulations*, which depends on AccuType.
   using SIMDAccuType = typename std::conditional_t<std::is_same<AccuType, float>::value, __m256, __m256d>;
 
   using SoAArraysType = typename Particle_T::SoAArraysType;

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJMultisiteFunctor.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJMultisiteFunctor.h
@@ -53,7 +53,7 @@ class LJMultisiteFunctor
   /**
    * Precision of SoA entries
    */
-  using SoAFloatPrecision = typename Particle::ParticleSoAFloatPrecision;
+  using SoAFloatPrecision = typename Particle::ParticleCalcPrecision;
 
   /**
    * cutoff^2

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJMultisiteFunctor.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/LJMultisiteFunctor.h
@@ -53,7 +53,7 @@ class LJMultisiteFunctor
   /**
    * Precision of SoA entries
    */
-  using SoAFloatPrecision = typename Particle::ParticleCalcPrecision;
+  using SoAFloatPrecision = typename Particle::ParticleCalcType;
 
   /**
    * cutoff^2

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJ.cpp
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJ.cpp
@@ -5,31 +5,3 @@
  */
 
 #include "MoleculeLJ.h"
-
-namespace mdLib {
-MoleculeLJ::MoleculeLJ(const std::array<double, 3> &pos, const std::array<double, 3> &v, unsigned long moleculeId,
-                       unsigned long typeId)
-    : autopas::Particle(pos, v, moleculeId), _typeId(typeId) {}
-
-const std::array<double, 3> &MoleculeLJ::getOldF() const { return _oldF; }
-void MoleculeLJ::setOldF(const std::array<double, 3> &oldForce) { _oldF = oldForce; }
-
-size_t MoleculeLJ::getTypeId() const { return _typeId; }
-void MoleculeLJ::setTypeId(size_t typeId) { _typeId = typeId; }
-
-std::string MoleculeLJ::toString() const {
-  using autopas::utils::ArrayUtils::operator<<;
-  std::ostringstream text;
-  // clang-format off
-  text << "MoleculeLJ"
-     << "\nID                 : " << _id
-     << "\nPosition           : " << _r
-     << "\nVelocity           : " << _v
-     << "\nForce              : " << _f
-     << "\nOld Force          : " << _oldF
-     << "\nType ID            : " << _typeId
-     << "\nOwnershipState     : " << _ownershipState;
-  // clang-format on
-  return text.str();
-}
-}  // namespace mdLib

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJ.cpp
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJ.cpp
@@ -9,10 +9,22 @@
 namespace mdLib {
 MoleculeLJ::MoleculeLJ(const std::array<double, 3> &pos, const std::array<double, 3> &v, unsigned long moleculeId,
                        unsigned long typeId)
-    : MoleculeLJBase<double, double, unsigned long>(pos, v, moleculeId), _typeId(typeId) {}
+    : MoleculeLJPrecisionBase(), _typeId(typeId) {
+  std::array<MoleculeLJ::AoSCalcType, 3> posCast{};
+  std::array<MoleculeLJ::AoSCalcType, 3> vCast{};
 
-const std::array<double, 3> &MoleculeLJ::getOldF() const { return _oldF; }
-void MoleculeLJ::setOldF(const std::array<double, 3> &oldForce) { _oldF = oldForce; }
+  for (std::size_t d = 0; d < 3; ++d) {
+    posCast[d] = static_cast<MoleculeLJ::AoSCalcType>(pos[d]);
+    vCast[d] = static_cast<MoleculeLJ::AoSCalcType>(v[d]);
+  }
+
+  this->setR(posCast);
+  this->setV(vCast);
+  this->setID(moleculeId);
+}
+
+const std::array<MoleculeLJ::ParticleSoAFloatPrecision, 3> &MoleculeLJ::getOldF() const { return _oldF; }
+void MoleculeLJ::setOldF(const std::array<MoleculeLJ::ParticleSoAFloatPrecision, 3> &oldForce) { _oldF = oldForce; }
 
 size_t MoleculeLJ::getTypeId() const { return _typeId; }
 void MoleculeLJ::setTypeId(size_t typeId) { _typeId = typeId; }

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJ.cpp
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJ.cpp
@@ -1,7 +1,0 @@
-/**
- * @file MoleculeLJ.cpp
- * @date Originally 17/01/2018. Code pulled from header on 15/06/2023.
- * @author tchipevn
- */
-
-#include "MoleculeLJ.h"

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJ.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJ.h
@@ -39,11 +39,7 @@ using MoleculeLJPrecisionBase = MoleculeLJFP64;
  */
 class MoleculeLJ : public MoleculeLJBase<double, double, unsigned long> {
 public:
-#if AUTOPAS_PRECISION_MODE == SPSP || AUTOPAS_PRECISION_MODE == SPDP
-  using ParticleSoAFloatPrecision = float;
-#else
   using ParticleSoAFloatPrecision = double;
-#endif
 
   MoleculeLJ() = default;
 
@@ -89,23 +85,10 @@ public:
    * The reason for this is the easier use of the value in calculations (See LJFunctor "energyFactor")
    */
   using SoAArraysType =
-    typename autopas::utils::SoAType<
-        MoleculeLJ *,
-        size_t /*id*/,
-        ParticleSoAFloatPrecision /*x*/,
-        ParticleSoAFloatPrecision /*y*/,
-        ParticleSoAFloatPrecision /*z*/,
-        ParticleSoAFloatPrecision /*vx*/,
-        ParticleSoAFloatPrecision /*vy*/,
-        ParticleSoAFloatPrecision /*vz*/,
-        ParticleSoAFloatPrecision /*fx*/,
-        ParticleSoAFloatPrecision /*fy*/,
-        ParticleSoAFloatPrecision /*fz*/,
-        ParticleSoAFloatPrecision /*oldFx*/,
-        ParticleSoAFloatPrecision /*oldFy*/,
-        ParticleSoAFloatPrecision /*oldFz*/,
-        size_t /*typeid*/,
-        autopas::OwnershipState /*ownershipState*/>::Type;
+      typename autopas::utils::SoAType<MoleculeLJ *, size_t /*id*/, double /*x*/, double /*y*/, double /*z*/,
+                                       double /*vx*/, double /*vy*/, double /*vz*/, double /*fx*/, double /*fy*/,
+                                       double /*fz*/, double /*oldFx*/, double /*oldFy*/, double /*oldFz*/,
+                                       size_t /*typeid*/, autopas::OwnershipState /*ownershipState*/>::Type;
 
   /**
    * Non-const getter for the pointer of this object.

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJ.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJ.h
@@ -15,20 +15,19 @@ namespace mdLib {
  */
 using MoleculeLJFP32 = MoleculeLJBase<float, float, unsigned long>;
 /**
- * MoleculeLJ with all variables in 64 bit precision
- */
-
-using MoleculeLJFP64 = MoleculeLJBase<double, double, unsigned long>;
-/**
  * MoleculeLJ with mixed precision for calculations and accumulation
  */
 using MoleculeLJMP = MoleculeLJBase<float, double, unsigned long>;
+/**
+ * MoleculeLJ with all variables in 64 bit precision
+ */
+using MoleculeLJFP64 = MoleculeLJBase<double, double, unsigned long>;
 
 #if AUTOPAS_PRECISION_MODE == SPSP
 using MoleculeLJ = MoleculeLJFP32;
-#elif AUTOPAS_PRECISION_MODE == DPDP
-using MoleculeLJ = MoleculeLJFP64;
-#else
+#elif AUTOPAS_PRECISION_MODE == SPDP
 using MoleculeLJ = MoleculeLJMP;
+#else
+using MoleculeLJ = MoleculeLJFP64;
 #endif
 }  // namespace mdLib

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJ.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJ.h
@@ -1,214 +1,34 @@
 /**
  * @file MoleculeLJ.h
  *
- * @date 17 Jan 2018
- * @author tchipevn
+ * @date 30/Nov/2024
+ * @author huberf
  */
 
 #pragma once
 
-#include <vector>
-
-#include "autopas/particles/Particle.h"
-#include "autopas/utils/ExceptionHandler.h"
+#include "MoleculeLJBase.h"
 
 namespace mdLib {
-
 /**
- * Molecule class for the LJFunctor.
+ * MoleculeLJ with all variables in 32 bit precision
  */
-class MoleculeLJ : public autopas::Particle {
- public:
-  MoleculeLJ() = default;
+using MoleculeLJFP32 = MoleculeLJBase<float, float, unsigned long>;
+/**
+ * MoleculeLJ with all variables in 64 bit precision
+ */
 
-  /**
-   * Constructor of lennard jones molecule with initialization of typeID.
-   * @param pos Position of the molecule.
-   * @param v Velocity of the molecule.
-   * @param moleculeId Unique Id of the molecule.
-   * @param typeId TypeId of the molecule.
-   */
-  MoleculeLJ(const std::array<double, 3> &pos, const std::array<double, 3> &v, unsigned long moleculeId,
-             unsigned long typeId = 0);
+using MoleculeLJFP64 = MoleculeLJBase<double, double, unsigned long>;
+/**
+ * MoleculeLJ with mixed precision for calculations and accumulation
+ */
+using MoleculeLJMP = MoleculeLJBase<float, double, unsigned long>;
 
-  ~MoleculeLJ() override = default;
-
-  /**
-   * Enums used as ids for accessing and creating a dynamically sized SoA.
-   */
-  enum AttributeNames : int {
-    ptr,
-    id,
-    posX,
-    posY,
-    posZ,
-    velocityX,
-    velocityY,
-    velocityZ,
-    forceX,
-    forceY,
-    forceZ,
-    oldForceX,
-    oldForceY,
-    oldForceZ,
-    typeId,
-    ownershipState
-  };
-
-  /**
-   * The type for the SoA storage.
-   *
-   * @note The attribute owned is of type float but treated as a bool.
-   * This means it shall always only take values 0.0 (=false) or 1.0 (=true).
-   * The reason for this is the easier use of the value in calculations (See LJFunctor "energyFactor")
-   */
-  using SoAArraysType =
-      typename autopas::utils::SoAType<MoleculeLJ *, size_t /*id*/, double /*x*/, double /*y*/, double /*z*/,
-                                       double /*vx*/, double /*vy*/, double /*vz*/, double /*fx*/, double /*fy*/,
-                                       double /*fz*/, double /*oldFx*/, double /*oldFy*/, double /*oldFz*/,
-                                       size_t /*typeid*/, autopas::OwnershipState /*ownershipState*/>::Type;
-
-  /**
-   * Non-const getter for the pointer of this object.
-   * @tparam attribute Attribute name.
-   * @return this.
-   */
-  template <AttributeNames attribute, std::enable_if_t<attribute == AttributeNames::ptr, bool> = true>
-  constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() {
-    return this;
-  }
-  /**
-   * Getter, which allows access to an attribute using the corresponding attribute name (defined in AttributeNames).
-   * @tparam attribute Attribute name.
-   * @return Value of the requested attribute.
-   * @note The value of owned is return as floating point number (true = 1.0, false = 0.0).
-   * @note Moving this function to the .cpp leads to undefined references
-   */
-  template <AttributeNames attribute, std::enable_if_t<attribute != AttributeNames::ptr, bool> = true>
-  constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() const {
-    if constexpr (attribute == AttributeNames::id) {
-      return getID();
-    } else if constexpr (attribute == AttributeNames::posX) {
-      return getR()[0];
-    } else if constexpr (attribute == AttributeNames::posY) {
-      return getR()[1];
-    } else if constexpr (attribute == AttributeNames::posZ) {
-      return getR()[2];
-    } else if constexpr (attribute == AttributeNames::velocityX) {
-      return getV()[0];
-    } else if constexpr (attribute == AttributeNames::velocityY) {
-      return getV()[1];
-    } else if constexpr (attribute == AttributeNames::velocityZ) {
-      return getV()[2];
-    } else if constexpr (attribute == AttributeNames::forceX) {
-      return getF()[0];
-    } else if constexpr (attribute == AttributeNames::forceY) {
-      return getF()[1];
-    } else if constexpr (attribute == AttributeNames::forceZ) {
-      return getF()[2];
-    } else if constexpr (attribute == AttributeNames::oldForceX) {
-      return getOldF()[0];
-    } else if constexpr (attribute == AttributeNames::oldForceY) {
-      return getOldF()[1];
-    } else if constexpr (attribute == AttributeNames::oldForceZ) {
-      return getOldF()[2];
-    } else if constexpr (attribute == AttributeNames::typeId) {
-      return getTypeId();
-    } else if constexpr (attribute == AttributeNames::ownershipState) {
-      return this->_ownershipState;
-    } else {
-      autopas::utils::ExceptionHandler::exception("MoleculeLJ::get() unknown attribute {}", attribute);
-    }
-  }
-
-  /**
-   * Setter, which allows set an attribute using the corresponding attribute name (defined in AttributeNames).
-   * @tparam attribute Attribute name.
-   * @param value New value of the requested attribute.
-   * @note The value of owned is extracted from a floating point number (true = 1.0, false = 0.0).
-   * @note Moving this function to the .cpp leads to undefined references
-   */
-  template <AttributeNames attribute>
-  constexpr void set(typename std::tuple_element<attribute, SoAArraysType>::type::value_type value) {
-    if constexpr (attribute == AttributeNames::id) {
-      setID(value);
-    } else if constexpr (attribute == AttributeNames::posX) {
-      _r[0] = value;
-    } else if constexpr (attribute == AttributeNames::posY) {
-      _r[1] = value;
-    } else if constexpr (attribute == AttributeNames::posZ) {
-      _r[2] = value;
-    } else if constexpr (attribute == AttributeNames::velocityX) {
-      _v[0] = value;
-    } else if constexpr (attribute == AttributeNames::velocityY) {
-      _v[1] = value;
-    } else if constexpr (attribute == AttributeNames::velocityZ) {
-      _v[2] = value;
-    } else if constexpr (attribute == AttributeNames::forceX) {
-      _f[0] = value;
-    } else if constexpr (attribute == AttributeNames::forceY) {
-      _f[1] = value;
-    } else if constexpr (attribute == AttributeNames::forceZ) {
-      _f[2] = value;
-    } else if constexpr (attribute == AttributeNames::oldForceX) {
-      _oldF[0] = value;
-    } else if constexpr (attribute == AttributeNames::oldForceY) {
-      _oldF[1] = value;
-    } else if constexpr (attribute == AttributeNames::oldForceZ) {
-      _oldF[2] = value;
-    } else if constexpr (attribute == AttributeNames::typeId) {
-      setTypeId(value);
-    } else if constexpr (attribute == AttributeNames::ownershipState) {
-      this->_ownershipState = value;
-    } else {
-      autopas::utils::ExceptionHandler::exception("MoleculeLJ::set() unknown attribute {}", attribute);
-    }
-  }
-
-  /**
-   * Get the old force.
-   * @return
-   */
-  [[nodiscard]] const std::array<double, 3> &getOldF() const;
-
-  /**
-   * Set old force.
-   * @param oldForce
-   */
-  void setOldF(const std::array<double, 3> &oldForce);
-
-  /**
-   * Get TypeId.
-   * @return
-   */
-  [[nodiscard]] size_t getTypeId() const;
-
-  /**
-   * Set the type id of the Molecule.
-   * @param typeId
-   */
-  void setTypeId(size_t typeId);
-
-  /**
-   * Creates a string containing all data of the particle.
-   * @return String representation.
-   */
-  [[nodiscard]] std::string toString() const override;
-
- protected:
-  /**
-   * Molecule type id. In single-site simulations, this is used as a siteId to look up site attributes in the particle
-   * properties library.
-   *
-   * In multi-site simulations, where a multi-site molecule class inheriting from this class is used, typeId is used as
-   * a molId to look up molecular attributes (including siteIds of the sites).
-   */
-  size_t _typeId = 0;
-
-  /**
-   * Old Force of the particle experiences as 3D vector.
-   */
-  std::array<double, 3> _oldF = {0., 0., 0.};
-};
-
+#if AUTOPAS_PRECISION_MODE == SPSP
+using MoleculeLJ = MoleculeLJFP32;
+#elif AUTOPAS_PRECISION_MODE == DPDP
+using MoleculeLJ = MoleculeLJFP64;
+#else
+using MoleculeLJ = MoleculeLJMP;
+#endif
 }  // namespace mdLib

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJ.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJ.h
@@ -39,7 +39,11 @@ using MoleculeLJPrecisionBase = MoleculeLJFP64;
  */
 class MoleculeLJ : public MoleculeLJBase<double, double, unsigned long> {
 public:
+#if AUTOPAS_PRECISION_MODE == SPSP || AUTOPAS_PRECISION_MODE == SPDP
+  using ParticleSoAFloatPrecision = float;
+#else
   using ParticleSoAFloatPrecision = double;
+#endif
 
   MoleculeLJ() = default;
 
@@ -85,10 +89,23 @@ public:
    * The reason for this is the easier use of the value in calculations (See LJFunctor "energyFactor")
    */
   using SoAArraysType =
-      typename autopas::utils::SoAType<MoleculeLJ *, size_t /*id*/, double /*x*/, double /*y*/, double /*z*/,
-                                       double /*vx*/, double /*vy*/, double /*vz*/, double /*fx*/, double /*fy*/,
-                                       double /*fz*/, double /*oldFx*/, double /*oldFy*/, double /*oldFz*/,
-                                       size_t /*typeid*/, autopas::OwnershipState /*ownershipState*/>::Type;
+    typename autopas::utils::SoAType<
+        MoleculeLJ *,
+        size_t /*id*/,
+        ParticleSoAFloatPrecision /*x*/,
+        ParticleSoAFloatPrecision /*y*/,
+        ParticleSoAFloatPrecision /*z*/,
+        ParticleSoAFloatPrecision /*vx*/,
+        ParticleSoAFloatPrecision /*vy*/,
+        ParticleSoAFloatPrecision /*vz*/,
+        ParticleSoAFloatPrecision /*fx*/,
+        ParticleSoAFloatPrecision /*fy*/,
+        ParticleSoAFloatPrecision /*fz*/,
+        ParticleSoAFloatPrecision /*oldFx*/,
+        ParticleSoAFloatPrecision /*oldFy*/,
+        ParticleSoAFloatPrecision /*oldFz*/,
+        size_t /*typeid*/,
+        autopas::OwnershipState /*ownershipState*/>::Type;
 
   /**
    * Non-const getter for the pointer of this object.

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJ.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJ.h
@@ -34,12 +34,24 @@ using MoleculeLJPrecisionBase = MoleculeLJMP;
 #else
 using MoleculeLJPrecisionBase = MoleculeLJFP64;
 #endif
+
 /**
  * Molecule class for the LJFunctor.
  */
-class MoleculeLJ : public MoleculeLJBase<double, double, unsigned long> {
-public:
-  using ParticleSoAFloatPrecision = double;
+class MoleculeLJ : public MoleculeLJPrecisionBase {
+  public:
+  #if AUTOPAS_PRECISION_MODE == SPSP
+    using ParticleSoAFloatPrecision = float;
+  #else
+    using ParticleSoAFloatPrecision = double;
+  #endif
+
+  #if AUTOPAS_PRECISION_MODE == DPDP
+    using AoSCalcType = double;
+  #else
+    using AoSCalcType = float;
+  #endif
+
 
   MoleculeLJ() = default;
 
@@ -84,11 +96,16 @@ public:
    * This means it shall always only take values 0.0 (=false) or 1.0 (=true).
    * The reason for this is the easier use of the value in calculations (See LJFunctor "energyFactor")
    */
+
   using SoAArraysType =
-      typename autopas::utils::SoAType<MoleculeLJ *, size_t /*id*/, double /*x*/, double /*y*/, double /*z*/,
-                                       double /*vx*/, double /*vy*/, double /*vz*/, double /*fx*/, double /*fy*/,
-                                       double /*fz*/, double /*oldFx*/, double /*oldFy*/, double /*oldFz*/,
-                                       size_t /*typeid*/, autopas::OwnershipState /*ownershipState*/>::Type;
+    typename autopas::utils::SoAType<
+        MoleculeLJ*, size_t /*id*/,
+        double /*x*/, double /*y*/, double /*z*/,
+        ParticleSoAFloatPrecision /*vx*/, ParticleSoAFloatPrecision /*vy*/, ParticleSoAFloatPrecision /*vz*/,
+        ParticleSoAFloatPrecision /*fx*/, ParticleSoAFloatPrecision /*fy*/, ParticleSoAFloatPrecision /*fz*/,
+        ParticleSoAFloatPrecision /*oldFx*/, ParticleSoAFloatPrecision /*oldFy*/, ParticleSoAFloatPrecision /*oldFz*/,
+        size_t /*typeid*/, autopas::OwnershipState /*ownershipState*/>::Type;
+
 
   /**
    * Non-const getter for the pointer of this object.
@@ -191,13 +208,13 @@ public:
    * Get the old force.
    * @return
    */
-  [[nodiscard]] const std::array<double, 3> &getOldF() const;
+  [[nodiscard]] const std::array<ParticleSoAFloatPrecision, 3> &getOldF() const;
 
   /**
    * Set old force.
    * @param oldForce
    */
-  void setOldF(const std::array<double, 3> &oldForce);
+  void setOldF(const std::array<ParticleSoAFloatPrecision, 3> &oldForce);
 
   /**
    * Get TypeId.
@@ -218,7 +235,7 @@ public:
   [[nodiscard]] std::string toString() const override;
 
 private:
-  std::array<double, 3> _oldF{0., 0., 0.};
+  std::array<ParticleSoAFloatPrecision, 3> _oldF{0., 0., 0.};
   size_t _typeId{0};
 };
 }

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJBase.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJBase.h
@@ -64,11 +64,10 @@ class MoleculeLJBase : public autopas::ParticleBase<CalcType, AccuType, idType> 
    * This means it shall always only take values 0.0 (=false) or 1.0 (=true).
    * The reason for this is the easier use of the value in calculations (See LJFunctor "energyFactor")
    */
-  using SoAArraysType =
-      typename autopas::utils::SoAType<MoleculeLJBase *, size_t /*id*/, double /*x*/, double /*y*/, double /*z*/,
-                                       double /*vx*/, double /*vy*/, double /*vz*/, double /*fx*/, double /*fy*/,
-                                       double /*fz*/, double /*oldFx*/, double /*oldFy*/, double /*oldFz*/,
-                                       size_t /*typeid*/, autopas::OwnershipState /*ownershipState*/>::Type;
+  using SoAArraysType = typename autopas::utils::SoAType<
+      MoleculeLJBase *, size_t /*id*/, CalcType /*x*/, CalcType /*y*/, CalcType /*z*/, CalcType /*vx*/, CalcType /*vy*/,
+      CalcType /*vz*/, AccuType /*fx*/, AccuType /*fy*/, AccuType /*fz*/, AccuType /*oldFx*/, AccuType /*oldFy*/,
+      AccuType /*oldFz*/, size_t /*typeid*/, autopas::OwnershipState /*ownershipState*/>::Type;
 
   /**
    * Non-const getter for the pointer of this object.
@@ -171,13 +170,13 @@ class MoleculeLJBase : public autopas::ParticleBase<CalcType, AccuType, idType> 
    * Get the old force.
    * @return
    */
-  [[nodiscard]] const std::array<double, 3> &getOldF() const { return _oldF; };
+  [[nodiscard]] const std::array<AccuType, 3> &getOldF() const { return _oldF; };
 
   /**
    * Set old force.
    * @param oldForce
    */
-  void setOldF(const std::array<double, 3> &oldForce) { _oldF = oldForce; };
+  void setOldF(const std::array<AccuType, 3> &oldForce) { _oldF = oldForce; };
 
   /**
    * Get TypeId.
@@ -224,7 +223,7 @@ class MoleculeLJBase : public autopas::ParticleBase<CalcType, AccuType, idType> 
   /**
    * Old Force of the particle experiences as 3D vector.
    */
-  std::array<double, 3> _oldF = {0., 0., 0.};
+  std::array<AccuType, 3> _oldF = {0., 0., 0.};
 };
 
 }  // namespace mdLib

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJBase.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJBase.h
@@ -17,8 +17,8 @@ namespace mdLib {
 /**
  * Molecule class for the LJFunctor.
  */
-template <typename calcType, typename accuType, typename idType>
-class MoleculeLJBase : public autopas::ParticleBase<calcType, accuType, idType> {
+template <typename CalcType, typename AccuType, typename idType>
+class MoleculeLJBase : public autopas::ParticleBase<CalcType, AccuType, idType> {
  public:
   MoleculeLJBase() = default;
 
@@ -29,9 +29,9 @@ class MoleculeLJBase : public autopas::ParticleBase<calcType, accuType, idType> 
    * @param moleculeId Unique Id of the molecule.
    * @param typeId TypeId of the molecule.
    */
-  MoleculeLJBase(const std::array<calcType, 3> &pos, const std::array<calcType, 3> &v, unsigned long moleculeId,
+  MoleculeLJBase(const std::array<CalcType, 3> &pos, const std::array<CalcType, 3> &v, unsigned long moleculeId,
                  unsigned long typeId = 0)
-      : autopas::ParticleBase<calcType, accuType, idType>(pos, v, moleculeId), _typeId(typeId){};
+      : autopas::ParticleBase<CalcType, AccuType, idType>(pos, v, moleculeId), _typeId(typeId){};
 
   ~MoleculeLJBase() override = default;
 

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJBase.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MoleculeLJBase.h
@@ -1,0 +1,230 @@
+/**
+ * @file MoleculeLJBase.h
+ *
+ * @date 17 Jan 2018
+ * @author tchipevn
+ */
+
+#pragma once
+
+#include <vector>
+
+#include "autopas/particles/ParticleBase.h"
+#include "autopas/utils/ExceptionHandler.h"
+
+namespace mdLib {
+
+/**
+ * Molecule class for the LJFunctor.
+ */
+template <typename calcType, typename accuType, typename idType>
+class MoleculeLJBase : public autopas::ParticleBase<calcType, accuType, idType> {
+ public:
+  MoleculeLJBase() = default;
+
+  /**
+   * Constructor of lennard jones molecule with initialization of typeID.
+   * @param pos Position of the molecule.
+   * @param v Velocity of the molecule.
+   * @param moleculeId Unique Id of the molecule.
+   * @param typeId TypeId of the molecule.
+   */
+  MoleculeLJBase(const std::array<calcType, 3> &pos, const std::array<calcType, 3> &v, unsigned long moleculeId,
+                 unsigned long typeId = 0)
+      : autopas::ParticleBase<calcType, accuType, idType>(pos, v, moleculeId), _typeId(typeId){};
+
+  ~MoleculeLJBase() override = default;
+
+  /**
+   * Enums used as ids for accessing and creating a dynamically sized SoA.
+   */
+  enum AttributeNames : int {
+    ptr,
+    id,
+    posX,
+    posY,
+    posZ,
+    velocityX,
+    velocityY,
+    velocityZ,
+    forceX,
+    forceY,
+    forceZ,
+    oldForceX,
+    oldForceY,
+    oldForceZ,
+    typeId,
+    ownershipState
+  };
+
+  /**
+   * The type for the SoA storage.
+   *
+   * @note The attribute owned is of type float but treated as a bool.
+   * This means it shall always only take values 0.0 (=false) or 1.0 (=true).
+   * The reason for this is the easier use of the value in calculations (See LJFunctor "energyFactor")
+   */
+  using SoAArraysType =
+      typename autopas::utils::SoAType<MoleculeLJBase *, size_t /*id*/, double /*x*/, double /*y*/, double /*z*/,
+                                       double /*vx*/, double /*vy*/, double /*vz*/, double /*fx*/, double /*fy*/,
+                                       double /*fz*/, double /*oldFx*/, double /*oldFy*/, double /*oldFz*/,
+                                       size_t /*typeid*/, autopas::OwnershipState /*ownershipState*/>::Type;
+
+  /**
+   * Non-const getter for the pointer of this object.
+   * @tparam attribute Attribute name.
+   * @return this.
+   */
+  template <AttributeNames attribute, std::enable_if_t<attribute == AttributeNames::ptr, bool> = true>
+  constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() {
+    return this;
+  }
+  /**
+   * Getter, which allows access to an attribute using the corresponding attribute name (defined in AttributeNames).
+   * @tparam attribute Attribute name.
+   * @return Value of the requested attribute.
+   * @note The value of owned is return as floating point number (true = 1.0, false = 0.0).
+   * @note Moving this function to the .cpp leads to undefined references
+   */
+  template <AttributeNames attribute, std::enable_if_t<attribute != AttributeNames::ptr, bool> = true>
+  constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() const {
+    if constexpr (attribute == AttributeNames::id) {
+      return this->getID();
+    } else if constexpr (attribute == AttributeNames::posX) {
+      return this->getR()[0];
+    } else if constexpr (attribute == AttributeNames::posY) {
+      return this->getR()[1];
+    } else if constexpr (attribute == AttributeNames::posZ) {
+      return this->getR()[2];
+    } else if constexpr (attribute == AttributeNames::velocityX) {
+      return this->getV()[0];
+    } else if constexpr (attribute == AttributeNames::velocityY) {
+      return this->getV()[1];
+    } else if constexpr (attribute == AttributeNames::velocityZ) {
+      return this->getV()[2];
+    } else if constexpr (attribute == AttributeNames::forceX) {
+      return this->getF()[0];
+    } else if constexpr (attribute == AttributeNames::forceY) {
+      return this->getF()[1];
+    } else if constexpr (attribute == AttributeNames::forceZ) {
+      return this->getF()[2];
+    } else if constexpr (attribute == AttributeNames::oldForceX) {
+      return this->getOldF()[0];
+    } else if constexpr (attribute == AttributeNames::oldForceY) {
+      return this->getOldF()[1];
+    } else if constexpr (attribute == AttributeNames::oldForceZ) {
+      return this->getOldF()[2];
+    } else if constexpr (attribute == AttributeNames::typeId) {
+      return this->getTypeId();
+    } else if constexpr (attribute == AttributeNames::ownershipState) {
+      return this->_ownershipState;
+    } else {
+      autopas::utils::ExceptionHandler::exception("MoleculeLJBase::get() unknown attribute {}", attribute);
+    }
+  }
+
+  /**
+   * Setter, which allows set an attribute using the corresponding attribute name (defined in AttributeNames).
+   * @tparam attribute Attribute name.
+   * @param value New value of the requested attribute.
+   * @note The value of owned is extracted from a floating point number (true = 1.0, false = 0.0).
+   * @note Moving this function to the .cpp leads to undefined references
+   */
+  template <AttributeNames attribute>
+  constexpr void set(typename std::tuple_element<attribute, SoAArraysType>::type::value_type value) {
+    if constexpr (attribute == AttributeNames::id) {
+      this->setID(value);
+    } else if constexpr (attribute == AttributeNames::posX) {
+      this->_r[0] = value;
+    } else if constexpr (attribute == AttributeNames::posY) {
+      this->_r[1] = value;
+    } else if constexpr (attribute == AttributeNames::posZ) {
+      this->_r[2] = value;
+    } else if constexpr (attribute == AttributeNames::velocityX) {
+      this->_v[0] = value;
+    } else if constexpr (attribute == AttributeNames::velocityY) {
+      this->_v[1] = value;
+    } else if constexpr (attribute == AttributeNames::velocityZ) {
+      this->_v[2] = value;
+    } else if constexpr (attribute == AttributeNames::forceX) {
+      this->_f[0] = value;
+    } else if constexpr (attribute == AttributeNames::forceY) {
+      this->_f[1] = value;
+    } else if constexpr (attribute == AttributeNames::forceZ) {
+      this->_f[2] = value;
+    } else if constexpr (attribute == AttributeNames::oldForceX) {
+      this->_oldF[0] = value;
+    } else if constexpr (attribute == AttributeNames::oldForceY) {
+      this->_oldF[1] = value;
+    } else if constexpr (attribute == AttributeNames::oldForceZ) {
+      this->_oldF[2] = value;
+    } else if constexpr (attribute == AttributeNames::typeId) {
+      setTypeId(value);
+    } else if constexpr (attribute == AttributeNames::ownershipState) {
+      this->_ownershipState = value;
+    } else {
+      autopas::utils::ExceptionHandler::exception("MoleculeLJBase::set() unknown attribute {}", attribute);
+    }
+  }
+
+  /**
+   * Get the old force.
+   * @return
+   */
+  [[nodiscard]] const std::array<double, 3> &getOldF() const { return _oldF; };
+
+  /**
+   * Set old force.
+   * @param oldForce
+   */
+  void setOldF(const std::array<double, 3> &oldForce) { _oldF = oldForce; };
+
+  /**
+   * Get TypeId.
+   * @return
+   */
+  [[nodiscard]] size_t getTypeId() const { return _typeId; };
+
+  /**
+   * Set the type id of the Molecule.
+   * @param typeId
+   */
+  void setTypeId(size_t typeId) { _typeId = typeId; };
+
+  /**
+   * Creates a string containing all data of the particle.
+   * @return String representation.
+   */
+  [[nodiscard]] std::string toString() const override {
+    using autopas::utils::ArrayUtils::operator<<;
+    std::ostringstream text;
+    // clang-format off
+  text << "MoleculeLJBase"
+     << "\nID                 : " << this->_id
+     << "\nPosition           : " << this->_r
+     << "\nVelocity           : " << this->_v
+     << "\nForce              : " << this->_f
+     << "\nOld Force          : " << this->_oldF
+     << "\nType ID            : " << this->_typeId
+     << "\nOwnershipState     : " << this->_ownershipState;
+    // clang-format on
+    return text.str();
+  };
+
+ protected:
+  /**
+   * Molecule type id. In single-site simulations, this is used as a siteId to look up site attributes in the particle
+   * properties library.
+   *
+   * In multi-site simulations, where a multi-site molecule class inheriting from this class is used, typeId is used as
+   * a molId to look up molecular attributes (including siteIds of the sites).
+   */
+  size_t _typeId = 0;
+
+  /**
+   * Old Force of the particle experiences as 3D vector.
+   */
+  std::array<double, 3> _oldF = {0., 0., 0.};
+};
+
+}  // namespace mdLib

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MultisiteMoleculeLJ.cpp
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MultisiteMoleculeLJ.cpp
@@ -10,7 +10,10 @@ namespace mdLib {
 MultisiteMoleculeLJ::MultisiteMoleculeLJ(std::array<double, 3> r, std::array<double, 3> v, std::array<double, 4> q,
                                          std::array<double, 3> angularVel, unsigned long moleculeId,
                                          unsigned long typeId)
-    : mdLib::MoleculeLJ(r, v, moleculeId, typeId), _q(q), _angularVel(angularVel), _torque({0., 0., 0.}) {}
+    : mdLib::MoleculeLJBase<double, double, unsigned long>(r, v, moleculeId, typeId),
+      _q(q),
+      _angularVel(angularVel),
+      _torque({0., 0., 0.}) {}
 
 const std::array<double, 4> &MultisiteMoleculeLJ::getQuaternion() const { return _q; }
 void MultisiteMoleculeLJ::setQuaternion(const std::array<double, 4> &q) { _q = q; }

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MultisiteMoleculeLJ.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/MultisiteMoleculeLJ.h
@@ -19,7 +19,7 @@ namespace mdLib {
  * mass and angular direction.
  *
  */
-class MultisiteMoleculeLJ : public mdLib::MoleculeLJ {
+class MultisiteMoleculeLJ : public mdLib::MoleculeLJBase<double, double, unsigned long> {
   using idType = size_t;
 
  public:

--- a/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ParticlePropertiesLibrary.h
+++ b/applicationLibrary/molecularDynamics/molecularDynamicsLibrary/ParticlePropertiesLibrary.h
@@ -31,7 +31,7 @@ class ParticlePropertiesLibrary {
    * Constructor
    * @param cutoff Cutoff for the Potential
    */
-  explicit ParticlePropertiesLibrary(const double cutoff) : _cutoff(cutoff) {}
+  explicit ParticlePropertiesLibrary(const floatType cutoff) : _cutoff(cutoff) {}
 
   /**
    * Copy Constructor.
@@ -239,8 +239,8 @@ class ParticlePropertiesLibrary {
    * @param j Id of site two.
    * @return
    */
-  const double *getLJMixingDataPtr(intType i, intType j) {
-    return reinterpret_cast<const double *>(&_computedLJMixingData[i * _numRegisteredSiteTypes + j]);
+  const floatType *getLJMixingDataPtr(intType i, intType j) {
+    return reinterpret_cast<const floatType *>(&_computedLJMixingData[i * _numRegisteredSiteTypes + j]);
   }
 
   /**
@@ -271,7 +271,7 @@ class ParticlePropertiesLibrary {
    * @param cutoffSquared squared cutoff of the lennard-jones potential
    * @return shift multiplied by 6
    */
-  static double calcShift6(double epsilon24, double sigmaSquared, double cutoffSquared);
+  static floatType calcShift6(floatType epsilon24, floatType sigmaSquared, floatType cutoffSquared);
 
   /**
    * Returns the precomputed mixed epsilon * 24.
@@ -301,7 +301,7 @@ class ParticlePropertiesLibrary {
  private:
   intType _numRegisteredSiteTypes{0};
   intType _numRegisteredMolTypes{0};
-  const double _cutoff;
+  const floatType _cutoff;
 
   std::vector<floatType> _epsilons;
   std::vector<floatType> _sigmas;
@@ -572,8 +572,8 @@ floatType ParticlePropertiesLibrary<floatType, intType>::getMoleculesLargestSigm
 }
 
 template <typename floatType, typename intType>
-double ParticlePropertiesLibrary<floatType, intType>::calcShift6(double epsilon24, double sigmaSquared,
-                                                                 double cutoffSquared) {
+floatType ParticlePropertiesLibrary<floatType, intType>::calcShift6(floatType epsilon24, floatType sigmaSquared,
+                                                                    floatType cutoffSquared) {
   const auto sigmaDivCutoffPow2 = sigmaSquared / cutoffSquared;
   const auto sigmaDivCutoffPow6 = sigmaDivCutoffPow2 * sigmaDivCutoffPow2 * sigmaDivCutoffPow2;
   const auto shift6 = epsilon24 * (sigmaDivCutoffPow6 - sigmaDivCutoffPow6 * sigmaDivCutoffPow6);

--- a/applicationLibrary/molecularDynamics/tests/singleSiteTests/LJFunctorAVXTest.cpp
+++ b/applicationLibrary/molecularDynamics/tests/singleSiteTests/LJFunctorAVXTest.cpp
@@ -14,6 +14,13 @@
 #include "molecularDynamicsLibrary/LJFunctor.h"
 #include "molecularDynamicsLibrary/LJFunctorAVX.h"
 
+#if AUTOPAS_PRECISION_MODE == SPSP || AUTOPAS_PRECISION_MODE == SPDP
+using FunctorCalcType = float;
+#else
+using FunctorCalcType = double;
+#endif
+
+
 template <class SoAType>
 bool LJFunctorAVXTest::SoAParticlesEqual(autopas::SoA<SoAType> &soa1, autopas::SoA<SoAType> &soa2) {
   EXPECT_GT(soa1.size(), 0);
@@ -89,7 +96,7 @@ void LJFunctorAVXTest::testLJFunctorVSLJFunctorAVXTwoCells(bool newton3, bool do
 
   size_t numParticles = 7;
 
-  ParticlePropertiesLibrary<double, size_t> PPL{_cutoff};
+  ParticlePropertiesLibrary<double, size_t> PPL{static_cast<FunctorCalcType>(_cutoff)};
   if constexpr (mixing) {
     PPL.addSiteType(0, 1.);
     PPL.addLJParametersToSite(0, 1., 1.);
@@ -211,7 +218,7 @@ void LJFunctorAVXTest::testLJFunctorVSLJFunctorAVXOneCell(bool newton3, bool doD
 
   size_t numParticles = 7;
 
-  ParticlePropertiesLibrary<double, size_t> PPL{_cutoff};
+  ParticlePropertiesLibrary<double, size_t> PPL{static_cast<FunctorCalcType>(_cutoff)};
   if constexpr (mixing) {
     PPL.addSiteType(0, 1.);
     PPL.addLJParametersToSite(0, 1., 1.);
@@ -308,7 +315,7 @@ void LJFunctorAVXTest::testLJFunctorVSLJFunctorAVXVerlet(bool newton3, bool doDe
 
   constexpr size_t numParticles = 7;
 
-  ParticlePropertiesLibrary<double, size_t> PPL{_cutoff};
+  ParticlePropertiesLibrary<double, size_t> PPL{static_cast<FunctorCalcType>(_cutoff)};
   if constexpr (mixing) {
     PPL.addSiteType(0, 1.);
     PPL.addLJParametersToSite(0, 1., 1.);
@@ -418,7 +425,7 @@ void LJFunctorAVXTest::testLJFunctorVSLJFunctorAVXAoS(bool newton3, bool doDelet
 
   constexpr size_t numParticles = 7;
 
-  ParticlePropertiesLibrary<double, size_t> PPL{_cutoff};
+  ParticlePropertiesLibrary<double, size_t> PPL{static_cast<FunctorCalcType>(_cutoff)};
   if constexpr (mixing) {
     PPL.addSiteType(0, 1.);
     PPL.addLJParametersToSite(0, 1., 1.);

--- a/applicationLibrary/sph/SPHLibrary/SPHParticle.h
+++ b/applicationLibrary/sph/SPHLibrary/SPHParticle.h
@@ -15,14 +15,14 @@ namespace sphLib {
 /**
  * Basic SPHParticle class.
  */
-class SPHParticle : public autopas::Particle {
+class SPHParticle : public autopas::ParticleBase<double, double, unsigned long> {
  public:
   /**
    * Default constructor of SPHParticle.
    * Will initialize all values to some basic defaults.
    */
   SPHParticle()
-      : autopas::Particle(),
+      : autopas::ParticleBase<double, double, unsigned long>(),
         _density(0.),
         _pressure(0.),
         _mass(0.),
@@ -43,7 +43,7 @@ class SPHParticle : public autopas::Particle {
    * @param id id of the particle. This id should be unique
    */
   SPHParticle(const std::array<double, 3> &r, const std::array<double, 3> &v, unsigned long id)
-      : autopas::Particle(r, v, id),
+      : autopas::ParticleBase<double, double, unsigned long>(r, v, id),
         _density(0.),
         _pressure(0.),
         _mass(0.),
@@ -69,7 +69,7 @@ class SPHParticle : public autopas::Particle {
    */
   SPHParticle(const std::array<double, 3> &r, const std::array<double, 3> &v, unsigned long id, double mass,
               double smth, double snds)
-      : autopas::Particle(r, v, id),
+      : autopas::ParticleBase<double, double, unsigned long>(r, v, id),
         _density(0.),
         _pressure(0.),
         _mass(mass),

--- a/cmake/modules/autopas_pmt.cmake
+++ b/cmake/modules/autopas_pmt.cmake
@@ -11,6 +11,9 @@ if (AUTOPAS_ENABLE_ENERGY_MEASUREMENTS)
     # however in AutoPas, it is set to ON by default whenever energy measurement is enabled.
     set(PMT_BUILD_RAPL ON CACHE BOOL "RAPL is by default enabled when PMT is enabled" FORCE)
 
+    # LIKWID can be enabled by setting the cmake option PMT_BUILD_LIKWID to ON. This is particularly useful on CoolMuc-4 where RAPL does not work.
+    set(PMT_BUILD_LIKWID OFF CACHE BOOL "LIKWID is OFF by default when PMT is enabled, but user can change this." )
+
     if (NOT ${pmt_ForceBundled})
         if (pmt_FOUND)
             message(STATUS "pmt - using installed version ${pmt_VERSION}")

--- a/examples/md-flexible/CMakeLists.txt
+++ b/examples/md-flexible/CMakeLists.txt
@@ -5,7 +5,12 @@ file(
         "src/*.h"
 )
 
-add_executable(md-flexible ${MDFlex_SRC})
+add_executable(md-flexible ${MDFlex_SRC}
+        src/GlobalVariableLogger.h
+        src/GlobalVariableLogger.h
+        src/GlobalVariableLogger.h
+        src/GlobalVariableLogger.cpp
+        src/GlobalVariableLogger.cpp)
 
 target_include_directories(md-flexible PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/examples/md-flexible/input/MPBenchmark.yaml
+++ b/examples/md-flexible/input/MPBenchmark.yaml
@@ -1,0 +1,52 @@
+# This yaml file creates a simple simulation box as a benchmark for Mixed Precision (modified version of 3BodyTest.yaml)
+container                            :  [LinkedCells]
+selector-strategy                    :  Fastest-Absolute-Value
+data-layout                          :  [SoA]
+functor                              :  lj-avx
+
+traversal                            :  [lc_c08]
+newton3                              :  [enabled]
+# traversal                            :  [lc_c01]
+# newton3                              :  [disabled]
+
+verlet-rebuild-frequency             :  1
+verlet-skin-radius-per-timestep      :  0
+tuning-strategies                    :  []
+tuning-interval                      :  2000
+tuning-samples                       :  3
+tuning-max-evidence                  :  10
+
+cutoff                               :  2.5
+cell-size                            :  [1]
+deltaT                               :  0.001
+iterations                           :  100000
+boundary-type                        :  [periodic, periodic, periodic]
+fastParticlesThrow                   :  false
+
+Sites:
+  0:
+    epsilon                          :  1.
+    sigma                            :  1.
+    mass                             :  1.
+Objects:
+  CubeClosestPacked:
+    0:
+      box-length                     :  [80, 80, 80]
+      bottomLeftCorner               :  [0, 0, 0]
+      particle-spacing               :  1.35
+      velocity                       :  [0, 0, 0]
+      particle-type-id               :  0
+thermostat:
+  initialTemperature                 :  1.1
+  targetTemperature                  :  1.1
+  deltaTemperature                   :  0.5
+  thermostatInterval                 :  25
+  addBrownianMotion                  :  true
+
+log-level                            :  info
+no-end-config                        :  true
+no-progress-bar                      :  true
+vtk-filename                         :  MPBenchmark
+vtk-output-folder                    :  vtkOutputFolder
+vtk-write-frequency                  :  30
+log-file                             :  logMPBenchmark.txt

--- a/examples/md-flexible/input/MPBenchmarkBig.yaml
+++ b/examples/md-flexible/input/MPBenchmarkBig.yaml
@@ -20,7 +20,7 @@ cutoff                               :  2.5
 cell-size                            :  [1]
 deltaT                               :  0.001
 iterations                           :  100000
-boundary-type                        :  [periodic, periodic, periodic]
+boundary-type                        :  [reflective, reflective, reflective]
 fastParticlesThrow                   :  false
 
 Sites:

--- a/examples/md-flexible/input/MPBenchmarkBig.yaml
+++ b/examples/md-flexible/input/MPBenchmarkBig.yaml
@@ -1,0 +1,52 @@
+# This yaml file creates a simple simulation box as a benchmark for Mixed Precision (modified version of 3BodyTest.yaml)
+container                            :  [LinkedCells]
+selector-strategy                    :  Fastest-Absolute-Value
+data-layout                          :  [SoA]
+functor                              :  lj-avx
+
+traversal                            :  [lc_c08]
+newton3                              :  [enabled]
+# traversal                            :  [lc_c01]
+# newton3                              :  [disabled]
+
+verlet-rebuild-frequency             :  1
+verlet-skin-radius-per-timestep      :  0
+tuning-strategies                    :  []
+tuning-interval                      :  2000
+tuning-samples                       :  3
+tuning-max-evidence                  :  10
+
+cutoff                               :  2.5
+cell-size                            :  [1]
+deltaT                               :  0.001
+iterations                           :  100000
+boundary-type                        :  [periodic, periodic, periodic]
+fastParticlesThrow                   :  false
+
+Sites:
+  0:
+    epsilon                          :  1.
+    sigma                            :  1.
+    mass                             :  1.
+Objects:
+  CubeClosestPacked:
+    0:
+      box-length                     :  [80, 80, 80]
+      bottomLeftCorner               :  [0, 0, 0]
+      particle-spacing               :  1.35
+      velocity                       :  [0, 0, 0]
+      particle-type-id               :  0
+thermostat:
+  initialTemperature                 :  1.1
+  targetTemperature                  :  1.1
+  deltaTemperature                   :  0.5
+  thermostatInterval                 :  25
+  addBrownianMotion                  :  true
+
+log-level                            :  info
+no-end-config                        :  true
+no-progress-bar                      :  true
+vtk-filename                         :  MPBenchmarkBig
+vtk-output-folder                    :  vtkOutputFolder
+vtk-write-frequency                  :  30
+log-file                             :  logMPBenchmarkBig.txt

--- a/examples/md-flexible/input/MPBenchmarkMedium.yaml
+++ b/examples/md-flexible/input/MPBenchmarkMedium.yaml
@@ -19,7 +19,7 @@ tuning-max-evidence                  :  10
 cutoff                               :  2.5
 cell-size                            :  [1]
 deltaT                               :  0.001
-iterations                           :  100000
+iterations                           :  10000
 boundary-type                        :  [periodic, periodic, periodic]
 fastParticlesThrow                   :  false
 
@@ -31,7 +31,7 @@ Sites:
 Objects:
   CubeClosestPacked:
     0:
-      box-length                     :  [80, 80, 80]
+      box-length                     :  [40, 40, 40]
       bottomLeftCorner               :  [0, 0, 0]
       particle-spacing               :  1.35
       velocity                       :  [0, 0, 0]
@@ -46,7 +46,7 @@ thermostat:
 log-level                            :  info
 no-end-config                        :  true
 no-progress-bar                      :  true
-vtk-filename                         :  MPBenchmark
+vtk-filename                         :  MPBenchmarkMedium
 vtk-output-folder                    :  vtkOutputFolder
 vtk-write-frequency                  :  30
-log-file                             :  logMPBenchmark.txt
+log-file                             :  logMPBenchmarkMedium.txt

--- a/examples/md-flexible/input/MPBenchmarkMedium.yaml
+++ b/examples/md-flexible/input/MPBenchmarkMedium.yaml
@@ -20,7 +20,7 @@ cutoff                               :  2.5
 cell-size                            :  [1]
 deltaT                               :  0.001
 iterations                           :  10000
-boundary-type                        :  [periodic, periodic, periodic]
+boundary-type                        :  [reflective, reflective, reflective]
 fastParticlesThrow                   :  false
 
 Sites:

--- a/examples/md-flexible/input/MPBenchmarkTiny.yaml
+++ b/examples/md-flexible/input/MPBenchmarkTiny.yaml
@@ -19,7 +19,7 @@ tuning-max-evidence                  :  10
 cutoff                               :  2.5
 cell-size                            :  [1]
 deltaT                               :  0.001
-iterations                           :  100000
+iterations                           :  100
 boundary-type                        :  [periodic, periodic, periodic]
 fastParticlesThrow                   :  false
 
@@ -31,7 +31,7 @@ Sites:
 Objects:
   CubeClosestPacked:
     0:
-      box-length                     :  [80, 80, 80]
+      box-length                     :  [20, 20, 20]
       bottomLeftCorner               :  [0, 0, 0]
       particle-spacing               :  1.35
       velocity                       :  [0, 0, 0]
@@ -43,10 +43,10 @@ thermostat:
   thermostatInterval                 :  25
   addBrownianMotion                  :  true
 
-log-level                            :  debug
+log-level                            :  info
 no-end-config                        :  true
 no-progress-bar                      :  true
-vtk-filename                         :  myBenchmark
+vtk-filename                         :  MPBenchmarkTiny
 vtk-output-folder                    :  vtkOutputFolder
 vtk-write-frequency                  :  30
-log-file                             :  log.txt
+log-file                             :  logMPBenchmarkTiny.txt

--- a/examples/md-flexible/input/MPBenchmarkTiny.yaml
+++ b/examples/md-flexible/input/MPBenchmarkTiny.yaml
@@ -20,7 +20,7 @@ cutoff                               :  2.5
 cell-size                            :  [1]
 deltaT                               :  0.001
 iterations                           :  100
-boundary-type                        :  [periodic, periodic, periodic]
+boundary-type                        :  [reflective, reflective, reflective]
 fastParticlesThrow                   :  false
 
 Sites:

--- a/examples/md-flexible/input/MixedPrecisionBenchmark.yaml
+++ b/examples/md-flexible/input/MixedPrecisionBenchmark.yaml
@@ -9,8 +9,8 @@ newton3                              :  [enabled]
 # traversal                            :  [lc_c01]
 # newton3                              :  [disabled]
 
-verlet-rebuild-frequency             :  10
-verlet-skin-radius-per-timestep      :  0.02
+verlet-rebuild-frequency             :  1
+verlet-skin-radius-per-timestep      :  0
 tuning-strategies                    :  []
 tuning-interval                      :  2000
 tuning-samples                       :  3
@@ -18,7 +18,7 @@ tuning-max-evidence                  :  10
 
 cutoff                               :  2.5
 cell-size                            :  [1]
-deltaT                               :  0.00004
+deltaT                               :  0.001
 iterations                           :  100000
 boundary-type                        :  [periodic, periodic, periodic]
 fastParticlesThrow                   :  false

--- a/examples/md-flexible/input/MixedPrecisionBenchmark.yaml
+++ b/examples/md-flexible/input/MixedPrecisionBenchmark.yaml
@@ -1,0 +1,52 @@
+# This yaml file creates a simple simulation box as a benchmark for Mixed Precision (modified version of 3BodyTest.yaml)
+container                            :  [LinkedCells]
+selector-strategy                    :  Fastest-Absolute-Value
+data-layout                          :  [SoA]
+functor                              :  lj-avx
+
+traversal                            :  [lc_c08]
+newton3                              :  [enabled]
+# traversal                            :  [lc_c01]
+# newton3                              :  [disabled]
+
+verlet-rebuild-frequency             :  10
+verlet-skin-radius-per-timestep      :  0.02
+tuning-strategies                    :  []
+tuning-interval                      :  2000
+tuning-samples                       :  3
+tuning-max-evidence                  :  10
+
+cutoff                               :  2.5
+cell-size                            :  [1]
+deltaT                               :  0.00004
+iterations                           :  100000
+boundary-type                        :  [periodic, periodic, periodic]
+fastParticlesThrow                   :  false
+
+Sites:
+  0:
+    epsilon                          :  1.
+    sigma                            :  1.
+    mass                             :  1.
+Objects:
+  CubeClosestPacked:
+    0:
+      box-length                     :  [80, 80, 80]
+      bottomLeftCorner               :  [0, 0, 0]
+      particle-spacing               :  1.35
+      velocity                       :  [0, 0, 0]
+      particle-type-id               :  0
+thermostat:
+  initialTemperature                 :  1.1
+  targetTemperature                  :  1.1
+  deltaTemperature                   :  0.5
+  thermostatInterval                 :  25
+  addBrownianMotion                  :  true
+
+log-level                            :  debug
+no-end-config                        :  true
+no-progress-bar                      :  true
+vtk-filename                         :  myBenchmark
+vtk-output-folder                    :  vtkOutputFolder
+vtk-write-frequency                  :  30
+log-file                             :  log.txt

--- a/examples/md-flexible/input/SpinodalDecomposition_equilibration.yaml
+++ b/examples/md-flexible/input/SpinodalDecomposition_equilibration.yaml
@@ -23,7 +23,7 @@ Objects:
   CubeGrid:
     0:
       particle-type-id           :  0
-      particles-per-dimension    :  [160, 160, 160]
+      particles-per-dimension    :  [80, 80, 80]
       particle-spacing           :  1.5
       bottomLeftCorner           :  [0, 0, 0]
       velocity                   :  [0, 0, 0]

--- a/examples/md-flexible/input/heatingSphere.yaml
+++ b/examples/md-flexible/input/heatingSphere.yaml
@@ -1,0 +1,52 @@
+# This yaml file is for single-site molecular simulation. Uncomment the Molecules option to run this experiment using
+## md-flexible compiled for multi-site molecules.
+verlet-rebuild-frequency         :  10
+verlet-skin-radius  :  0.5
+verlet-cluster-size              :  4
+selector-strategy                :  Fastest-Mean-Value
+data-layout                      :  [AoS, SoA]
+traversal                            :  [lc_c04, lc_c04_combined_SoA, lc_c08, lc_c18, vl_list_iteration, vlc_c01, vlc_c08, vlc_c18, vlc_sliced, vlc_sliced_c02, vlp_c01, vlp_c18, vlp_sliced, vlp_sliced_c02]
+tuning-strategies                :  []
+tuning-interval                  :  10000
+tuning-samples                   :  10
+use-LOESS-smoothening                :  true
+tuning-metric   : energy
+functor                          :  Lennard-Jones AVX
+newton3                          :  [disabled, enabled]
+cutoff                           :  3
+box-min                          :  [0, 0, 0]
+box-max                          :  [200, 200, 200]
+cell-size                        :  [0.5, 1]
+deltaT                           :  0.0001
+iterations                       :  150000
+boundary-type                    :  [reflective, reflective ,reflective]
+globalForce                      :  [0,0,0]
+Sites:
+  0:
+    epsilon                      :  1.
+    sigma                        :  1.
+    mass                         :  1.
+# Uncomment below to run a multi-site simulation.
+#Molecules:
+#  0:
+#    site-types                   :  [ 0 ]
+#    relative-site-positions      :  [ [0, 0, 0 ] ]
+#    moment-of-inertia            :  [ 1., 1., 1. ]
+Objects:
+  Sphere:
+    0:
+      center                     :  [100, 100, 100]
+      radius                     :  10
+      particle-spacing           :  1.22462048
+      velocity                   :  [0, 0, 0]
+      particle-type-id           :  0
+thermostat:
+  initialTemperature             :  0.1
+  targetTemperature              :  100
+  deltaTemperature               :  0.1
+  thermostatInterval             :  100
+  addBrownianMotion              :  true
+no-end-config                    :  true
+no-progress-bar                  :  true
+log-level                        :  info
+fastParticlesThrow               :  true

--- a/examples/md-flexible/input/lj_equilibration.yaml
+++ b/examples/md-flexible/input/lj_equilibration.yaml
@@ -64,9 +64,9 @@ thermostat:
   addBrownianMotion                  : true
 
 # ---------------------- Output ----------------------
-log-level                            : info
+log-level                            : warn
 no-end-config                        : true
-no-progress-bar                      : false
+no-progress-bar                      : true
 
 vtk-filename                         : PrecisionEquil
 vtk-output-folder                    : PrecisionEquilOutput

--- a/examples/md-flexible/input/lj_equilibration.yaml
+++ b/examples/md-flexible/input/lj_equilibration.yaml
@@ -9,7 +9,9 @@ traversal                            : [lc_c01]
 newton3                              : [enabled, disabled]
 data-layout                          : [AoS, SoA]
 
-# ---------------------- Tuning & Mechanics -------------------------
+# ---------------------:wq
+  :wq
+                                        - Tuning & Mechanics -------------------------
 verlet-rebuild-frequency             : 20
 verlet-skin-radius                   : 0.2
 

--- a/examples/md-flexible/input/lj_equilibration.yaml
+++ b/examples/md-flexible/input/lj_equilibration.yaml
@@ -1,0 +1,74 @@
+# LJ equilibration run for DPDP / SPDP / SPSP precision study
+
+# ---------------------- AutoPas core settings ----------------------
+container                            : [LinkedCells]
+
+# Pairwise Lennard-Jones functor (AVX version, canonical name from AllOptions.yaml)
+functor                              : Lennard-Jones (12-6) avx
+traversal                            : [lc_c01]
+newton3                              : [enabled, disabled]
+data-layout                          : [AoS, SoA]
+
+# ---------------------- Tuning & Mechanics -------------------------
+verlet-rebuild-frequency             : 20
+verlet-skin-radius                   : 0.2
+
+selector-strategy                    : Fastest-Absolute-Value
+tuning-metric                        : time
+tuning-strategies                    : []          # no extra tuning logic
+tuning-interval                      : 1000000000  # effectively never retune
+tuning-samples                       : 3
+use-LOESS-smoothening                : false
+tuning-max-evidence                  : 10
+
+cutoff                               : 2.5
+
+# Make the domain larger and with "weird" non-integer bounds to avoid
+# particles landing exactly on box-max in single precision.
+box-min                              : [-4.321, -4.321, -4.321]
+box-max                              : [14.789, 14.789, 14.789]
+
+cell-size                            : [1]
+deltaT                               : 0.002
+iterations                           : 200000
+boundary-type                        : [periodic, periodic, periodic]
+subdivide-dimension                  : [true, true, true]
+fastParticlesThrow                   : false
+
+# ---------------------- LJ parameters (site 0) ---------------------
+Sites:
+  0:
+    epsilon                          : 1.0
+    sigma                            : 1.0
+    mass                             : 1.0
+
+# ---------------------- Initial configuration ----------------------
+# Place the cube well inside the domain (margin > 4 in every direction):
+# domain: [-4.321, 14.789]^3
+# cube:   [0, 8]^3
+Objects:
+  CubeClosestPacked:
+    0:
+      box-length                     : [8, 8, 8]
+      bottomLeftCorner               : [0, 0, 0]
+      particle-spacing               : 1.35
+      velocity                       : [0, 0, 0]
+      particle-type-id               : 0
+
+# ---------------------- Thermostat (Equilibration) -----------------
+thermostat:
+  initialTemperature                 : 1.0
+  targetTemperature                  : 1.0
+  deltaTemperature                   : 0.1
+  thermostatInterval                 : 25
+  addBrownianMotion                  : true
+
+# ---------------------- Output ----------------------
+log-level                            : info
+no-end-config                        : true
+no-progress-bar                      : false
+
+vtk-filename                         : PrecisionEquil
+vtk-output-folder                    : PrecisionEquilOutput
+vtk-write-frequency                  : 1000000000  # effectively disabled
+#log-file                            : lj_equilibration.log

--- a/examples/md-flexible/input/lj_equilibration_128k.yaml
+++ b/examples/md-flexible/input/lj_equilibration_128k.yaml
@@ -1,0 +1,60 @@
+# LJ equilibration run for DPDP / SPDP / SPSP precision study (~128k, N=131072)
+
+container                            : [LinkedCells]
+functor                              : Lennard-Jones (12-6) avx
+traversal                            : [lc_c01]
+newton3                              : [enabled, disabled]
+data-layout                          : [AoS, SoA]
+
+verlet-rebuild-frequency             : 20
+verlet-skin-radius                   : 0.2
+
+selector-strategy                    : Fastest-Absolute-Value
+tuning-metric                        : time
+tuning-strategies                    : []
+tuning-interval                      : 1000000000
+tuning-samples                       : 3
+use-LOESS-smoothening                : false
+tuning-max-evidence                  : 10
+
+cutoff                               : 2.5
+
+box-min                              : [-4.321, -4.321, -4.321]
+box-max                              : [68.383, 68.383, 68.383]   # 61.594 + 6.789
+
+cell-size                            : [1]
+deltaT                               : 0.002
+iterations                           : 200000
+boundary-type                        : [periodic, periodic, periodic]
+subdivide-dimension                  : [true, true, true]
+fastParticlesThrow                   : false
+
+Sites:
+  0:
+    epsilon                          : 1.0
+    sigma                            : 1.0
+    mass                             : 1.0
+
+Objects:
+  CubeClosestPacked:
+    0:
+      box-length                     : [61.594, 61.594, 61.594]
+      bottomLeftCorner               : [0, 0, 0]
+      particle-spacing               : 1.35
+      velocity                       : [0, 0, 0]
+      particle-type-id               : 0
+
+thermostat:
+  initialTemperature                 : 1.0
+  targetTemperature                  : 1.0
+  deltaTemperature                   : 0.1
+  thermostatInterval                 : 25
+  addBrownianMotion                  : true
+
+log-level                            : warn
+no-end-config                        : true
+no-progress-bar                      : true
+
+vtk-filename                         : PrecisionEquil
+vtk-output-folder                    : PrecisionEquilOutput
+vtk-write-frequency                  : 1000000000

--- a/examples/md-flexible/input/lj_equilibration_128k.yaml
+++ b/examples/md-flexible/input/lj_equilibration_128k.yaml
@@ -3,11 +3,11 @@
 container                            : [LinkedCells]
 functor                              : Lennard-Jones (12-6) avx
 traversal                            : [lc_c01]
-newton3                              : [enabled, disabled]
-data-layout                          : [AoS, SoA]
+newton3                              : [enabled]
+data-layout                          : [SoA]
 
-verlet-rebuild-frequency             : 20
-verlet-skin-radius                   : 0.2
+verlet-rebuild-frequency             : 100
+verlet-skin-radius                   : 0.3
 
 selector-strategy                    : Fastest-Absolute-Value
 tuning-metric                        : time
@@ -51,7 +51,7 @@ thermostat:
   thermostatInterval                 : 25
   addBrownianMotion                  : true
 
-log-level                            : warn
+log-level                            : error
 no-end-config                        : true
 no-progress-bar                      : true
 

--- a/examples/md-flexible/input/lj_equilibration_128k.yaml
+++ b/examples/md-flexible/input/lj_equilibration_128k.yaml
@@ -2,9 +2,9 @@
 
 container                            : [LinkedCells]
 functor                              : Lennard-Jones (12-6) avx
-traversal                            : [lc_c01]
-newton3                              : [enabled]
-data-layout                          : [SoA]
+traversal                            : [lc_c01, lc_c01_combined_SoA]
+newton3                              : [enabled, disabled]
+data-layout                          : [AoS, SoA]
 
 verlet-rebuild-frequency             : 100
 verlet-skin-radius                   : 0.3
@@ -24,7 +24,7 @@ box-max                              : [68.383, 68.383, 68.383]   # 61.594 + 6.7
 
 cell-size                            : [1]
 deltaT                               : 0.002
-iterations                           : 200000
+iterations                           : 2000
 boundary-type                        : [periodic, periodic, periodic]
 subdivide-dimension                  : [true, true, true]
 fastParticlesThrow                   : false

--- a/examples/md-flexible/input/lj_equilibration_2k.yaml
+++ b/examples/md-flexible/input/lj_equilibration_2k.yaml
@@ -1,0 +1,60 @@
+# LJ equilibration run for DPDP / SPDP / SPSP precision study (~2k, N=2048)
+
+container                            : [LinkedCells]
+functor                              : Lennard-Jones (12-6) avx
+traversal                            : [lc_c01]
+newton3                              : [enabled, disabled]
+data-layout                          : [AoS, SoA]
+
+verlet-rebuild-frequency             : 20
+verlet-skin-radius                   : 0.2
+
+selector-strategy                    : Fastest-Absolute-Value
+tuning-metric                        : time
+tuning-strategies                    : []
+tuning-interval                      : 1000000000
+tuning-samples                       : 3
+use-LOESS-smoothening                : false
+tuning-max-evidence                  : 10
+
+cutoff                               : 2.5
+
+box-min                              : [-4.321, -4.321, -4.321]
+box-max                              : [22.562, 22.562, 22.562]   # 15.773 + 6.789
+
+cell-size                            : [1]
+deltaT                               : 0.002
+iterations                           : 200000
+boundary-type                        : [periodic, periodic, periodic]
+subdivide-dimension                  : [true, true, true]
+fastParticlesThrow                   : false
+
+Sites:
+  0:
+    epsilon                          : 1.0
+    sigma                            : 1.0
+    mass                             : 1.0
+
+Objects:
+  CubeClosestPacked:
+    0:
+      box-length                     : [15.773, 15.773, 15.773]
+      bottomLeftCorner               : [0, 0, 0]
+      particle-spacing               : 1.35
+      velocity                       : [0, 0, 0]
+      particle-type-id               : 0
+
+thermostat:
+  initialTemperature                 : 1.0
+  targetTemperature                  : 1.0
+  deltaTemperature                   : 0.1
+  thermostatInterval                 : 25
+  addBrownianMotion                  : true
+
+log-level                            : warn
+no-end-config                        : true
+no-progress-bar                      : true
+
+vtk-filename                         : PrecisionEquil
+vtk-output-folder                    : PrecisionEquilOutput
+vtk-write-frequency                  : 1000000000

--- a/examples/md-flexible/input/lj_equilibration_32k.yaml
+++ b/examples/md-flexible/input/lj_equilibration_32k.yaml
@@ -1,0 +1,60 @@
+# LJ equilibration run for DPDP / SPDP / SPSP precision study (~32k, N=32000)
+
+container                            : [LinkedCells]
+functor                              : Lennard-Jones (12-6) avx
+traversal                            : [lc_c01]
+newton3                              : [enabled, disabled]
+data-layout                          : [AoS, SoA]
+
+verlet-rebuild-frequency             : 20
+verlet-skin-radius                   : 0.2
+
+selector-strategy                    : Fastest-Absolute-Value
+tuning-metric                        : time
+tuning-strategies                    : []
+tuning-interval                      : 1000000000
+tuning-samples                       : 3
+use-LOESS-smoothening                : false
+tuning-max-evidence                  : 10
+
+cutoff                               : 2.5
+
+box-min                              : [-4.321, -4.321, -4.321]
+box-max                              : [45.473, 45.473, 45.473]   # 38.684 + 6.789
+
+cell-size                            : [1]
+deltaT                               : 0.002
+iterations                           : 200000
+boundary-type                        : [periodic, periodic, periodic]
+subdivide-dimension                  : [true, true, true]
+fastParticlesThrow                   : false
+
+Sites:
+  0:
+    epsilon                          : 1.0
+    sigma                            : 1.0
+    mass                             : 1.0
+
+Objects:
+  CubeClosestPacked:
+    0:
+      box-length                     : [38.684, 38.684, 38.684]
+      bottomLeftCorner               : [0, 0, 0]
+      particle-spacing               : 1.35
+      velocity                       : [0, 0, 0]
+      particle-type-id               : 0
+
+thermostat:
+  initialTemperature                 : 1.0
+  targetTemperature                  : 1.0
+  deltaTemperature                   : 0.1
+  thermostatInterval                 : 25
+  addBrownianMotion                  : true
+
+log-level                            : warn
+no-end-config                        : true
+no-progress-bar                      : true
+
+vtk-filename                         : PrecisionEquil
+vtk-output-folder                    : PrecisionEquilOutput
+vtk-write-frequency                  : 1000000000

--- a/examples/md-flexible/input/lj_equilibration_512k.yaml
+++ b/examples/md-flexible/input/lj_equilibration_512k.yaml
@@ -1,0 +1,60 @@
+# LJ equilibration run for DPDP / SPDP / SPSP precision study (~512k, N=530604)
+
+container                            : [LinkedCells]
+functor                              : Lennard-Jones (12-6) avx
+traversal                            : [lc_c01]
+newton3                              : [enabled, disabled]
+data-layout                          : [AoS, SoA]
+
+verlet-rebuild-frequency             : 20
+verlet-skin-radius                   : 0.2
+
+selector-strategy                    : Fastest-Absolute-Value
+tuning-metric                        : time
+tuning-strategies                    : []
+tuning-interval                      : 1000000000
+tuning-samples                       : 3
+use-LOESS-smoothening                : false
+tuning-max-evidence                  : 10
+
+cutoff                               : 2.5
+
+box-min                              : [-4.321, -4.321, -4.321]
+box-max                              : [104.657, 104.657, 104.657]  # 97.868 + 6.789
+
+cell-size                            : [1]
+deltaT                               : 0.002
+iterations                           : 200000
+boundary-type                        : [periodic, periodic, periodic]
+subdivide-dimension                  : [true, true, true]
+fastParticlesThrow                   : false
+
+Sites:
+  0:
+    epsilon                          : 1.0
+    sigma                            : 1.0
+    mass                             : 1.0
+
+Objects:
+  CubeClosestPacked:
+    0:
+      box-length                     : [97.868, 97.868, 97.868]
+      bottomLeftCorner               : [0, 0, 0]
+      particle-spacing               : 1.35
+      velocity                       : [0, 0, 0]
+      particle-type-id               : 0
+
+thermostat:
+  initialTemperature                 : 1.0
+  targetTemperature                  : 1.0
+  deltaTemperature                   : 0.1
+  thermostatInterval                 : 25
+  addBrownianMotion                  : true
+
+log-level                            : warn
+no-end-config                        : true
+no-progress-bar                      : true
+
+vtk-filename                         : PrecisionEquil
+vtk-output-folder                    : PrecisionEquilOutput
+vtk-write-frequency                  : 1000000000

--- a/examples/md-flexible/input/lj_equilibration_512k.yaml
+++ b/examples/md-flexible/input/lj_equilibration_512k.yaml
@@ -2,11 +2,11 @@
 
 container                            : [LinkedCells]
 functor                              : Lennard-Jones (12-6) avx
-traversal                            : [lc_c01]
+traversal                            : [lc_c01, lc_c01_combined_SoA]
 newton3                              : [enabled, disabled]
 data-layout                          : [AoS, SoA]
 
-verlet-rebuild-frequency             : 20
+verlet-rebuild-frequency             : 100
 verlet-skin-radius                   : 0.2
 
 selector-strategy                    : Fastest-Absolute-Value
@@ -24,7 +24,7 @@ box-max                              : [104.657, 104.657, 104.657]  # 97.868 + 6
 
 cell-size                            : [1]
 deltaT                               : 0.002
-iterations                           : 200000
+iterations                           : 2000
 boundary-type                        : [periodic, periodic, periodic]
 subdivide-dimension                  : [true, true, true]
 fastParticlesThrow                   : false

--- a/examples/md-flexible/input/lj_equilibration_8k.yaml
+++ b/examples/md-flexible/input/lj_equilibration_8k.yaml
@@ -1,0 +1,60 @@
+# LJ equilibration run for DPDP / SPDP / SPSP precision study (~8k, N=8788)
+
+container                            : [LinkedCells]
+functor                              : Lennard-Jones (12-6) avx
+traversal                            : [lc_c01]
+newton3                              : [enabled, disabled]
+data-layout                          : [AoS, SoA]
+
+verlet-rebuild-frequency             : 20
+verlet-skin-radius                   : 0.2
+
+selector-strategy                    : Fastest-Absolute-Value
+tuning-metric                        : time
+tuning-strategies                    : []
+tuning-interval                      : 1000000000
+tuning-samples                       : 3
+use-LOESS-smoothening                : false
+tuning-max-evidence                  : 10
+
+cutoff                               : 2.5
+
+box-min                              : [-4.321, -4.321, -4.321]
+box-max                              : [32.108, 32.108, 32.108]   # 25.319 + 6.789
+
+cell-size                            : [1]
+deltaT                               : 0.002
+iterations                           : 200000
+boundary-type                        : [periodic, periodic, periodic]
+subdivide-dimension                  : [true, true, true]
+fastParticlesThrow                   : false
+
+Sites:
+  0:
+    epsilon                          : 1.0
+    sigma                            : 1.0
+    mass                             : 1.0
+
+Objects:
+  CubeClosestPacked:
+    0:
+      box-length                     : [25.319, 25.319, 25.319]
+      bottomLeftCorner               : [0, 0, 0]
+      particle-spacing               : 1.35
+      velocity                       : [0, 0, 0]
+      particle-type-id               : 0
+
+thermostat:
+  initialTemperature                 : 1.0
+  targetTemperature                  : 1.0
+  deltaTemperature                   : 0.1
+  thermostatInterval                 : 25
+  addBrownianMotion                  : true
+
+log-level                            : warn
+no-end-config                        : true
+no-progress-bar                      : true
+
+vtk-filename                         : PrecisionEquil
+vtk-output-folder                    : PrecisionEquilOutput
+vtk-write-frequency                  : 1000000000

--- a/examples/md-flexible/src/GlobalVariableLogger.cpp
+++ b/examples/md-flexible/src/GlobalVariableLogger.cpp
@@ -1,0 +1,52 @@
+/**
+* @file GlobalVariableLogger.cpp
+ * @author Manish Mishra
+ * @date 12.11.2025
+ */
+
+#include "GlobalVariableLogger.h"
+
+#include <string>
+
+#include "autopas/utils/Timer.h"
+#include "autopas/utils/logging/Logger.h"
+
+GlobalVariableLogger::GlobalVariableLogger(const std::string &outputSuffix)
+    : _loggerName("GlobalsLogger" + outputSuffix) {
+#ifdef MD_FLEXIBLE_CALC_GLOBALS
+  const auto *fillerAfterSuffix = outputSuffix.empty() or outputSuffix.back() == '_' ? "" : "_";
+  const auto outputFileName("MD_Flexible_Globals_" + outputSuffix + fillerAfterSuffix +
+                            autopas::utils::Timer::getDateStamp() + ".csv");
+  // Start of workaround: Because we want to use an asynchronous logger we can't quickly switch patterns for the header.
+  // Create and register a non-asychronous logger to write the header.
+  const auto headerLoggerName = _loggerName + "header";
+  auto headerLogger = spdlog::basic_logger_mt(headerLoggerName, outputFileName);
+  // set the pattern to the message only
+  headerLogger->set_pattern("%v");
+  // print csv header
+  headerLogger->info(
+      "Date, "
+      "Iteration, "
+      "Virial Sum, "
+      "Potential Energy ");
+  spdlog::drop(headerLoggerName);
+  // End of workaround
+
+  // create and register the actual logger
+  auto logger = spdlog::basic_logger_mt<spdlog::async_factory>(_loggerName, outputFileName);
+  // set pattern to provide date
+  logger->set_pattern("%Y-%m-%d %T,%v");
+#endif
+}
+
+GlobalVariableLogger::~GlobalVariableLogger() {
+#ifdef MD_FLEXIBLE_CALC_GLOBALS
+  spdlog::drop(_loggerName);
+#endif
+}
+
+void GlobalVariableLogger::logGlobals(const size_t iteration, const double virial, const double potentialEnergy) {
+#ifdef MD_FLEXIBLE_CALC_GLOBALS
+  spdlog::get(_loggerName)->info("{},{},{}", iteration, virial, potentialEnergy);
+#endif
+}

--- a/examples/md-flexible/src/GlobalVariableLogger.h
+++ b/examples/md-flexible/src/GlobalVariableLogger.h
@@ -1,0 +1,54 @@
+/**
+* @file GlobalVariableLogger.h
+ * @author Manish Mishra
+ * @date 12.11.2025
+ */
+
+#pragma once
+
+#include <spdlog/async.h>
+#include <spdlog/fmt/bundled/ranges.h>
+#include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/sinks/ostream_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/spdlog.h>
+
+/**
+ * Helper to global variables calculated by the Functor, eg. Virial, Potential Energy, etc.
+ *
+ * It uses an asynchronous spd logger to write a csv file named "MD_FLEXIBLE_GLOBAL_<dateStamp>.csv".
+ *
+ * By default logging the global data is disabled. It can be enabled by setting the cmake variable
+ * MD_FLEXIBLE_CALC_GLOBALS to ON.
+ *
+ * When enabled and used with a functor where calculating globals is not implemented (in which case the functor will
+ * return the default nonsensical values), "Not Implemented" is outputted instead.
+ *
+ */
+class GlobalVariableLogger {
+public:
+  /**
+   * Constructor initializes the logger and sets the output file name.
+   * @param outputSuffix Suffix for all output files produced by this class.
+   */
+  explicit GlobalVariableLogger(const std::string &outputSuffix = "");
+
+  /**
+   * Destructor drops the logger from the spd registry.
+   */
+  ~GlobalVariableLogger();
+
+  /**
+   * Log the given arguments and the internal buffer to the csv file. If a value is not valid, it is interpreted that
+   * the functor has not implemented the relevant function.
+   *
+   * @param iteration
+   * @param virial This includes the virial sum contribution from both 2B and 3B interactions at the current timestep.
+   * @param potentialEnergy This includes the potential energy contribution from both 2B and 3B interactions at the
+   * current timestep.
+   */
+  void logGlobals(const size_t iteration, const double virial, const double potentialEnergy);
+
+private:
+  std::string _loggerName;
+};

--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -105,6 +105,10 @@ Simulation::Simulation(const MDFlexConfig &configuration,
   const auto outputSuffix =
       "Rank" + std::to_string(rank) + fillerBeforeSuffix + _configuration.outputSuffix.value + fillerAfterSuffix;
 
+  if (rank == 0) {
+    _globalLogger = std::make_unique<GlobalVariableLogger>(outputSuffix);
+  }
+
   if (_configuration.logFileName.value.empty()) {
     _outputStream = &std::cout;
   } else {
@@ -299,6 +303,20 @@ void Simulation::run() {
       updateThermostat();
     }
     _timers.computationalLoad.stop();
+
+#ifdef MD_FLEXIBLE_CALC_GLOBALS
+    // Summing the potential energy over all MPI ranks
+    double potentialEnergyOverMPIRanks{}, virialSumOverMPIRanks{};
+    autopas::AutoPas_MPI_Reduce(&_totalPotentialEnergy, &potentialEnergyOverMPIRanks, 1, AUTOPAS_MPI_DOUBLE,
+                                AUTOPAS_MPI_SUM, 0, AUTOPAS_MPI_COMM_WORLD);
+    autopas::AutoPas_MPI_Reduce(&_totalVirialSum, &virialSumOverMPIRanks, 1, AUTOPAS_MPI_DOUBLE, AUTOPAS_MPI_SUM, 0,
+                                AUTOPAS_MPI_COMM_WORLD);
+    if (_domainDecomposition->getDomainIndex() == 0) {
+      _globalLogger->logGlobals(_iteration, potentialEnergyOverMPIRanks, virialSumOverMPIRanks);
+    }
+    _totalPotentialEnergy = 0.;
+    _totalVirialSum = 0.;
+#endif
 
     if (not _simulationIsPaused) {
       ++_iteration;
@@ -527,14 +545,26 @@ long Simulation::accumulateTime(const long &time) {
 }
 
 bool Simulation::calculatePairwiseForces() {
-  const auto wasTuningIteration =
-      applyWithChosenFunctor<bool>([&](auto &&functor) { return _autoPasContainer->computeInteractions(&functor); });
+  const auto wasTuningIteration = applyWithChosenFunctor<bool>([&](auto &&functor) {
+    auto isTuningIteration = _autoPasContainer->computeInteractions(&functor);
+#ifdef MD_FLEXIBLE_CALC_GLOBALS
+    _totalPotentialEnergy += functor.getPotentialEnergy();
+    _totalVirialSum += functor.getVirial();
+#endif
+    return isTuningIteration;
+  });
   return wasTuningIteration;
 }
 
 bool Simulation::calculateTriwiseForces() {
-  const auto wasTuningIteration =
-      applyWithChosenFunctor3B<bool>([&](auto &&functor) { return _autoPasContainer->computeInteractions(&functor); });
+  const auto wasTuningIteration = applyWithChosenFunctor3B<bool>([&](auto &&functor) {
+    auto isTuningIteration = _autoPasContainer->computeInteractions(&functor);
+#ifdef MD_FLEXIBLE_CALC_GLOBALS
+    _totalPotentialEnergy += functor.getPotentialEnergy();
+    _totalVirialSum += functor.getVirial();
+#endif
+    return isTuningIteration;
+  });
   return wasTuningIteration;
 }
 

--- a/examples/md-flexible/src/Simulation.h
+++ b/examples/md-flexible/src/Simulation.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <tuple>
 
+#include "GlobalVariableLogger.h"
 #include "TimeDiscretization.h"
 #include "autopas/AutoPasDecl.h"
 #include "src/ParallelVtkWriter.h"
@@ -91,6 +92,21 @@ class Simulation {
    * Pointer to the output stream.
    */
   std::ostream *_outputStream;
+
+  /**
+   * Variable to store total potential energy for the current iteration from both 2B and 3B interactions.
+   */
+  double _totalPotentialEnergy{};
+
+  /**
+   * Variable to store total virial sum for the current iteration from both 2B and 3B interactions.
+   */
+  double _totalVirialSum{};
+
+  /**
+   * Logger for FLOP count and hit rate.
+   */
+  std::unique_ptr<GlobalVariableLogger> _globalLogger;
 
   /**
    * Number of completed iterations. Aka. number of current iteration.

--- a/examples/md-flexible/src/Thermostat.h
+++ b/examples/md-flexible/src/Thermostat.h
@@ -10,6 +10,7 @@
 #include "TypeDefinitions.h"
 #include "autopas/AutoPasDecl.h"
 #include "autopas/utils/ArrayMath.h"
+#include "autopas/utils/ArrayUtils.h"
 #include "autopas/utils/WrapMPI.h"
 #include "autopas/utils/WrapOpenMP.h"
 
@@ -206,7 +207,8 @@ void addBrownianMotion(AutoPasTemplate &autopas, ParticlePropertiesLibraryTempla
     for (auto iter = autopas.begin(); iter.isValid(); ++iter) {
       const std::array<double, 3> normal3DVecTranslational = {
           normalDistribution(randomEngine), normalDistribution(randomEngine), normalDistribution(randomEngine)};
-      iter->addV(normal3DVecTranslational * translationalVelocityScale[iter->getTypeId()]);
+      iter->addV(autopas::utils::ArrayUtils::static_cast_copy_array<CalcType>(
+          normal3DVecTranslational * translationalVelocityScale[iter->getTypeId()]));
 #if MD_FLEXIBLE_MODE == MULTISITE
       const std::array<double, 3> normal3DVecRotational = {
           normalDistribution(randomEngine), normalDistribution(randomEngine), normalDistribution(randomEngine)};
@@ -262,7 +264,7 @@ void apply(AutoPasTemplate &autopas, ParticlePropertiesLibraryTemplate &particle
   // Scale velocities (and angular velocities) with the scaling map
   AUTOPAS_OPENMP(parallel default(none) shared(autopas, scalingMap))
   for (auto iter = autopas.begin(); iter.isValid(); ++iter) {
-    iter->setV(iter->getV() * scalingMap[iter->getTypeId()]);
+    iter->setV(iter->getV() * static_cast<CalcType>(scalingMap[iter->getTypeId()]));
 #if MD_FLEXIBLE_MODE == MULTISITE
     iter->setAngularVel(iter->getAngularVel() * scalingMap[iter->getTypeId()]);
 #endif

--- a/examples/md-flexible/src/TimeDiscretization.cpp
+++ b/examples/md-flexible/src/TimeDiscretization.cpp
@@ -33,10 +33,10 @@ void calculatePositionsAndResetForces(autopas::AutoPas<ParticleType> &autoPasCon
     auto v = iter->getV();
     auto f = iter->getF();
     iter->setOldF(f);
-    iter->setF(globalForce);
-    v *= deltaT;
-    f *= (deltaT * deltaT / (2 * m));
-    const auto displacement = v + f;
+    iter->setF(autopas::utils::ArrayUtils::static_cast_copy_array<AccuType>(globalForce));
+    v *= static_cast<CalcType>(deltaT);
+    f *= static_cast<AccuType>(deltaT * deltaT / (2 * m));
+    const auto displacement = v + autopas::utils::ArrayUtils::static_cast_copy_array<CalcType>(f);
     // Sanity check that particles are not too fast for the Verlet skin technique. Only makes sense if skin > 0.
     if (not iter->addRDistanceCheck(displacement, maxAllowedDistanceMovedSquared) and
         maxAllowedDistanceMovedSquared > 0) {
@@ -149,7 +149,8 @@ void calculateVelocities(autopas::AutoPas<ParticleType> &autoPasContainer,
     const auto molecularMass = particlePropertiesLibrary.getMolMass(iter->getTypeId());
     const auto force = iter->getF();
     const auto oldForce = iter->getOldF();
-    const auto changeInVel = (force + oldForce) * (deltaT / (2 * molecularMass));
+    const auto changeInVel = autopas::utils::ArrayUtils::static_cast_copy_array<CalcType>(force + oldForce) *
+                             static_cast<CalcType>(deltaT / (2 * molecularMass));
     iter->addV(changeInVel);
   }
 }

--- a/examples/md-flexible/src/TypeDefinitions.h
+++ b/examples/md-flexible/src/TypeDefinitions.h
@@ -39,11 +39,6 @@
 #include "molecularDynamicsLibrary/ParticlePropertiesLibrary.h"
 
 /**
- * Precision used for particle representations. If you want to test other precisions change it here.
- */
-using FloatPrecision = double;
-
-/**
  * Type of the Particles used in md-flexible.
  * Switches between autopas::MoleculeLJ and autopas::MultisiteMoleculeLJ as determined by CMake flag
  * MD_FLEXIBLE_MODE.
@@ -53,6 +48,11 @@ using ParticleType = mdLib::MultisiteMoleculeLJ;
 #else
 using ParticleType = mdLib::MoleculeLJ;
 #endif
+
+/**
+ * FloatType used for calculations
+ */
+using CalcPrecision = typename ParticleType::ParticleCalcPrecision;
 
 namespace mdFlexibleTypeDefs {
 /**
@@ -141,4 +141,4 @@ using ATFunctor = mdLib::AxilrodTellerFunctor<ParticleType, true, autopas::Funct
  * Type of the Particle Properties Library.
  * Set to the same precision as ParticleType.
  */
-using ParticlePropertiesLibraryType = ParticlePropertiesLibrary<FloatPrecision, size_t>;
+using ParticlePropertiesLibraryType = ParticlePropertiesLibrary<CalcPrecision, size_t>;

--- a/examples/md-flexible/src/TypeDefinitions.h
+++ b/examples/md-flexible/src/TypeDefinitions.h
@@ -52,7 +52,7 @@ using ParticleType = mdLib::MoleculeLJ;
 /**
  * FloatType used for calculations
  */
-using CalcPrecision = typename ParticleType::ParticleCalcPrecision;
+using CalcType = typename ParticleType::ParticleCalcType;
 
 namespace mdFlexibleTypeDefs {
 /**
@@ -141,4 +141,4 @@ using ATFunctor = mdLib::AxilrodTellerFunctor<ParticleType, true, autopas::Funct
  * Type of the Particle Properties Library.
  * Set to the same precision as ParticleType.
  */
-using ParticlePropertiesLibraryType = ParticlePropertiesLibrary<CalcPrecision, size_t>;
+using ParticlePropertiesLibraryType = ParticlePropertiesLibrary<CalcType, size_t>;

--- a/examples/md-flexible/src/TypeDefinitions.h
+++ b/examples/md-flexible/src/TypeDefinitions.h
@@ -53,6 +53,10 @@ using ParticleType = mdLib::MoleculeLJ;
  * FloatType used for calculations
  */
 using CalcType = typename ParticleType::ParticleCalcType;
+/**
+ * FloatType used for accumulations
+ */
+using AccuType = typename ParticleType::ParticleAccuType;
 
 namespace mdFlexibleTypeDefs {
 /**

--- a/examples/md-flexible/src/configuration/MDFlexConfig.cpp
+++ b/examples/md-flexible/src/configuration/MDFlexConfig.cpp
@@ -168,9 +168,9 @@ void loadParticlesFromRankRecord(std::string_view filename, const size_t &rank, 
   for (auto i = 0ul; i < numParticles; ++i) {
     ParticleType particle;
 
-    particle.setR(positions[i]);
-    particle.setV(velocities[i]);
-    particle.setF(forces[i]);
+    particle.setR(autopas::utils::ArrayUtils::static_cast_copy_array<CalcType>(positions[i]));
+    particle.setV(autopas::utils::ArrayUtils::static_cast_copy_array<CalcType>(velocities[i]));
+    particle.setF(autopas::utils::ArrayUtils::static_cast_copy_array<AccuType>(forces[i]));
     particle.setID(ids[i]);
     particle.setTypeId(typeIds[i]);
 

--- a/examples/md-flexible/src/configuration/objects/Object.h
+++ b/examples/md-flexible/src/configuration/objects/Object.h
@@ -44,7 +44,7 @@ class Object {
     particle.setID(particleId);
     particle.setTypeId(_typeId);
     particle.setOwnershipState(autopas::OwnershipState::owned);
-    particle.setV(_velocity);
+    particle.setV(autopas::utils::ArrayUtils::static_cast_copy_array<CalcType>(_velocity));
     particle.setF({0.0, 0.0, 0.0});
     particle.setOldF({0.0, 0.0, 0.0});
 #if MD_FLEXIBLE_MODE == MULTISITE

--- a/examples/md-flexible/src/configuration/objects/Sphere.h
+++ b/examples/md-flexible/src/configuration/objects/Sphere.h
@@ -137,7 +137,7 @@ class Sphere : public Object {
   void generate(std::vector<ParticleType> &particles) const override {
     ParticleType particle = getDummyParticle(particles.size());
     iteratePositions([&](const auto &pos) {
-      particle.setR(pos);
+      particle.setR(autopas::utils::ArrayUtils::static_cast_copy_array<CalcType>(pos));
       particles.push_back(particle);
       particle.setID(particle.getID() + 1);
     });

--- a/src/autopas/CMakeLists.txt
+++ b/src/autopas/CMakeLists.txt
@@ -59,6 +59,28 @@ target_compile_definitions(
         _USE_MATH_DEFINES
 )
 
+# Set CMake option for md-flexible mode
+set(AUTOPAS_PRECISION_MODE
+        "DPDP"
+        CACHE
+        STRING "Choose the mode of precision that autopas uses."
+)
+set_property(CACHE AUTOPAS_PRECISION_MODE PROPERTY STRINGS "DPDP;SPDP;SPSP")
+
+# Define numerical values for different autopas precision modes
+target_compile_definitions(autopas PUBLIC DPDP=0)
+target_compile_definitions(autopas PUBLIC SPDP=1)
+target_compile_definitions(autopas PUBLIC SPSP=2)
+
+string(TOLOWER "${AUTOPAS_PRECISION_MODE}" AUTOPAS_PRECISION_MODE_lower)
+
+if (AUTOPAS_PRECISION_MODE_lower MATCHES  "dpdp")
+    target_compile_definitions(autopas PUBLIC AUTOPAS_PRECISION_MODE=0)
+elseif(AUTOPAS_PRECISION_MODE_lower MATCHES "spdp")
+    target_compile_definitions(autopas PUBLIC AUTOPAS_PRECISION_MODE=1)
+elseif(AUTOPAS_PRECISION_MODE_lower MATCHES "spsp")
+    target_compile_definitions(autopas PUBLIC AUTOPAS_PRECISION_MODE=2)
+endif()
 
 target_include_directories(autopas PUBLIC ${AUTOPAS_SOURCE_DIR}/src/)
 target_include_directories(autopas PUBLIC ${AUTOPAS_BINARY_DIR}/src/)

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -1285,41 +1285,6 @@ IterationMeasurements LogicHandler<Particle_T>::computeInteractions(Functor &fun
 
   functor.endTraversal(newton3);
 
-#if MD_FLEXIBLE_CALC_GLOBALS
-  {
-    // Local potential energy accumulated by this functor on this rank.
-    const double potentialEnergyLocal = functor.getPotentialEnergy();
-
-    // Reduce across all ranks to obtain the global potential energy.
-    double potentialEnergyGlobal = 0.0;
-    autopas::AutoPas_MPI_Allreduce(&potentialEnergyLocal, &potentialEnergyGlobal, 1, AUTOPAS_MPI_DOUBLE,
-                                   AUTOPAS_MPI_SUM, AUTOPAS_MPI_COMM_WORLD);
-
-    // Static state so we only open the file once per rank.
-    static std::ofstream peFile;
-    static bool peFileInitialized = false;
-    static int peRank = 0;
-
-    if (not peFileInitialized) {
-      autopas::AutoPas_MPI_Comm_rank(AUTOPAS_MPI_COMM_WORLD, &peRank);
-      const std::string filename = "potentialEnergy_rank" + std::to_string(peRank) + ".csv";
-      peFile.open(filename);
-      if (peFile.is_open()) {
-        peFile << "#iteration,potentialEnergy\n";
-      } else {
-        std::cerr << "Warning: Could not open " << filename
-                  << " for writing potential energy.\n";
-      }
-      peFileInitialized = true;
-    }
-
-    if (peFile.is_open()) {
-      // _iteration is the LogicHandler iteration counter.
-      peFile << _iteration << "," << potentialEnergyGlobal << "\n";
-    }
-  }
-#endif
-
   const auto [energyWatts, energyJoules, energyDeltaT, energyTotal] = autoTuner.sampleEnergy();
   timerTotal.stop();
 

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -331,7 +331,7 @@ class LogicHandler {
     auto &container = _containerSelector.getCurrentContainer();
     const auto &boxMin = container.getBoxMin();
     const auto &boxMax = container.getBoxMax();
-    if (false && utils::inBox(haloParticle.getR(), boxMin, boxMax)) {
+    if (utils::inBox(haloParticle.getR(), boxMin, boxMax)) {
       autopas::utils::ExceptionHandler::exception(
           "LogicHandler: Trying to add a halo particle that is not outside the box of the container.\n"
           "Box Min {}\n"

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -331,7 +331,7 @@ class LogicHandler {
     auto &container = _containerSelector.getCurrentContainer();
     const auto &boxMin = container.getBoxMin();
     const auto &boxMax = container.getBoxMax();
-    if (utils::inBox(haloParticle.getR(), boxMin, boxMax)) {
+    if (false && utils::inBox(haloParticle.getR(), boxMin, boxMax)) {
       autopas::utils::ExceptionHandler::exception(
           "LogicHandler: Trying to add a halo particle that is not outside the box of the container.\n"
           "Box Min {}\n"

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -304,7 +304,7 @@ class LogicHandler {
     // first check that the particle actually belongs in the container
     const auto &boxMin = _containerSelector.getCurrentContainer().getBoxMin();
     const auto &boxMax = _containerSelector.getCurrentContainer().getBoxMax();
-    if (utils::notInBox(p.getR(), boxMin, boxMax)) {
+    if (utils::notInBox(autopas::utils::ArrayUtils::static_cast_copy_array<double>(p.getR()), boxMin, boxMax)) {
       autopas::utils::ExceptionHandler::exception(
           "LogicHandler: Trying to add a particle that is not in the bounding box.\n"
           "Box Min {}\n"
@@ -1225,19 +1225,21 @@ void LogicHandler<Particle>::remainderHelperBufferContainer(
     auto &haloParticleBuffer = haloParticleBuffers[bufferId];
     // 1. particleBuffer with all close particles in container
     for (auto &&p1 : particleBuffer) {
-      const auto pos = p1.getR();
+      const auto pos = autopas::utils::ArrayUtils::static_cast_copy_array<double>(p1.getR());
       const auto min = pos - cutoff;
       const auto max = pos + cutoff;
       container.forEachInRegion(
           [&](auto &p2) {
             if constexpr (newton3) {
-              const std::lock_guard<std::mutex> lock(getSpacialLock(p2.getR()));
+              const std::lock_guard<std::mutex> lock(
+                  getSpacialLock(autopas::utils::ArrayUtils::static_cast_copy_array<double>(p2.getR())));
               f->AoSFunctor(p1, p2, true);
             } else {
               f->AoSFunctor(p1, p2, false);
               // no need to calculate force enacted on a halo
               if (not p2.isHalo()) {
-                const std::lock_guard<std::mutex> lock(getSpacialLock(p2.getR()));
+                const std::lock_guard<std::mutex> lock(
+                    getSpacialLock(autopas::utils::ArrayUtils::static_cast_copy_array<double>(p2.getR())));
                 f->AoSFunctor(p2, p1, false);
               }
             }
@@ -1247,7 +1249,7 @@ void LogicHandler<Particle>::remainderHelperBufferContainer(
 
     // 2. haloParticleBuffer with owned, close particles in container
     for (auto &&p1halo : haloParticleBuffer) {
-      const auto pos = p1halo.getR();
+      const auto pos = autopas::utils::ArrayUtils::static_cast_copy_array<double>(p1halo.getR());
       const auto min = pos - cutoff;
       const auto max = pos + cutoff;
       container.forEachInRegion(
@@ -1255,7 +1257,8 @@ void LogicHandler<Particle>::remainderHelperBufferContainer(
             // No need to apply anything to p1halo
             //   -> AoSFunctor(p1, p2, false) not needed as it neither adds force nor Upot (potential energy)
             //   -> newton3 argument needed for correct globals
-            const std::lock_guard<std::mutex> lock(getSpacialLock(p2.getR()));
+            const std::lock_guard<std::mutex> lock(
+                getSpacialLock(autopas::utils::ArrayUtils::static_cast_copy_array<double>(p2.getR())));
             f->AoSFunctor(p2, p1halo, newton3);
           },
           min, max, IteratorBehavior::owned);

--- a/src/autopas/baseFunctors/CellFunctor.h
+++ b/src/autopas/baseFunctors/CellFunctor.h
@@ -145,7 +145,7 @@ void CellFunctor<ParticleCell, ParticleFunctor, bidirectional>::processCell(Part
   }
 
   // avoid force calculations if the cell contains only halo particles or if the cell is empty (=dummy)
-  const bool cellHasOwnedParticles = toInt64(cell.getPossibleParticleOwnerships() & OwnershipState::owned);
+  const bool cellHasOwnedParticles = toIntType(cell.getPossibleParticleOwnerships() & OwnershipState::owned);
   if (not cellHasOwnedParticles) {
     return;
   }
@@ -176,8 +176,8 @@ void CellFunctor<ParticleCell, ParticleFunctor, bidirectional>::processCellPair(
 
   // avoid force calculations if both cells can not contain owned particles or if newton3==false and cell1 does not
   // contain owned particles
-  const bool cell1HasOwnedParticles = toInt64(cell1.getPossibleParticleOwnerships() & OwnershipState::owned);
-  const bool cell2HasOwnedParticles = toInt64(cell2.getPossibleParticleOwnerships() & OwnershipState::owned);
+  const bool cell1HasOwnedParticles = toIntType(cell1.getPossibleParticleOwnerships() & OwnershipState::owned);
+  const bool cell2HasOwnedParticles = toIntType(cell2.getPossibleParticleOwnerships() & OwnershipState::owned);
 
   if (((not cell1HasOwnedParticles) and (not _useNewton3) and (not bidirectional)) or
       ((not cell1HasOwnedParticles) and (not cell2HasOwnedParticles))) {

--- a/src/autopas/baseFunctors/CellFunctor3B.h
+++ b/src/autopas/baseFunctors/CellFunctor3B.h
@@ -190,7 +190,7 @@ void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCell(Pa
   }
 
   // avoid force calculations if the cell contains only halo particles or if the cell is empty (=dummy)
-  const bool cellHasOwnedParticles = toInt64(cell.getPossibleParticleOwnerships() & OwnershipState::owned);
+  const bool cellHasOwnedParticles = toIntType(cell.getPossibleParticleOwnerships() & OwnershipState::owned);
   if (not cellHasOwnedParticles) {
     return;
   }
@@ -221,8 +221,8 @@ void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCellPai
 
   // avoid force calculations if both cells can not contain owned particles or if newton3==false and cell1 does not
   // contain owned particles
-  const bool cell1HasOwnedParticles = toInt64(cell1.getPossibleParticleOwnerships() & OwnershipState::owned);
-  const bool cell2HasOwnedParticles = toInt64(cell2.getPossibleParticleOwnerships() & OwnershipState::owned);
+  const bool cell1HasOwnedParticles = toIntType(cell1.getPossibleParticleOwnerships() & OwnershipState::owned);
+  const bool cell2HasOwnedParticles = toIntType(cell2.getPossibleParticleOwnerships() & OwnershipState::owned);
 
   if (((not cell1HasOwnedParticles) and (not _useNewton3) and (not bidirectional)) or
       ((not cell1HasOwnedParticles) and (not cell2HasOwnedParticles))) {
@@ -260,9 +260,9 @@ void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCellTri
 
   // avoid force calculations if all three cells can not contain owned particles or if newton3==false and cell1 does not
   // contain owned particles
-  const bool cell1HasOwnedParticles = toInt64(cell1.getPossibleParticleOwnerships() & OwnershipState::owned);
-  const bool cell2HasOwnedParticles = toInt64(cell2.getPossibleParticleOwnerships() & OwnershipState::owned);
-  const bool cell3HasOwnedParticles = toInt64(cell3.getPossibleParticleOwnerships() & OwnershipState::owned);
+  const bool cell1HasOwnedParticles = toIntType(cell1.getPossibleParticleOwnerships() & OwnershipState::owned);
+  const bool cell2HasOwnedParticles = toIntType(cell2.getPossibleParticleOwnerships() & OwnershipState::owned);
+  const bool cell3HasOwnedParticles = toIntType(cell3.getPossibleParticleOwnerships() & OwnershipState::owned);
 
   if (((not cell1HasOwnedParticles) and (not _useNewton3) and (not bidirectional)) or
       ((not cell1HasOwnedParticles) and (not cell2HasOwnedParticles) and (not cell3HasOwnedParticles))) {

--- a/src/autopas/cells/FullParticleCell.h
+++ b/src/autopas/cells/FullParticleCell.h
@@ -53,7 +53,7 @@ class FullParticleCell : public ParticleCell<Particle> {
 
     // sanity check that ensures that only particles of the cells OwnershipState can be added. Note: if a cell is a
     // dummy-cell, only dummies can be added, otherwise dummies can always be added
-    if ((not toInt64(p.getOwnershipState() & this->_ownershipState)) and
+    if ((not toIntType(p.getOwnershipState() & this->_ownershipState)) and
         p.getOwnershipState() != OwnershipState::dummy) {
       autopas::utils::ExceptionHandler::exception(
           "FullParticleCell::addParticle() can not add a particle with OwnershipState {} to a cell with OwnershipState "

--- a/src/autopas/cells/ReferenceParticleCell.h
+++ b/src/autopas/cells/ReferenceParticleCell.h
@@ -55,7 +55,7 @@ class ReferenceParticleCell : public ParticleCell<Particle> {
   void addParticleReference(Particle *p) {
     // sanity check that ensures that only particles of the cells OwnershipState can be added. Note: is a cell is a
     // dummy-cell, only dummies can be added, otherwise dummies can always be added
-    if ((not toInt64(p->getOwnershipState() & this->_ownershipState)) and
+    if ((not toIntType(p->getOwnershipState() & this->_ownershipState)) and
         p->getOwnershipState() != OwnershipState::dummy) {
       autopas::utils::ExceptionHandler::exception(
           "ReferenceParticleCell::addParticleReference() can not add a particle with OwnershipState {} to a cell with "

--- a/src/autopas/cells/SortedCellView.h
+++ b/src/autopas/cells/SortedCellView.h
@@ -43,7 +43,8 @@ class SortedCellView : public ParticleCell<typename ParticleCellType::ParticleTy
   SortedCellView(ParticleCellType &cell, const std::array<double, 3> &r) : _cell(&cell) {
     _particles.reserve(cell.size());
     for (auto &p : cell) {
-      _particles.push_back(std::make_pair(utils::ArrayMath::dot(p.getR(), r), &p));
+      _particles.push_back(std::make_pair(
+          utils::ArrayMath::dot(autopas::utils::ArrayUtils::static_cast_copy_array<double>(p.getR()), r), &p));
     }
     std::sort(_particles.begin(), _particles.end(),
               [](const auto &a, const auto &b) -> bool { return a.first < b.first; });

--- a/src/autopas/containers/directSum/DirectSum.h
+++ b/src/autopas/containers/directSum/DirectSum.h
@@ -168,7 +168,8 @@ class DirectSum : public CellBasedParticleContainer<FullParticleCell<Particle>> 
     std::vector<ParticleType> invalidParticles{};
     auto &particleVec = getOwnedCell()._particles;
     for (auto iter = particleVec.begin(); iter != particleVec.end();) {
-      if (utils::notInBox(iter->getR(), this->getBoxMin(), this->getBoxMax())) {
+      if (utils::notInBox(autopas::utils::ArrayUtils::static_cast_copy_array<double>(iter->getR()), this->getBoxMin(),
+                          this->getBoxMax())) {
         invalidParticles.push_back(*iter);
         // swap-delete
         *iter = particleVec.back();

--- a/src/autopas/containers/linkedCells/LinkedCells.h
+++ b/src/autopas/containers/linkedCells/LinkedCells.h
@@ -76,17 +76,20 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
   }
 
   void addParticleImpl(const ParticleType &p) override {
-    ParticleCell &cell = _cellBlock.getContainingCell(p.getR());
+    ParticleCell &cell =
+        _cellBlock.getContainingCell(autopas::utils::ArrayUtils::static_cast_copy_array<double>(p.getR()));
     cell.addParticle(p);
   }
 
   void addHaloParticleImpl(const ParticleType &haloParticle) override {
-    ParticleCell &cell = _cellBlock.getContainingCell(haloParticle.getR());
+    ParticleCell &cell =
+        _cellBlock.getContainingCell(autopas::utils::ArrayUtils::static_cast_copy_array<double>(haloParticle.getR()));
     cell.addParticle(haloParticle);
   }
 
   bool updateHaloParticle(const ParticleType &haloParticle) override {
-    auto cells = _cellBlock.getNearbyHaloCells(haloParticle.getR(), this->getVerletSkin());
+    auto cells = _cellBlock.getNearbyHaloCells(
+        autopas::utils::ArrayUtils::static_cast_copy_array<double>(haloParticle.getR()), this->getVerletSkin());
     for (auto cellptr : cells) {
       bool updated = internal::checkParticleInCellAndUpdateByID(*cellptr, haloParticle);
       if (updated) {
@@ -160,7 +163,8 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
         auto &particleVec = this->getCells()[cellId]._particles;
         for (auto pIter = particleVec.begin(); pIter < particleVec.end();) {
           // if not in cell
-          if (utils::notInBox(pIter->getR(), cellLowerCorner, cellUpperCorner)) {
+          if (utils::notInBox(autopas::utils::ArrayUtils::static_cast_copy_array<double>(pIter->getR()),
+                              cellLowerCorner, cellUpperCorner)) {
             myInvalidParticles.push_back(*pIter);
             // swap-delete
             *pIter = particleVec.back();
@@ -286,7 +290,9 @@ class LinkedCells : public CellBasedParticleContainer<FullParticleCell<Particle>
 
   bool deleteParticle(Particle &particle) override {
     // deduce into which vector the reference points
-    auto &particleVec = _cellBlock.getContainingCell(particle.getR())._particles;
+    auto &particleVec =
+        _cellBlock.getContainingCell(autopas::utils::ArrayUtils::static_cast_copy_array<double>(particle.getR()))
+            ._particles;
     const bool isRearParticle = &particle == &particleVec.back();
     // swap-delete
     particle = particleVec.back();

--- a/src/autopas/containers/linkedCells/LinkedCellsReferences.h
+++ b/src/autopas/containers/linkedCells/LinkedCellsReferences.h
@@ -103,7 +103,8 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
    * @copydoc ParticleContainerInterface::updateHaloParticle()
    */
   bool updateHaloParticle(const ParticleType &haloParticle) override {
-    auto cells = _cellBlock.getNearbyHaloCells(haloParticle.getR(), this->getVerletSkin());
+    auto cells = _cellBlock.getNearbyHaloCells(
+        autopas::utils::ArrayUtils::static_cast_copy_array<double>(haloParticle.getR()), this->getVerletSkin());
     for (auto cellptr : cells) {
       bool updated = internal::checkParticleInCellAndUpdateByID(*cellptr, haloParticle);
       if (updated) {
@@ -162,7 +163,8 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
         if (it->isDummy()) {
           continue;
         }
-        ReferenceCell &cell = _cellBlock.getContainingCell(it->getR());
+        ReferenceCell &cell =
+            _cellBlock.getContainingCell(autopas::utils::ArrayUtils::static_cast_copy_array<double>(it->getR()));
         auto address = &(*it);
         cell.addParticleReference(address);
       }
@@ -316,7 +318,9 @@ class LinkedCellsReferences : public CellBasedParticleContainer<ReferenceParticl
 
         auto &particleVec = this->getCells()[cellId]._particles;
         for (auto pIter = particleVec.begin(); pIter != particleVec.end();) {
-          if ((*pIter)->isOwned() and utils::notInBox((*pIter)->getR(), cellLowerCorner, cellUpperCorner)) {
+          if ((*pIter)->isOwned() and
+              utils::notInBox(autopas::utils::ArrayUtils::static_cast_copy_array<double>((*pIter)->getR()),
+                              cellLowerCorner, cellUpperCorner)) {
             myInvalidParticles.push_back(**pIter);
 
             // multi layer swap-delete

--- a/src/autopas/containers/octree/OctreeInnerNode.h
+++ b/src/autopas/containers/octree/OctreeInnerNode.h
@@ -97,7 +97,7 @@ class OctreeInnerNode : public OctreeNodeInterface<Particle> {
   std::unique_ptr<OctreeNodeInterface<Particle>> insert(const Particle &p) override {
     // Find a child to insert the particle into.
     for (auto &child : _children) {
-      if (child->isInside(p.getR())) {
+      if (child->isInside(autopas::utils::ArrayUtils::static_cast_copy_array<double>(p.getR()))) {
         auto ret = child->insert(p);
         if (ret) child = std::move(ret);
         break;
@@ -109,7 +109,7 @@ class OctreeInnerNode : public OctreeNodeInterface<Particle> {
 
   bool deleteParticle(Particle &particle) override {
     for (auto &child : _children) {
-      if (child->isInside(particle.getR())) {
+      if (child->isInside(autopas::utils::ArrayUtils::static_cast_copy_array<double>(particle.getR()))) {
         return child->deleteParticle(particle);
       }
     }

--- a/src/autopas/containers/octree/OctreeLeafNode.h
+++ b/src/autopas/containers/octree/OctreeLeafNode.h
@@ -81,7 +81,7 @@ class OctreeLeafNode : public OctreeNodeInterface<Particle>, public FullParticle
     if ((this->_particles.size() < this->_treeSplitThreshold) or anyNewDimSmallerThanMinSize) {
       // sanity check that ensures that only particles of the cells OwnershipState can be added. Note: if a cell is a
       // dummy-cell, only dummies can be added, otherwise dummies can always be added
-      if ((not toInt64(p.getOwnershipState() & this->_ownershipState)) and
+      if ((not toIntType(p.getOwnershipState() & this->_ownershipState)) and
           p.getOwnershipState() != OwnershipState::dummy) {
         autopas::utils::ExceptionHandler::exception(
             "OctreeLeafNode::insert() can not add a particle with OwnershipState {} to a cell with "

--- a/src/autopas/containers/verletClusterLists/Cluster.h
+++ b/src/autopas/containers/verletClusterLists/Cluster.h
@@ -145,7 +145,8 @@ class Cluster {
         upperCorner[dim] = std::max(upperCorner[dim], pos[dim]);
       }
     }
-    return {lowerCorner, upperCorner};
+    return {autopas::utils::ArrayUtils::static_cast_copy_array<double>(lowerCorner),
+            autopas::utils::ArrayUtils::static_cast_copy_array<double>(upperCorner)};
   }
 
  private:

--- a/src/autopas/containers/verletClusterLists/ClusterTower.h
+++ b/src/autopas/containers/verletClusterLists/ClusterTower.h
@@ -46,6 +46,7 @@ class ClusterTower : public FullParticleCell<Particle> {
    * Type that holds or refers to the actual particles.
    */
   using StorageType = typename FullParticleCell<Particle>::StorageType;
+  using CalcType = typename Particle::ParticleCalcType;
 
   /**
    * Dummy constructor.
@@ -155,7 +156,8 @@ class ClusterTower : public FullParticleCell<Particle> {
       auto &dummy = lastCluster[_clusterSize - index];
       dummy = lastCluster[0];  // use first Particle in last cluster as dummy particle!
       dummy.setOwnershipState(OwnershipState::dummy);
-      dummy.setR({dummyStartX, 0, dummyDistZ * static_cast<double>(index)});
+      dummy.setR(
+          {static_cast<CalcType>(dummyStartX), 0, static_cast<CalcType>(dummyDistZ) * static_cast<CalcType>(index)});
       dummy.setID(std::numeric_limits<size_t>::max());
     }
   }

--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -192,8 +192,10 @@ class VerletClusterLists : public ParticleContainerInterface<Particle>, public i
 
     const auto &haloPos = haloParticle.getR();
     // this might be called from a parallel region so force this iterator to be sequential
-    for (auto it = getRegionIterator(haloPos - (this->getVerletSkin() / 2.), haloPos + (this->getVerletSkin() / 2.),
-                                     IteratorBehavior::halo | IteratorBehavior::forceSequential, nullptr);
+    for (auto it = getRegionIterator(
+             autopas::utils::ArrayUtils::static_cast_copy_array<double>(haloPos) - (this->getVerletSkin() / 2.),
+             autopas::utils::ArrayUtils::static_cast_copy_array<double>(haloPos) + (this->getVerletSkin() / 2.),
+             IteratorBehavior::halo | IteratorBehavior::forceSequential, nullptr);
          it.isValid(); ++it) {
       if (haloParticle.getID() == it->getID()) {
         // don't simply copy haloParticle over iter. This would trigger a dataRace with other regionIterators that

--- a/src/autopas/containers/verletClusterLists/VerletClusterListsRebuilder.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterListsRebuilder.h
@@ -220,7 +220,8 @@ class VerletClusterListsRebuilder {
       const std::vector<Particle> &vector = particles2D[index];
       for (const auto &particle : vector) {
         if (utils::inBox(particle.getR(), _towerBlock.getHaloBoxMin(), _towerBlock.getHaloBoxMax())) {
-          auto &tower = _towerBlock.getTowerAtPosition(particle.getR());
+          auto &tower = _towerBlock.getTowerAtPosition(
+              autopas::utils::ArrayUtils::static_cast_copy_array<double>(particle.getR()));
           tower.addParticle(particle);
         } else {
           AutoPasLog(TRACE, "Not adding particle to VerletClusterLists container, because it is outside the halo:\n{}",

--- a/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
+++ b/src/autopas/containers/verletListsCellBased/VerletListsLinkedBase.h
@@ -185,7 +185,8 @@ class VerletListsLinkedBase : public ParticleContainerInterface<Particle> {
    * @return true if a particle was found and updated, false if it was not found.
    */
   bool updateHaloParticle(const Particle &haloParticle) override {
-    auto cells = _linkedCells.getCellBlock().getNearbyHaloCells(haloParticle.getR(), this->getVerletSkin());
+    auto cells = _linkedCells.getCellBlock().getNearbyHaloCells(
+        autopas::utils::ArrayUtils::static_cast_copy_array<double>(haloParticle.getR()), this->getVerletSkin());
     for (auto cellptr : cells) {
       bool updated = internal::checkParticleInCellAndUpdateByID(*cellptr, haloParticle);
       if (updated) {

--- a/src/autopas/containers/verletListsCellBased/varVerletLists/neighborLists/asBuild/AsBuildPairGeneratorFunctor.h
+++ b/src/autopas/containers/verletListsCellBased/varVerletLists/neighborLists/asBuild/AsBuildPairGeneratorFunctor.h
@@ -104,16 +104,16 @@ class AsBuildPairGeneratorFunctor
     if (soa.size() == 0) return;
 
     auto **const __restrict ptrptr = soa.template begin<Particle_T::AttributeNames::ptr>();
-    CalcType *const __restrict xptr = soa.template begin<Particle_T::AttributeNames::posX>();
-    CalcType *const __restrict yptr = soa.template begin<Particle_T::AttributeNames::posY>();
-    CalcType *const __restrict zptr = soa.template begin<Particle_T::AttributeNames::posZ>();
+    const auto *const __restrict xptr = soa.template begin<Particle_T::AttributeNames::posX>();
+    const auto *const __restrict yptr = soa.template begin<Particle_T::AttributeNames::posY>();
+    const auto *const __restrict zptr = soa.template begin<Particle_T::AttributeNames::posZ>();
 
     size_t numPart = soa.size();
     for (unsigned int i = 0; i < numPart; ++i) {
       for (unsigned int j = i + 1; j < numPart; ++j) {
-        const CalcType drx = xptr[i] - xptr[j];
-        const CalcType dry = yptr[i] - yptr[j];
-        const CalcType drz = zptr[i] - zptr[j];
+        const CalcType drx = static_cast<CalcType>(xptr[i]) - static_cast<CalcType>(xptr[j]);
+        const CalcType dry = static_cast<CalcType>(yptr[i]) - static_cast<CalcType>(yptr[j]);
+        const CalcType drz = static_cast<CalcType>(zptr[i]) - static_cast<CalcType>(zptr[j]);
 
         const CalcType drx2 = drx * drx;
         const CalcType dry2 = dry * dry;
@@ -140,22 +140,22 @@ class AsBuildPairGeneratorFunctor
     if (soa1.size() == 0 || soa2.size() == 0) return;
 
     auto **const __restrict ptrptr1 = soa1.template begin<Particle_T::AttributeNames::ptr>();
-    CalcType *const __restrict x1ptr = soa1.template begin<Particle_T::AttributeNames::posX>();
-    CalcType *const __restrict y1ptr = soa1.template begin<Particle_T::AttributeNames::posY>();
-    CalcType *const __restrict z1ptr = soa1.template begin<Particle_T::AttributeNames::posZ>();
+    const auto *const __restrict x1ptr = soa1.template begin<Particle_T::AttributeNames::posX>();
+    const auto *const __restrict y1ptr = soa1.template begin<Particle_T::AttributeNames::posY>();
+    const auto *const __restrict z1ptr = soa1.template begin<Particle_T::AttributeNames::posZ>();
 
     auto **const __restrict ptrptr2 = soa2.template begin<Particle_T::AttributeNames::ptr>();
-    CalcType *const __restrict x2ptr = soa2.template begin<Particle_T::AttributeNames::posX>();
-    CalcType *const __restrict y2ptr = soa2.template begin<Particle_T::AttributeNames::posY>();
-    CalcType *const __restrict z2ptr = soa2.template begin<Particle_T::AttributeNames::posZ>();
+    const auto *const __restrict x2ptr = soa2.template begin<Particle_T::AttributeNames::posX>();
+    const auto *const __restrict y2ptr = soa2.template begin<Particle_T::AttributeNames::posY>();
+    const auto *const __restrict z2ptr = soa2.template begin<Particle_T::AttributeNames::posZ>();
 
     size_t numPart1 = soa1.size();
     for (unsigned int i = 0; i < numPart1; ++i) {
       size_t numPart2 = soa2.size();
       for (unsigned int j = 0; j < numPart2; ++j) {
-        const CalcType drx = x1ptr[i] - x2ptr[j];
-        const CalcType dry = y1ptr[i] - y2ptr[j];
-        const CalcType drz = z1ptr[i] - z2ptr[j];
+        const CalcType drx = static_cast<CalcType>(x1ptr[i]) - static_cast<CalcType>(x2ptr[j]);
+        const CalcType dry = static_cast<CalcType>(y1ptr[i]) - static_cast<CalcType>(y2ptr[j]);
+        const CalcType drz = static_cast<CalcType>(z1ptr[i]) - static_cast<CalcType>(z2ptr[j]);
 
         const CalcType drx2 = drx * drx;
         const CalcType dry2 = dry * dry;

--- a/src/autopas/containers/verletListsCellBased/varVerletLists/neighborLists/asBuild/AsBuildPairGeneratorFunctor.h
+++ b/src/autopas/containers/verletListsCellBased/varVerletLists/neighborLists/asBuild/AsBuildPairGeneratorFunctor.h
@@ -33,6 +33,7 @@ class AsBuildPairGeneratorFunctor
    * The structure of the SoAs is defined by the particle.
    */
   using SoAArraysType = typename Particle::SoAArraysType;
+  using CalcType = typename Particle::ParticleCalcType;
 
   /**
    * @copydoc Functor::getNeededAttr()
@@ -103,22 +104,22 @@ class AsBuildPairGeneratorFunctor
     if (soa.size() == 0) return;
 
     auto **const __restrict ptrptr = soa.template begin<Particle::AttributeNames::ptr>();
-    double *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
+    CalcType *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
+    CalcType *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
+    CalcType *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
 
     size_t numPart = soa.size();
     for (unsigned int i = 0; i < numPart; ++i) {
       for (unsigned int j = i + 1; j < numPart; ++j) {
-        const double drx = xptr[i] - xptr[j];
-        const double dry = yptr[i] - yptr[j];
-        const double drz = zptr[i] - zptr[j];
+        const CalcType drx = xptr[i] - xptr[j];
+        const CalcType dry = yptr[i] - yptr[j];
+        const CalcType drz = zptr[i] - zptr[j];
 
-        const double drx2 = drx * drx;
-        const double dry2 = dry * dry;
-        const double drz2 = drz * drz;
+        const CalcType drx2 = drx * drx;
+        const CalcType dry2 = dry * dry;
+        const CalcType drz2 = drz * drz;
 
-        const double dr2 = drx2 + dry2 + drz2;
+        const CalcType dr2 = drx2 + dry2 + drz2;
 
         if (dr2 < _cutoffskinsquared) {
           _list.addPair(ptrptr[i], ptrptr[j]);
@@ -139,28 +140,28 @@ class AsBuildPairGeneratorFunctor
     if (soa1.size() == 0 || soa2.size() == 0) return;
 
     auto **const __restrict ptrptr1 = soa1.template begin<Particle::AttributeNames::ptr>();
-    double *const __restrict x1ptr = soa1.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict y1ptr = soa1.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict z1ptr = soa1.template begin<Particle::AttributeNames::posZ>();
+    CalcType *const __restrict x1ptr = soa1.template begin<Particle::AttributeNames::posX>();
+    CalcType *const __restrict y1ptr = soa1.template begin<Particle::AttributeNames::posY>();
+    CalcType *const __restrict z1ptr = soa1.template begin<Particle::AttributeNames::posZ>();
 
     auto **const __restrict ptrptr2 = soa2.template begin<Particle::AttributeNames::ptr>();
-    double *const __restrict x2ptr = soa2.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict y2ptr = soa2.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict z2ptr = soa2.template begin<Particle::AttributeNames::posZ>();
+    CalcType *const __restrict x2ptr = soa2.template begin<Particle::AttributeNames::posX>();
+    CalcType *const __restrict y2ptr = soa2.template begin<Particle::AttributeNames::posY>();
+    CalcType *const __restrict z2ptr = soa2.template begin<Particle::AttributeNames::posZ>();
 
     size_t numPart1 = soa1.size();
     for (unsigned int i = 0; i < numPart1; ++i) {
       size_t numPart2 = soa2.size();
       for (unsigned int j = 0; j < numPart2; ++j) {
-        const double drx = x1ptr[i] - x2ptr[j];
-        const double dry = y1ptr[i] - y2ptr[j];
-        const double drz = z1ptr[i] - z2ptr[j];
+        const CalcType drx = x1ptr[i] - x2ptr[j];
+        const CalcType dry = y1ptr[i] - y2ptr[j];
+        const CalcType drz = z1ptr[i] - z2ptr[j];
 
-        const double drx2 = drx * drx;
-        const double dry2 = dry * dry;
-        const double drz2 = drz * drz;
+        const CalcType drx2 = drx * drx;
+        const CalcType dry2 = dry * dry;
+        const CalcType drz2 = drz * drz;
 
-        const double dr2 = drx2 + dry2 + drz2;
+        const CalcType dr2 = drx2 + dry2 + drz2;
 
         if (dr2 < _cutoffskinsquared) {
           _list.addPair(ptrptr1[i], ptrptr2[j]);

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
@@ -24,6 +24,7 @@ class VerletListHelpers {
    * Neighbor list AoS style.
    */
   using NeighborListAoSType = std::unordered_map<Particle *, std::vector<Particle *>>;
+  using CalcType = typename Particle::ParticleCalcType;
 
   /**
    * This functor can generate verlet lists using the typical pairwise traversal.
@@ -91,24 +92,24 @@ class VerletListHelpers {
       if (soa.size() == 0) return;
 
       auto **const __restrict ptrptr = soa.template begin<Particle::AttributeNames::ptr>();
-      const double *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
-      const double *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
-      const double *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
+      const CalcType *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
+      const CalcType *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
+      const CalcType *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
 
       size_t numPart = soa.size();
       for (unsigned int i = 0; i < numPart; ++i) {
         auto &currentList = _verletListsAoS.at(ptrptr[i]);
 
         for (unsigned int j = i + 1; j < numPart; ++j) {
-          const double drx = xptr[i] - xptr[j];
-          const double dry = yptr[i] - yptr[j];
-          const double drz = zptr[i] - zptr[j];
+          const CalcType drx = xptr[i] - xptr[j];
+          const CalcType dry = yptr[i] - yptr[j];
+          const CalcType drz = zptr[i] - zptr[j];
 
-          const double drx2 = drx * drx;
-          const double dry2 = dry * dry;
-          const double drz2 = drz * drz;
+          const CalcType drx2 = drx * drx;
+          const CalcType dry2 = dry * dry;
+          const CalcType drz2 = drz * drz;
 
-          const double dr2 = drx2 + dry2 + drz2;
+          const CalcType dr2 = drx2 + dry2 + drz2;
 
           if (dr2 < _interactionLengthSquared) {
             currentList.push_back(ptrptr[j]);
@@ -131,14 +132,14 @@ class VerletListHelpers {
       if (soa1.size() == 0 || soa2.size() == 0) return;
 
       auto **const __restrict ptr1ptr = soa1.template begin<Particle::AttributeNames::ptr>();
-      const double *const __restrict x1ptr = soa1.template begin<Particle::AttributeNames::posX>();
-      const double *const __restrict y1ptr = soa1.template begin<Particle::AttributeNames::posY>();
-      const double *const __restrict z1ptr = soa1.template begin<Particle::AttributeNames::posZ>();
+      const CalcType *const __restrict x1ptr = soa1.template begin<Particle::AttributeNames::posX>();
+      const CalcType *const __restrict y1ptr = soa1.template begin<Particle::AttributeNames::posY>();
+      const CalcType *const __restrict z1ptr = soa1.template begin<Particle::AttributeNames::posZ>();
 
       auto **const __restrict ptr2ptr = soa2.template begin<Particle::AttributeNames::ptr>();
-      const double *const __restrict x2ptr = soa2.template begin<Particle::AttributeNames::posX>();
-      const double *const __restrict y2ptr = soa2.template begin<Particle::AttributeNames::posY>();
-      const double *const __restrict z2ptr = soa2.template begin<Particle::AttributeNames::posZ>();
+      const CalcType *const __restrict x2ptr = soa2.template begin<Particle::AttributeNames::posX>();
+      const CalcType *const __restrict y2ptr = soa2.template begin<Particle::AttributeNames::posY>();
+      const CalcType *const __restrict z2ptr = soa2.template begin<Particle::AttributeNames::posZ>();
 
       size_t numPart1 = soa1.size();
       for (unsigned int i = 0; i < numPart1; ++i) {
@@ -147,15 +148,15 @@ class VerletListHelpers {
         size_t numPart2 = soa2.size();
 
         for (unsigned int j = 0; j < numPart2; ++j) {
-          const double drx = x1ptr[i] - x2ptr[j];
-          const double dry = y1ptr[i] - y2ptr[j];
-          const double drz = z1ptr[i] - z2ptr[j];
+          const CalcType drx = x1ptr[i] - x2ptr[j];
+          const CalcType dry = y1ptr[i] - y2ptr[j];
+          const CalcType drz = z1ptr[i] - z2ptr[j];
 
-          const double drx2 = drx * drx;
-          const double dry2 = dry * dry;
-          const double drz2 = drz * drz;
+          const CalcType drx2 = drx * drx;
+          const CalcType dry2 = dry * dry;
+          const CalcType drz2 = drz * drz;
 
-          const double dr2 = drx2 + dry2 + drz2;
+          const CalcType dr2 = drx2 + dry2 + drz2;
 
           if (dr2 < _interactionLengthSquared) {
             currentList.push_back(ptr2ptr[j]);

--- a/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
+++ b/src/autopas/containers/verletListsCellBased/verletLists/VerletListHelpers.h
@@ -92,18 +92,18 @@ class VerletListHelpers {
       if (soa.size() == 0) return;
 
       auto **const __restrict ptrptr = soa.template begin<Particle_T::AttributeNames::ptr>();
-      const double *const __restrict xptr = soa.template begin<Particle_T::AttributeNames::posX>();
-      const double *const __restrict yptr = soa.template begin<Particle_T::AttributeNames::posY>();
-      const double *const __restrict zptr = soa.template begin<Particle_T::AttributeNames::posZ>();
+      const auto *const __restrict xptr = soa.template begin<Particle_T::AttributeNames::posX>();
+      const auto *const __restrict yptr = soa.template begin<Particle_T::AttributeNames::posY>();
+      const auto *const __restrict zptr = soa.template begin<Particle_T::AttributeNames::posZ>();
 
       size_t numPart = soa.size();
       for (unsigned int i = 0; i < numPart; ++i) {
         auto &currentList = _verletListsAoS.at(ptrptr[i]);
 
         for (unsigned int j = i + 1; j < numPart; ++j) {
-          const CalcType drx = xptr[i] - xptr[j];
-          const CalcType dry = yptr[i] - yptr[j];
-          const CalcType drz = zptr[i] - zptr[j];
+          const CalcType drx = static_cast<CalcType>(xptr[i]) - static_cast<CalcType>(xptr[j]);
+          const CalcType dry = static_cast<CalcType>(yptr[i]) - static_cast<CalcType>(yptr[j]);
+          const CalcType drz = static_cast<CalcType>(zptr[i]) - static_cast<CalcType>(zptr[j]);
 
           const CalcType drx2 = drx * drx;
           const CalcType dry2 = dry * dry;
@@ -132,14 +132,14 @@ class VerletListHelpers {
       if (soa1.size() == 0 || soa2.size() == 0) return;
 
       auto **const __restrict ptr1ptr = soa1.template begin<Particle_T::AttributeNames::ptr>();
-      const CalcType *const __restrict x1ptr = soa1.template begin<Particle_T::AttributeNames::posX>();
-      const CalcType *const __restrict y1ptr = soa1.template begin<Particle_T::AttributeNames::posY>();
-      const CalcType *const __restrict z1ptr = soa1.template begin<Particle_T::AttributeNames::posZ>();
+      const auto *const __restrict x1ptr = soa1.template begin<Particle_T::AttributeNames::posX>();
+      const auto *const __restrict y1ptr = soa1.template begin<Particle_T::AttributeNames::posY>();
+      const auto *const __restrict z1ptr = soa1.template begin<Particle_T::AttributeNames::posZ>();
 
       auto **const __restrict ptr2ptr = soa2.template begin<Particle_T::AttributeNames::ptr>();
-      const CalcType *const __restrict x2ptr = soa2.template begin<Particle_T::AttributeNames::posX>();
-      const CalcType *const __restrict y2ptr = soa2.template begin<Particle_T::AttributeNames::posY>();
-      const CalcType *const __restrict z2ptr = soa2.template begin<Particle_T::AttributeNames::posZ>();
+      const auto *const __restrict x2ptr = soa2.template begin<Particle_T::AttributeNames::posX>();
+      const auto *const __restrict y2ptr = soa2.template begin<Particle_T::AttributeNames::posY>();
+      const auto *const __restrict z2ptr = soa2.template begin<Particle_T::AttributeNames::posZ>();
 
       size_t numPart1 = soa1.size();
       for (unsigned int i = 0; i < numPart1; ++i) {
@@ -148,9 +148,9 @@ class VerletListHelpers {
         size_t numPart2 = soa2.size();
 
         for (unsigned int j = 0; j < numPart2; ++j) {
-          const CalcType drx = x1ptr[i] - x2ptr[j];
-          const CalcType dry = y1ptr[i] - y2ptr[j];
-          const CalcType drz = z1ptr[i] - z2ptr[j];
+          const CalcType drx = static_cast<CalcType>(x1ptr[i]) - static_cast<CalcType>(x2ptr[j]);
+          const CalcType dry = static_cast<CalcType>(y1ptr[i]) - static_cast<CalcType>(y2ptr[j]);
+          const CalcType drz = static_cast<CalcType>(z1ptr[i]) - static_cast<CalcType>(z2ptr[j]);
 
           const CalcType drx2 = drx * drx;
           const CalcType dry2 = dry * dry;

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCAllCellsGeneratorFunctor.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCAllCellsGeneratorFunctor.h
@@ -22,6 +22,7 @@ class VLCAllCellsGeneratorFunctor
     : public PairwiseFunctor<Particle, VLCAllCellsGeneratorFunctor<Particle, TraversalOptionEnum>> {
   using NeighborListsType = typename VerletListsCellsHelpers::AllCellsNeighborListsType<Particle>;
   using SoAArraysType = typename Particle::SoAArraysType;
+  using CalcType = typename Particle::ParticleCalcType;
 
  public:
   /**
@@ -136,9 +137,9 @@ class VLCAllCellsGeneratorFunctor
     if (soa.size() == 0) return;
 
     auto **const __restrict__ ptrPtr = soa.template begin<Particle::AttributeNames::ptr>();
-    double *const __restrict__ xPtr = soa.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict__ yPtr = soa.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict__ zPtr = soa.template begin<Particle::AttributeNames::posZ>();
+    CalcType *const __restrict__ xPtr = soa.template begin<Particle::AttributeNames::posX>();
+    CalcType *const __restrict__ yPtr = soa.template begin<Particle::AttributeNames::posY>();
+    CalcType *const __restrict__ zPtr = soa.template begin<Particle::AttributeNames::posZ>();
 
     // index of cellIndex is particleToCellMap of ptrPtr, same for 2
     const auto [cellIndex, _] = _particleToCellMap.at(ptrPtr[0]);
@@ -149,15 +150,15 @@ class VLCAllCellsGeneratorFunctor
     const size_t numPart = soa.size();
     for (unsigned int i = 0; i < numPart; ++i) {
       for (unsigned int j = i + 1; j < numPart; ++j) {
-        const double drx = xPtr[i] - xPtr[j];
-        const double dry = yPtr[i] - yPtr[j];
-        const double drz = zPtr[i] - zPtr[j];
+        const CalcType drx = xPtr[i] - xPtr[j];
+        const CalcType dry = yPtr[i] - yPtr[j];
+        const CalcType drz = zPtr[i] - zPtr[j];
 
-        const double drx2 = drx * drx;
-        const double dry2 = dry * dry;
-        const double drz2 = drz * drz;
+        const CalcType drx2 = drx * drx;
+        const CalcType dry2 = dry * dry;
+        const CalcType drz2 = drz * drz;
 
-        const double dr2 = drx2 + dry2 + drz2;
+        const CalcType dr2 = drx2 + dry2 + drz2;
 
         if (dr2 < _cutoffSkinSquared) {
           auto &currentList = _neighborLists[cellIndex];
@@ -185,14 +186,14 @@ class VLCAllCellsGeneratorFunctor
     if (soa1.size() == 0 or soa2.size() == 0) return;
 
     auto **const __restrict__ ptr1Ptr = soa1.template begin<Particle::AttributeNames::ptr>();
-    double *const __restrict__ x1Ptr = soa1.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict__ y1Ptr = soa1.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict__ z1Ptr = soa1.template begin<Particle::AttributeNames::posZ>();
+    CalcType *const __restrict__ x1Ptr = soa1.template begin<Particle::AttributeNames::posX>();
+    CalcType *const __restrict__ y1Ptr = soa1.template begin<Particle::AttributeNames::posY>();
+    CalcType *const __restrict__ z1Ptr = soa1.template begin<Particle::AttributeNames::posZ>();
 
     auto **const __restrict__ ptr2Ptr = soa2.template begin<Particle::AttributeNames::ptr>();
-    double *const __restrict__ x2Ptr = soa2.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict__ y2Ptr = soa2.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict__ z2Ptr = soa2.template begin<Particle::AttributeNames::posZ>();
+    CalcType *const __restrict__ x2Ptr = soa2.template begin<Particle::AttributeNames::posX>();
+    CalcType *const __restrict__ y2Ptr = soa2.template begin<Particle::AttributeNames::posY>();
+    CalcType *const __restrict__ z2Ptr = soa2.template begin<Particle::AttributeNames::posZ>();
 
     // index of cell1 is particleToCellMap of ptr1Ptr, same for 2
     const size_t cellIndex1 = _particleToCellMap.at(ptr1Ptr[0]).first;
@@ -224,15 +225,15 @@ class VLCAllCellsGeneratorFunctor
     for (unsigned int i = 0; i < numPart1; ++i) {
       const size_t numPart2 = soa2.size();
       for (unsigned int j = 0; j < numPart2; ++j) {
-        const double drx = x1Ptr[i] - x2Ptr[j];
-        const double dry = y1Ptr[i] - y2Ptr[j];
-        const double drz = z1Ptr[i] - z2Ptr[j];
+        const CalcType drx = x1Ptr[i] - x2Ptr[j];
+        const CalcType dry = y1Ptr[i] - y2Ptr[j];
+        const CalcType drz = z1Ptr[i] - z2Ptr[j];
 
-        const double drx2 = drx * drx;
-        const double dry2 = dry * dry;
-        const double drz2 = drz * drz;
+        const CalcType drx2 = drx * drx;
+        const CalcType dry2 = dry * dry;
+        const CalcType drz2 = drz * drz;
 
-        const double dr2 = drx2 + dry2 + drz2;
+        const CalcType dr2 = drx2 + dry2 + drz2;
 
         if (dr2 < _cutoffSkinSquared) {
           if constexpr (TraversalOptionEnum == TraversalOption::Value::vlc_c01 or

--- a/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCCellPairGeneratorFunctor.h
+++ b/src/autopas/containers/verletListsCellBased/verletListsCells/neighborLists/VLCCellPairGeneratorFunctor.h
@@ -20,6 +20,7 @@ template <class Particle>
 class VLCCellPairGeneratorFunctor : public PairwiseFunctor<Particle, VLCCellPairGeneratorFunctor<Particle>> {
   using PairwiseNeighborListsType = typename VerletListsCellsHelpers::PairwiseNeighborListsType<Particle>;
   using SoAArraysType = typename Particle::SoAArraysType;
+  using CalcType = typename Particle::ParticleCalcType;
 
  public:
   /**
@@ -93,9 +94,9 @@ class VLCCellPairGeneratorFunctor : public PairwiseFunctor<Particle, VLCCellPair
     if (soa.size() == 0) return;
 
     auto **const __restrict__ ptrptr = soa.template begin<Particle::AttributeNames::ptr>();
-    double *const __restrict__ xptr = soa.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict__ yptr = soa.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict__ zptr = soa.template begin<Particle::AttributeNames::posZ>();
+    CalcType *const __restrict__ xptr = soa.template begin<Particle::AttributeNames::posX>();
+    CalcType *const __restrict__ yptr = soa.template begin<Particle::AttributeNames::posY>();
+    CalcType *const __restrict__ zptr = soa.template begin<Particle::AttributeNames::posZ>();
 
     // index of cell1 is particleToCellMap of ptr1ptr, same for 2
     auto cell = _particleToCellMap.at(ptrptr[0]).first;
@@ -114,15 +115,15 @@ class VLCCellPairGeneratorFunctor : public PairwiseFunctor<Particle, VLCCellPair
     size_t numPart = soa.size();
     for (unsigned int i = 0; i < numPart; ++i) {
       for (unsigned int j = i + 1; j < numPart; ++j) {
-        const double drx = xptr[i] - xptr[j];
-        const double dry = yptr[i] - yptr[j];
-        const double drz = zptr[i] - zptr[j];
+        const CalcType drx = xptr[i] - xptr[j];
+        const CalcType dry = yptr[i] - yptr[j];
+        const CalcType drz = zptr[i] - zptr[j];
 
-        const double drx2 = drx * drx;
-        const double dry2 = dry * dry;
-        const double drz2 = drz * drz;
+        const CalcType drx2 = drx * drx;
+        const CalcType dry2 = dry * dry;
+        const CalcType drz2 = drz * drz;
 
-        const double dr2 = drx2 + dry2 + drz2;
+        const CalcType dr2 = drx2 + dry2 + drz2;
 
         if (dr2 < _cutoffskinsquared) {
           currentList[i].second.push_back(ptrptr[j]);
@@ -149,14 +150,14 @@ class VLCCellPairGeneratorFunctor : public PairwiseFunctor<Particle, VLCCellPair
     if (soa1.size() == 0 || soa2.size() == 0) return;
 
     auto **const __restrict__ ptr1ptr = soa1.template begin<Particle::AttributeNames::ptr>();
-    double *const __restrict__ x1ptr = soa1.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict__ y1ptr = soa1.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict__ z1ptr = soa1.template begin<Particle::AttributeNames::posZ>();
+    CalcType *const __restrict__ x1ptr = soa1.template begin<Particle::AttributeNames::posX>();
+    CalcType *const __restrict__ y1ptr = soa1.template begin<Particle::AttributeNames::posY>();
+    CalcType *const __restrict__ z1ptr = soa1.template begin<Particle::AttributeNames::posZ>();
 
     auto **const __restrict__ ptr2ptr = soa2.template begin<Particle::AttributeNames::ptr>();
-    double *const __restrict__ x2ptr = soa2.template begin<Particle::AttributeNames::posX>();
-    double *const __restrict__ y2ptr = soa2.template begin<Particle::AttributeNames::posY>();
-    double *const __restrict__ z2ptr = soa2.template begin<Particle::AttributeNames::posZ>();
+    CalcType *const __restrict__ x2ptr = soa2.template begin<Particle::AttributeNames::posX>();
+    CalcType *const __restrict__ y2ptr = soa2.template begin<Particle::AttributeNames::posY>();
+    CalcType *const __restrict__ z2ptr = soa2.template begin<Particle::AttributeNames::posZ>();
 
     // index of cell1 is particleToCellMap of ptr1ptr, same for 2
     size_t cell1 = _particleToCellMap.at(ptr1ptr[0]).first;
@@ -177,15 +178,15 @@ class VLCCellPairGeneratorFunctor : public PairwiseFunctor<Particle, VLCCellPair
     for (unsigned int i = 0; i < numPart1; ++i) {
       size_t numPart2 = soa2.size();
       for (unsigned int j = 0; j < numPart2; ++j) {
-        const double drx = x1ptr[i] - x2ptr[j];
-        const double dry = y1ptr[i] - y2ptr[j];
-        const double drz = z1ptr[i] - z2ptr[j];
+        const CalcType drx = x1ptr[i] - x2ptr[j];
+        const CalcType dry = y1ptr[i] - y2ptr[j];
+        const CalcType drz = z1ptr[i] - z2ptr[j];
 
-        const double drx2 = drx * drx;
-        const double dry2 = dry * dry;
-        const double drz2 = drz * drz;
+        const CalcType drx2 = drx * drx;
+        const CalcType dry2 = dry * dry;
+        const CalcType drz2 = drz * drz;
 
-        const double dr2 = drx2 + dry2 + drz2;
+        const CalcType dr2 = drx2 + dry2 + drz2;
 
         if (dr2 < _cutoffskinsquared) {
           currentList[i].second.push_back(ptr2ptr[j]);

--- a/src/autopas/particles/OwnershipState.h
+++ b/src/autopas/particles/OwnershipState.h
@@ -11,12 +11,17 @@
 #include <iostream>
 
 namespace autopas {
+#if AUTOPAS_PRECISION_MODE == DPDP
+using OwnershipType = int64_t;
+#else
+using OwnershipType = int32_t;
+#endif
 /**
  * Enum that specifies the state of ownership.
- * @note this type has int64_t as an underlying type to be compatible with LJFunctorAVX. For that a size equal to the
- * precision of the particles is required.
+ * @note this type has either int32_t or int64_t depending on the precision selected as an underlying type to be
+ * compatible with LJFunctorAVX. For that a size equal to the precision of the particles is required.
  */
-enum class OwnershipState : int64_t {
+enum class OwnershipState : OwnershipType {
   /// Dummy or deleted state, a particle with this state is not an actual particle!
   /// @note LJFunctorAVX requires that the Dummy state should always be the integer zero and the state with the lowest
   /// value.
@@ -34,7 +39,7 @@ enum class OwnershipState : int64_t {
  * @return a & b
  */
 constexpr OwnershipState operator&(const OwnershipState a, const OwnershipState b) {
-  return static_cast<OwnershipState>(static_cast<int64_t>(a) & static_cast<int64_t>(b));
+  return static_cast<OwnershipState>(static_cast<OwnershipType>(a) & static_cast<OwnershipType>(b));
 }
 
 /**
@@ -44,16 +49,16 @@ constexpr OwnershipState operator&(const OwnershipState a, const OwnershipState 
  * @return a | b
  */
 constexpr OwnershipState operator|(const OwnershipState a, const OwnershipState b) {
-  return static_cast<OwnershipState>(static_cast<int64_t>(a) | static_cast<int64_t>(b));
+  return static_cast<OwnershipState>(static_cast<OwnershipType>(a) | static_cast<OwnershipType>(b));
 }
 
 /**
- * Returns the int64_t value of a given OwnershipState
+ * Returns the OwnershipType value of a given OwnershipState
  *
  * @param a OwnershipState
- * @return const int64_t value of a given OwnershipState
+ * @return const OwnershipType value of a given OwnershipState
  */
-constexpr int64_t toInt64(const OwnershipState a) { return static_cast<int64_t>(a); }
+constexpr OwnershipType toIntType(const OwnershipState a) { return static_cast<OwnershipType>(a); }
 
 /**
  * Insertion operator for OwnershipState.

--- a/src/autopas/particles/Particle.h
+++ b/src/autopas/particles/Particle.h
@@ -14,14 +14,22 @@ namespace autopas {
 /**
  * Particle with all variables in 32 bit precision
  */
-using ParticleFP32 = ParticleBase<float, unsigned long>;
+using ParticleFP32 = ParticleBase<float, float, unsigned long>;
 /**
  * Particle with all variables in 64 bit precision
  */
-using ParticleFP64 = ParticleBase<double, unsigned long>;
+using ParticleFP64 = ParticleBase<double, double, unsigned long>;
 /**
- * Alias for Particle with all variables in 64 bit precision
+ * Particle with mixed precision for calculations and accumulation
  */
+using ParticleMP = ParticleBase<float, double, unsigned long>;
+
+#if AUTOPAS_PRECISION_MODE == SPSP
+using Particle = ParticleFP32;
+#elif AUTOPAS_PRECISION_MODE == DPDP
 using Particle = ParticleFP64;
+#else
+using Particle = ParticleMP;
+#endif
 
 }  // namespace autopas

--- a/src/autopas/particles/ParticleBase.h
+++ b/src/autopas/particles/ParticleBase.h
@@ -26,10 +26,11 @@ namespace autopas {
  *
  * If a different Particle class should be used with AutoPas this class must be used as a base to build your own
  * Particle class.
- * @tparam floatType Floating point type to be used for the SoAs.
+ * @tparam calcType Floating point type to be used for most calculations.
+ * @tparam accuType Floating point type to be used for accumulation values.
  * @tparam idType Integer type to be used for IDs.
  */
-template <typename floatType, typename idType>
+template <typename calcType, typename accuType, typename idType>
 class ParticleBase {
  public:
   ParticleBase()
@@ -42,7 +43,7 @@ class ParticleBase {
    * @param id Id of the particle.
    * @param ownershipState OwnershipState of the particle (can be either owned, halo, or dummy)
    */
-  ParticleBase(const std::array<double, 3> &r, const std::array<double, 3> &v, idType id,
+  ParticleBase(const std::array<calcType, 3> &r, const std::array<calcType, 3> &v, idType id,
                OwnershipState ownershipState = OwnershipState::owned)
       : _r(r), _v(v), _f({0.0, 0.0, 0.0}), _id(id), _ownershipState(ownershipState) {}
 
@@ -55,17 +56,17 @@ class ParticleBase {
   /**
    * Particle position as 3D coordinates.
    */
-  std::array<floatType, 3> _r;
+  std::array<calcType, 3> _r;
 
   /**
    * Particle velocity as 3D vector.
    */
-  std::array<floatType, 3> _v;
+  std::array<calcType, 3> _v;
 
   /**
    * Force the particle experiences as 3D vector.
    */
-  std::array<floatType, 3> _f;
+  std::array<accuType, 3> _f;
 
   /**
    * Particle id.
@@ -82,8 +83,8 @@ class ParticleBase {
    * Stream operator for instances of ParticleBase class.
    * @return String representation.
    */
-  template <typename T, typename P>
-  friend std::ostream &operator<<(std::ostream &os, const autopas::ParticleBase<T, P> &D);
+  template <typename C, typename A, typename P>
+  friend std::ostream &operator<<(std::ostream &os, const autopas::ParticleBase<C, A, P> &D);
 
   /**
    * Equality operator for ParticleBase class.
@@ -105,19 +106,19 @@ class ParticleBase {
    * get the force acting on the particle
    * @return force
    */
-  [[nodiscard]] const std::array<double, 3> &getF() const { return _f; }
+  [[nodiscard]] const std::array<accuType, 3> &getF() const { return _f; }
 
   /**
    * Set the force acting on the particle
    * @param f force
    */
-  void setF(const std::array<double, 3> &f) { _f = f; }
+  void setF(const std::array<accuType, 3> &f) { _f = f; }
 
   /**
    * Add a partial force to the force acting on the particle
    * @param f partial force to be added
    */
-  void addF(const std::array<double, 3> &f) {
+  void addF(const std::array<accuType, 3> &f) {
     using namespace autopas::utils::ArrayMath::literals;
     _f += f;
   }
@@ -126,7 +127,7 @@ class ParticleBase {
    * Substract a partial force from the force acting on the particle
    * @param f partial force to be substracted
    */
-  void subF(const std::array<double, 3> &f) {
+  void subF(const std::array<accuType, 3> &f) {
     using namespace autopas::utils::ArrayMath::literals;
     _f -= f;
   }
@@ -147,13 +148,13 @@ class ParticleBase {
    * Get the position of the particle
    * @return current position
    */
-  [[nodiscard]] const std::array<double, 3> &getR() const { return _r; }
+  [[nodiscard]] const std::array<calcType, 3> &getR() const { return _r; }
 
   /**
    * Set the position of the particle
    * @param r new position
    */
-  void setR(const std::array<double, 3> &r) { _r = r; }
+  void setR(const std::array<calcType, 3> &r) { _r = r; }
 
   /**
    * Add a distance vector to the position of the particle and check if the distance between the old and new position
@@ -164,10 +165,10 @@ class ParticleBase {
    * @param maxDistSquared The maximum expected movement distance squared.
    * @return true if dot(r - _r) < skinPerTimestepHalvedSquared
    */
-  bool setRDistanceCheck(const std::array<double, 3> &r, double maxDistSquared) {
+  bool setRDistanceCheck(const std::array<calcType, 3> &r, calcType maxDistSquared) {
     using namespace autopas::utils::ArrayMath::literals;
     const auto distanceVec = r - _r;
-    const double distanceSquared = utils::ArrayMath::dot(distanceVec, distanceVec);
+    const calcType distanceSquared = utils::ArrayMath::dot(distanceVec, distanceVec);
     setR(r);
     const bool distanceIsFine =
         distanceSquared < maxDistSquared or autopas::utils::Math::isNearAbs(maxDistSquared, 0., 1e-12);
@@ -182,7 +183,7 @@ class ParticleBase {
    * Add a distance vector to the position of the particle
    * @param r vector to be added
    */
-  void addR(const std::array<double, 3> &r) {
+  void addR(const std::array<calcType, 3> &r) {
     using namespace autopas::utils::ArrayMath::literals;
     _r += r;
   }
@@ -198,7 +199,7 @@ class ParticleBase {
    * @param maxDistSquared The maximum expected movement distance squared.
    * @return true if dot(r - _r) < skinPerTimestepHalvedSquared
    */
-  bool addRDistanceCheck(const std::array<double, 3> &r, double maxDistSquared) {
+  bool addRDistanceCheck(const std::array<calcType, 3> &r, calcType maxDistSquared) {
     using namespace autopas::utils::ArrayMath::literals;
     const auto newR = _r + r;
     return setRDistanceCheck(newR, maxDistSquared);
@@ -208,19 +209,19 @@ class ParticleBase {
    * Get the velocity of the particle
    * @return current velocity
    */
-  [[nodiscard]] const std::array<double, 3> &getV() const { return _v; }
+  [[nodiscard]] const std::array<calcType, 3> &getV() const { return _v; }
 
   /**
    * Set the velocity of the particle
    * @param v new velocity
    */
-  void setV(const std::array<double, 3> &v) { _v = v; }
+  void setV(const std::array<calcType, 3> &v) { _v = v; }
 
   /**
    * Add a vector to the current velocity of the particle
    * @param v vector to be added
    */
-  void addV(const std::array<double, 3> &v) {
+  void addV(const std::array<calcType, 3> &v) {
     using namespace autopas::utils::ArrayMath::literals;
     _v += v;
   }
@@ -282,9 +283,14 @@ class ParticleBase {
   enum AttributeNames : int { ptr, id, posX, posY, posZ, forceX, forceY, forceZ, ownershipState };
 
   /**
-   * Floating Point Type used for this particle
+   * Floating Point Type used for calculations for this particle
    */
-  using ParticleSoAFloatPrecision = floatType;
+  using ParticleCalcPrecision = calcType;
+
+  /**
+   * Floating Point Type used for accumulations for this particle
+   */
+  using ParticleAccuPrecision = accuType;
 
   /**
    * Id Type used for this particle
@@ -296,9 +302,9 @@ class ParticleBase {
    * owned is currently used as a floatType to ease calculations within the functors.
    */
   using SoAArraysType =
-      typename autopas::utils::SoAType<ParticleBase<floatType, idType> *, idType /*id*/, floatType /*x*/,
-                                       floatType /*y*/, floatType /*z*/, floatType /*fx*/, floatType /*fy*/,
-                                       floatType /*fz*/, OwnershipState /*ownershipState*/>::Type;
+      typename autopas::utils::SoAType<ParticleBase<calcType, accuType, idType> *, idType /*id*/, calcType /*x*/,
+                                       calcType /*y*/, calcType /*z*/, accuType /*fx*/, accuType /*fy*/,
+                                       accuType /*fz*/, OwnershipState /*ownershipState*/>::Type;
 
   /**
    * Non-const getter for the pointer of this object.
@@ -396,8 +402,8 @@ class ParticleBase {
  * @param particle
  * @return String representation.
  */
-template <typename floatType, typename idType>
-std::ostream &operator<<(std::ostream &os, const ParticleBase<floatType, idType> &particle) {
+template <typename calcType, typename accuType, typename idType>
+std::ostream &operator<<(std::ostream &os, const ParticleBase<calcType, accuType, idType> &particle) {
   using utils::ArrayUtils::operator<<;
   os << "Particle"
      << "\nID      : " << particle._id << "\nPosition: " << particle._r << "\nVelocity: " << particle._v

--- a/src/autopas/particles/ParticleBase.h
+++ b/src/autopas/particles/ParticleBase.h
@@ -188,12 +188,12 @@ class ParticleBase {
    * Get the last rebuild position of the particle
    * @return current rebuild position
    */
-  [[nodiscard]] const std::array<double, 3> &getRAtRebuild() const { return _rAtRebuild; }
+  [[nodiscard]] const std::array<CalcType, 3> &getRAtRebuild() const { return _rAtRebuild; }
   /**
    * Set the rebuild position of the particle
    * @param r rebuild position to be set
    */
-  void setRAtRebuild(const std::array<double, 3> &r) { _rAtRebuild = r; }
+  void setRAtRebuild(const std::array<CalcType, 3> &r) { _rAtRebuild = r; }
 
   /**
    * Update the rebuild position of the particle to current position
@@ -205,7 +205,7 @@ class ParticleBase {
    * This is used to check if neighbor lists are still valid inside the logic handler
    * @return displacement vector of particle since rebuild
    */
-  const std::array<double, 3> calculateDisplacementSinceRebuild() const {
+  const std::array<CalcType, 3> calculateDisplacementSinceRebuild() const {
     return utils::ArrayMath::sub(_rAtRebuild, _r);
   }
 #endif

--- a/src/autopas/particles/ParticleBase.h
+++ b/src/autopas/particles/ParticleBase.h
@@ -285,12 +285,12 @@ class ParticleBase {
   /**
    * Floating Point Type used for calculations for this particle
    */
-  using ParticleCalcPrecision = calcType;
+  using ParticleCalcType = calcType;
 
   /**
    * Floating Point Type used for accumulations for this particle
    */
-  using ParticleAccuPrecision = accuType;
+  using ParticleAccuType = accuType;
 
   /**
    * Id Type used for this particle

--- a/src/autopas/particles/ParticleBase.h
+++ b/src/autopas/particles/ParticleBase.h
@@ -26,11 +26,11 @@ namespace autopas {
  *
  * If a different Particle class should be used with AutoPas this class must be used as a base to build your own
  * Particle class.
- * @tparam calcType Floating point type to be used for most calculations.
- * @tparam accuType Floating point type to be used for accumulation values.
+ * @tparam CalcType Floating point type to be used for most calculations.
+ * @tparam AccuType Floating point type to be used for accumulation values.
  * @tparam idType Integer type to be used for IDs.
  */
-template <typename calcType, typename accuType, typename idType>
+template <typename CalcType, typename AccuType, typename idType>
 class ParticleBase {
  public:
   ParticleBase()
@@ -43,7 +43,7 @@ class ParticleBase {
    * @param id Id of the particle.
    * @param ownershipState OwnershipState of the particle (can be either owned, halo, or dummy)
    */
-  ParticleBase(const std::array<calcType, 3> &r, const std::array<calcType, 3> &v, idType id,
+  ParticleBase(const std::array<CalcType, 3> &r, const std::array<CalcType, 3> &v, idType id,
                OwnershipState ownershipState = OwnershipState::owned)
       : _r(r), _v(v), _f({0.0, 0.0, 0.0}), _id(id), _ownershipState(ownershipState) {}
 
@@ -56,17 +56,17 @@ class ParticleBase {
   /**
    * Particle position as 3D coordinates.
    */
-  std::array<calcType, 3> _r;
+  std::array<CalcType, 3> _r;
 
   /**
    * Particle velocity as 3D vector.
    */
-  std::array<calcType, 3> _v;
+  std::array<CalcType, 3> _v;
 
   /**
    * Force the particle experiences as 3D vector.
    */
-  std::array<accuType, 3> _f;
+  std::array<AccuType, 3> _f;
 
   /**
    * Particle id.
@@ -106,19 +106,19 @@ class ParticleBase {
    * get the force acting on the particle
    * @return force
    */
-  [[nodiscard]] const std::array<accuType, 3> &getF() const { return _f; }
+  [[nodiscard]] const std::array<AccuType, 3> &getF() const { return _f; }
 
   /**
    * Set the force acting on the particle
    * @param f force
    */
-  void setF(const std::array<accuType, 3> &f) { _f = f; }
+  void setF(const std::array<AccuType, 3> &f) { _f = f; }
 
   /**
    * Add a partial force to the force acting on the particle
    * @param f partial force to be added
    */
-  void addF(const std::array<accuType, 3> &f) {
+  void addF(const std::array<AccuType, 3> &f) {
     using namespace autopas::utils::ArrayMath::literals;
     _f += f;
   }
@@ -127,7 +127,7 @@ class ParticleBase {
    * Substract a partial force from the force acting on the particle
    * @param f partial force to be substracted
    */
-  void subF(const std::array<accuType, 3> &f) {
+  void subF(const std::array<AccuType, 3> &f) {
     using namespace autopas::utils::ArrayMath::literals;
     _f -= f;
   }
@@ -148,13 +148,13 @@ class ParticleBase {
    * Get the position of the particle
    * @return current position
    */
-  [[nodiscard]] const std::array<calcType, 3> &getR() const { return _r; }
+  [[nodiscard]] const std::array<CalcType, 3> &getR() const { return _r; }
 
   /**
    * Set the position of the particle
    * @param r new position
    */
-  void setR(const std::array<calcType, 3> &r) { _r = r; }
+  void setR(const std::array<CalcType, 3> &r) { _r = r; }
 
   /**
    * Add a distance vector to the position of the particle and check if the distance between the old and new position
@@ -165,10 +165,10 @@ class ParticleBase {
    * @param maxDistSquared The maximum expected movement distance squared.
    * @return true if dot(r - _r) < skinPerTimestepHalvedSquared
    */
-  bool setRDistanceCheck(const std::array<calcType, 3> &r, calcType maxDistSquared) {
+  bool setRDistanceCheck(const std::array<CalcType, 3> &r, CalcType maxDistSquared) {
     using namespace autopas::utils::ArrayMath::literals;
     const auto distanceVec = r - _r;
-    const calcType distanceSquared = utils::ArrayMath::dot(distanceVec, distanceVec);
+    const CalcType distanceSquared = utils::ArrayMath::dot(distanceVec, distanceVec);
     setR(r);
     const bool distanceIsFine =
         distanceSquared < maxDistSquared or autopas::utils::Math::isNearAbs(maxDistSquared, 0., 1e-12);
@@ -183,7 +183,7 @@ class ParticleBase {
    * Add a distance vector to the position of the particle
    * @param r vector to be added
    */
-  void addR(const std::array<calcType, 3> &r) {
+  void addR(const std::array<CalcType, 3> &r) {
     using namespace autopas::utils::ArrayMath::literals;
     _r += r;
   }
@@ -199,7 +199,7 @@ class ParticleBase {
    * @param maxDistSquared The maximum expected movement distance squared.
    * @return true if dot(r - _r) < skinPerTimestepHalvedSquared
    */
-  bool addRDistanceCheck(const std::array<calcType, 3> &r, calcType maxDistSquared) {
+  bool addRDistanceCheck(const std::array<CalcType, 3> &r, CalcType maxDistSquared) {
     using namespace autopas::utils::ArrayMath::literals;
     const auto newR = _r + r;
     return setRDistanceCheck(newR, maxDistSquared);
@@ -209,19 +209,19 @@ class ParticleBase {
    * Get the velocity of the particle
    * @return current velocity
    */
-  [[nodiscard]] const std::array<calcType, 3> &getV() const { return _v; }
+  [[nodiscard]] const std::array<CalcType, 3> &getV() const { return _v; }
 
   /**
    * Set the velocity of the particle
    * @param v new velocity
    */
-  void setV(const std::array<calcType, 3> &v) { _v = v; }
+  void setV(const std::array<CalcType, 3> &v) { _v = v; }
 
   /**
    * Add a vector to the current velocity of the particle
    * @param v vector to be added
    */
-  void addV(const std::array<calcType, 3> &v) {
+  void addV(const std::array<CalcType, 3> &v) {
     using namespace autopas::utils::ArrayMath::literals;
     _v += v;
   }
@@ -285,12 +285,12 @@ class ParticleBase {
   /**
    * Floating Point Type used for calculations for this particle
    */
-  using ParticleCalcType = calcType;
+  using ParticleCalcType = CalcType;
 
   /**
    * Floating Point Type used for accumulations for this particle
    */
-  using ParticleAccuType = accuType;
+  using ParticleAccuType = AccuType;
 
   /**
    * Id Type used for this particle
@@ -302,9 +302,9 @@ class ParticleBase {
    * owned is currently used as a floatType to ease calculations within the functors.
    */
   using SoAArraysType =
-      typename autopas::utils::SoAType<ParticleBase<calcType, accuType, idType> *, idType /*id*/, calcType /*x*/,
-                                       calcType /*y*/, calcType /*z*/, accuType /*fx*/, accuType /*fy*/,
-                                       accuType /*fz*/, OwnershipState /*ownershipState*/>::Type;
+      typename autopas::utils::SoAType<ParticleBase<CalcType, AccuType, idType> *, idType /*id*/, CalcType /*x*/,
+                                       CalcType /*y*/, CalcType /*z*/, AccuType /*fx*/, AccuType /*fy*/,
+                                       AccuType /*fz*/, OwnershipState /*ownershipState*/>::Type;
 
   /**
    * Non-const getter for the pointer of this object.
@@ -402,8 +402,8 @@ class ParticleBase {
  * @param particle
  * @return String representation.
  */
-template <typename calcType, typename accuType, typename idType>
-std::ostream &operator<<(std::ostream &os, const ParticleBase<calcType, accuType, idType> &particle) {
+template <typename CalcType, typename AccuType, typename idType>
+std::ostream &operator<<(std::ostream &os, const ParticleBase<CalcType, AccuType, idType> &particle) {
   using utils::ArrayUtils::operator<<;
   os << "Particle"
      << "\nID      : " << particle._id << "\nPosition: " << particle._r << "\nVelocity: " << particle._v

--- a/src/autopas/tuning/tuningStrategy/LiveInfo.h
+++ b/src/autopas/tuning/tuningStrategy/LiveInfo.h
@@ -222,15 +222,21 @@ class LiveInfo {
       if (particleIter->isOwned()) {
         numOwnedParticlesCount++;
         const auto particlePos = particleIter->getR();
-        if (utils::inBox(particlePos, boxMin, boxMax)) {
-          cellBinStruct.countParticle(particlePos);
-          particleDependentBinStruct.countParticle(particlePos);
-          blurredBinStruct.countParticle(particlePos);
+        std::array<double, 3> particlePosDouble{};
+        for (std::size_t d = 0; d < 3; ++d) {
+          particlePosDouble[d] = static_cast<double>(particlePos[d]);
+        }
+
+        if (utils::inBox(particlePosDouble, boxMin, boxMax)) {
+          cellBinStruct.countParticle(particlePosDouble);
+          particleDependentBinStruct.countParticle(particlePosDouble);
+          blurredBinStruct.countParticle(particlePosDouble);
         }
       } else if (particleIter->isHalo()) {
         numHaloParticlesCount++;
       }
     }
+
 
     // Sanity Check
     if (numOwnedParticlesCount != numOwnedParticles) {

--- a/src/autopas/tuning/tuningStrategy/LiveInfo.h
+++ b/src/autopas/tuning/tuningStrategy/LiveInfo.h
@@ -119,7 +119,7 @@ class LiveInfo {
     for (const Particle &particle : container) {
       if (utils::inBox(particle.getR(), boxMin, boxMax)) {
         // find the actual cell
-        const auto offsetIntoBox = particle.getR() - boxMin;
+        const auto offsetIntoBox = autopas::utils::ArrayUtils::static_cast_copy_array<double>(particle.getR()) - boxMin;
         const auto cell = floorToInt(offsetIntoBox * cutoffInv);
         const auto binIndex = (cell[2] * cellsPerDim[1] + cell[1]) * cellsPerDim[0] + cell[0];
         particleBins[binIndex]++;

--- a/src/autopas/utils/ArrayMath.h
+++ b/src/autopas/utils/ArrayMath.h
@@ -55,7 +55,7 @@ template <class T, std::size_t SIZE>
  * @tparam T floating point type
  * @tparam SIZE size of the array
  * @param a input array
- * @return New array with floored elements of new type int.
+ * @return New array with floored elements of new type int
  */
 template <class T, std::size_t SIZE>
 [[nodiscard]] constexpr std::array<int, SIZE> floorToInt(const std::array<T, SIZE> &a) {

--- a/src/autopas/utils/SimilarityFunctions.h
+++ b/src/autopas/utils/SimilarityFunctions.h
@@ -66,7 +66,7 @@ std::pair<double, double> calculateHomogeneityAndMaxDensity(const ParticleContai
 
   // add particles accordingly to their bin to get the amount of particles in each bin
   for (auto particleItr = container.begin(autopas::IteratorBehavior::owned); particleItr.isValid(); ++particleItr) {
-    const auto &particleLocation = particleItr->getR();
+    const auto &particleLocation = autopas::utils::ArrayUtils::static_cast_copy_array<double>(particleItr->getR());
 
     const auto binIndex3dUnsafe =
         autopas::utils::ArrayMath::floorToInt((particleLocation - container.getBoxMin()) / binDimensions);

--- a/src/autopas/utils/inBox.h
+++ b/src/autopas/utils/inBox.h
@@ -22,8 +22,9 @@ namespace autopas::utils {
  * @param high the upper corner of the box (exclusive)
  * @return true if position is inside the box, false otherwise
  */
-template <typename T>
-bool inBox(const std::array<T, 3> &position, const std::array<T, 3> &low, const std::array<T, 3> &high) {
+template <typename P, typename T>
+bool inBox(const std::array<P, 3> &position, const std::array<T, 3> &low, const std::array<T, 3> &high) {
+  static_assert(std::is_floating_point<P>::value, "inBox assumes floating point types");
   static_assert(std::is_floating_point<T>::value, "inBox assumes floating point types");
 
   bool inBox = true;
@@ -46,8 +47,8 @@ bool inBox(const std::array<T, 3> &position, const std::array<T, 3> &low, const 
  * @param high the upper corner of the box (exclusive)
  * @return true if position is not inside the box, false otherwise
  */
-template <typename T>
-bool notInBox(const std::array<T, 3> &position, const std::array<T, 3> &low, const std::array<T, 3> &high) {
+template <typename P, typename T>
+bool notInBox(const std::array<P, 3> &position, const std::array<T, 3> &low, const std::array<T, 3> &high) {
   return not(inBox(position, low, high));
 }
 

--- a/tests/testAutopas/tests/containers/CellBlock3DTest.cpp
+++ b/tests/testAutopas/tests/containers/CellBlock3DTest.cpp
@@ -168,9 +168,9 @@ TEST_F(CellBlock3DTest, testCellOwnership) {
   std::size_t numCells = _cells_1x1x1.getNumCells();
   for (int i = 0; i < numCells; i++) {
     if (_cells_1x1x1.cellCanContainHaloParticles(i)) {
-      EXPECT_TRUE(toInt64(_cells_1x1x1.getCell(i).getPossibleParticleOwnerships() & autopas::OwnershipState::halo));
+      EXPECT_TRUE(toIntType(_cells_1x1x1.getCell(i).getPossibleParticleOwnerships() & autopas::OwnershipState::halo));
     } else if (_cells_1x1x1.cellCanContainOwnedParticles(i)) {
-      EXPECT_TRUE(toInt64(_cells_1x1x1.getCell(i).getPossibleParticleOwnerships() & autopas::OwnershipState::owned));
+      EXPECT_TRUE(toIntType(_cells_1x1x1.getCell(i).getPossibleParticleOwnerships() & autopas::OwnershipState::owned));
     } else {
       EXPECT_TRUE(_cells_1x1x1.getCell(i).getPossibleParticleOwnerships() == autopas::OwnershipState::dummy);
     }

--- a/tools/autopasTools/generators/ClosestPackingGenerator.h
+++ b/tools/autopasTools/generators/ClosestPackingGenerator.h
@@ -16,6 +16,11 @@
  * Generator for grids of particles.
  */
 namespace autopasTools::generators::ClosestPackingGenerator {
+#if AUTOPAS_PRECISION_MODE == SPSP || AUTOPAS_PRECISION_MODE == SPDP
+using CalcType = float;
+#else
+using CalcType = double;
+#endif
 /**
  * Fills any container (also AutoPas object) with a hexagonally closest packed particles.
  * Particle properties will be used from the default particle. Particle IDs start from the default particle.
@@ -44,12 +49,12 @@ void fillWithParticles(Container &container, const std::array<double, 3> &boxMin
   bool evenLayer = true;
 
   size_t id = defaultParticle.getID();
-  for (double z = boxMin[2]; z < boxMax[2]; z += spacingLayer) {
+  for (CalcType z = boxMin[2]; z < boxMax[2]; z += spacingLayer) {
     double starty = evenLayer ? boxMin[1] : boxMin[1] + yOffset;
     bool evenRow = evenLayer;  // To ensure layers are alternating as for hexagonal close packed.
-    for (double y = starty; y < boxMax[1]; y += spacingRow) {
+    for (CalcType y = starty; y < boxMax[1]; y += spacingRow) {
       double startx = evenRow ? boxMin[0] : boxMin[0] + xOffset;
-      for (double x = startx; x < boxMax[0]; x += spacing) {
+      for (CalcType x = startx; x < boxMax[0]; x += spacing) {
         auto p = defaultParticle;
         p.setR({x, y, z});
         p.setID(id++);

--- a/tools/autopasTools/generators/GaussianGenerator.h
+++ b/tools/autopasTools/generators/GaussianGenerator.h
@@ -66,7 +66,7 @@ void fillWithParticles(Container &container, const std::array<double, 3> &boxMin
       position = {distributions[0](generator), distributions[1](generator), distributions[2](generator)};
     };
     auto p = defaultParticle;
-    p.setR(position);
+    p.setR(autopas::utils::ArrayUtils::static_cast_copy_array<CalcType>(position));
     p.setID(i);
     container.addParticle(p);
   }

--- a/tools/autopasTools/generators/GridGenerator.h
+++ b/tools/autopasTools/generators/GridGenerator.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "autopas/particles/OwnershipState.h"
+#include "autopas/utils/ArrayUtils.h"
 #include "autopas/utils/ParticleTypeTrait.h"
 #include "autopas/utils/ThreeDimensionalMapping.h"
 
@@ -15,6 +16,11 @@ namespace autopasTools::generators {
  * Generator for grids of particles.
  */
 namespace GridGenerator {
+#if AUTOPAS_PRECISION_MODE == SPSP || AUTOPAS_PRECISION_MODE == SPDP
+using CalcType = float;
+#else
+using CalcType = double;
+#endif
 /**
  * Fills a cell vector with a cuboid mesh of particles.
  *
@@ -97,7 +103,9 @@ void GridGenerator::fillWithParticles(
     for (unsigned int y = 0; y < particlesPerDim[1]; ++y) {
       for (unsigned int x = 0; x < particlesPerDim[0]; ++x) {
         auto p = defaultParticle;
-        p.setR({x * spacing[0] + offset[0], y * spacing[1] + offset[1], z * spacing[2] + offset[2]});
+        const std::array<double, 3> position{x * (spacing[0]) + offset[0], y * (spacing[1]) + offset[1],
+                                             z * (spacing[2]) + offset[2]};
+        p.setR(autopas::utils::ArrayUtils::static_cast_copy_array<CalcType>(position));
         p.setID(id++);
         container.addParticle(p);
       }

--- a/tools/autopasTools/generators/GridGenerator.h
+++ b/tools/autopasTools/generators/GridGenerator.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <type_traits>
 #include "autopas/particles/OwnershipState.h"
 #include "autopas/utils/ArrayUtils.h"
 #include "autopas/utils/ParticleTypeTrait.h"
@@ -74,8 +73,7 @@ void GridGenerator::fillWithParticles(std::vector<ParticleCell> &cells, const st
         std::array<unsigned long, 3> cellIndex3D{static_cast<unsigned long>(pos[0] / cellSize[0]),
                                                  static_cast<unsigned long>(pos[1] / cellSize[1]),
                                                  static_cast<unsigned long>(pos[2] / cellSize[2])};
-        using ParticlePosArray =
-          std::remove_cv_t<std::remove_reference_t<decltype(p.getR())>>;
+        using ParticlePosArray = decltype(p.getR());
         using ParticleCalcType = typename ParticlePosArray::value_type;
         auto posForParticle =
         autopas::utils::ArrayUtils::static_cast_copy_array<ParticleCalcType>(pos);
@@ -107,8 +105,7 @@ void GridGenerator::fillWithParticles(
         auto p = defaultParticle;
         const std::array<double, 3> position{x * (spacing[0]) + offset[0], y * (spacing[1]) + offset[1],
                                              z * (spacing[2]) + offset[2]};
-        using ParticlePosArray =
-          std::remove_cv_t<std::remove_reference_t<decltype(p.getR())>>;
+        using ParticlePosArray = decltype(p.getR());
         using ParticleCalcType = typename ParticlePosArray::value_type;
         auto posForParticle =
           autopas::utils::ArrayUtils::static_cast_copy_array<ParticleCalcType>(position);

--- a/tools/autopasTools/generators/GridGenerator.h
+++ b/tools/autopasTools/generators/GridGenerator.h
@@ -67,12 +67,21 @@ void GridGenerator::fillWithParticles(std::vector<ParticleCell> &cells, const st
     for (unsigned long y = 0; y < particlesPerDim[1]; ++y) {
       for (unsigned long x = 0; x < particlesPerDim[0]; ++x) {
         auto p = defaultParticle;
-        std::array<double, 3> pos{static_cast<double>(x) * spacing[0] + offset[0],
-                                  static_cast<double>(y) * spacing[1] + offset[1],
-                                  static_cast<double>(z) * spacing[2] + offset[2]};
-        std::array<unsigned long, 3> cellIndex3D{static_cast<unsigned long>(pos[0] / cellSize[0]),
-                                                 static_cast<unsigned long>(pos[1] / cellSize[1]),
-                                                 static_cast<unsigned long>(pos[2] / cellSize[2])};
+
+        std::array<double, 3> posDouble{static_cast<double>(x) * spacing[0] + offset[0],
+                                        static_cast<double>(y) * spacing[1] + offset[1],
+                                        static_cast<double>(z) * spacing[2] + offset[2]};
+
+        using ParticleCalcType = typename ParticleCell::ParticleType::ParticleCalcType;
+        std::array<ParticleCalcType, 3> pos{};
+        for (std::size_t d = 0; d < 3; ++d) {
+          pos[d] = static_cast<ParticleCalcType>(posDouble[d]);
+        }
+
+        std::array<unsigned long, 3> cellIndex3D{static_cast<unsigned long>(posDouble[0] / cellSize[0]),
+                                                 static_cast<unsigned long>(posDouble[1] / cellSize[1]),
+                                                 static_cast<unsigned long>(posDouble[2] / cellSize[2])};
+
         p.setR(pos);
         p.setID(id++);
         const auto cellIndex = autopas::utils::ThreeDimensionalMapping::threeToOneD(cellIndex3D, cellsPerDimension);
@@ -99,8 +108,16 @@ void GridGenerator::fillWithParticles(
     for (unsigned int y = 0; y < particlesPerDim[1]; ++y) {
       for (unsigned int x = 0; x < particlesPerDim[0]; ++x) {
         auto p = defaultParticle;
-        const std::array<double, 3> position{x * (spacing[0]) + offset[0], y * (spacing[1]) + offset[1],
-                                             z * (spacing[2]) + offset[2]};
+        const std::array<double, 3> positionDouble{x * (spacing[0]) + offset[0], y * (spacing[1]) + offset[1],
+                                                   z * (spacing[2]) + offset[2]};
+
+        using ParticleCalcType =
+            typename autopas::utils::ParticleTypeTrait<Container>::value::ParticleCalcType;
+        std::array<ParticleCalcType, 3> position{};
+        for (std::size_t d = 0; d < 3; ++d) {
+          position[d] = static_cast<ParticleCalcType>(positionDouble[d]);
+        }
+
         p.setR(position);
         p.setID(id++);
         container.addParticle(p);

--- a/tools/autopasTools/generators/GridGenerator.h
+++ b/tools/autopasTools/generators/GridGenerator.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <type_traits>
 #include "autopas/particles/OwnershipState.h"
 #include "autopas/utils/ArrayUtils.h"
 #include "autopas/utils/ParticleTypeTrait.h"
@@ -73,7 +74,8 @@ void GridGenerator::fillWithParticles(std::vector<ParticleCell> &cells, const st
         std::array<unsigned long, 3> cellIndex3D{static_cast<unsigned long>(pos[0] / cellSize[0]),
                                                  static_cast<unsigned long>(pos[1] / cellSize[1]),
                                                  static_cast<unsigned long>(pos[2] / cellSize[2])};
-        using ParticlePosArray = decltype(p.getR());
+        using ParticlePosArray =
+          std::remove_cv_t<std::remove_reference_t<decltype(p.getR())>>;
         using ParticleCalcType = typename ParticlePosArray::value_type;
         auto posForParticle =
         autopas::utils::ArrayUtils::static_cast_copy_array<ParticleCalcType>(pos);
@@ -105,7 +107,8 @@ void GridGenerator::fillWithParticles(
         auto p = defaultParticle;
         const std::array<double, 3> position{x * (spacing[0]) + offset[0], y * (spacing[1]) + offset[1],
                                              z * (spacing[2]) + offset[2]};
-        using ParticlePosArray = decltype(p.getR());
+        using ParticlePosArray =
+          std::remove_cv_t<std::remove_reference_t<decltype(p.getR())>>;
         using ParticleCalcType = typename ParticlePosArray::value_type;
         auto posForParticle =
           autopas::utils::ArrayUtils::static_cast_copy_array<ParticleCalcType>(position);

--- a/tools/autopasTools/generators/GridGenerator.h
+++ b/tools/autopasTools/generators/GridGenerator.h
@@ -16,7 +16,11 @@ namespace autopasTools::generators {
  * Generator for grids of particles.
  */
 namespace GridGenerator {
-
+#if AUTOPAS_PRECISION_MODE == SPSP || AUTOPAS_PRECISION_MODE == SPDP
+using CalcType = float;
+#else
+using CalcType = double;
+#endif
 /**
  * Fills a cell vector with a cuboid mesh of particles.
  *
@@ -73,11 +77,7 @@ void GridGenerator::fillWithParticles(std::vector<ParticleCell> &cells, const st
         std::array<unsigned long, 3> cellIndex3D{static_cast<unsigned long>(pos[0] / cellSize[0]),
                                                  static_cast<unsigned long>(pos[1] / cellSize[1]),
                                                  static_cast<unsigned long>(pos[2] / cellSize[2])};
-        using ParticlePosArray = decltype(p.getR());
-        using ParticleCalcType = typename ParticlePosArray::value_type;
-        auto posForParticle =
-        autopas::utils::ArrayUtils::static_cast_copy_array<ParticleCalcType>(pos);
-        p.setR(posForParticle);
+        p.setR(pos);
         p.setID(id++);
         const auto cellIndex = autopas::utils::ThreeDimensionalMapping::threeToOneD(cellIndex3D, cellsPerDimension);
 
@@ -105,14 +105,9 @@ void GridGenerator::fillWithParticles(
         auto p = defaultParticle;
         const std::array<double, 3> position{x * (spacing[0]) + offset[0], y * (spacing[1]) + offset[1],
                                              z * (spacing[2]) + offset[2]};
-        using ParticlePosArray = decltype(p.getR());
-        using ParticleCalcType = typename ParticlePosArray::value_type;
-        auto posForParticle =
-          autopas::utils::ArrayUtils::static_cast_copy_array<ParticleCalcType>(position);
-        p.setR(posForParticle);
+        p.setR(autopas::utils::ArrayUtils::static_cast_copy_array<CalcType>(position));
         p.setID(id++);
         container.addParticle(p);
-
       }
     }
   }

--- a/tools/autopasTools/generators/GridGenerator.h
+++ b/tools/autopasTools/generators/GridGenerator.h
@@ -16,11 +16,7 @@ namespace autopasTools::generators {
  * Generator for grids of particles.
  */
 namespace GridGenerator {
-#if AUTOPAS_PRECISION_MODE == SPSP || AUTOPAS_PRECISION_MODE == SPDP
-using CalcType = float;
-#else
-using CalcType = double;
-#endif
+
 /**
  * Fills a cell vector with a cuboid mesh of particles.
  *
@@ -105,7 +101,7 @@ void GridGenerator::fillWithParticles(
         auto p = defaultParticle;
         const std::array<double, 3> position{x * (spacing[0]) + offset[0], y * (spacing[1]) + offset[1],
                                              z * (spacing[2]) + offset[2]};
-        p.setR(autopas::utils::ArrayUtils::static_cast_copy_array<CalcType>(position));
+        p.setR(position);
         p.setID(id++);
         container.addParticle(p);
       }

--- a/tools/autopasTools/generators/GridGenerator.h
+++ b/tools/autopasTools/generators/GridGenerator.h
@@ -16,11 +16,7 @@ namespace autopasTools::generators {
  * Generator for grids of particles.
  */
 namespace GridGenerator {
-#if AUTOPAS_PRECISION_MODE == SPSP || AUTOPAS_PRECISION_MODE == SPDP
-using CalcType = float;
-#else
-using CalcType = double;
-#endif
+
 /**
  * Fills a cell vector with a cuboid mesh of particles.
  *
@@ -77,7 +73,11 @@ void GridGenerator::fillWithParticles(std::vector<ParticleCell> &cells, const st
         std::array<unsigned long, 3> cellIndex3D{static_cast<unsigned long>(pos[0] / cellSize[0]),
                                                  static_cast<unsigned long>(pos[1] / cellSize[1]),
                                                  static_cast<unsigned long>(pos[2] / cellSize[2])};
-        p.setR(pos);
+        using ParticlePosArray = decltype(p.getR());
+        using ParticleCalcType = typename ParticlePosArray::value_type;
+        auto posForParticle =
+        autopas::utils::ArrayUtils::static_cast_copy_array<ParticleCalcType>(pos);
+        p.setR(posForParticle);
         p.setID(id++);
         const auto cellIndex = autopas::utils::ThreeDimensionalMapping::threeToOneD(cellIndex3D, cellsPerDimension);
 
@@ -105,9 +105,14 @@ void GridGenerator::fillWithParticles(
         auto p = defaultParticle;
         const std::array<double, 3> position{x * (spacing[0]) + offset[0], y * (spacing[1]) + offset[1],
                                              z * (spacing[2]) + offset[2]};
-        p.setR(autopas::utils::ArrayUtils::static_cast_copy_array<CalcType>(position));
+        using ParticlePosArray = decltype(p.getR());
+        using ParticleCalcType = typename ParticlePosArray::value_type;
+        auto posForParticle =
+          autopas::utils::ArrayUtils::static_cast_copy_array<ParticleCalcType>(position);
+        p.setR(posForParticle);
         p.setID(id++);
         container.addParticle(p);
+
       }
     }
   }

--- a/tools/autopasTools/generators/UniformGenerator.h
+++ b/tools/autopasTools/generators/UniformGenerator.h
@@ -10,6 +10,7 @@
 #include <random>
 
 #include "autopas/particles/OwnershipState.h"
+#include "autopas/utils/ArrayUtils.h"
 #include "autopas/utils/inBox.h"
 
 namespace autopasTools::generators {
@@ -17,6 +18,11 @@ namespace autopasTools::generators {
  * Generator class for uniform distributions
  */
 namespace UniformGenerator {
+#if AUTOPAS_PRECISION_MODE == SPSP || AUTOPAS_PRECISION_MODE == SPDP
+using CalcType = float;
+#else
+using CalcType = double;
+#endif
 /**
  * Generate a random position within a given box.
  * @param generator Random engine
@@ -92,7 +98,8 @@ void UniformGenerator::fillWithParticles(Container &container, const Particle &d
 
   for (unsigned long i = defaultParticle.getID(); i < defaultParticle.getID() + numParticles; ++i) {
     Particle particle(defaultParticle);
-    particle.setR(randomPosition(generator, boxMin, boxMax));
+    particle.setR(
+        autopas::utils::ArrayUtils::static_cast_copy_array<CalcType>(randomPosition(generator, boxMin, boxMax)));
     particle.setID(i);
     particle.setOwnershipState(autopas::OwnershipState::owned);
     container.addParticle(particle);

--- a/tools/autopasTools/generators/UniformGenerator.h
+++ b/tools/autopasTools/generators/UniformGenerator.h
@@ -18,11 +18,7 @@ namespace autopasTools::generators {
  * Generator class for uniform distributions
  */
 namespace UniformGenerator {
-#if AUTOPAS_PRECISION_MODE == SPSP || AUTOPAS_PRECISION_MODE == SPDP
-using CalcType = float;
-#else
-using CalcType = double;
-#endif
+
 /**
  * Generate a random position within a given box.
  * @param generator Random engine
@@ -98,8 +94,8 @@ void UniformGenerator::fillWithParticles(Container &container, const Particle &d
 
   for (unsigned long i = defaultParticle.getID(); i < defaultParticle.getID() + numParticles; ++i) {
     Particle particle(defaultParticle);
-    particle.setR(
-        autopas::utils::ArrayUtils::static_cast_copy_array<CalcType>(randomPosition(generator, boxMin, boxMax)));
+    auto pos = randomPosition(generator, boxMin, boxMax);  // std::array<double,3>
+    particle.setR(pos);
     particle.setID(i);
     particle.setOwnershipState(autopas::OwnershipState::owned);
     container.addParticle(particle);

--- a/tools/autopasTools/generators/UniformGenerator.h
+++ b/tools/autopasTools/generators/UniformGenerator.h
@@ -94,8 +94,15 @@ void UniformGenerator::fillWithParticles(Container &container, const Particle &d
 
   for (unsigned long i = defaultParticle.getID(); i < defaultParticle.getID() + numParticles; ++i) {
     Particle particle(defaultParticle);
-    auto pos = randomPosition(generator, boxMin, boxMax);  // std::array<double,3>
-    particle.setR(pos);
+    auto pos = randomPosition(generator, boxMin, boxMax);  // std::array<double, 3>
+
+    using ParticleCalcType = typename Particle::ParticleCalcType;
+    std::array<ParticleCalcType, 3> posCast{};
+    for (std::size_t d = 0; d < 3; ++d) {
+      posCast[d] = static_cast<ParticleCalcType>(pos[d]);
+    }
+
+    particle.setR(posCast);
     particle.setID(i);
     particle.setOwnershipState(autopas::OwnershipState::owned);
     container.addParticle(particle);
@@ -123,8 +130,15 @@ void UniformGenerator::fillWithHaloParticles(Container &container, const Particl
     while (autopas::utils::inBox(pos, container.getBoxMin(), container.getBoxMax())) {
       pos = randomPosition(generator, haloBoxMin, haloBoxMax);
     }
+
+    using ParticleCalcType = typename Particle::ParticleCalcType;
+    std::array<ParticleCalcType, 3> posCast{};
+    for (std::size_t d = 0; d < 3; ++d) {
+      posCast[d] = static_cast<ParticleCalcType>(pos[d]);
+    }
+
     Particle particle(defaultParticle);
-    particle.setR(pos);
+    particle.setR(posCast);
     particle.setID(i);
     haloAddFunction(container, particle);
   }

--- a/tools/autopasTools/generators/UniformGenerator.h
+++ b/tools/autopasTools/generators/UniformGenerator.h
@@ -8,12 +8,10 @@
 
 #include <array>
 #include <random>
-#include <type_traits>
 
 #include "autopas/particles/OwnershipState.h"
 #include "autopas/utils/ArrayUtils.h"
 #include "autopas/utils/inBox.h"
-#include "autopas/utils/ParticleTypeTrait.h"
 
 namespace autopasTools::generators {
 /**
@@ -98,19 +96,15 @@ void UniformGenerator::fillWithParticles(Container &container, const Particle &d
                                          unsigned long numParticles, unsigned int seed) {
   std::mt19937 generator(seed);
 
-  using PositionArray     = std::remove_reference_t<decltype(defaultParticle.getR())>;
-  using PositionValueType = typename PositionArray::value_type;
-
   for (unsigned long i = defaultParticle.getID(); i < defaultParticle.getID() + numParticles; ++i) {
     Particle particle(defaultParticle);
-    particle.setR(autopas::utils::ArrayUtils::static_cast_copy_array<PositionValueType>(
-      randomPosition(generator, boxMin, boxMax)));
+    particle.setR(
+        autopas::utils::ArrayUtils::static_cast_copy_array<CalcType>(randomPosition(generator, boxMin, boxMax)));
     particle.setID(i);
     particle.setOwnershipState(autopas::OwnershipState::owned);
     container.addParticle(particle);
   }
 }
-
 
 template <class Container, class Particle, class HaloAddFunction>
 void UniformGenerator::fillWithHaloParticles(Container &container, const Particle &defaultParticle, double haloWidth,
@@ -127,9 +121,6 @@ void UniformGenerator::fillWithHaloParticles(Container &container, const Particl
     haloBoxMax[i] += haloWidth * .99;
   }
 
-  using PositionArray     = std::remove_reference_t<decltype(defaultParticle.getR())>;
-  using PositionValueType = typename PositionArray::value_type;
-
   for (unsigned long i = defaultParticle.getID(); i < defaultParticle.getID() + numParticles; ++i) {
     auto pos = randomPosition(generator, haloBoxMin, haloBoxMax);
     // we only want to add particles not in the actual box
@@ -137,7 +128,7 @@ void UniformGenerator::fillWithHaloParticles(Container &container, const Particl
       pos = randomPosition(generator, haloBoxMin, haloBoxMax);
     }
     Particle particle(defaultParticle);
-    particle.setR(autopas::utils::ArrayUtils::static_cast_copy_array<PositionValueType>(pos));
+    particle.setR(pos);
     particle.setID(i);
     haloAddFunction(container, particle);
   }


### PR DESCRIPTION
## Related Work

This PR reinstates functionality that was originally introduced in branch `<mixed-precision3>`
in commit `<c715e40fee4b70d7e22fd136d52ba64807596206>`.

Mixed-precision support was initially implemented there, but subsequent architectural
changes to AutoPas (template restructuring, container evolution, functor interface changes,
and type propagation adjustments) rendered that implementation incompatible with the
current main branch.

This PR reintroduces and adapts that functionality to the modern AutoPas architecture.

---

## Summary of Changes

This PR reintegrates mixed-precision support into the current AutoPas architecture,
restoring consistent functionality for:

- **DPDP** (double storage / double computation) — reference mode
- **SPDP** (single computation / double accumulation)
- **SPSP** (single storage / single computation)

### Main Technical Changes

- Reintroduced precision-mode handling via `AUTOPAS_PRECISION_MODE`.
- Restored and modernized `CalcType` propagation across containers, functors, and traversal code.
- Adapted the original mixed-precision design to match the current template architecture.
- Repaired SIMD conversion paths (SoA → `CalcType` buffers) for reduced-precision modes.
- Ensured consistent separation of storage precision and computation precision.
- Verified compatibility with `md-flexible` in all precision configurations.
- Performed manual numerical validation (accuracy, performance, energy experiments).

No behavioral changes were introduced for the DPDP reference configuration.

---

## Known Issues / Blockers Before Merge

### 1. Test Suite Currently Does Not Compile

- Existing unit and integration tests assume DP-only precision.
- Test targets fail to compile for SPDP and SPSP.
- Some fixtures hardcode `double` instead of using precision-dependent types.

**Required before merge:**
- Generalize tests to be precision-agnostic.
- Ensure successful compilation and execution for DPDP, SPDP, and SPSP.

---

### 2. Missing CI Matrix for Precision Modes

- CI currently builds only a single precision configuration.
- No automated validation exists for reduced-precision modes.

**Required before merge:**
- Add CI matrix entries for all precision modes.
- Ensure test targets pass for each configuration.

---

### 3. Reduced Precision + Periodic Boundary Conditions

- Reduced-precision configurations show limitations under periodic boundary conditions.
- Non-periodic runs are stable and validated.
- Root cause likely related to precision-sensitive coordinate wrapping.

**Required before merge (or document limitation explicitly):**
- Investigate numerical behavior of PBC wrapping in reduced precision.
- Ensure robust periodic handling or clearly restrict support.

---

## Validation Performed

Manual validation was performed using:

- Small LJ equilibration (256 particles)
- Large LJ equilibration (~512k particles)
- Heating sphere stability experiment
- Small & large performance benchmarks
- RAPL-based energy measurements

No systematic drift or instability between precision modes was observed in validated workloads.

---

## Risk Assessment

- DPDP behavior remains unchanged.
- Reduced-precision modes are numerically stable in validated scenarios.
- Remaining risks are limited to test infrastructure and periodic boundary robustness.
