### PR TITLE
Verlet Cluster List to work with Cell-Size-Factor > 1

### DIFF
--- a/src/autopas/containers/verletClusterLists/VerletClusterLists.h
+++ b/src/autopas/containers/verletClusterLists/VerletClusterLists.h
@@ -38,7 +38,7 @@ namespace autopas {
  * The VerletClusterLists class uses neighborhood lists for each cluster to calculate pairwise interactions of
  * particles. It is optimized for a constant, i.e. particle independent, cutoff radius of the interaction.
  *
- * This Container does (currently?) not make use of the cellSizeFactor.
+ * This Container only works with values greater than 1 for cellSizeFactor.
  *
  * The _particlesToAdd buffer structure is (currently) still necessary, even if the LogicHandler basically holds
  * the same buffer structure. In principle, moving the particles directly into one of the towers would be possible,
@@ -91,19 +91,24 @@ class VerletClusterLists : public ParticleContainerInterface<Particle_T>, public
    * @param boxMax The upper corner of the domain.
    * @param cutoff The cutoff radius of the interaction.
    * @param skin The skin radius.
+   * @param cellSizeFactor the cellSizeFactor, only values greater than 1 are currently allowed.
    * @param clusterSize Number of particles per cluster.
    * @param loadEstimator load estimation algorithm for balanced traversals.
    */
   VerletClusterLists(const std::array<double, 3> &boxMin, const std::array<double, 3> &boxMax, double cutoff,
-                     double skin, size_t clusterSize, LoadEstimatorOption loadEstimator = LoadEstimatorOption::none)
+                     double skin, const double cellSizeFactor, size_t clusterSize,
+                     LoadEstimatorOption loadEstimator = LoadEstimatorOption::none)
       : ParticleContainerInterface<Particle_T>(skin),
-        _towerBlock{boxMin, boxMax, cutoff + skin},
+        _towerBlock{boxMin, boxMax, std::max(1.0, cellSizeFactor) * (cutoff + skin)},
         _clusterSize{clusterSize},
         _particlesToAdd(autopas_get_max_threads()),
         _cutoff{cutoff},
         _loadEstimator(loadEstimator) {
     // always have at least one tower.
     _towerBlock.addTower(_clusterSize);
+    if (cellSizeFactor < 1.0) {
+      AutoPasLog(DEBUG, "VerletClusterList: CellSizeFactor smaller than 1 detected. Set to 1.");
+    }
   }
 
   [[nodiscard]] ContainerOption getContainerType() const override { return ContainerOption::verletClusterLists; }

--- a/src/autopas/tuning/selectors/ContainerSelector.h
+++ b/src/autopas/tuning/selectors/ContainerSelector.h
@@ -81,7 +81,7 @@ std::unique_ptr<ParticleContainerInterface<Particle_T>> ContainerSelector<Partic
       break;
     }
     case ContainerOption::verletClusterLists: {
-      container = std::make_unique<VerletClusterLists<Particle_T>>(boxMin, boxMax, cutoff, verletSkin,
+      container = std::make_unique<VerletClusterLists<Particle_T>>(boxMin, boxMax, cutoff, verletSkin, cellSizeFactor,
                                                                    verletClusterSize, loadEstimator);
       break;
     }

--- a/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
+++ b/tests/testAutopas/tests/containers/verletClusterLists/VerletClusterListsTest.cpp
@@ -21,7 +21,7 @@ TEST_F(VerletClusterListsTest, VerletListConstructor) {
   const double cutoff = 1.;
   const double skin = 0.2;
   const size_t clusterSize = 4;
-  const autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, clusterSize);
+  const autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, 1, clusterSize);
 }
 
 TEST_F(VerletClusterListsTest, testVerletListBuild) {
@@ -30,7 +30,7 @@ TEST_F(VerletClusterListsTest, testVerletListBuild) {
   const double cutoff = 1.;
   const double skin = 0.2;
   const size_t clusterSize = 4;
-  autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, clusterSize);
+  autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, 1, clusterSize);
 
   const std::array<double, 3> r = {2, 2, 2};
   const ParticleFP64 p(r, {0., 0., 0.}, 0);
@@ -54,7 +54,7 @@ TEST_F(VerletClusterListsTest, testAddParticlesAndBuildTwice) {
   const double skin = 0.2;
   const unsigned long numParticles = 271;
   const size_t clusterSize = 4;
-  autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, clusterSize);
+  autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, 1, clusterSize);
 
   autopasTools::generators::UniformGenerator::fillWithParticles(verletLists, ParticleFP64{}, verletLists.getBoxMin(),
                                                                 verletLists.getBoxMax(), numParticles);
@@ -75,7 +75,7 @@ TEST_F(VerletClusterListsTest, testIterator) {
   const double skin = 0.2;
   const unsigned long numParticles = 271;
   const size_t clusterSize = 4;
-  autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, clusterSize);
+  autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, 1, clusterSize);
 
   autopasTools::generators::UniformGenerator::fillWithParticles(verletLists, ParticleFP64{}, verletLists.getBoxMin(),
                                                                 verletLists.getBoxMax(), numParticles);
@@ -135,7 +135,7 @@ TEST_F(VerletClusterListsTest, testNeighborListsValidAfterMovingLessThanHalfSkin
   const double skin = 0.2;
   const unsigned long numParticles = 30;
   const size_t clusterSize = 4;
-  autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, clusterSize);
+  autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, 1, clusterSize);
 
   // Fill the container with random particles and build neighbor lists
   autopasTools::generators::UniformGenerator::fillWithParticles(verletLists, ParticleFP64{}, verletLists.getBoxMin(),
@@ -223,7 +223,7 @@ TEST_F(VerletClusterListsTest, testNewton3NeighborList) {
   std::unordered_map<size_t, std::vector<size_t>> neighborsNoN3{}, neighborsN3{};
 
   for (bool newton3 : {true, false}) {
-    autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, clusterSize);
+    autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, 1, clusterSize);
 
     autopasTools::generators::UniformGenerator::fillWithParticles(verletLists, ParticleFP64{}, verletLists.getBoxMin(),
                                                                   verletLists.getBoxMax(), numParticles);
@@ -264,7 +264,7 @@ TEST_F(VerletClusterListsTest, testGridAlignment) {
   const double cutoff{2.};
   const double skin{0.05};
   const size_t clusterSize{4};
-  autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, clusterSize);
+  autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, 1, clusterSize);
   size_t numParticles{0};
   // lower corner of the inner box, thus in the first inner tower
   const ParticleFP64 p0{boxMin, {0., 0., 0.}, numParticles++};
@@ -315,7 +315,7 @@ TEST_F(VerletClusterListsTest, testVerletListColoringTraversalNewton3NoDataRace)
   const double skin = 0.1;
   const int numParticles = 5000;
   const size_t clusterSize = 4;
-  autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, clusterSize);
+  autopas::VerletClusterLists<ParticleFP64> verletLists(boxMin, boxMax, cutoff, skin, 1, clusterSize);
 
   autopasTools::generators::UniformGenerator::fillWithParticles(verletLists, ParticleFP64{}, boxMin, boxMax,
                                                                 numParticles);


### PR DESCRIPTION
# Description

This PR enables use of cell-size-factor larger than 1 for `VerletClusterLists` based configurations. This can be helpful in certain scenarios. This is handled in the same way as `csf` in the `VerletListsCells` are currently handled.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] CI
- [x] Running all the tests locally
- [x] Example simulations with `csf > 1` 
- [ ] The coverage report shows all relevant lines are tested.
