### PR TITLE
Test1/3b traversal parallelization

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,13 @@
+have_fun: true
+memory_config:
+  disabled: false
+code_review:
+  disable: false
+  comment_severity_threshold: LOW
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: true
+    code_review: true
+    include_drafts: true
+ignore_patterns: []

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -1846,10 +1846,10 @@ void LogicHandler<Particle_T>::remainderHelper3bBufferContainerContainerAoS(
     index++;
   }
 
-  // Step 4: Iterate over the binned buffer particles in a 2-colored parallel manner.
-  for (auto color = 0; color < 2; color++) {
+  // Step 4: Iterate over the binned buffer particles in a 3-colored parallel manner.
+  for (auto color = 0; color < 3; color++) {
     AUTOPAS_OPENMP(parallel for)
-    for (auto i = 0 + color; i < binnedBufferParticles.size(); i += 2) {
+    for (auto i = 0 + color; i < binnedBufferParticles.size(); i += 3) {
       for (auto p1Iter = binnedBufferParticles[i].begin(); p1Iter != binnedBufferParticles[i].end(); ++p1Iter) {
         auto &[p1Index, p1Ptr] = *p1Iter;
         for (auto &[p2Ptr, p3Ptr] : bufferParticleNeighborLists[p1Index]) {

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -1664,7 +1664,7 @@ void LogicHandler<Particle_T>::computeRemainderInteractions3B(
 #endif
 
   // Step 3: Triwise interactions of 1 buffer particle and 2 container particles
-  remainderHelper3bBufferContainerContainerAoS<newton3>(bufferParticles, numOwnedBufferParticles, container, f);
+  remainderHelper3bBufferContainerContainerAoS<newton3>(bufferParticles, container, f);
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE
   timerBufferContainerContainer.stop();

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -1789,7 +1789,8 @@ void LogicHandler<Particle_T>::remainderHelper3bBufferContainerContainerAoS(
   }
   SortedCellView<ReferenceParticleCell<Particle_T>> sortedCellView(cellView, domainDiagonal);
 
-  // Step 2: Create a neighbor list of pairs for each of the buffer particles. Read-only, so it can be parallelized.
+  // Step 2: Create a neighbor list of pairs for each of the buffer particles.
+  // This step accesses all particles in read-only mode and can be fully parallelized.
   std::vector<std::vector<std::pair<Particle_T *, Particle_T *>>> bufferParticleNeighborLists(numBufferParticles);
 
   AUTOPAS_OPENMP(parallel for schedule(static))

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -969,7 +969,6 @@ class LogicHandler {
    * @tparam ContainerType Type of the particle container.
    * @tparam TriwiseFunctor Functor type to use for the interactions.
    * @param bufferParticles Vector of Particle pointers containing pointers to all buffer particles (owned and halo).
-   * @param numOwnedBufferParticles Number of owned particles. (First half of the bufferParticles).
    * @param container
    * @param f
    */

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -1637,7 +1637,7 @@ void LogicHandler<Particle_T>::computeRemainderInteractions3B(
   // Vector to collect pointers to all buffer particles
   std::vector<Particle_T *> bufferParticles;
   const auto numOwnedBufferParticles = collectBufferParticles(bufferParticles, particleBuffers, haloParticleBuffers);
-  std::cout << "Number of owned buffer particles: " << numOwnedBufferParticles << std::endl;
+
   // The following part performs the main remainder traversal.
 
   // only activate time measurements if it will actually be logged


### PR DESCRIPTION
# Description

This PR improves the method `LogicHandler::remainderHelper3bBufferContainerContainerAoS()`, which can become a bottleneck very quickly with just a few buffer particles. 
This is, because it was not parallelized and included many extra distance checks.

The following method is implemented now:
1. Place all buffer particles in a sorted cell view on a `ReferenceParticleCell`. The sorting direction is along the domain diagonal.
2. Create neighbor lists for all buffer particles, including all possible pairs for the buffer particles. This can be done fully parallel as it only reads on the container particles.
3. Bin the buffer particles in slices along the sorting direction with thickness = cutoff.
4. Separate the bins into 3 colors (black, white, red, black, white, red, ...). Iterate over the bins of each color, which can be parallelized because interactions of same-colored bins don't overlap.

## Resolved Issues

- [x] fixes #904

# How Has This Been Tested?

- [x] remainder traversal tests pass
- [x] Include performance comparisons to previous implementation.

<img width="865" height="551" alt="image" src="https://github.com/user-attachments/assets/b52a2a32-5451-4222-8614-a86e4532eff4" />

<details>
<summary> Configuration </summary>

```yaml
container                            :  [LinkedCells] # DirectSum
functor-3b                           :  axilrod-teller-muto
traversal-3b                         :  [lc_c01] # ds_sequential
newton3-3b                           :  [disabled]
data-layout-3b                       :  [SoA]

functor                              :  lj-avx
traversal                            :  [lc_c01]
newton3                              :  [disabled]
data-layout                          :  [SoA]

verlet-rebuild-frequency             :  10
verlet-skin-radius                   :  0.5

cutoff                               :  2.5
cell-size                            :  [1]
deltaT                               :  0.002
iterations                           :  300
boundary-type                        :  [periodic, periodic, periodic]
fastParticlesThrow                   :  false

Sites:
  0:
    epsilon                          :  1.
    sigma                            :  1.
    mass                             :  1.
    nu                               :  0.073 # Value for Argon
Objects:
  CubeClosestPacked:
    0:
      box-length                     :  [35, 35, 12]
      bottomLeftCorner               :  [0, 0, 0]
      particle-spacing               :  1.2
      velocity                       :  [0, 0, 0]
      particle-type-id               :  0
thermostat:
  initialTemperature                 :  3.0
  targetTemperature                  :  3.0
  deltaTemperature                   :  0.5
  thermostatInterval                 :  2
  addBrownianMotion                  :  true

log-level                            :  warn
no-end-config                        :  true
no-progress-bar                      :  true
``` 
</details>