### PR TITLE
Refactor CellFunctor and CellFunctor3B

### DIFF
--- a/examples/md-flexible/src/Simulation.cpp
+++ b/examples/md-flexible/src/Simulation.cpp
@@ -893,12 +893,12 @@ ReturnType Simulation::applyWithChosenFunctor3B(FunctionType f) {
   auto &particlePropertiesLibrary = *_configuration.getParticlePropertiesLibrary();
   switch (_configuration.functorOption3B.value) {
     case MDFlexConfig::FunctorOption3B::at: {
-#if defined(MD_FLEXIBLE_FUNCTOR_AT_AUTOVEC)
+#if defined(MD_FLEXIBLE_FUNCTOR_ATM_AUTOVEC)
       return f(ATMFunctor{cutoff, particlePropertiesLibrary});
 #else
       throw std::runtime_error(
           "MD-Flexible was not compiled with support for AxilrodTellerMuto Functor. Activate it via `cmake "
-          "-DMD_FLEXIBLE_FUNCTOR_AT_AUTOVEC=ON`.");
+          "-DMD_FLEXIBLE_FUNCTOR_ATM_AUTOVEC=ON`.");
 #endif
     }
     default: {

--- a/src/autopas/baseFunctors/CellFunctor.h
+++ b/src/autopas/baseFunctors/CellFunctor.h
@@ -87,7 +87,7 @@ class CellFunctor {
    */
   [[nodiscard]] bool shouldUseSorting(size_t particleCount, const std::array<double, 3> &sortingDirection) const {
     return particleCount >= _sortingThreshold and
-           (sortingDirection[0] != 0.0 and sortingDirection[1] != 0.0 and sortingDirection[2] != 0.0);
+           (sortingDirection[0] != 0.0 or sortingDirection[1] != 0.0 or sortingDirection[2] != 0.0);
   }
 
   /**

--- a/src/autopas/baseFunctors/CellFunctor.h
+++ b/src/autopas/baseFunctors/CellFunctor.h
@@ -138,60 +138,57 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::setSortingTh
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
 void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCell(ParticleCell_T &cell) {
-  // avoid force calculations if the cell contains only halo particles or if the cell is empty (=dummy)
+  const bool isAoS = _dataLayout == DataLayoutOption::aos ? true : false;
+  const bool isSoA = _dataLayout == DataLayoutOption::soa ? true : false;
+
+  // Return early if the cell is empty.
+  if ((isSoA and cell._particleSoABuffer.size() == 0) or (isAoS and cell.isEmpty())) {
+    return;
+  }
+  // Avoid force calculations if the cell contains only halo particles or if the cell is empty (=dummy)
   const bool cellHasOwnedParticles = toInt64(cell.getPossibleParticleOwnerships() & OwnershipState::owned);
   if (not cellHasOwnedParticles) {
     return;
   }
 
-  switch (_dataLayout) {
-    case DataLayoutOption::aos:
-      if (cell.isEmpty()) {
-        return;
-      }
-      processCellAoSImpl(cell);
-      break;
-    case DataLayoutOption::soa:
-      if (cell._particleSoABuffer.size() == 0) {
-        return;
-      }
-      _functor.SoAFunctorSingle(cell._particleSoABuffer, _useNewton3);
-      break;
+  if (isAoS) {
+    processCellAoSImpl(cell);
+  } else if (isSoA) {
+    _functor.SoAFunctorSingle(cell._particleSoABuffer, _useNewton3);
   }
 }
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
 void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPair(
     ParticleCell_T &cell1, ParticleCell_T &cell2, const std::array<double, 3> &sortingDirection) {
-  const bool cell1HasOwnedParticles = toInt64(cell1.getPossibleParticleOwnerships() & OwnershipState::owned);
-  const bool cell2HasOwnedParticles = toInt64(cell2.getPossibleParticleOwnerships() & OwnershipState::owned);
+  const bool isAoS = _dataLayout == DataLayoutOption::aos ? true : false;
+  const bool isSoA = _dataLayout == DataLayoutOption::soa ? true : false;
 
-  // Avoid force calculations if both cells cannot contain owned particles.
-  if (not cell1HasOwnedParticles and not cell2HasOwnedParticles) {
+  // Return early if a cell is empty.
+  if ((isSoA and (cell1._particleSoABuffer.size() == 0 or cell2._particleSoABuffer.size() == 0)) or
+      (isAoS and (cell1.isEmpty() or cell2.isEmpty()))) {
     return;
   }
 
-  // In Newton3==false and functor is not bidirectional, only interactions from cell1 to cell2 are computed. Therefore,
-  // if cell1 cannot contain owned particles, there is nothing useful to do.
-  if constexpr (not bidirectional) {
-    if (not _useNewton3 and not cell1HasOwnedParticles) {
+  const bool cell1HasOwnedParticles = toInt64(cell1.getPossibleParticleOwnerships() & OwnershipState::owned);
+  if (not cell1HasOwnedParticles) {
+    // Nothing to do if cell1 has no owned particles and we don't write to cell2 particles.
+    if constexpr (not bidirectional) {
+      if (not _useNewton3) {
+        return;
+      }
+    }
+    // Nothing to do if both cells cannot have owned particles.
+    const bool cell2HasOwnedParticles = toInt64(cell2.getPossibleParticleOwnerships() & OwnershipState::owned);
+    if (not cell2HasOwnedParticles) {
       return;
     }
   }
 
-  switch (_dataLayout) {
-    case DataLayoutOption::aos:
-      if (cell1.isEmpty() or cell2.isEmpty()) {
-        return;
-      }
-      processCellPairAoSImpl(cell1, cell2, sortingDirection);
-      break;
-    case DataLayoutOption::soa:
-      if (cell1._particleSoABuffer.size() == 0 or cell2._particleSoABuffer.size() == 0) {
-        return;
-      }
-      processCellPairSoAImpl(cell1, cell2);
-      break;
+  if (isAoS) {
+    processCellPairAoSImpl(cell1, cell2, sortingDirection);
+  } else if (isSoA) {
+    processCellPairSoAImpl(cell1, cell2);
   }
 }
 

--- a/src/autopas/baseFunctors/CellFunctor.h
+++ b/src/autopas/baseFunctors/CellFunctor.h
@@ -147,8 +147,7 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCell(
     return;
   }
   // Avoid force calculations if the cell contains only halo particles or if the cell is empty (=dummy)
-  const bool cellHasOwnedParticles = toInt64(cell.getPossibleParticleOwnerships() & OwnershipState::owned);
-  if (not cellHasOwnedParticles) {
+  if (not cell.canHaveOwnedParticles()) {
     return;
   }
 
@@ -171,8 +170,7 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellP
     return;
   }
 
-  const bool cell1HasOwnedParticles = toInt64(cell1.getPossibleParticleOwnerships() & OwnershipState::owned);
-  if (not cell1HasOwnedParticles) {
+  if (not cell1.canHaveOwnedParticles()) {
     // Nothing to do if cell1 has no owned particles and we don't write to cell2 particles.
     if constexpr (not bidirectional) {
       if (not _useNewton3) {
@@ -180,8 +178,7 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellP
       }
     }
     // Nothing to do if both cells cannot have owned particles.
-    const bool cell2HasOwnedParticles = toInt64(cell2.getPossibleParticleOwnerships() & OwnershipState::owned);
-    if (not cell2HasOwnedParticles) {
+    if (not cell2.canHaveOwnedParticles()) {
       return;
     }
   }

--- a/src/autopas/baseFunctors/CellFunctor.h
+++ b/src/autopas/baseFunctors/CellFunctor.h
@@ -79,32 +79,15 @@ class CellFunctor {
   void setSortingThreshold(size_t sortingThreshold);
 
  private:
-  static constexpr std::array<double, 3> zeroDirection{0., 0., 0.};
-
-  /**
-   * Returns true if the given cell is empty for the current _dataLayout.
-   * @param cell
-   * @return whether the given cell is empty.
-   */
-  [[nodiscard]] bool cellIsEmptyForCurrentLayout(const ParticleCell_T &cell) const {
-    switch (_dataLayout) {
-      case DataLayoutOption::aos:
-        return cell.isEmpty();
-      case DataLayoutOption::soa:
-        return cell._particleSoABuffer.size() == 0;
-    }
-    utils::ExceptionHandler::exception("CellFunctor::cellIsEmptyForCurrentLayout(): Unsupported data layout.");
-    return false;
-  }
-
   /**
    *
    * @param particleCount
    * @param sortingDirection
    * @return
    */
-  [[nodiscard]] bool shouldUseSorting(std::size_t particleCount, const std::array<double, 3> &sortingDirection) const {
-    return particleCount >= _sortingThreshold and sortingDirection != zeroDirection;
+  [[nodiscard]] bool shouldUseSorting(size_t particleCount, const std::array<double, 3> &sortingDirection) const {
+    return particleCount >= _sortingThreshold and
+           (sortingDirection[0] != 0.0 and sortingDirection[1] != 0.0 and sortingDirection[2] != 0.0);
   }
 
   /**
@@ -161,10 +144,6 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::setSortingTh
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
 void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCell(ParticleCell_T &cell) {
-  if (cellIsEmptyForCurrentLayout(cell)) {
-    return;
-  }
-
   // avoid force calculations if the cell contains only halo particles or if the cell is empty (=dummy)
   const bool cellHasOwnedParticles = toInt64(cell.getPossibleParticleOwnerships() & OwnershipState::owned);
   if (not cellHasOwnedParticles) {
@@ -173,6 +152,9 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCell(
 
   switch (_dataLayout) {
     case DataLayoutOption::aos:
+      if (cell.isEmpty()) {
+        return;
+      }
       if (_useNewton3) {
         processCellAoSImpl<true>(cell);
       } else {
@@ -180,6 +162,9 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCell(
       }
       break;
     case DataLayoutOption::soa:
+      if (cell._particleSoABuffer.size() == 0) {
+        return;
+      }
       _functor.SoAFunctorSingle(cell._particleSoABuffer, _useNewton3);
       break;
   }
@@ -188,10 +173,6 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCell(
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
 void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPair(
     ParticleCell_T &cell1, ParticleCell_T &cell2, const std::array<double, 3> &sortingDirection) {
-  if (cellIsEmptyForCurrentLayout(cell1) or cellIsEmptyForCurrentLayout(cell2)) {
-    return;
-  }
-
   const bool cell1HasOwnedParticles = toInt64(cell1.getPossibleParticleOwnerships() & OwnershipState::owned);
   const bool cell2HasOwnedParticles = toInt64(cell2.getPossibleParticleOwnerships() & OwnershipState::owned);
 
@@ -210,6 +191,9 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellP
 
   switch (_dataLayout) {
     case DataLayoutOption::aos:
+      if (cell1.isEmpty() or cell2.isEmpty()) {
+        return;
+      }
       if (_useNewton3) {
         processCellPairAoSImpl<true>(cell1, cell2, sortingDirection);
       } else {
@@ -217,6 +201,9 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellP
       }
       break;
     case DataLayoutOption::soa:
+      if (cell1._particleSoABuffer.size() == 0 or cell2._particleSoABuffer.size() == 0) {
+        return;
+      }
       if (_useNewton3) {
         processCellPairSoAImpl<true>(cell1, cell2);
       } else {
@@ -230,15 +217,15 @@ template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
 template <bool newton3>
 void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellAoSImpl(ParticleCell_T &cell) {
   // helper function
-  const auto interactParticles = [this](auto &p1, auto &p2) {
+  const auto interactParticles = [&f = this->_functor](auto &p1, auto &p2) {
     if constexpr (newton3) {
-      _functor.AoSFunctor(p1, p2, true);
+      f.AoSFunctor(p1, p2, true);
     } else {
       if (not p1.isHalo()) {
-        _functor.AoSFunctor(p1, p2, false);
+        f.AoSFunctor(p1, p2, false);
       }
       if (not p2.isHalo()) {
-        _functor.AoSFunctor(p2, p1, false);
+        f.AoSFunctor(p2, p1, false);
       }
     }
   };
@@ -272,14 +259,14 @@ template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
 template <bool newton3>
 void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairAoSImpl(
     ParticleCell_T &cell1, ParticleCell_T &cell2, const std::array<double, 3> &sortingDirection) {
-  const auto interactParticles = [this](auto &p1, auto &p2) {
+  const auto interactParticles = [&f = this->_functor](auto &p1, auto &p2) {
     if constexpr (newton3) {
-      _functor.AoSFunctor(p1, p2, true);
+      f.AoSFunctor(p1, p2, true);
     } else {
-      _functor.AoSFunctor(p1, p2, false);
+      f.AoSFunctor(p1, p2, false);
 
       if constexpr (bidirectional) {
-        _functor.AoSFunctor(p2, p1, false);
+        f.AoSFunctor(p2, p1, false);
       }
     }
   };

--- a/src/autopas/baseFunctors/CellFunctor.h
+++ b/src/autopas/baseFunctors/CellFunctor.h
@@ -195,16 +195,11 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellP
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
 void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellAoSImpl(ParticleCell_T &cell) {
   // helper function
-  const auto interactParticles = [&f = this->_functor, n3 = this->_useNewton3](auto &p1, auto &p2) {
-    if (n3) {
-      f.AoSFunctor(p1, p2, true);
-    } else {
-      if (not p1.isHalo()) {
-        f.AoSFunctor(p1, p2, false);
-      }
-      if (not p2.isHalo()) {
-        f.AoSFunctor(p2, p1, false);
-      }
+  const auto interactParticles = [this](auto &p1, auto &p2) {
+    this->_functor.AoSFunctor(p1, p2, this->_useNewton3);
+
+    if (not this->_useNewton3) {
+      this->_functor.AoSFunctor(p2, p1, false);
     }
   };
 
@@ -236,14 +231,11 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellA
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
 void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairAoSImpl(
     ParticleCell_T &cell1, ParticleCell_T &cell2, const std::array<double, 3> &sortingDirection) {
-  const auto interactParticles = [&f = this->_functor, n3 = this->_useNewton3](auto &p1, auto &p2) {
-    if (n3) {
-      f.AoSFunctor(p1, p2, true);
-    } else {
-      f.AoSFunctor(p1, p2, false);
-
-      if constexpr (bidirectional) {
-        f.AoSFunctor(p2, p1, false);
+  const auto interactParticles = [this](auto &p1, auto &p2) {
+    this->_functor.AoSFunctor(p1, p2, this->_useNewton3);
+    if constexpr (bidirectional) {
+      if (not this->_useNewton3) {
+        this->_functor.AoSFunctor(p2, p1, false);
       }
     }
   };
@@ -276,12 +268,9 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellP
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
 void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairSoAImpl(ParticleCell_T &cell1,
                                                                                            ParticleCell_T &cell2) {
-  if (_useNewton3) {
-    _functor.SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, true);
-  } else {
-    _functor.SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, false);
-
-    if constexpr (bidirectional) {
+  _functor.SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, _useNewton3);
+  if constexpr (bidirectional) {
+    if (not _useNewton3) {
       _functor.SoAFunctorPair(cell2._particleSoABuffer, cell1._particleSoABuffer, false);
     }
   }

--- a/src/autopas/baseFunctors/CellFunctor.h
+++ b/src/autopas/baseFunctors/CellFunctor.h
@@ -80,10 +80,10 @@ class CellFunctor {
 
  private:
   /**
-   *
-   * @param particleCount
-   * @param sortingDirection
-   * @return
+   * Evaluate whether the AoSFunctor should use sorting, depending on the set sorting threshold.
+   * @param particleCount Total number of involved particles.
+   * @param sortingDirection No sorting when the sorting direction is {0., 0., 0.}.
+   * @return whether the AoSFunctor should use the SortedCellView.
    */
   [[nodiscard]] bool shouldUseSorting(size_t particleCount, const std::array<double, 3> &sortingDirection) const {
     return particleCount >= _sortingThreshold and
@@ -94,8 +94,9 @@ class CellFunctor {
    * Applies the functor to all particle pairs exploiting Newton's third law of motion.
    * There is only one version of this function as newton3 is always allowed to be applied inside a cell.
    * The value of newton3 defines how to apply the aos functor:
-   * - If newton3 is true: The aos functor will be applied once for each pair (only i,j), passing newton3=true.
-   * - If newton3 is false: The aos functor will be applied twice for each pair (i,j and j,i), passing newton3=false.
+   * - If _useNewton3 is true: The aos functor will be applied once for each pair (only i,j), passing newton3=true.
+   * - If _useNewton3 is false: The aos functor will be applied twice for each pair (i,j and j,i), passing
+   * newton3=false.
    * @param cell
    */
   void processCellAoSImpl(ParticleCell_T &cell);

--- a/src/autopas/baseFunctors/CellFunctor.h
+++ b/src/autopas/baseFunctors/CellFunctor.h
@@ -14,33 +14,33 @@
 namespace autopas::internal {
 /**
  * A cell functor. This functor is built from the normal Functor of the template
- * type ParticleFunctor. It is an internal object to handle interactions between
+ * type ParticleFunctor_T. It is an internal object to handle interactions between
  * two cells of particles.
- * @tparam ParticleCell
- * @tparam ParticleFunctor the functor which
+ * @tparam ParticleCell_T
+ * @tparam ParticleFunctor_T the functor which
  * @tparam bidirectional if no newton3 is used processCellPair(cell1, cell2) should also handle processCellPair(cell2,
  * cell1)
  */
-template <class ParticleCell, class ParticleFunctor, bool bidirectional = true>
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional = true>
 class CellFunctor {
  public:
   /**
    * The constructor of CellFunctor.
-   * @param f The ParticleFunctor which should be used for the interaction.
+   * @param f The particle functor, which should be used for the interaction.
    * @param sortingCutoff This parameter indicates the maximal distance the sorted particles are to interact. This
    * parameter is only relevant for optimization (sorting). This parameter normally should be the cutoff, for building
    * verlet lists, this should be cutoff+skin.
    * @param dataLayout The data layout to be used.
    * @param useNewton3 Parameter to specify whether newton3 is used or not.
    */
-  explicit CellFunctor(ParticleFunctor &f, const double sortingCutoff, DataLayoutOption dataLayout, bool useNewton3)
+  explicit CellFunctor(ParticleFunctor_T &f, const double sortingCutoff, DataLayoutOption dataLayout, bool useNewton3)
       : _functor(f), _sortingCutoff(sortingCutoff), _dataLayout(dataLayout), _useNewton3(useNewton3) {}
 
   /**
    * Process the interactions inside one cell.
    * @param cell All pairwise interactions of particles inside this cell are calculated.
    */
-  void processCell(ParticleCell &cell);
+  void processCell(ParticleCell_T &cell);
 
   /**
    * Process the interactions between the particles of cell1 with particles of cell2.
@@ -49,7 +49,7 @@ class CellFunctor {
    * @param sortingDirection Normalized vector connecting centers of cell1 and cell2. If no parameter or {0, 0, 0} is
    * given, sorting will be disabled.
    */
-  void processCellPair(ParticleCell &cell1, ParticleCell &cell2,
+  void processCellPair(ParticleCell_T &cell1, ParticleCell_T &cell2,
                        const std::array<double, 3> &sortingDirection = {0., 0., 0.});
 
   /**
@@ -89,7 +89,7 @@ class CellFunctor {
    * newton3=false.
    * @param cell
    */
-  void processCellAoS(ParticleCell &cell);
+  void processCellAoS(ParticleCell_T &cell);
 
   /**
    * Applies the functor to all particle pairs between cell1 and cell2
@@ -98,7 +98,8 @@ class CellFunctor {
    * @param cell2
    * @param sortingDirection Normalized vector connecting centers of cell1 and cell2.
    */
-  void processCellPairAoSN3(ParticleCell &cell1, ParticleCell &cell2, const std::array<double, 3> &sortingDirection);
+  void processCellPairAoSN3(ParticleCell_T &cell1, ParticleCell_T &cell2,
+                            const std::array<double, 3> &sortingDirection);
 
   /**
    * Applies the functor to all particle pairs between cell1 and cell2
@@ -107,17 +108,18 @@ class CellFunctor {
    * @param cell2
    * @param sortingDirection Normalized vector connecting centers of cell1 and cell2.
    */
-  void processCellPairAoSNoN3(ParticleCell &cell1, ParticleCell &cell2, const std::array<double, 3> &sortingDirection);
+  void processCellPairAoSNoN3(ParticleCell_T &cell1, ParticleCell_T &cell2,
+                              const std::array<double, 3> &sortingDirection);
 
-  void processCellPairSoAN3(ParticleCell &cell1, ParticleCell &cell2);
+  void processCellPairSoAN3(ParticleCell_T &cell1, ParticleCell_T &cell2);
 
-  void processCellPairSoANoN3(ParticleCell &cell1, ParticleCell &cell2);
+  void processCellPairSoANoN3(ParticleCell_T &cell1, ParticleCell_T &cell2);
 
-  void processCellSoAN3(ParticleCell &cell);
+  void processCellSoAN3(ParticleCell_T &cell);
 
-  void processCellSoANoN3(ParticleCell &cell);
+  void processCellSoANoN3(ParticleCell_T &cell);
 
-  ParticleFunctor &_functor;
+  ParticleFunctor_T &_functor;
 
   const double _sortingCutoff;
 
@@ -132,13 +134,13 @@ class CellFunctor {
   bool _useNewton3;
 };
 
-template <class ParticleCell, class ParticleFunctor, bool bidirectional>
-void CellFunctor<ParticleCell, ParticleFunctor, bidirectional>::setSortingThreshold(size_t sortingThreshold) {
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
+void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::setSortingThreshold(size_t sortingThreshold) {
   _sortingThreshold = sortingThreshold;
 }
 
-template <class ParticleCell, class ParticleFunctor, bool bidirectional>
-void CellFunctor<ParticleCell, ParticleFunctor, bidirectional>::processCell(ParticleCell &cell) {
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
+void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCell(ParticleCell_T &cell) {
   if ((_dataLayout == DataLayoutOption::soa and cell._particleSoABuffer.size() == 0) or
       (_dataLayout == DataLayoutOption::aos and cell.isEmpty())) {
     return;
@@ -165,9 +167,9 @@ void CellFunctor<ParticleCell, ParticleFunctor, bidirectional>::processCell(Part
   }
 }
 
-template <class ParticleCell, class ParticleFunctor, bool bidirectional>
-void CellFunctor<ParticleCell, ParticleFunctor, bidirectional>::processCellPair(
-    ParticleCell &cell1, ParticleCell &cell2, const std::array<double, 3> &sortingDirection) {
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
+void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPair(
+    ParticleCell_T &cell1, ParticleCell_T &cell2, const std::array<double, 3> &sortingDirection) {
   if ((_dataLayout == DataLayoutOption::soa and
        (cell1._particleSoABuffer.size() == 0 or cell2._particleSoABuffer.size() == 0)) or
       (_dataLayout == DataLayoutOption::aos and (cell1.isEmpty() or cell2.isEmpty()))) {
@@ -203,8 +205,8 @@ void CellFunctor<ParticleCell, ParticleFunctor, bidirectional>::processCellPair(
   }
 }
 
-template <class ParticleCell, class ParticleFunctor, bool bidirectional>
-void CellFunctor<ParticleCell, ParticleFunctor, bidirectional>::processCellAoS(ParticleCell &cell) {
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
+void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellAoS(ParticleCell_T &cell) {
   // helper function
   const auto interactParticles = [&](auto &p1, auto &p2) {
     if (_useNewton3) {
@@ -220,7 +222,7 @@ void CellFunctor<ParticleCell, ParticleFunctor, bidirectional>::processCellAoS(P
   };
 
   if (cell.size() > _sortingThreshold) {
-    SortedCellView<ParticleCell> cellSorted(cell, utils::ArrayMath::normalize(cell.getCellLength()));
+    SortedCellView<ParticleCell_T> cellSorted(cell, utils::ArrayMath::normalize(cell.getCellLength()));
 
     for (auto cellIter1 = cellSorted._particles.begin(); cellIter1 != cellSorted._particles.end(); ++cellIter1) {
       auto &[p1Projection, p1Ptr] = *cellIter1;
@@ -244,12 +246,12 @@ void CellFunctor<ParticleCell, ParticleFunctor, bidirectional>::processCellAoS(P
   }
 }
 
-template <class ParticleCell, class ParticleFunctor, bool bidirectional>
-void CellFunctor<ParticleCell, ParticleFunctor, bidirectional>::processCellPairAoSN3(
-    ParticleCell &cell1, ParticleCell &cell2, const std::array<double, 3> &sortingDirection) {
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
+void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairAoSN3(
+    ParticleCell_T &cell1, ParticleCell_T &cell2, const std::array<double, 3> &sortingDirection) {
   if ((cell1.size() + cell2.size() > _sortingThreshold) and (sortingDirection != std::array<double, 3>{0., 0., 0.})) {
-    SortedCellView<ParticleCell> cell1Sorted(cell1, sortingDirection);
-    SortedCellView<ParticleCell> cell2Sorted(cell2, sortingDirection);
+    SortedCellView<ParticleCell_T> cell1Sorted(cell1, sortingDirection);
+    SortedCellView<ParticleCell_T> cell2Sorted(cell2, sortingDirection);
 
     for (auto &[p1Projection, p1Ptr] : cell1Sorted._particles) {
       for (auto &[p2Projection, p2Ptr] : cell2Sorted._particles) {
@@ -268,9 +270,9 @@ void CellFunctor<ParticleCell, ParticleFunctor, bidirectional>::processCellPairA
   }
 }
 
-template <class ParticleCell, class ParticleFunctor, bool bidirectional>
-void CellFunctor<ParticleCell, ParticleFunctor, bidirectional>::processCellPairAoSNoN3(
-    ParticleCell &cell1, ParticleCell &cell2, const std::array<double, 3> &sortingDirection) {
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
+void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairAoSNoN3(
+    ParticleCell_T &cell1, ParticleCell_T &cell2, const std::array<double, 3> &sortingDirection) {
   // helper function
   const auto interactParticlesNoN3 = [&](auto &p1, auto &p2) {
     _functor.AoSFunctor(p1, p2, false);
@@ -280,8 +282,8 @@ void CellFunctor<ParticleCell, ParticleFunctor, bidirectional>::processCellPairA
   };
 
   if ((cell1.size() + cell2.size() > _sortingThreshold) and (sortingDirection != std::array<double, 3>{0., 0., 0.})) {
-    SortedCellView<ParticleCell> cell1Sorted(cell1, sortingDirection);
-    SortedCellView<ParticleCell> cell2Sorted(cell2, sortingDirection);
+    SortedCellView<ParticleCell_T> cell1Sorted(cell1, sortingDirection);
+    SortedCellView<ParticleCell_T> cell2Sorted(cell2, sortingDirection);
 
     for (auto &[p1Projection, p1Ptr] : cell1Sorted._particles) {
       for (auto &[p2Projection, p2Ptr] : cell2Sorted._particles) {
@@ -300,28 +302,28 @@ void CellFunctor<ParticleCell, ParticleFunctor, bidirectional>::processCellPairA
   }
 }
 
-template <class ParticleCell, class ParticleFunctor, bool bidirectional>
-void CellFunctor<ParticleCell, ParticleFunctor, bidirectional>::processCellPairSoAN3(ParticleCell &cell1,
-                                                                                     ParticleCell &cell2) {
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
+void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairSoAN3(ParticleCell_T &cell1,
+                                                                                         ParticleCell_T &cell2) {
   _functor.SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, true);
 }
 
-template <class ParticleCell, class ParticleFunctor, bool bidirectional>
-void CellFunctor<ParticleCell, ParticleFunctor, bidirectional>::processCellPairSoANoN3(ParticleCell &cell1,
-                                                                                       ParticleCell &cell2) {
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
+void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairSoANoN3(ParticleCell_T &cell1,
+                                                                                           ParticleCell_T &cell2) {
   _functor.SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, false);
   if constexpr (bidirectional) {
     _functor.SoAFunctorPair(cell2._particleSoABuffer, cell1._particleSoABuffer, false);
   }
 }
 
-template <class ParticleCell, class ParticleFunctor, bool bidirectional>
-void CellFunctor<ParticleCell, ParticleFunctor, bidirectional>::processCellSoAN3(ParticleCell &cell) {
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
+void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellSoAN3(ParticleCell_T &cell) {
   _functor.SoAFunctorSingle(cell._particleSoABuffer, true);
 }
 
-template <class ParticleCell, class ParticleFunctor, bool bidirectional>
-void CellFunctor<ParticleCell, ParticleFunctor, bidirectional>::processCellSoANoN3(ParticleCell &cell) {
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
+void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellSoANoN3(ParticleCell_T &cell) {
   _functor.SoAFunctorSingle(cell._particleSoABuffer, false);  // the functor has to enable this...
 }
 }  // namespace autopas::internal

--- a/src/autopas/baseFunctors/CellFunctor.h
+++ b/src/autopas/baseFunctors/CellFunctor.h
@@ -310,10 +310,10 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellP
 }
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-template <bool useNewton3>
+template <bool newton3>
 void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairSoAImpl(ParticleCell_T &cell1,
                                                                                            ParticleCell_T &cell2) {
-  if constexpr (useNewton3) {
+  if constexpr (newton3) {
     _functor.SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, true);
   } else {
     _functor.SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, false);

--- a/src/autopas/baseFunctors/CellFunctor.h
+++ b/src/autopas/baseFunctors/CellFunctor.h
@@ -225,7 +225,7 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellA
     }
   };
 
-  if (cell.size() > _sortingThreshold) {
+  if (cell.size() >= _sortingThreshold) {
     SortedCellView<ParticleCell_T> cellSorted(cell, utils::ArrayMath::normalize(cell.getCellLength()));
 
     for (auto cellIter1 = cellSorted._particles.begin(); cellIter1 != cellSorted._particles.end(); ++cellIter1) {
@@ -266,7 +266,7 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellP
     }
   };
 
-  if ((cell1.size() + cell2.size() > _sortingThreshold) and (sortingDirection != std::array<double, 3>{0., 0., 0.})) {
+  if ((cell1.size() + cell2.size() >= _sortingThreshold) and (sortingDirection != std::array<double, 3>{0., 0., 0.})) {
     // Use sorted cell views
     SortedCellView<ParticleCell_T> cell1Sorted(cell1, sortingDirection);
     SortedCellView<ParticleCell_T> cell2Sorted(cell2, sortingDirection);

--- a/src/autopas/baseFunctors/CellFunctor.h
+++ b/src/autopas/baseFunctors/CellFunctor.h
@@ -228,7 +228,7 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellA
       // start inner loop ahead of the outer loop
       for (auto cellIter2 = std::next(cellIter1); cellIter2 != cellSorted._particles.end(); ++cellIter2) {
         auto &[p2Projection, p2Ptr] = *cellIter2;
-        if (std::abs(p1Projection - p2Projection) > _sortingCutoff) {
+        if (p2Projection - p1Projection > _sortingCutoff) {
           break;
         }
         interactParticles(*p1Ptr, *p2Ptr);
@@ -254,7 +254,8 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellP
 
     for (auto &[p1Projection, p1Ptr] : cell1Sorted._particles) {
       for (auto &[p2Projection, p2Ptr] : cell2Sorted._particles) {
-        if (std::abs(p1Projection - p2Projection) > _sortingCutoff) {
+        // p2Projection > p1Projection guaranteed by sorting direction
+        if (p2Projection - p1Projection > _sortingCutoff) {
           break;
         }
         _functor.AoSFunctor(*p1Ptr, *p2Ptr, true);
@@ -286,7 +287,8 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellP
 
     for (auto &[p1Projection, p1Ptr] : cell1Sorted._particles) {
       for (auto &[p2Projection, p2Ptr] : cell2Sorted._particles) {
-        if (std::abs(p1Projection - p2Projection) > _sortingCutoff) {
+        // p2Projection > p1Projection guaranteed by sorting direction
+        if (p2Projection - p1Projection > _sortingCutoff) {
           break;
         }
         interactParticlesNoN3(*p1Ptr, *p2Ptr);

--- a/src/autopas/baseFunctors/CellFunctor.h
+++ b/src/autopas/baseFunctors/CellFunctor.h
@@ -96,30 +96,24 @@ class CellFunctor {
    * The value of newton3 defines how to apply the aos functor:
    * - If newton3 is true: The aos functor will be applied once for each pair (only i,j), passing newton3=true.
    * - If newton3 is false: The aos functor will be applied twice for each pair (i,j and j,i), passing newton3=false.
-   * @tparam newton3
    * @param cell
    */
-  template <bool newton3>
   void processCellAoSImpl(ParticleCell_T &cell);
 
   /**
    * Applies the AoS functor to all particle pairs between cell1 and cell2.
-   * @tparam newton3 Whether to use Newton's third law of motion.
    * @param cell1
    * @param cell2
    * @param sortingDirection Normalized vector connecting centers of cell1 and cell2.
    */
-  template <bool newton3>
   void processCellPairAoSImpl(ParticleCell_T &cell1, ParticleCell_T &cell2,
                               const std::array<double, 3> &sortingDirection);
 
   /**
    * Applies the SoA functor to all particle pairs between cell1 and cell2.
-   * @tparam newton3 Whether to use Newton's third law of motion.
    * @param cell1
    * @param cell2
    */
-  template <bool newton3>
   void processCellPairSoAImpl(ParticleCell_T &cell1, ParticleCell_T &cell2);
 
   ParticleFunctor_T &_functor;
@@ -155,11 +149,7 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCell(
       if (cell.isEmpty()) {
         return;
       }
-      if (_useNewton3) {
-        processCellAoSImpl<true>(cell);
-      } else {
-        processCellAoSImpl<false>(cell);
-      }
+      processCellAoSImpl(cell);
       break;
     case DataLayoutOption::soa:
       if (cell._particleSoABuffer.size() == 0) {
@@ -194,31 +184,22 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellP
       if (cell1.isEmpty() or cell2.isEmpty()) {
         return;
       }
-      if (_useNewton3) {
-        processCellPairAoSImpl<true>(cell1, cell2, sortingDirection);
-      } else {
-        processCellPairAoSImpl<false>(cell1, cell2, sortingDirection);
-      }
+      processCellPairAoSImpl(cell1, cell2, sortingDirection);
       break;
     case DataLayoutOption::soa:
       if (cell1._particleSoABuffer.size() == 0 or cell2._particleSoABuffer.size() == 0) {
         return;
       }
-      if (_useNewton3) {
-        processCellPairSoAImpl<true>(cell1, cell2);
-      } else {
-        processCellPairSoAImpl<false>(cell1, cell2);
-      }
+      processCellPairSoAImpl(cell1, cell2);
       break;
   }
 }
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-template <bool newton3>
 void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellAoSImpl(ParticleCell_T &cell) {
   // helper function
-  const auto interactParticles = [&f = this->_functor](auto &p1, auto &p2) {
-    if constexpr (newton3) {
+  const auto interactParticles = [&f = this->_functor, n3 = this->_useNewton3](auto &p1, auto &p2) {
+    if (n3) {
       f.AoSFunctor(p1, p2, true);
     } else {
       if (not p1.isHalo()) {
@@ -256,11 +237,10 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellA
 }
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-template <bool newton3>
 void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairAoSImpl(
     ParticleCell_T &cell1, ParticleCell_T &cell2, const std::array<double, 3> &sortingDirection) {
-  const auto interactParticles = [&f = this->_functor](auto &p1, auto &p2) {
-    if constexpr (newton3) {
+  const auto interactParticles = [&f = this->_functor, n3 = this->_useNewton3](auto &p1, auto &p2) {
+    if (n3) {
       f.AoSFunctor(p1, p2, true);
     } else {
       f.AoSFunctor(p1, p2, false);
@@ -297,10 +277,9 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellP
 }
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-template <bool newton3>
 void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairSoAImpl(ParticleCell_T &cell1,
                                                                                            ParticleCell_T &cell2) {
-  if constexpr (newton3) {
+  if (_useNewton3) {
     _functor.SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, true);
   } else {
     _functor.SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, false);

--- a/src/autopas/baseFunctors/CellFunctor.h
+++ b/src/autopas/baseFunctors/CellFunctor.h
@@ -212,7 +212,7 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellA
       // start inner loop ahead of the outer loop
       for (auto cellIter2 = std::next(cellIter1); cellIter2 != cellSorted._particles.end(); ++cellIter2) {
         auto &[p2Projection, p2Ptr] = *cellIter2;
-        if (p2Projection - p1Projection > _sortingCutoff) {
+        if (std::abs(p2Projection - p1Projection) > _sortingCutoff) {
           break;
         }
         interactParticles(*p1Ptr, *p2Ptr);
@@ -248,8 +248,7 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellP
 
     for (auto &[p1Projection, p1Ptr] : cell1Sorted._particles) {
       for (auto &[p2Projection, p2Ptr] : cell2Sorted._particles) {
-        // p2Projection > p1Projection guaranteed by sorting direction
-        if (p2Projection - p1Projection > _sortingCutoff) {
+        if (std::abs(p2Projection - p1Projection) > _sortingCutoff) {
           break;
         }
 

--- a/src/autopas/baseFunctors/CellFunctor.h
+++ b/src/autopas/baseFunctors/CellFunctor.h
@@ -104,35 +104,27 @@ class CellFunctor {
    * newton3=false.
    * @param cell
    */
-  void processCellAoS(ParticleCell_T &cell);
+  void processCellAoSImpl(ParticleCell_T &cell);
 
   /**
-   * Applies the functor to all particle pairs between cell1 and cell2
-   * exploiting newtons third law of motion.
+   * Applies the AoS functor to all particle pairs between cell1 and cell2.
+   * @tparam newton3 Whether to use Newton's third law of motion.
    * @param cell1
    * @param cell2
    * @param sortingDirection Normalized vector connecting centers of cell1 and cell2.
    */
-  void processCellPairAoSN3(ParticleCell_T &cell1, ParticleCell_T &cell2,
-                            const std::array<double, 3> &sortingDirection);
-
-  /**
-   * Applies the functor to all particle pairs between cell1 and cell2
-   * without exploiting newtons third law of motion.
-   * @param cell1
-   * @param cell2
-   * @param sortingDirection Normalized vector connecting centers of cell1 and cell2.
-   */
-  void processCellPairAoSNoN3(ParticleCell_T &cell1, ParticleCell_T &cell2,
+  template <bool newton3>
+  void processCellPairAoSImpl(ParticleCell_T &cell1, ParticleCell_T &cell2,
                               const std::array<double, 3> &sortingDirection);
 
-  void processCellPairSoAN3(ParticleCell_T &cell1, ParticleCell_T &cell2);
-
-  void processCellPairSoANoN3(ParticleCell_T &cell1, ParticleCell_T &cell2);
-
-  void processCellSoAN3(ParticleCell_T &cell);
-
-  void processCellSoANoN3(ParticleCell_T &cell);
+  /**
+   * Applies the SoA functor to all particle pairs between cell1 and cell2.
+   * @tparam newton3 Whether to use Newton's third law of motion.
+   * @param cell1
+   * @param cell2
+   */
+  template <bool newton3>
+  void processCellPairSoAImpl(ParticleCell_T &cell1, ParticleCell_T &cell2);
 
   ParticleFunctor_T &_functor;
 
@@ -168,14 +160,10 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCell(
 
   switch (_dataLayout) {
     case DataLayoutOption::aos:
-      processCellAoS(cell);
+      processCellAoSImpl(cell);
       break;
     case DataLayoutOption::soa:
-      if (_useNewton3) {
-        processCellSoAN3(cell);
-      } else {
-        processCellSoANoN3(cell);
-      }
+      _functor.SoAFunctorSingle(cell._particleSoABuffer, _useNewton3);
       break;
   }
 }
@@ -187,37 +175,42 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellP
     return;
   }
 
-  // avoid force calculations if both cells can not contain owned particles or if newton3==false and cell1 does not
-  // contain owned particles
   const bool cell1HasOwnedParticles = toInt64(cell1.getPossibleParticleOwnerships() & OwnershipState::owned);
   const bool cell2HasOwnedParticles = toInt64(cell2.getPossibleParticleOwnerships() & OwnershipState::owned);
 
-  if (((not cell1HasOwnedParticles) and (not _useNewton3) and (not bidirectional)) or
-      ((not cell1HasOwnedParticles) and (not cell2HasOwnedParticles))) {
+  // Avoid force calculations if both cells cannot contain owned particles.
+  if (not cell1HasOwnedParticles and not cell2HasOwnedParticles) {
     return;
   }
 
-  // (Explicit) static cast required for Apple Clang (last tested version: 15.0.0)
-  switch (static_cast<DataLayoutOption::Value>(_dataLayout)) {
+  // In Newton3==false and functor is not bidirectional, only interactions from cell1 to cell2 are computed. Therefore,
+  // if cell1 cannot contain owned particles, there is nothing useful to do.
+  if constexpr (not bidirectional) {
+    if (not _useNewton3 and not cell1HasOwnedParticles) {
+      return;
+    }
+  }
+
+  switch (_dataLayout) {
     case DataLayoutOption::aos:
       if (_useNewton3) {
-        processCellPairAoSN3(cell1, cell2, sortingDirection);
+        processCellPairAoSImpl<true>(cell1, cell2, sortingDirection);
       } else {
-        processCellPairAoSNoN3(cell1, cell2, sortingDirection);
+        processCellPairAoSImpl<false>(cell1, cell2, sortingDirection);
       }
       break;
     case DataLayoutOption::soa:
       if (_useNewton3) {
-        processCellPairSoAN3(cell1, cell2);
+        processCellPairSoAImpl<true>(cell1, cell2);
       } else {
-        processCellPairSoANoN3(cell1, cell2);
+        processCellPairSoAImpl<false>(cell1, cell2);
       }
       break;
   }
 }
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellAoS(ParticleCell_T &cell) {
+void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellAoSImpl(ParticleCell_T &cell) {
   // helper function
   const auto interactParticles = [&](auto &p1, auto &p2) {
     if (_useNewton3) {
@@ -258,42 +251,23 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellA
 }
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairAoSN3(
+template <bool newton3>
+void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairAoSImpl(
     ParticleCell_T &cell1, ParticleCell_T &cell2, const std::array<double, 3> &sortingDirection) {
-  if ((cell1.size() + cell2.size() > _sortingThreshold) and (sortingDirection != std::array<double, 3>{0., 0., 0.})) {
-    SortedCellView<ParticleCell_T> cell1Sorted(cell1, sortingDirection);
-    SortedCellView<ParticleCell_T> cell2Sorted(cell2, sortingDirection);
+  const auto interactParticles = [this](auto &p1, auto &p2) {
+    if constexpr (newton3) {
+      _functor.AoSFunctor(p1, p2, true);
+    } else {
+      _functor.AoSFunctor(p1, p2, false);
 
-    for (auto &[p1Projection, p1Ptr] : cell1Sorted._particles) {
-      for (auto &[p2Projection, p2Ptr] : cell2Sorted._particles) {
-        // p2Projection > p1Projection guaranteed by sorting direction
-        if (p2Projection - p1Projection > _sortingCutoff) {
-          break;
-        }
-        _functor.AoSFunctor(*p1Ptr, *p2Ptr, true);
+      if constexpr (bidirectional) {
+        _functor.AoSFunctor(p2, p1, false);
       }
-    }
-  } else {
-    for (auto &p1 : cell1) {
-      for (auto &p2 : cell2) {
-        _functor.AoSFunctor(p1, p2, true);
-      }
-    }
-  }
-}
-
-template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairAoSNoN3(
-    ParticleCell_T &cell1, ParticleCell_T &cell2, const std::array<double, 3> &sortingDirection) {
-  // helper function
-  const auto interactParticlesNoN3 = [&](auto &p1, auto &p2) {
-    _functor.AoSFunctor(p1, p2, false);
-    if constexpr (bidirectional) {
-      _functor.AoSFunctor(p2, p1, false);
     }
   };
 
   if ((cell1.size() + cell2.size() > _sortingThreshold) and (sortingDirection != std::array<double, 3>{0., 0., 0.})) {
+    // Use sorted cell views
     SortedCellView<ParticleCell_T> cell1Sorted(cell1, sortingDirection);
     SortedCellView<ParticleCell_T> cell2Sorted(cell2, sortingDirection);
 
@@ -303,40 +277,32 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellP
         if (p2Projection - p1Projection > _sortingCutoff) {
           break;
         }
-        interactParticlesNoN3(*p1Ptr, *p2Ptr);
+
+        interactParticles(*p1Ptr, *p2Ptr);
       }
     }
   } else {
+    // Without sorting
     for (auto &p1 : cell1) {
       for (auto &p2 : cell2) {
-        interactParticlesNoN3(p1, p2);
+        interactParticles(p1, p2);
       }
     }
   }
 }
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairSoAN3(ParticleCell_T &cell1,
-                                                                                         ParticleCell_T &cell2) {
-  _functor.SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, true);
-}
-
-template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairSoANoN3(ParticleCell_T &cell1,
+template <bool useNewton3>
+void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairSoAImpl(ParticleCell_T &cell1,
                                                                                            ParticleCell_T &cell2) {
-  _functor.SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, false);
-  if constexpr (bidirectional) {
-    _functor.SoAFunctorPair(cell2._particleSoABuffer, cell1._particleSoABuffer, false);
+  if constexpr (useNewton3) {
+    _functor.SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, true);
+  } else {
+    _functor.SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, false);
+
+    if constexpr (bidirectional) {
+      _functor.SoAFunctorPair(cell2._particleSoABuffer, cell1._particleSoABuffer, false);
+    }
   }
-}
-
-template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellSoAN3(ParticleCell_T &cell) {
-  _functor.SoAFunctorSingle(cell._particleSoABuffer, true);
-}
-
-template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellSoANoN3(ParticleCell_T &cell) {
-  _functor.SoAFunctorSingle(cell._particleSoABuffer, false);  // the functor has to enable this...
 }
 }  // namespace autopas::internal

--- a/src/autopas/baseFunctors/CellFunctor.h
+++ b/src/autopas/baseFunctors/CellFunctor.h
@@ -80,6 +80,21 @@ class CellFunctor {
 
  private:
   /**
+   * Returns true if the given cell is empty for the current _dataLayout. False by default in the case of other data
+   * layouts than aos or soa.
+   * @param cell
+   * @return whether the given cell is empty.
+   */
+  [[nodiscard]] bool cellIsEmptyForCurrentLayout(const ParticleCell_T &cell) const {
+    if (_dataLayout == DataLayoutOption::aos) {
+      return cell.isEmpty();
+    } else if (_dataLayout == DataLayoutOption::soa) {
+      return cell._particleSoABuffer.size() == 0;
+    }
+    return false;
+  }
+
+  /**
    * Applies the functor to all particle pairs exploiting newtons third law of motion.
    * There is only one version of this function as newton3 is always allowed to be applied inside of a cell.
    * The value of _useNewton3 defines whether or whether not to apply the aos version functor in a newton3 fashion or
@@ -141,8 +156,7 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::setSortingTh
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
 void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCell(ParticleCell_T &cell) {
-  if ((_dataLayout == DataLayoutOption::soa and cell._particleSoABuffer.size() == 0) or
-      (_dataLayout == DataLayoutOption::aos and cell.isEmpty())) {
+  if (cellIsEmptyForCurrentLayout(cell)) {
     return;
   }
 
@@ -169,9 +183,7 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCell(
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
 void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPair(
     ParticleCell_T &cell1, ParticleCell_T &cell2, const std::array<double, 3> &sortingDirection) {
-  if ((_dataLayout == DataLayoutOption::soa and
-       (cell1._particleSoABuffer.size() == 0 or cell2._particleSoABuffer.size() == 0)) or
-      (_dataLayout == DataLayoutOption::aos and (cell1.isEmpty() or cell2.isEmpty()))) {
+  if (cellIsEmptyForCurrentLayout(cell1) or cellIsEmptyForCurrentLayout(cell2)) {
     return;
   }
 

--- a/src/autopas/baseFunctors/CellFunctor.h
+++ b/src/autopas/baseFunctors/CellFunctor.h
@@ -95,15 +95,15 @@ class CellFunctor {
   }
 
   /**
-   * Applies the functor to all particle pairs exploiting newtons third law of motion.
-   * There is only one version of this function as newton3 is always allowed to be applied inside of a cell.
-   * The value of _useNewton3 defines whether or whether not to apply the aos version functor in a newton3 fashion or
-   * not:
-   * - if _useNewton3 is true: the aos functor will be applied once for each pair (only i,j), passing newton3=true.
-   * - if _useNewton3 is false: the aos functor will be applied twice for each pair (i,j and j,i), passing
-   * newton3=false.
+   * Applies the functor to all particle pairs exploiting Newton's third law of motion.
+   * There is only one version of this function as newton3 is always allowed to be applied inside a cell.
+   * The value of newton3 defines how to apply the aos functor:
+   * - If newton3 is true: The aos functor will be applied once for each pair (only i,j), passing newton3=true.
+   * - If newton3 is false: The aos functor will be applied twice for each pair (i,j and j,i), passing newton3=false.
+   * @tparam newton3
    * @param cell
    */
+  template <bool newton3>
   void processCellAoSImpl(ParticleCell_T &cell);
 
   /**
@@ -160,7 +160,11 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCell(
 
   switch (_dataLayout) {
     case DataLayoutOption::aos:
-      processCellAoSImpl(cell);
+      if (_useNewton3) {
+        processCellAoSImpl<true>(cell);
+      } else {
+        processCellAoSImpl<false>(cell);
+      }
       break;
     case DataLayoutOption::soa:
       _functor.SoAFunctorSingle(cell._particleSoABuffer, _useNewton3);
@@ -210,10 +214,11 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellP
 }
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
+template <bool newton3>
 void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellAoSImpl(ParticleCell_T &cell) {
   // helper function
   const auto interactParticles = [&](auto &p1, auto &p2) {
-    if (_useNewton3) {
+    if constexpr (newton3) {
       _functor.AoSFunctor(p1, p2, true);
     } else {
       if (not p1.isHalo()) {

--- a/src/autopas/baseFunctors/CellFunctor.h
+++ b/src/autopas/baseFunctors/CellFunctor.h
@@ -79,19 +79,32 @@ class CellFunctor {
   void setSortingThreshold(size_t sortingThreshold);
 
  private:
+  static constexpr std::array<double, 3> zeroDirection{0., 0., 0.};
+
   /**
-   * Returns true if the given cell is empty for the current _dataLayout. False by default in the case of other data
-   * layouts than aos or soa.
+   * Returns true if the given cell is empty for the current _dataLayout.
    * @param cell
    * @return whether the given cell is empty.
    */
   [[nodiscard]] bool cellIsEmptyForCurrentLayout(const ParticleCell_T &cell) const {
-    if (_dataLayout == DataLayoutOption::aos) {
-      return cell.isEmpty();
-    } else if (_dataLayout == DataLayoutOption::soa) {
-      return cell._particleSoABuffer.size() == 0;
+    switch (_dataLayout) {
+      case DataLayoutOption::aos:
+        return cell.isEmpty();
+      case DataLayoutOption::soa:
+        return cell._particleSoABuffer.size() == 0;
     }
+    utils::ExceptionHandler::exception("CellFunctor::cellIsEmptyForCurrentLayout(): Unsupported data layout.");
     return false;
+  }
+
+  /**
+   *
+   * @param particleCount
+   * @param sortingDirection
+   * @return
+   */
+  [[nodiscard]] bool shouldUseSorting(std::size_t particleCount, const std::array<double, 3> &sortingDirection) const {
+    return particleCount >= _sortingThreshold and sortingDirection != zeroDirection;
   }
 
   /**
@@ -217,7 +230,7 @@ template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
 template <bool newton3>
 void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellAoSImpl(ParticleCell_T &cell) {
   // helper function
-  const auto interactParticles = [&](auto &p1, auto &p2) {
+  const auto interactParticles = [this](auto &p1, auto &p2) {
     if constexpr (newton3) {
       _functor.AoSFunctor(p1, p2, true);
     } else {
@@ -271,7 +284,7 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellP
     }
   };
 
-  if ((cell1.size() + cell2.size() >= _sortingThreshold) and (sortingDirection != std::array<double, 3>{0., 0., 0.})) {
+  if (shouldUseSorting(cell1.size() + cell2.size(), sortingDirection)) {
     // Use sorted cell views
     SortedCellView<ParticleCell_T> cell1Sorted(cell1, sortingDirection);
     SortedCellView<ParticleCell_T> cell2Sorted(cell2, sortingDirection);

--- a/src/autopas/baseFunctors/CellFunctor.h
+++ b/src/autopas/baseFunctors/CellFunctor.h
@@ -56,7 +56,7 @@ class CellFunctor {
    * Getter
    * @return
    */
-  [[nodiscard]] DataLayoutOption getDataLayout() const { return _dataLayout; }
+  [[nodiscard]] DataLayoutOption::Value getDataLayout() const { return _dataLayout; }
 
   /**
    * Getter
@@ -129,9 +129,9 @@ class CellFunctor {
    */
   size_t _sortingThreshold{8};
 
-  DataLayoutOption _dataLayout;
+  const DataLayoutOption::Value _dataLayout;
 
-  bool _useNewton3;
+  const bool _useNewton3;
 };
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
@@ -152,8 +152,7 @@ void CellFunctor<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCell(
     return;
   }
 
-  // (Explicit) static cast required for Apple Clang (last tested version: 15.0.0)
-  switch (static_cast<DataLayoutOption::Value>(_dataLayout)) {
+  switch (_dataLayout) {
     case DataLayoutOption::aos:
       processCellAoS(cell);
       break;

--- a/src/autopas/baseFunctors/CellFunctor3B.h
+++ b/src/autopas/baseFunctors/CellFunctor3B.h
@@ -13,33 +13,33 @@
 namespace autopas::internal {
 /**
  * A cell functor. This functor is built from the normal Functor of the template
- * type ParticleFunctor. It is an internal object to handle interactions between
+ * type ParticleFunctor_T. It is an internal object to handle interactions between
  * up to three cells of particles.
- * @tparam ParticleCell
- * @tparam ParticleFunctor the functor which is used for particle interactions
+ * @tparam ParticleCell_T
+ * @tparam ParticleFunctor_T the functor which is used for particle interactions
  * @tparam bidirectional if no newton3 is used, processCellPair(..) and processCellPair(..) should handle interactions
  * for particles from all cells.
  */
-template <class ParticleCell, class ParticleFunctor, bool bidirectional = true>
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional = true>
 class CellFunctor3B {
  public:
   /**
    * The constructor of CellFunctor3B.
-   * @param f The ParticleFunctor which should be used for the interaction.
+   * @param f The particle functor, which should be used for the interaction.
    * @param sortingCutoff This parameter indicates the maximal distance the sorted particles are to interact. This
    * parameter is only relevant for optimization (sorting). This parameter normally should be the cutoff, for building
    * verlet lists, this should be cutoff+skin.
    * @param dataLayout The data layout to be used.
    * @param useNewton3 Parameter to specify whether newton3 is used or not.
    */
-  explicit CellFunctor3B(ParticleFunctor &f, const double sortingCutoff, DataLayoutOption dataLayout, bool useNewton3)
+  explicit CellFunctor3B(ParticleFunctor_T &f, const double sortingCutoff, DataLayoutOption dataLayout, bool useNewton3)
       : _functor(f), _sortingCutoff(sortingCutoff), _dataLayout(dataLayout), _useNewton3(useNewton3) {}
 
   /**
    * Process the interactions inside one cell.
    * @param cell All triwise interactions of particles inside this cell are calculated.
    */
-  void processCell(ParticleCell &cell);
+  void processCell(ParticleCell_T &cell);
 
   /**
    * Process the interactions between the particles of cell1 with particles of cell2. This includes both triwise
@@ -50,7 +50,7 @@ class CellFunctor3B {
    * @param sortingDirection Normalized vector connecting centers of cell1 and cell2. If no parameter or {0, 0, 0} is
    * given, sorting will be disabled.
    */
-  void processCellPair(ParticleCell &cell1, ParticleCell &cell2,
+  void processCellPair(ParticleCell_T &cell1, ParticleCell_T &cell2,
                        const std::array<double, 3> &sortingDirection = {0., 0., 0.});
 
   /**
@@ -61,7 +61,7 @@ class CellFunctor3B {
    * @param sortingDirection Normalized vector along which particles will be sorted.If no parameter or {0, 0, 0} is
    * given, sorting will be disabled.
    */
-  void processCellTriple(ParticleCell &cell1, ParticleCell &cell2, ParticleCell &cell3,
+  void processCellTriple(ParticleCell_T &cell1, ParticleCell_T &cell2, ParticleCell_T &cell3,
                          const std::array<double, 3> &sortingDirection = {0., 0., 0.});
 
   /**
@@ -101,7 +101,7 @@ class CellFunctor3B {
    * k,i,j), passing newton3=false.
    * @param cell
    */
-  void processCellAoS(ParticleCell &cell);
+  void processCellAoS(ParticleCell_T &cell);
 
   /**
    * Applies the functor to all particle triplets between cell1 and cell2
@@ -110,7 +110,8 @@ class CellFunctor3B {
    * @param cell2
    * @param sortingDirection Normalized vector connecting centers of cell1 and cell2.
    */
-  void processCellPairAoSN3(ParticleCell &cell1, ParticleCell &cell2, const std::array<double, 3> &sortingDirection);
+  void processCellPairAoSN3(ParticleCell_T &cell1, ParticleCell_T &cell2,
+                            const std::array<double, 3> &sortingDirection);
 
   /**
    * Applies the functor to all particle triplets between cell1 and cell2
@@ -119,7 +120,8 @@ class CellFunctor3B {
    * @param cell2
    * @param sortingDirection Normalized vector connecting centers of cell1 and cell2.
    */
-  void processCellPairAoSNoN3(ParticleCell &cell1, ParticleCell &cell2, const std::array<double, 3> &sortingDirection);
+  void processCellPairAoSNoN3(ParticleCell_T &cell1, ParticleCell_T &cell2,
+                              const std::array<double, 3> &sortingDirection);
 
   /**
    * Applies the functor to all particle triples between cell1, cell2 and cell3
@@ -132,7 +134,7 @@ class CellFunctor3B {
    * @warning If sorting is used, sortingDirection should correspond to the pairwise sorting direction between cell1 and
    * cell2.
    */
-  void processCellTripleAoSN3(ParticleCell &cell1, ParticleCell &cell2, ParticleCell &cell3,
+  void processCellTripleAoSN3(ParticleCell_T &cell1, ParticleCell_T &cell2, ParticleCell_T &cell3,
                               const std::array<double, 3> &sortingDirection);
 
   /**
@@ -146,22 +148,22 @@ class CellFunctor3B {
    * @warning If sorting is used, sortingDirection should correspond to the pairwise sorting direction between cell1 and
    * cell2.
    */
-  void processCellTripleAoSNoN3(ParticleCell &cell1, ParticleCell &cell2, ParticleCell &cell3,
+  void processCellTripleAoSNoN3(ParticleCell_T &cell1, ParticleCell_T &cell2, ParticleCell_T &cell3,
                                 const std::array<double, 3> &sortingDirection);
 
-  void processCellPairSoAN3(ParticleCell &cell1, ParticleCell &cell2);
+  void processCellPairSoAN3(ParticleCell_T &cell1, ParticleCell_T &cell2);
 
-  void processCellPairSoANoN3(ParticleCell &cell1, ParticleCell &cell2);
+  void processCellPairSoANoN3(ParticleCell_T &cell1, ParticleCell_T &cell2);
 
-  void processCellTripleSoAN3(ParticleCell &cell1, ParticleCell &cell2, ParticleCell &cell3);
+  void processCellTripleSoAN3(ParticleCell_T &cell1, ParticleCell_T &cell2, ParticleCell_T &cell3);
 
-  void processCellTripleSoANoN3(ParticleCell &cell1, ParticleCell &cell2, ParticleCell &cell3);
+  void processCellTripleSoANoN3(ParticleCell_T &cell1, ParticleCell_T &cell2, ParticleCell_T &cell3);
 
-  void processCellSoAN3(ParticleCell &cell);
+  void processCellSoAN3(ParticleCell_T &cell);
 
-  void processCellSoANoN3(ParticleCell &cell);
+  void processCellSoANoN3(ParticleCell_T &cell);
 
-  ParticleFunctor &_functor;
+  ParticleFunctor_T &_functor;
 
   const double _sortingCutoff;
 
@@ -177,13 +179,13 @@ class CellFunctor3B {
   bool _useNewton3;
 };
 
-template <class ParticleCell, class ParticleFunctor, bool bidirectional>
-void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::setSortingThreshold(size_t sortingThreshold) {
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
+void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::setSortingThreshold(size_t sortingThreshold) {
   _sortingThreshold = sortingThreshold;
 }
 
-template <class ParticleCell, class ParticleFunctor, bool bidirectional>
-void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCell(ParticleCell &cell) {
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
+void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCell(ParticleCell_T &cell) {
   if ((_dataLayout == DataLayoutOption::soa and cell._particleSoABuffer.size() == 0) or
       (_dataLayout == DataLayoutOption::aos and cell.isEmpty())) {
     return;
@@ -210,10 +212,10 @@ void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCell(Pa
   }
 }
 
-template <class ParticleCell, class ParticleFunctor, bool bidirectional>
-void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCellPair(
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
+void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPair(
 
-    ParticleCell &cell1, ParticleCell &cell2, const std::array<double, 3> &sortingDirection) {
+    ParticleCell_T &cell1, ParticleCell_T &cell2, const std::array<double, 3> &sortingDirection) {
   if ((_dataLayout == DataLayoutOption::soa and
        (cell1._particleSoABuffer.size() == 0 or cell2._particleSoABuffer.size() == 0)) or
       (_dataLayout == DataLayoutOption::aos and (cell1.size() == 0 or cell2.size() == 0))) {
@@ -249,10 +251,11 @@ void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCellPai
   }
 }
 
-template <class ParticleCell, class ParticleFunctor, bool bidirectional>
-void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCellTriple(
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
+void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellTriple(
 
-    ParticleCell &cell1, ParticleCell &cell2, ParticleCell &cell3, const std::array<double, 3> &sortingDirection) {
+    ParticleCell_T &cell1, ParticleCell_T &cell2, ParticleCell_T &cell3,
+    const std::array<double, 3> &sortingDirection) {
   if ((_dataLayout == DataLayoutOption::soa and
        (cell1._particleSoABuffer.size() == 0 or cell2._particleSoABuffer.size() == 0 or
         cell3._particleSoABuffer.size() == 0)) or
@@ -290,8 +293,8 @@ void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCellTri
   }
 }
 
-template <class ParticleCell, class ParticleFunctor, bool bidirectional>
-void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCellAoS(ParticleCell &cell) {
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
+void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellAoS(ParticleCell_T &cell) {
   // helper function
   const auto interactParticles = [&](auto &p1, auto &p2, auto &p3) {
     if (_useNewton3) {
@@ -310,7 +313,7 @@ void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCellAoS
   };
 
   if (cell.size() > _sortingThreshold) {
-    SortedCellView<ParticleCell> cellSorted(cell, utils::ArrayMath::normalize(std::array<double, 3>{1.0, 1.0, 1.0}));
+    SortedCellView<ParticleCell_T> cellSorted(cell, utils::ArrayMath::normalize(std::array<double, 3>{1.0, 1.0, 1.0}));
 
     for (auto cellIter1 = cellSorted._particles.begin(); cellIter1 != cellSorted._particles.end(); ++cellIter1) {
       auto &[p1Projection, p1Ptr] = *cellIter1;
@@ -346,12 +349,12 @@ void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCellAoS
   }
 }
 
-template <class ParticleCell, class ParticleFunctor, bool bidirectional>
-void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCellPairAoSN3(
-    ParticleCell &cell1, ParticleCell &cell2, const std::array<double, 3> &sortingDirection) {
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
+void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairAoSN3(
+    ParticleCell_T &cell1, ParticleCell_T &cell2, const std::array<double, 3> &sortingDirection) {
   if ((cell1.size() + cell2.size() > _sortingThreshold) and sortingDirection != std::array<double, 3>{0., 0., 0.}) {
-    SortedCellView<ParticleCell> cell1Sorted(cell1, sortingDirection);
-    SortedCellView<ParticleCell> cell2Sorted(cell2, sortingDirection);
+    SortedCellView<ParticleCell_T> cell1Sorted(cell1, sortingDirection);
+    SortedCellView<ParticleCell_T> cell2Sorted(cell2, sortingDirection);
 
     // Particle 1 from cell1
     for (auto cellIter1 = cell1Sorted._particles.begin(); cellIter1 != cell1Sorted._particles.end(); ++cellIter1) {
@@ -412,9 +415,9 @@ void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCellPai
   }
 }
 
-template <class ParticleCell, class ParticleFunctor, bool bidirectional>
-void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCellPairAoSNoN3(
-    ParticleCell &cell1, ParticleCell &cell2, const std::array<double, 3> &sortingDirection) {
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
+void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairAoSNoN3(
+    ParticleCell_T &cell1, ParticleCell_T &cell2, const std::array<double, 3> &sortingDirection) {
   // helper function
   const auto interactParticles = [&](auto &p1, auto &p2, auto &p3, const bool p2FromCell1) {
     _functor.AoSFunctor(p1, p2, p3, false);
@@ -431,8 +434,8 @@ void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCellPai
   };
 
   if ((cell1.size() + cell2.size() > _sortingThreshold) and sortingDirection != std::array<double, 3>{0., 0., 0.}) {
-    SortedCellView<ParticleCell> cell1Sorted(cell1, sortingDirection);
-    SortedCellView<ParticleCell> cell2Sorted(cell2, sortingDirection);
+    SortedCellView<ParticleCell_T> cell1Sorted(cell1, sortingDirection);
+    SortedCellView<ParticleCell_T> cell2Sorted(cell2, sortingDirection);
 
     // Particle 1 always from cell1
     for (auto cellIter1 = cell1Sorted._particles.begin(); cellIter1 != cell1Sorted._particles.end(); ++cellIter1) {
@@ -493,13 +496,14 @@ void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCellPai
   }
 }
 
-template <class ParticleCell, class ParticleFunctor, bool bidirectional>
-void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCellTripleAoSN3(
-    ParticleCell &cell1, ParticleCell &cell2, ParticleCell &cell3, const std::array<double, 3> &sortingDirection) {
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
+void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellTripleAoSN3(
+    ParticleCell_T &cell1, ParticleCell_T &cell2, ParticleCell_T &cell3,
+    const std::array<double, 3> &sortingDirection) {
   if ((cell1.size() + cell2.size() + cell3.size() > _sortingThreshold) and
       sortingDirection != std::array<double, 3>{0., 0., 0.}) {
-    SortedCellView<ParticleCell> cell1Sorted(cell1, sortingDirection);
-    SortedCellView<ParticleCell> cell2Sorted(cell2, sortingDirection);
+    SortedCellView<ParticleCell_T> cell1Sorted(cell1, sortingDirection);
+    SortedCellView<ParticleCell_T> cell2Sorted(cell2, sortingDirection);
 
     for (auto &[p1Projection, p1Ptr] : cell1Sorted._particles) {
       for (auto &[p2Projection, p2Ptr] : cell2Sorted._particles) {
@@ -522,9 +526,10 @@ void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCellTri
   }
 }
 
-template <class ParticleCell, class ParticleFunctor, bool bidirectional>
-void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCellTripleAoSNoN3(
-    ParticleCell &cell1, ParticleCell &cell2, ParticleCell &cell3, const std::array<double, 3> &sortingDirection) {
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
+void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellTripleAoSNoN3(
+    ParticleCell_T &cell1, ParticleCell_T &cell2, ParticleCell_T &cell3,
+    const std::array<double, 3> &sortingDirection) {
   // helper function
   const auto interactParticlesNoN3 = [&](auto &p1, auto &p2, auto &p3) {
     _functor.AoSFunctor(p1, p2, p3, false);
@@ -536,8 +541,8 @@ void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCellTri
 
   if (cell1.size() + cell2.size() + cell3.size() > _sortingThreshold and
       sortingDirection != std::array<double, 3>{0., 0., 0.}) {
-    SortedCellView<ParticleCell> cell1Sorted(cell1, sortingDirection);
-    SortedCellView<ParticleCell> cell2Sorted(cell2, sortingDirection);
+    SortedCellView<ParticleCell_T> cell1Sorted(cell1, sortingDirection);
+    SortedCellView<ParticleCell_T> cell2Sorted(cell2, sortingDirection);
 
     for (auto &[p1Projection, p1Ptr] : cell1Sorted._particles) {
       for (auto &[p2Projection, p2Ptr] : cell2Sorted._particles) {
@@ -561,40 +566,40 @@ void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCellTri
   }
 }
 
-template <class ParticleCell, class ParticleFunctor, bool bidirectional>
-void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCellSoAN3(ParticleCell &cell) {
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
+void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellSoAN3(ParticleCell_T &cell) {
   _functor.SoAFunctorSingle(cell._particleSoABuffer, true);
 }
 
-template <class ParticleCell, class ParticleFunctor, bool bidirectional>
-void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCellSoANoN3(ParticleCell &cell) {
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
+void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellSoANoN3(ParticleCell_T &cell) {
   _functor.SoAFunctorSingle(cell._particleSoABuffer, false);  // the functor has to enable this...
 }
 
-template <class ParticleCell, class ParticleFunctor, bool bidirectional>
-void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCellPairSoAN3(ParticleCell &cell1,
-                                                                                       ParticleCell &cell2) {
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
+void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairSoAN3(ParticleCell_T &cell1,
+                                                                                           ParticleCell_T &cell2) {
   _functor.SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, true);
 }
 
-template <class ParticleCell, class ParticleFunctor, bool bidirectional>
-void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCellPairSoANoN3(ParticleCell &cell1,
-                                                                                         ParticleCell &cell2) {
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
+void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairSoANoN3(ParticleCell_T &cell1,
+                                                                                             ParticleCell_T &cell2) {
   _functor.SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, false);
   if (bidirectional) _functor.SoAFunctorPair(cell2._particleSoABuffer, cell1._particleSoABuffer, false);
 }
 
-template <class ParticleCell, class ParticleFunctor, bool bidirectional>
-void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCellTripleSoAN3(ParticleCell &cell1,
-                                                                                         ParticleCell &cell2,
-                                                                                         ParticleCell &cell3) {
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
+void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellTripleSoAN3(ParticleCell_T &cell1,
+                                                                                             ParticleCell_T &cell2,
+                                                                                             ParticleCell_T &cell3) {
   _functor.SoAFunctorTriple(cell1._particleSoABuffer, cell2._particleSoABuffer, cell3._particleSoABuffer, true);
 }
 
-template <class ParticleCell, class ParticleFunctor, bool bidirectional>
-void CellFunctor3B<ParticleCell, ParticleFunctor, bidirectional>::processCellTripleSoANoN3(ParticleCell &cell1,
-                                                                                           ParticleCell &cell2,
-                                                                                           ParticleCell &cell3) {
+template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
+void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellTripleSoANoN3(ParticleCell_T &cell1,
+                                                                                               ParticleCell_T &cell2,
+                                                                                               ParticleCell_T &cell3) {
   _functor.SoAFunctorTriple(cell1._particleSoABuffer, cell2._particleSoABuffer, cell3._particleSoABuffer, false);
   if (bidirectional) {
     _functor.SoAFunctorTriple(cell2._particleSoABuffer, cell1._particleSoABuffer, cell3._particleSoABuffer, false);

--- a/src/autopas/baseFunctors/CellFunctor3B.h
+++ b/src/autopas/baseFunctors/CellFunctor3B.h
@@ -105,7 +105,7 @@ class CellFunctor3B {
       case DataLayoutOption::soa:
         return cell._particleSoABuffer.size() == 0;
     }
-    utils::ExceptionHandler::exception("CellFunctor::cellIsEmptyForCurrentLayout(): Unsupported data layout.");
+    utils::ExceptionHandler::exception("CellFunctor3B::cellIsEmptyForCurrentLayout(): Unsupported data layout.");
     return false;
   }
 
@@ -349,7 +349,7 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
 
         for (auto cellIter3 = std::next(cellIter2); cellIter3 != cellSorted._particles.end(); ++cellIter3) {
           auto &[p3Projection, p3Ptr] = *cellIter3;
-          if (p3Projection - p3Projection > _sortingCutoff or p3Projection - p2Projection > _sortingCutoff) {
+          if (p3Projection - p1Projection > _sortingCutoff or p3Projection - p2Projection > _sortingCutoff) {
             break;
           }
           interactParticles(*p1Ptr, *p2Ptr, *p3Ptr);
@@ -507,7 +507,7 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
   } else {
     _functor.SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, false);
     if constexpr (bidirectional) {
-      if (bidirectional) _functor.SoAFunctorPair(cell2._particleSoABuffer, cell1._particleSoABuffer, false);
+      _functor.SoAFunctorPair(cell2._particleSoABuffer, cell1._particleSoABuffer, false);
     }
   }
 }

--- a/src/autopas/baseFunctors/CellFunctor3B.h
+++ b/src/autopas/baseFunctors/CellFunctor3B.h
@@ -91,41 +91,62 @@ class CellFunctor3B {
   void setSortingThreshold(size_t sortingThreshold);
 
  private:
+  static constexpr std::array<double, 3> zeroDirection{0., 0., 0.};
+
+  /**
+   * Returns true if the given cell is empty for the current _dataLayout.
+   * @param cell
+   * @return whether the given cell is empty.
+   */
+  [[nodiscard]] bool cellIsEmptyForCurrentLayout(const ParticleCell_T &cell) const {
+    switch (_dataLayout) {
+      case DataLayoutOption::aos:
+        return cell.isEmpty();
+      case DataLayoutOption::soa:
+        return cell._particleSoABuffer.size() == 0;
+    }
+    utils::ExceptionHandler::exception("CellFunctor::cellIsEmptyForCurrentLayout(): Unsupported data layout.");
+    return false;
+  }
+
+  /**
+   *
+   * @param particleCount
+   * @param sortingDirection
+   * @return
+   */
+  [[nodiscard]] bool shouldUseSorting(std::size_t particleCount, const std::array<double, 3> &sortingDirection) const {
+    return particleCount >= _sortingThreshold and sortingDirection != zeroDirection;
+  }
+
   /**
    * Applies the functor to all particle triplets exploiting newtons third law of motion.
-   * There is only one version of this function as newton3 is always allowed to be applied inside of a cell.
-   * The value of _useNewton3 defines whether or whether not to apply the aos version functor in a newton3 fashion or
-   * not:
-   * - if _useNewton3 is true: the aos functor will be applied once for each triplet (only i,j,k), passing newton3=true.
-   * - if _useNewton3 is false: the aos functor will be applied three times for each triplet (i,j,k and j,i,k and
+   * There is only one version of this function as newton3 is always allowed to be applied inside a cell.
+   * The value of newton3 defines how to apply the aos functor:
+   * - If _useNewton3 is true: The aos functor will be applied once for each triplet (only i,j,k), passing newton3=true.
+   * - If _useNewton3 is false: The aos functor will be applied three times for each triplet (i,j,k and j,i,k and
    * k,i,j), passing newton3=false.
+   * @tparam newton3
    * @param cell
    */
-  void processCellAoS(ParticleCell_T &cell);
+  template <bool newton3>
+  void processCellAoSImpl(ParticleCell_T &cell);
 
   /**
    * Applies the functor to all particle triplets between cell1 and cell2
    * exploiting newtons third law of motion.
+   * @tparam newton3
    * @param cell1
    * @param cell2
    * @param sortingDirection Normalized vector connecting centers of cell1 and cell2.
    */
-  void processCellPairAoSN3(ParticleCell_T &cell1, ParticleCell_T &cell2,
-                            const std::array<double, 3> &sortingDirection);
-
-  /**
-   * Applies the functor to all particle triplets between cell1 and cell2
-   * without exploiting newtons third law of motion.
-   * @param cell1
-   * @param cell2
-   * @param sortingDirection Normalized vector connecting centers of cell1 and cell2.
-   */
-  void processCellPairAoSNoN3(ParticleCell_T &cell1, ParticleCell_T &cell2,
+  template <bool newton3>
+  void processCellPairAoSImpl(ParticleCell_T &cell1, ParticleCell_T &cell2,
                               const std::array<double, 3> &sortingDirection);
 
   /**
-   * Applies the functor to all particle triples between cell1, cell2 and cell3
-   * exploiting newtons third law of motion.
+   * Applies the functor to all particle triples between cell1, cell2 and cell3.
+   * @tparam newton3 Whether to use Newton's third law of motion.
    * @param cell1
    * @param cell2
    * @param cell3
@@ -134,34 +155,28 @@ class CellFunctor3B {
    * @warning If sorting is used, sortingDirection should correspond to the pairwise sorting direction between cell1 and
    * cell2.
    */
-  void processCellTripleAoSN3(ParticleCell_T &cell1, ParticleCell_T &cell2, ParticleCell_T &cell3,
-                              const std::array<double, 3> &sortingDirection);
-
-  /**
-   * Applies the functor to all particle triples between cell1, cell2 and cell3
-   * without exploiting newtons third law of motion.
-   * @param cell1
-   * @param cell2
-   * @param cell3
-   * @param sortingDirection Normalized vector along which particles from cell1 and cell2 are sorted.
-   *
-   * @warning If sorting is used, sortingDirection should correspond to the pairwise sorting direction between cell1 and
-   * cell2.
-   */
-  void processCellTripleAoSNoN3(ParticleCell_T &cell1, ParticleCell_T &cell2, ParticleCell_T &cell3,
+  template <bool newton3>
+  void processCellTripleAoSImpl(ParticleCell_T &cell1, ParticleCell_T &cell2, ParticleCell_T &cell3,
                                 const std::array<double, 3> &sortingDirection);
 
-  void processCellPairSoAN3(ParticleCell_T &cell1, ParticleCell_T &cell2);
+  /**
+   * Applies the SoA functor to all particle triplets between cell1 and cell2.
+   * @tparam newton3 Whether to use Newton's third law of motion.
+   * @param cell1
+   * @param cell2
+   */
+  template <bool newton3>
+  void processCellPairSoAImpl(ParticleCell_T &cell1, ParticleCell_T &cell2);
 
-  void processCellPairSoANoN3(ParticleCell_T &cell1, ParticleCell_T &cell2);
-
-  void processCellTripleSoAN3(ParticleCell_T &cell1, ParticleCell_T &cell2, ParticleCell_T &cell3);
-
-  void processCellTripleSoANoN3(ParticleCell_T &cell1, ParticleCell_T &cell2, ParticleCell_T &cell3);
-
-  void processCellSoAN3(ParticleCell_T &cell);
-
-  void processCellSoANoN3(ParticleCell_T &cell);
+  /**
+   * Applies the SoA functor to all particle triplets between cell1, cell2 and cell3.
+   * @tparam newton3 Whether to use Newton's third law of motion.
+   * @param cell1
+   * @param cell2
+   * @param cell3
+   */
+  template <bool newton3>
+  void processCellTripleSoAImpl(ParticleCell_T &cell1, ParticleCell_T &cell2, ParticleCell_T &cell3);
 
   ParticleFunctor_T &_functor;
 
@@ -174,9 +189,9 @@ class CellFunctor3B {
    */
   size_t _sortingThreshold{8};
 
-  DataLayoutOption _dataLayout;
+  const DataLayoutOption::Value _dataLayout;
 
-  bool _useNewton3;
+  const bool _useNewton3;
 };
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
@@ -186,8 +201,7 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::setSorting
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
 void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCell(ParticleCell_T &cell) {
-  if ((_dataLayout == DataLayoutOption::soa and cell._particleSoABuffer.size() == 0) or
-      (_dataLayout == DataLayoutOption::aos and cell.isEmpty())) {
+  if (cellIsEmptyForCurrentLayout(cell)) {
     return;
   }
 
@@ -197,16 +211,19 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
     return;
   }
 
-  // (Explicit) static cast required for Apple Clang (last tested version: 17.0.0)
-  switch (static_cast<DataLayoutOption::Value>(_dataLayout)) {
+  switch (_dataLayout) {
     case DataLayoutOption::aos:
-      processCellAoS(cell);
+      if (_useNewton3) {
+        processCellAoSImpl<true>(cell);
+      } else {
+        processCellAoSImpl<false>(cell);
+      }
       break;
     case DataLayoutOption::soa:
       if (_useNewton3) {
-        processCellSoAN3(cell);
+        _functor.SoAFunctorSingle(cell._particleSoABuffer, true);
       } else {
-        processCellSoANoN3(cell);
+        _functor.SoAFunctorSingle(cell._particleSoABuffer, false);
       }
       break;
   }
@@ -216,36 +233,39 @@ template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
 void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPair(
 
     ParticleCell_T &cell1, ParticleCell_T &cell2, const std::array<double, 3> &sortingDirection) {
-  if ((_dataLayout == DataLayoutOption::soa and
-       (cell1._particleSoABuffer.size() == 0 or cell2._particleSoABuffer.size() == 0)) or
-      (_dataLayout == DataLayoutOption::aos and (cell1.size() == 0 or cell2.size() == 0))) {
+  if (cellIsEmptyForCurrentLayout(cell1) or cellIsEmptyForCurrentLayout(cell2)) {
     return;
   }
 
-  // avoid force calculations if both cells can not contain owned particles or if newton3==false and cell1 does not
-  // contain owned particles
   const bool cell1HasOwnedParticles = toInt64(cell1.getPossibleParticleOwnerships() & OwnershipState::owned);
   const bool cell2HasOwnedParticles = toInt64(cell2.getPossibleParticleOwnerships() & OwnershipState::owned);
 
-  if (((not cell1HasOwnedParticles) and (not _useNewton3) and (not bidirectional)) or
-      ((not cell1HasOwnedParticles) and (not cell2HasOwnedParticles))) {
+  // Avoid force calculations if both cells cannot contain owned particles.
+  if (not cell1HasOwnedParticles and not cell2HasOwnedParticles) {
     return;
   }
 
-  // (Explicit) static cast required for Apple Clang (last tested version: 17.0.0)
-  switch (static_cast<DataLayoutOption::Value>(_dataLayout)) {
+  // In Newton3==false and functor is not bidirectional, only interactions from cell1 to cell2 are computed. Therefore,
+  // if cell1 cannot contain owned particles, there is nothing useful to do.
+  if constexpr (not bidirectional) {
+    if (not _useNewton3 and not cell1HasOwnedParticles) {
+      return;
+    }
+  }
+
+  switch (_dataLayout) {
     case DataLayoutOption::aos:
       if (_useNewton3) {
-        processCellPairAoSN3(cell1, cell2, sortingDirection);
+        processCellPairAoSImpl<true>(cell1, cell2, sortingDirection);
       } else {
-        processCellPairAoSNoN3(cell1, cell2, sortingDirection);
+        processCellPairAoSImpl<false>(cell1, cell2, sortingDirection);
       }
       break;
     case DataLayoutOption::soa:
       if (_useNewton3) {
-        processCellPairSoAN3(cell1, cell2);
+        processCellPairSoAImpl<true>(cell1, cell2);
       } else {
-        processCellPairSoANoN3(cell1, cell2);
+        processCellPairSoAImpl<false>(cell1, cell2);
       }
       break;
   }
@@ -256,48 +276,51 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
 
     ParticleCell_T &cell1, ParticleCell_T &cell2, ParticleCell_T &cell3,
     const std::array<double, 3> &sortingDirection) {
-  if ((_dataLayout == DataLayoutOption::soa and
-       (cell1._particleSoABuffer.size() == 0 or cell2._particleSoABuffer.size() == 0 or
-        cell3._particleSoABuffer.size() == 0)) or
-      (_dataLayout == DataLayoutOption::aos and (cell1.size() == 0 or cell2.size() == 0 or cell3.size() == 0))) {
+  if (cellIsEmptyForCurrentLayout(cell1) or cellIsEmptyForCurrentLayout(cell2) or cellIsEmptyForCurrentLayout(cell3)) {
     return;
   }
 
-  // avoid force calculations if all three cells can not contain owned particles or if newton3==false and cell1 does not
-  // contain owned particles
   const bool cell1HasOwnedParticles = toInt64(cell1.getPossibleParticleOwnerships() & OwnershipState::owned);
   const bool cell2HasOwnedParticles = toInt64(cell2.getPossibleParticleOwnerships() & OwnershipState::owned);
   const bool cell3HasOwnedParticles = toInt64(cell3.getPossibleParticleOwnerships() & OwnershipState::owned);
 
-  if (((not cell1HasOwnedParticles) and (not _useNewton3) and (not bidirectional)) or
-      ((not cell1HasOwnedParticles) and (not cell2HasOwnedParticles) and (not cell3HasOwnedParticles))) {
+  // Avoid force calculations if all three cells cannot contain owned particles.
+  if (not cell1HasOwnedParticles and not cell2HasOwnedParticles and not cell3HasOwnedParticles) {
     return;
   }
 
-  // (Explicit) static cast required for Apple Clang (last tested version: 17.0.0)
-  switch (static_cast<DataLayoutOption::Value>(_dataLayout)) {
+  // In Newton3==false and functor is not bidirectional, only interactions from cell1 are computed. Therefore,
+  // if cell1 cannot contain owned particles, there is nothing useful to do.
+  if constexpr (not bidirectional) {
+    if (not _useNewton3 and not cell1HasOwnedParticles) {
+      return;
+    }
+  }
+
+  switch (_dataLayout) {
     case DataLayoutOption::aos:
       if (_useNewton3) {
-        processCellTripleAoSN3(cell1, cell2, cell3, sortingDirection);
+        processCellTripleAoSImpl<true>(cell1, cell2, cell3, sortingDirection);
       } else {
-        processCellTripleAoSNoN3(cell1, cell2, cell3, sortingDirection);
+        processCellTripleAoSImpl<false>(cell1, cell2, cell3, sortingDirection);
       }
       break;
     case DataLayoutOption::soa:
       if (_useNewton3) {
-        processCellTripleSoAN3(cell1, cell2, cell3);
+        processCellTripleSoAImpl<true>(cell1, cell2, cell3);
       } else {
-        processCellTripleSoANoN3(cell1, cell2, cell3);
+        processCellTripleSoAImpl<false>(cell1, cell2, cell3);
       }
       break;
   }
 }
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellAoS(ParticleCell_T &cell) {
+template <bool newton3>
+void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellAoSImpl(ParticleCell_T &cell) {
   // helper function
   const auto interactParticles = [&](auto &p1, auto &p2, auto &p3) {
-    if (_useNewton3) {
+    if constexpr (newton3) {
       _functor.AoSFunctor(p1, p2, p3, true);
     } else {
       if (not p1.isHalo()) {
@@ -320,14 +343,13 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
 
       for (auto cellIter2 = std::next(cellIter1); cellIter2 != cellSorted._particles.end(); ++cellIter2) {
         auto &[p2Projection, p2Ptr] = *cellIter2;
-        if (std::abs(p1Projection - p2Projection) > _sortingCutoff) {
+        if (p2Projection - p1Projection > _sortingCutoff) {
           break;
         }
 
         for (auto cellIter3 = std::next(cellIter2); cellIter3 != cellSorted._particles.end(); ++cellIter3) {
           auto &[p3Projection, p3Ptr] = *cellIter3;
-          if (std::abs(p1Projection - p3Projection) > _sortingCutoff or
-              std::abs(p2Projection - p3Projection) > _sortingCutoff) {
+          if (p3Projection - p3Projection > _sortingCutoff or p3Projection - p2Projection > _sortingCutoff) {
             break;
           }
           interactParticles(*p1Ptr, *p2Ptr, *p3Ptr);
@@ -350,9 +372,28 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
 }
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairAoSN3(
+template <bool newton3>
+void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairAoSImpl(
     ParticleCell_T &cell1, ParticleCell_T &cell2, const std::array<double, 3> &sortingDirection) {
-  if ((cell1.size() + cell2.size() > _sortingThreshold) and sortingDirection != std::array<double, 3>{0., 0., 0.}) {
+  const auto interactParticles = [this](auto &p1, auto &p2, auto &p3, const bool p2FromCell1) {
+    if constexpr (newton3) {
+      _functor.AoSFunctor(p1, p2, p3, true);
+    } else {
+      _functor.AoSFunctor(p1, p2, p3, false);
+      if (p2FromCell1) {
+        _functor.AoSFunctor(p2, p1, p3, false);  // because of no newton3 and p2 is still in cell1
+      } else {
+        if constexpr (bidirectional) {
+          _functor.AoSFunctor(p2, p1, p3, false);
+        }
+      }
+      if constexpr (bidirectional) {
+        _functor.AoSFunctor(p3, p1, p2, false);
+      }
+    }
+  };
+
+  if (shouldUseSorting(cell1.size() + cell2.size(), sortingDirection)) {
     SortedCellView<ParticleCell_T> cell1Sorted(cell1, sortingDirection);
     SortedCellView<ParticleCell_T> cell2Sorted(cell2, sortingDirection);
 
@@ -363,31 +404,29 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
       // Particle 2 in cell1, particle 3 in cell2
       for (auto cellIter2 = std::next(cellIter1); cellIter2 != cell1Sorted._particles.end(); ++cellIter2) {
         auto &[p2Projection, p2Ptr] = *cellIter2;
-        if (std::abs(p1Projection - p2Projection) > _sortingCutoff) {
+        if (p2Projection - p1Projection > _sortingCutoff) {
           break;
         }
         for (auto &[p3Projection, p3Ptr] : cell2Sorted._particles) {
-          if (std::abs(p2Projection - p3Projection) > _sortingCutoff or
-              std::abs(p1Projection - p3Projection) > _sortingCutoff) {
+          if (p3Projection - p2Projection > _sortingCutoff or p3Projection - p1Projection > _sortingCutoff) {
             break;
           }
-          _functor.AoSFunctor(*p1Ptr, *p2Ptr, *p3Ptr, true);
+          interactParticles(*p1Ptr, *p2Ptr, *p3Ptr, true);
         }
       }
 
       // Particle 2 and 3 in cell 2
       for (auto cellIter2 = cell2Sorted._particles.begin(); cellIter2 != cell2Sorted._particles.end(); ++cellIter2) {
         auto &[p2Projection, p2Ptr] = *cellIter2;
-        if (std::abs(p1Projection - p2Projection) > _sortingCutoff) {
+        if (p2Projection - p1Projection > _sortingCutoff) {
           break;
         }
         for (auto cellIter3 = std::next(cellIter2); cellIter3 != cell2Sorted._particles.end(); ++cellIter3) {
           auto &[p3Projection, p3Ptr] = *cellIter3;
-          if (std::abs(p2Projection - p3Projection) > _sortingCutoff or
-              std::abs(p1Projection - p3Projection) > _sortingCutoff) {
+          if (p3Projection - p2Projection > _sortingCutoff or p3Projection - p1Projection > _sortingCutoff) {
             break;
           }
-          _functor.AoSFunctor(*p1Ptr, *p2Ptr, *p3Ptr, true);
+          interactParticles(*p1Ptr, *p2Ptr, *p3Ptr, false);
         }
       }
     }
@@ -399,7 +438,7 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
       ++p2Ptr;
       for (; p2Ptr != cell1.end(); ++p2Ptr) {
         for (auto &p3 : cell2) {
-          _functor.AoSFunctor(*p1Ptr, *p2Ptr, p3, true);
+          interactParticles(*p1Ptr, *p2Ptr, p3, true);
         }
       }
 
@@ -408,7 +447,7 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
         auto p3Ptr = p2Ptr;
         ++p3Ptr;
         for (; p3Ptr != cell2.end(); ++p3Ptr) {
-          _functor.AoSFunctor(*p1Ptr, *p2Ptr, *p3Ptr, true);
+          interactParticles(*p1Ptr, *p2Ptr, *p3Ptr, false);
         }
       }
     }
@@ -416,102 +455,35 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
 }
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairAoSNoN3(
-    ParticleCell_T &cell1, ParticleCell_T &cell2, const std::array<double, 3> &sortingDirection) {
-  // helper function
-  const auto interactParticles = [&](auto &p1, auto &p2, auto &p3, const bool p2FromCell1) {
-    _functor.AoSFunctor(p1, p2, p3, false);
-    if (p2FromCell1) {
-      _functor.AoSFunctor(p2, p1, p3, false);  // because of no newton3 and p2 is still in cell1
+template <bool newton3>
+void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellTripleAoSImpl(
+    ParticleCell_T &cell1, ParticleCell_T &cell2, ParticleCell_T &cell3,
+    const std::array<double, 3> &sortingDirection) {
+  const auto interactParticles = [this](auto &p1, auto &p2, auto &p3) {
+    if constexpr (newton3) {
+      _functor.AoSFunctor(p1, p2, p3, true);
     } else {
+      _functor.AoSFunctor(p1, p2, p3, false);
+
       if constexpr (bidirectional) {
         _functor.AoSFunctor(p2, p1, p3, false);
+        _functor.AoSFunctor(p3, p1, p2, false);
       }
-    }
-    if constexpr (bidirectional) {
-      _functor.AoSFunctor(p3, p1, p2, false);
     }
   };
 
-  if ((cell1.size() + cell2.size() > _sortingThreshold) and sortingDirection != std::array<double, 3>{0., 0., 0.}) {
-    SortedCellView<ParticleCell_T> cell1Sorted(cell1, sortingDirection);
-    SortedCellView<ParticleCell_T> cell2Sorted(cell2, sortingDirection);
-
-    // Particle 1 always from cell1
-    for (auto cellIter1 = cell1Sorted._particles.begin(); cellIter1 != cell1Sorted._particles.end(); ++cellIter1) {
-      auto &[p1Projection, p1Ptr] = *cellIter1;
-
-      // Particle 2 in cell1, particle 3 in cell2
-      for (auto cellIter2 = std::next(cellIter1); cellIter2 != cell1Sorted._particles.end(); ++cellIter2) {
-        auto &[p2Projection, p2Ptr] = *cellIter2;
-        if (std::abs(p1Projection - p2Projection) > _sortingCutoff) {
-          break;
-        }
-        for (auto &[p3Projection, p3Ptr] : cell2Sorted._particles) {
-          if (std::abs(p2Projection - p3Projection) > _sortingCutoff or
-              std::abs(p1Projection - p3Projection) > _sortingCutoff) {
-            break;
-          }
-          interactParticles(*p1Ptr, *p2Ptr, *p3Ptr, true);
-        }
-      }
-
-      // Particles 2 and 3 both in cell2
-      for (auto cellIter2 = cell2Sorted._particles.begin(); cellIter2 != cell2Sorted._particles.end(); ++cellIter2) {
-        auto &[p2Projection, p2Ptr] = *cellIter2;
-        if (std::abs(p1Projection - p2Projection) > _sortingCutoff) {
-          break;
-        }
-        for (auto cellIter3 = std::next(cellIter2); cellIter3 != cell2Sorted._particles.end(); ++cellIter3) {
-          auto &[p3Projection, p3Ptr] = *cellIter3;
-          if (std::abs(p2Projection - p3Projection) > _sortingCutoff or
-              std::abs(p1Projection - p3Projection) > _sortingCutoff) {
-            break;
-          }
-          interactParticles(*p1Ptr, *p2Ptr, *p3Ptr, false);
-        }
-      }
-    }
-  } else {  // no sorting
-    // Particle 1 from cell1
-    for (auto p1Ptr = cell1.begin(); p1Ptr != cell1.end(); ++p1Ptr) {
-      // Particle 2 in cell1, particle 3 in cell2
-      auto p2Ptr = p1Ptr;
-      ++p2Ptr;
-      for (; p2Ptr != cell1.end(); ++p2Ptr) {
-        for (auto &p3 : cell2) {
-          interactParticles(*p1Ptr, *p2Ptr, p3, true);
-        }
-      }
-
-      // Particles 2 and 3 both in cell2
-      for (auto p2Ptr = cell2.begin(); p2Ptr != cell2.end(); ++p2Ptr) {
-        auto p3Ptr = p2Ptr;
-        ++p3Ptr;
-        for (; p3Ptr != cell2.end(); ++p3Ptr) {
-          interactParticles(*p1Ptr, *p2Ptr, *p3Ptr, false);
-        }
-      }
-    }
-  }
-}
-
-template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellTripleAoSN3(
-    ParticleCell_T &cell1, ParticleCell_T &cell2, ParticleCell_T &cell3,
-    const std::array<double, 3> &sortingDirection) {
-  if ((cell1.size() + cell2.size() + cell3.size() > _sortingThreshold) and
-      sortingDirection != std::array<double, 3>{0., 0., 0.}) {
+  if (shouldUseSorting(cell1.size() + cell2.size() + cell3.size(), sortingDirection)) {
     SortedCellView<ParticleCell_T> cell1Sorted(cell1, sortingDirection);
     SortedCellView<ParticleCell_T> cell2Sorted(cell2, sortingDirection);
 
     for (auto &[p1Projection, p1Ptr] : cell1Sorted._particles) {
       for (auto &[p2Projection, p2Ptr] : cell2Sorted._particles) {
-        if (std::abs(p1Projection - p2Projection) > _sortingCutoff) {
+        // p2Projection > p1Projection guaranteed by sorting direction
+        if (p2Projection - p1Projection > _sortingCutoff) {
           break;
         }
         for (auto &p3 : cell3) {
-          _functor.AoSFunctor(*p1Ptr, *p2Ptr, p3, true);
+          interactParticles(*p1Ptr, *p2Ptr, p3);
         }
       }
     }
@@ -519,7 +491,7 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
     for (auto &p1 : cell1) {
       for (auto &p2 : cell2) {
         for (auto &p3 : cell3) {
-          _functor.AoSFunctor(p1, p2, p3, true);
+          interactParticles(p1, p2, p3);
         }
       }
     }
@@ -527,84 +499,32 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
 }
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellTripleAoSNoN3(
-    ParticleCell_T &cell1, ParticleCell_T &cell2, ParticleCell_T &cell3,
-    const std::array<double, 3> &sortingDirection) {
-  // helper function
-  const auto interactParticlesNoN3 = [&](auto &p1, auto &p2, auto &p3) {
-    _functor.AoSFunctor(p1, p2, p3, false);
-    if constexpr (bidirectional) {
-      _functor.AoSFunctor(p2, p1, p3, false);
-      _functor.AoSFunctor(p3, p1, p2, false);
-    }
-  };
-
-  if (cell1.size() + cell2.size() + cell3.size() > _sortingThreshold and
-      sortingDirection != std::array<double, 3>{0., 0., 0.}) {
-    SortedCellView<ParticleCell_T> cell1Sorted(cell1, sortingDirection);
-    SortedCellView<ParticleCell_T> cell2Sorted(cell2, sortingDirection);
-
-    for (auto &[p1Projection, p1Ptr] : cell1Sorted._particles) {
-      for (auto &[p2Projection, p2Ptr] : cell2Sorted._particles) {
-        if (std::abs(p1Projection - p2Projection) > _sortingCutoff) {
-          break;
-        }
-
-        for (auto &p3 : cell3) {
-          interactParticlesNoN3(*p1Ptr, *p2Ptr, p3);
-        }
-      }
-    }
-  } else {
-    for (auto &p1 : cell1) {
-      for (auto &p2 : cell2) {
-        for (auto &p3 : cell3) {
-          interactParticlesNoN3(p1, p2, p3);
-        }
-      }
-    }
-  }
-}
-
-template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellSoAN3(ParticleCell_T &cell) {
-  _functor.SoAFunctorSingle(cell._particleSoABuffer, true);
-}
-
-template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellSoANoN3(ParticleCell_T &cell) {
-  _functor.SoAFunctorSingle(cell._particleSoABuffer, false);  // the functor has to enable this...
-}
-
-template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairSoAN3(ParticleCell_T &cell1,
-                                                                                           ParticleCell_T &cell2) {
-  _functor.SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, true);
-}
-
-template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairSoANoN3(ParticleCell_T &cell1,
+template <bool newton3>
+void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairSoAImpl(ParticleCell_T &cell1,
                                                                                              ParticleCell_T &cell2) {
-  _functor.SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, false);
-  if (bidirectional) _functor.SoAFunctorPair(cell2._particleSoABuffer, cell1._particleSoABuffer, false);
+  if constexpr (newton3) {
+    _functor.SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, true);
+  } else {
+    _functor.SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, false);
+    if constexpr (bidirectional) {
+      if (bidirectional) _functor.SoAFunctorPair(cell2._particleSoABuffer, cell1._particleSoABuffer, false);
+    }
+  }
 }
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellTripleSoAN3(ParticleCell_T &cell1,
-                                                                                             ParticleCell_T &cell2,
-                                                                                             ParticleCell_T &cell3) {
-  _functor.SoAFunctorTriple(cell1._particleSoABuffer, cell2._particleSoABuffer, cell3._particleSoABuffer, true);
-}
-
-template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellTripleSoANoN3(ParticleCell_T &cell1,
+template <bool newton3>
+void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellTripleSoAImpl(ParticleCell_T &cell1,
                                                                                                ParticleCell_T &cell2,
                                                                                                ParticleCell_T &cell3) {
-  _functor.SoAFunctorTriple(cell1._particleSoABuffer, cell2._particleSoABuffer, cell3._particleSoABuffer, false);
-  if (bidirectional) {
-    _functor.SoAFunctorTriple(cell2._particleSoABuffer, cell1._particleSoABuffer, cell3._particleSoABuffer, false);
-    _functor.SoAFunctorTriple(cell3._particleSoABuffer, cell1._particleSoABuffer, cell2._particleSoABuffer, false);
+  if constexpr (newton3) {
+    _functor.SoAFunctorTriple(cell1._particleSoABuffer, cell2._particleSoABuffer, cell3._particleSoABuffer, true);
+  } else {
+    _functor.SoAFunctorTriple(cell1._particleSoABuffer, cell2._particleSoABuffer, cell3._particleSoABuffer, false);
+    if constexpr (bidirectional) {
+      _functor.SoAFunctorTriple(cell2._particleSoABuffer, cell1._particleSoABuffer, cell3._particleSoABuffer, false);
+      _functor.SoAFunctorTriple(cell3._particleSoABuffer, cell1._particleSoABuffer, cell2._particleSoABuffer, false);
+    }
   }
 }
-
 }  // namespace autopas::internal

--- a/src/autopas/baseFunctors/CellFunctor3B.h
+++ b/src/autopas/baseFunctors/CellFunctor3B.h
@@ -286,13 +286,14 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
 
       for (auto cellIter2 = std::next(cellIter1); cellIter2 != cellSorted._particles.end(); ++cellIter2) {
         auto &[p2Projection, p2Ptr] = *cellIter2;
-        if (p2Projection - p1Projection > _sortingCutoff) {
+        if (std::abs(p2Projection - p1Projection) > _sortingCutoff) {
           break;
         }
 
         for (auto cellIter3 = std::next(cellIter2); cellIter3 != cellSorted._particles.end(); ++cellIter3) {
           auto &[p3Projection, p3Ptr] = *cellIter3;
-          if (p3Projection - p1Projection > _sortingCutoff or p3Projection - p2Projection > _sortingCutoff) {
+          if (std::abs(p3Projection - p1Projection) > _sortingCutoff or
+              std::abs(p3Projection - p2Projection) > _sortingCutoff) {
             break;
           }
           interactParticles(*p1Ptr, *p2Ptr, *p3Ptr);
@@ -344,11 +345,12 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
       // Particle 2 in cell1, particle 3 in cell2
       for (auto cellIter2 = std::next(cellIter1); cellIter2 != cell1Sorted._particles.end(); ++cellIter2) {
         auto &[p2Projection, p2Ptr] = *cellIter2;
-        if (p2Projection - p1Projection > _sortingCutoff) {
+        if (std::abs(p2Projection - p1Projection) > _sortingCutoff) {
           break;
         }
         for (auto &[p3Projection, p3Ptr] : cell2Sorted._particles) {
-          if (p3Projection - p2Projection > _sortingCutoff or p3Projection - p1Projection > _sortingCutoff) {
+          if (std::abs(p3Projection - p2Projection) > _sortingCutoff or
+              std::abs(p3Projection - p1Projection) > _sortingCutoff) {
             break;
           }
           interactParticles(*p1Ptr, *p2Ptr, *p3Ptr, true);
@@ -358,12 +360,13 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
       // Particle 2 and 3 in cell 2
       for (auto cellIter2 = cell2Sorted._particles.begin(); cellIter2 != cell2Sorted._particles.end(); ++cellIter2) {
         auto &[p2Projection, p2Ptr] = *cellIter2;
-        if (p2Projection - p1Projection > _sortingCutoff) {
+        if (std::abs(p2Projection - p1Projection) > _sortingCutoff) {
           break;
         }
         for (auto cellIter3 = std::next(cellIter2); cellIter3 != cell2Sorted._particles.end(); ++cellIter3) {
           auto &[p3Projection, p3Ptr] = *cellIter3;
-          if (p3Projection - p2Projection > _sortingCutoff or p3Projection - p1Projection > _sortingCutoff) {
+          if (std::abs(p3Projection - p2Projection) > _sortingCutoff or
+              std::abs(p3Projection - p1Projection) > _sortingCutoff) {
             break;
           }
           interactParticles(*p1Ptr, *p2Ptr, *p3Ptr, false);
@@ -415,8 +418,7 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
 
     for (auto &[p1Projection, p1Ptr] : cell1Sorted._particles) {
       for (auto &[p2Projection, p2Ptr] : cell2Sorted._particles) {
-        // p2Projection > p1Projection guaranteed by sorting direction
-        if (p2Projection - p1Projection > _sortingCutoff) {
+        if (std::abs(p2Projection - p1Projection) > _sortingCutoff) {
           break;
         }
         for (auto &p3 : cell3) {

--- a/src/autopas/baseFunctors/CellFunctor3B.h
+++ b/src/autopas/baseFunctors/CellFunctor3B.h
@@ -109,27 +109,22 @@ class CellFunctor3B {
    * - If _useNewton3 is true: The aos functor will be applied once for each triplet (only i,j,k), passing newton3=true.
    * - If _useNewton3 is false: The aos functor will be applied three times for each triplet (i,j,k and j,i,k and
    * k,i,j), passing newton3=false.
-   * @tparam newton3
    * @param cell
    */
-  template <bool newton3>
   void processCellAoSImpl(ParticleCell_T &cell);
 
   /**
    * Applies the functor to all particle triplets between cell1 and cell2
    * exploiting newtons third law of motion.
-   * @tparam newton3
    * @param cell1
    * @param cell2
    * @param sortingDirection Normalized vector connecting centers of cell1 and cell2.
    */
-  template <bool newton3>
   void processCellPairAoSImpl(ParticleCell_T &cell1, ParticleCell_T &cell2,
                               const std::array<double, 3> &sortingDirection);
 
   /**
    * Applies the functor to all particle triples between cell1, cell2 and cell3.
-   * @tparam newton3 Whether to use Newton's third law of motion.
    * @param cell1
    * @param cell2
    * @param cell3
@@ -138,27 +133,22 @@ class CellFunctor3B {
    * @warning If sorting is used, sortingDirection should correspond to the pairwise sorting direction between cell1 and
    * cell2.
    */
-  template <bool newton3>
   void processCellTripleAoSImpl(ParticleCell_T &cell1, ParticleCell_T &cell2, ParticleCell_T &cell3,
                                 const std::array<double, 3> &sortingDirection);
 
   /**
    * Applies the SoA functor to all particle triplets between cell1 and cell2.
-   * @tparam newton3 Whether to use Newton's third law of motion.
    * @param cell1
    * @param cell2
    */
-  template <bool newton3>
   void processCellPairSoAImpl(ParticleCell_T &cell1, ParticleCell_T &cell2);
 
   /**
    * Applies the SoA functor to all particle triplets between cell1, cell2 and cell3.
-   * @tparam newton3 Whether to use Newton's third law of motion.
    * @param cell1
    * @param cell2
    * @param cell3
    */
-  template <bool newton3>
   void processCellTripleSoAImpl(ParticleCell_T &cell1, ParticleCell_T &cell2, ParticleCell_T &cell3);
 
   ParticleFunctor_T &_functor;
@@ -195,11 +185,7 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
       if (cell.isEmpty()) {
         return;
       }
-      if (_useNewton3) {
-        processCellAoSImpl<true>(cell);
-      } else {
-        processCellAoSImpl<false>(cell);
-      }
+      processCellAoSImpl(cell);
       break;
     case DataLayoutOption::soa:
       if (cell._particleSoABuffer.size() == 0) {
@@ -239,21 +225,13 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
       if (cell1.isEmpty() or cell2.isEmpty()) {
         return;
       }
-      if (_useNewton3) {
-        processCellPairAoSImpl<true>(cell1, cell2, sortingDirection);
-      } else {
-        processCellPairAoSImpl<false>(cell1, cell2, sortingDirection);
-      }
+      processCellPairAoSImpl(cell1, cell2, sortingDirection);
       break;
     case DataLayoutOption::soa:
       if (cell1._particleSoABuffer.size() == 0 or cell2._particleSoABuffer.size() == 0) {
         return;
       }
-      if (_useNewton3) {
-        processCellPairSoAImpl<true>(cell1, cell2);
-      } else {
-        processCellPairSoAImpl<false>(cell1, cell2);
-      }
+      processCellPairSoAImpl(cell1, cell2);
       break;
   }
 }
@@ -285,32 +263,23 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
       if (cell1.isEmpty() or cell2.isEmpty() or cell3.isEmpty()) {
         return;
       }
-      if (_useNewton3) {
-        processCellTripleAoSImpl<true>(cell1, cell2, cell3, sortingDirection);
-      } else {
-        processCellTripleAoSImpl<false>(cell1, cell2, cell3, sortingDirection);
-      }
+      processCellTripleAoSImpl(cell1, cell2, cell3, sortingDirection);
       break;
     case DataLayoutOption::soa:
       if (cell1._particleSoABuffer.size() == 0 or cell2._particleSoABuffer.size() == 0 or
           cell3._particleSoABuffer.size() == 0) {
         return;
       }
-      if (_useNewton3) {
-        processCellTripleSoAImpl<true>(cell1, cell2, cell3);
-      } else {
-        processCellTripleSoAImpl<false>(cell1, cell2, cell3);
-      }
+      processCellTripleSoAImpl(cell1, cell2, cell3);
       break;
   }
 }
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-template <bool newton3>
 void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellAoSImpl(ParticleCell_T &cell) {
   // helper function
-  const auto interactParticles = [&f = this->_functor](auto &p1, auto &p2, auto &p3) {
-    if constexpr (newton3) {
+  const auto interactParticles = [&f = this->_functor, n3 = this->_useNewton3](auto &p1, auto &p2, auto &p3) {
+    if (n3) {
       f.AoSFunctor(p1, p2, p3, true);
     } else {
       if (not p1.isHalo()) {
@@ -362,11 +331,11 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
 }
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-template <bool newton3>
 void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairAoSImpl(
     ParticleCell_T &cell1, ParticleCell_T &cell2, const std::array<double, 3> &sortingDirection) {
-  const auto interactParticles = [&f = this->_functor](auto &p1, auto &p2, auto &p3, const bool p2FromCell1) {
-    if constexpr (newton3) {
+  const auto interactParticles = [&f = this->_functor, n3 = this->_useNewton3](auto &p1, auto &p2, auto &p3,
+                                                                               const bool p2FromCell1) {
+    if (n3) {
       f.AoSFunctor(p1, p2, p3, true);
     } else {
       f.AoSFunctor(p1, p2, p3, false);
@@ -445,12 +414,11 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
 }
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-template <bool newton3>
 void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellTripleAoSImpl(
     ParticleCell_T &cell1, ParticleCell_T &cell2, ParticleCell_T &cell3,
     const std::array<double, 3> &sortingDirection) {
-  const auto interactParticles = [&f = this->_functor](auto &p1, auto &p2, auto &p3) {
-    if constexpr (newton3) {
+  const auto interactParticles = [&f = this->_functor, n3 = this->_useNewton3](auto &p1, auto &p2, auto &p3) {
+    if (n3) {
       f.AoSFunctor(p1, p2, p3, true);
     } else {
       f.AoSFunctor(p1, p2, p3, false);
@@ -489,10 +457,9 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
 }
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-template <bool newton3>
 void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairSoAImpl(ParticleCell_T &cell1,
                                                                                              ParticleCell_T &cell2) {
-  if constexpr (newton3) {
+  if (_useNewton3) {
     _functor.SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, true);
   } else {
     _functor.SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, false);
@@ -503,11 +470,10 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
 }
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
-template <bool newton3>
 void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellTripleSoAImpl(ParticleCell_T &cell1,
                                                                                                ParticleCell_T &cell2,
                                                                                                ParticleCell_T &cell3) {
-  if constexpr (newton3) {
+  if (_useNewton3) {
     _functor.SoAFunctorTriple(cell1._particleSoABuffer, cell2._particleSoABuffer, cell3._particleSoABuffer, true);
   } else {
     _functor.SoAFunctorTriple(cell1._particleSoABuffer, cell2._particleSoABuffer, cell3._particleSoABuffer, false);

--- a/src/autopas/baseFunctors/CellFunctor3B.h
+++ b/src/autopas/baseFunctors/CellFunctor3B.h
@@ -278,7 +278,7 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
     }
   };
 
-  if (cell.size() > _sortingThreshold) {
+  if (cell.size() >= _sortingThreshold) {
     SortedCellView<ParticleCell_T> cellSorted(cell, utils::ArrayMath::normalize(std::array<double, 3>{1.0, 1.0, 1.0}));
 
     for (auto cellIter1 = cellSorted._particles.begin(); cellIter1 != cellSorted._particles.end(); ++cellIter1) {

--- a/src/autopas/baseFunctors/CellFunctor3B.h
+++ b/src/autopas/baseFunctors/CellFunctor3B.h
@@ -92,10 +92,10 @@ class CellFunctor3B {
 
  private:
   /**
-   *
-   * @param particleCount
-   * @param sortingDirection
-   * @return
+   * Evaluate whether the AoSFunctor should use sorting, depending on the set sorting threshold.
+   * @param particleCount Total number of involved particles.
+   * @param sortingDirection No sorting when the sorting direction is {0., 0., 0.}.
+   * @return whether the AoSFunctor should use the SortedCellView.
    */
   [[nodiscard]] bool shouldUseSorting(size_t particleCount, const std::array<double, 3> &sortingDirection) const {
     return particleCount >= _sortingThreshold and
@@ -103,9 +103,9 @@ class CellFunctor3B {
   }
 
   /**
-   * Applies the functor to all particle triplets exploiting newtons third law of motion.
+   * Applies the functor to all particle triplets exploiting Newton's third law of motion.
    * There is only one version of this function as newton3 is always allowed to be applied inside a cell.
-   * The value of newton3 defines how to apply the aos functor:
+   * The value of _useNewton3 defines how to apply the aos functor:
    * - If _useNewton3 is true: The aos functor will be applied once for each triplet (only i,j,k), passing newton3=true.
    * - If _useNewton3 is false: The aos functor will be applied three times for each triplet (i,j,k and j,i,k and
    * k,i,j), passing newton3=false.

--- a/src/autopas/baseFunctors/CellFunctor3B.h
+++ b/src/autopas/baseFunctors/CellFunctor3B.h
@@ -91,32 +91,15 @@ class CellFunctor3B {
   void setSortingThreshold(size_t sortingThreshold);
 
  private:
-  static constexpr std::array<double, 3> zeroDirection{0., 0., 0.};
-
-  /**
-   * Returns true if the given cell is empty for the current _dataLayout.
-   * @param cell
-   * @return whether the given cell is empty.
-   */
-  [[nodiscard]] bool cellIsEmptyForCurrentLayout(const ParticleCell_T &cell) const {
-    switch (_dataLayout) {
-      case DataLayoutOption::aos:
-        return cell.isEmpty();
-      case DataLayoutOption::soa:
-        return cell._particleSoABuffer.size() == 0;
-    }
-    utils::ExceptionHandler::exception("CellFunctor3B::cellIsEmptyForCurrentLayout(): Unsupported data layout.");
-    return false;
-  }
-
   /**
    *
    * @param particleCount
    * @param sortingDirection
    * @return
    */
-  [[nodiscard]] bool shouldUseSorting(std::size_t particleCount, const std::array<double, 3> &sortingDirection) const {
-    return particleCount >= _sortingThreshold and sortingDirection != zeroDirection;
+  [[nodiscard]] bool shouldUseSorting(size_t particleCount, const std::array<double, 3> &sortingDirection) const {
+    return particleCount >= _sortingThreshold and
+           (sortingDirection[0] != 0.0 and sortingDirection[1] != 0.0 and sortingDirection[2] != 0.0);
   }
 
   /**
@@ -201,10 +184,6 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::setSorting
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
 void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCell(ParticleCell_T &cell) {
-  if (cellIsEmptyForCurrentLayout(cell)) {
-    return;
-  }
-
   // avoid force calculations if the cell contains only halo particles or if the cell is empty (=dummy)
   const bool cellHasOwnedParticles = toInt64(cell.getPossibleParticleOwnerships() & OwnershipState::owned);
   if (not cellHasOwnedParticles) {
@@ -213,6 +192,9 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
 
   switch (_dataLayout) {
     case DataLayoutOption::aos:
+      if (cell.isEmpty()) {
+        return;
+      }
       if (_useNewton3) {
         processCellAoSImpl<true>(cell);
       } else {
@@ -220,6 +202,9 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
       }
       break;
     case DataLayoutOption::soa:
+      if (cell._particleSoABuffer.size() == 0) {
+        return;
+      }
       if (_useNewton3) {
         _functor.SoAFunctorSingle(cell._particleSoABuffer, true);
       } else {
@@ -233,10 +218,6 @@ template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
 void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPair(
 
     ParticleCell_T &cell1, ParticleCell_T &cell2, const std::array<double, 3> &sortingDirection) {
-  if (cellIsEmptyForCurrentLayout(cell1) or cellIsEmptyForCurrentLayout(cell2)) {
-    return;
-  }
-
   const bool cell1HasOwnedParticles = toInt64(cell1.getPossibleParticleOwnerships() & OwnershipState::owned);
   const bool cell2HasOwnedParticles = toInt64(cell2.getPossibleParticleOwnerships() & OwnershipState::owned);
 
@@ -255,6 +236,9 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
 
   switch (_dataLayout) {
     case DataLayoutOption::aos:
+      if (cell1.isEmpty() or cell2.isEmpty()) {
+        return;
+      }
       if (_useNewton3) {
         processCellPairAoSImpl<true>(cell1, cell2, sortingDirection);
       } else {
@@ -262,6 +246,9 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
       }
       break;
     case DataLayoutOption::soa:
+      if (cell1._particleSoABuffer.size() == 0 or cell2._particleSoABuffer.size() == 0) {
+        return;
+      }
       if (_useNewton3) {
         processCellPairSoAImpl<true>(cell1, cell2);
       } else {
@@ -276,10 +263,6 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
 
     ParticleCell_T &cell1, ParticleCell_T &cell2, ParticleCell_T &cell3,
     const std::array<double, 3> &sortingDirection) {
-  if (cellIsEmptyForCurrentLayout(cell1) or cellIsEmptyForCurrentLayout(cell2) or cellIsEmptyForCurrentLayout(cell3)) {
-    return;
-  }
-
   const bool cell1HasOwnedParticles = toInt64(cell1.getPossibleParticleOwnerships() & OwnershipState::owned);
   const bool cell2HasOwnedParticles = toInt64(cell2.getPossibleParticleOwnerships() & OwnershipState::owned);
   const bool cell3HasOwnedParticles = toInt64(cell3.getPossibleParticleOwnerships() & OwnershipState::owned);
@@ -299,6 +282,9 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
 
   switch (_dataLayout) {
     case DataLayoutOption::aos:
+      if (cell1.isEmpty() or cell2.isEmpty() or cell3.isEmpty()) {
+        return;
+      }
       if (_useNewton3) {
         processCellTripleAoSImpl<true>(cell1, cell2, cell3, sortingDirection);
       } else {
@@ -306,6 +292,10 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
       }
       break;
     case DataLayoutOption::soa:
+      if (cell1._particleSoABuffer.size() == 0 or cell2._particleSoABuffer.size() == 0 or
+          cell3._particleSoABuffer.size() == 0) {
+        return;
+      }
       if (_useNewton3) {
         processCellTripleSoAImpl<true>(cell1, cell2, cell3);
       } else {
@@ -319,18 +309,18 @@ template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
 template <bool newton3>
 void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellAoSImpl(ParticleCell_T &cell) {
   // helper function
-  const auto interactParticles = [&](auto &p1, auto &p2, auto &p3) {
+  const auto interactParticles = [&f = this->_functor](auto &p1, auto &p2, auto &p3) {
     if constexpr (newton3) {
-      _functor.AoSFunctor(p1, p2, p3, true);
+      f.AoSFunctor(p1, p2, p3, true);
     } else {
       if (not p1.isHalo()) {
-        _functor.AoSFunctor(p1, p2, p3, false);
+        f.AoSFunctor(p1, p2, p3, false);
       }
       if (not p2.isHalo()) {
-        _functor.AoSFunctor(p2, p1, p3, false);
+        f.AoSFunctor(p2, p1, p3, false);
       }
       if (not p3.isHalo()) {
-        _functor.AoSFunctor(p3, p1, p2, false);
+        f.AoSFunctor(p3, p1, p2, false);
       }
     }
   };
@@ -375,20 +365,20 @@ template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
 template <bool newton3>
 void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairAoSImpl(
     ParticleCell_T &cell1, ParticleCell_T &cell2, const std::array<double, 3> &sortingDirection) {
-  const auto interactParticles = [this](auto &p1, auto &p2, auto &p3, const bool p2FromCell1) {
+  const auto interactParticles = [&f = this->_functor](auto &p1, auto &p2, auto &p3, const bool p2FromCell1) {
     if constexpr (newton3) {
-      _functor.AoSFunctor(p1, p2, p3, true);
+      f.AoSFunctor(p1, p2, p3, true);
     } else {
-      _functor.AoSFunctor(p1, p2, p3, false);
+      f.AoSFunctor(p1, p2, p3, false);
       if (p2FromCell1) {
-        _functor.AoSFunctor(p2, p1, p3, false);  // because of no newton3 and p2 is still in cell1
+        f.AoSFunctor(p2, p1, p3, false);  // because of no newton3 and p2 is still in cell1
       } else {
         if constexpr (bidirectional) {
-          _functor.AoSFunctor(p2, p1, p3, false);
+          f.AoSFunctor(p2, p1, p3, false);
         }
       }
       if constexpr (bidirectional) {
-        _functor.AoSFunctor(p3, p1, p2, false);
+        f.AoSFunctor(p3, p1, p2, false);
       }
     }
   };
@@ -459,15 +449,15 @@ template <bool newton3>
 void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellTripleAoSImpl(
     ParticleCell_T &cell1, ParticleCell_T &cell2, ParticleCell_T &cell3,
     const std::array<double, 3> &sortingDirection) {
-  const auto interactParticles = [this](auto &p1, auto &p2, auto &p3) {
+  const auto interactParticles = [&f = this->_functor](auto &p1, auto &p2, auto &p3) {
     if constexpr (newton3) {
-      _functor.AoSFunctor(p1, p2, p3, true);
+      f.AoSFunctor(p1, p2, p3, true);
     } else {
-      _functor.AoSFunctor(p1, p2, p3, false);
+      f.AoSFunctor(p1, p2, p3, false);
 
       if constexpr (bidirectional) {
-        _functor.AoSFunctor(p2, p1, p3, false);
-        _functor.AoSFunctor(p3, p1, p2, false);
+        f.AoSFunctor(p2, p1, p3, false);
+        f.AoSFunctor(p3, p1, p2, false);
       }
     }
   };

--- a/src/autopas/baseFunctors/CellFunctor3B.h
+++ b/src/autopas/baseFunctors/CellFunctor3B.h
@@ -174,29 +174,23 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::setSorting
 
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
 void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCell(ParticleCell_T &cell) {
-  // avoid force calculations if the cell contains only halo particles or if the cell is empty (=dummy)
+  const bool isAoS = _dataLayout == DataLayoutOption::aos ? true : false;
+  const bool isSoA = _dataLayout == DataLayoutOption::soa ? true : false;
+
+  // Return early if the cell is empty.
+  if ((isSoA and cell._particleSoABuffer.size() == 0) or (isAoS and cell.isEmpty())) {
+    return;
+  }
+  // Avoid force calculations if the cell contains only halo particles or if the cell is empty (=dummy)
   const bool cellHasOwnedParticles = toInt64(cell.getPossibleParticleOwnerships() & OwnershipState::owned);
   if (not cellHasOwnedParticles) {
     return;
   }
 
-  switch (_dataLayout) {
-    case DataLayoutOption::aos:
-      if (cell.isEmpty()) {
-        return;
-      }
-      processCellAoSImpl(cell);
-      break;
-    case DataLayoutOption::soa:
-      if (cell._particleSoABuffer.size() == 0) {
-        return;
-      }
-      if (_useNewton3) {
-        _functor.SoAFunctorSingle(cell._particleSoABuffer, true);
-      } else {
-        _functor.SoAFunctorSingle(cell._particleSoABuffer, false);
-      }
-      break;
+  if (isAoS) {
+    processCellAoSImpl(cell);
+  } else if (isSoA) {
+    _functor.SoAFunctorSingle(cell._particleSoABuffer, _useNewton3);
   }
 }
 
@@ -204,35 +198,34 @@ template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
 void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPair(
 
     ParticleCell_T &cell1, ParticleCell_T &cell2, const std::array<double, 3> &sortingDirection) {
-  const bool cell1HasOwnedParticles = toInt64(cell1.getPossibleParticleOwnerships() & OwnershipState::owned);
-  const bool cell2HasOwnedParticles = toInt64(cell2.getPossibleParticleOwnerships() & OwnershipState::owned);
+  const bool isAoS = _dataLayout == DataLayoutOption::aos ? true : false;
+  const bool isSoA = _dataLayout == DataLayoutOption::soa ? true : false;
 
-  // Avoid force calculations if both cells cannot contain owned particles.
-  if (not cell1HasOwnedParticles and not cell2HasOwnedParticles) {
+  // Return early if a cell is empty.
+  if ((isSoA and (cell1._particleSoABuffer.size() == 0 or cell2._particleSoABuffer.size() == 0)) or
+      (isAoS and (cell1.isEmpty() or cell2.isEmpty()))) {
     return;
   }
 
-  // In Newton3==false and functor is not bidirectional, only interactions from cell1 to cell2 are computed. Therefore,
-  // if cell1 cannot contain owned particles, there is nothing useful to do.
-  if constexpr (not bidirectional) {
-    if (not _useNewton3 and not cell1HasOwnedParticles) {
+  const bool cell1HasOwnedParticles = toInt64(cell1.getPossibleParticleOwnerships() & OwnershipState::owned);
+  if (not cell1HasOwnedParticles) {
+    // Nothing to do if cell1 has no owned particles and we don't write to cell2 particles.
+    if constexpr (not bidirectional) {
+      if (not _useNewton3) {
+        return;
+      }
+    }
+    // Nothing to do if both cells cannot have owned particles.
+    const bool cell2HasOwnedParticles = toInt64(cell2.getPossibleParticleOwnerships() & OwnershipState::owned);
+    if (not cell2HasOwnedParticles) {
       return;
     }
   }
 
-  switch (_dataLayout) {
-    case DataLayoutOption::aos:
-      if (cell1.isEmpty() or cell2.isEmpty()) {
-        return;
-      }
-      processCellPairAoSImpl(cell1, cell2, sortingDirection);
-      break;
-    case DataLayoutOption::soa:
-      if (cell1._particleSoABuffer.size() == 0 or cell2._particleSoABuffer.size() == 0) {
-        return;
-      }
-      processCellPairSoAImpl(cell1, cell2);
-      break;
+  if (isAoS) {
+    processCellPairAoSImpl(cell1, cell2, sortingDirection);
+  } else if (isSoA) {
+    processCellPairSoAImpl(cell1, cell2);
   }
 }
 
@@ -241,37 +234,36 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
 
     ParticleCell_T &cell1, ParticleCell_T &cell2, ParticleCell_T &cell3,
     const std::array<double, 3> &sortingDirection) {
-  const bool cell1HasOwnedParticles = toInt64(cell1.getPossibleParticleOwnerships() & OwnershipState::owned);
-  const bool cell2HasOwnedParticles = toInt64(cell2.getPossibleParticleOwnerships() & OwnershipState::owned);
-  const bool cell3HasOwnedParticles = toInt64(cell3.getPossibleParticleOwnerships() & OwnershipState::owned);
+  const bool isAoS = _dataLayout == DataLayoutOption::aos ? true : false;
+  const bool isSoA = _dataLayout == DataLayoutOption::soa ? true : false;
 
-  // Avoid force calculations if all three cells cannot contain owned particles.
-  if (not cell1HasOwnedParticles and not cell2HasOwnedParticles and not cell3HasOwnedParticles) {
+  // Return early if a cell is empty.
+  if ((isSoA and (cell1._particleSoABuffer.size() == 0 or cell2._particleSoABuffer.size() == 0 or
+                  cell3._particleSoABuffer.size() == 0)) or
+      (isAoS and (cell1.isEmpty() or cell2.isEmpty() or cell3.isEmpty()))) {
     return;
   }
 
-  // In Newton3==false and functor is not bidirectional, only interactions from cell1 are computed. Therefore,
-  // if cell1 cannot contain owned particles, there is nothing useful to do.
-  if constexpr (not bidirectional) {
-    if (not _useNewton3 and not cell1HasOwnedParticles) {
+  const bool cell1HasOwnedParticles = toInt64(cell1.getPossibleParticleOwnerships() & OwnershipState::owned);
+  if (not cell1HasOwnedParticles) {
+    // Nothing to do if cell1 has no owned particles and we would only write to cell1 particles.
+    if constexpr (not bidirectional) {
+      if (not _useNewton3) {
+        return;
+      }
+    }
+    // Nothing to do if all three cells cannot have owned particles.
+    const bool cell2HasOwnedParticles = toInt64(cell2.getPossibleParticleOwnerships() & OwnershipState::owned);
+    const bool cell3HasOwnedParticles = toInt64(cell3.getPossibleParticleOwnerships() & OwnershipState::owned);
+    if (not cell2HasOwnedParticles and not cell3HasOwnedParticles) {
       return;
     }
   }
 
-  switch (_dataLayout) {
-    case DataLayoutOption::aos:
-      if (cell1.isEmpty() or cell2.isEmpty() or cell3.isEmpty()) {
-        return;
-      }
-      processCellTripleAoSImpl(cell1, cell2, cell3, sortingDirection);
-      break;
-    case DataLayoutOption::soa:
-      if (cell1._particleSoABuffer.size() == 0 or cell2._particleSoABuffer.size() == 0 or
-          cell3._particleSoABuffer.size() == 0) {
-        return;
-      }
-      processCellTripleSoAImpl(cell1, cell2, cell3);
-      break;
+  if (isAoS) {
+    processCellTripleAoSImpl(cell1, cell2, cell3, sortingDirection);
+  } else if (isSoA) {
+    processCellTripleSoAImpl(cell1, cell2, cell3);
   }
 }
 

--- a/src/autopas/baseFunctors/CellFunctor3B.h
+++ b/src/autopas/baseFunctors/CellFunctor3B.h
@@ -99,7 +99,7 @@ class CellFunctor3B {
    */
   [[nodiscard]] bool shouldUseSorting(size_t particleCount, const std::array<double, 3> &sortingDirection) const {
     return particleCount >= _sortingThreshold and
-           (sortingDirection[0] != 0.0 and sortingDirection[1] != 0.0 and sortingDirection[2] != 0.0);
+           (sortingDirection[0] != 0.0 or sortingDirection[1] != 0.0 or sortingDirection[2] != 0.0);
   }
 
   /**

--- a/src/autopas/baseFunctors/CellFunctor3B.h
+++ b/src/autopas/baseFunctors/CellFunctor3B.h
@@ -182,8 +182,7 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
     return;
   }
   // Avoid force calculations if the cell contains only halo particles or if the cell is empty (=dummy)
-  const bool cellHasOwnedParticles = toInt64(cell.getPossibleParticleOwnerships() & OwnershipState::owned);
-  if (not cellHasOwnedParticles) {
+  if (not cell.canHaveOwnedParticles()) {
     return;
   }
 
@@ -207,8 +206,7 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
     return;
   }
 
-  const bool cell1HasOwnedParticles = toInt64(cell1.getPossibleParticleOwnerships() & OwnershipState::owned);
-  if (not cell1HasOwnedParticles) {
+  if (not cell1.canHaveOwnedParticles()) {
     // Nothing to do if cell1 has no owned particles and we don't write to cell2 particles.
     if constexpr (not bidirectional) {
       if (not _useNewton3) {
@@ -216,8 +214,7 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
       }
     }
     // Nothing to do if both cells cannot have owned particles.
-    const bool cell2HasOwnedParticles = toInt64(cell2.getPossibleParticleOwnerships() & OwnershipState::owned);
-    if (not cell2HasOwnedParticles) {
+    if (not cell2.canHaveOwnedParticles()) {
       return;
     }
   }
@@ -244,8 +241,7 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
     return;
   }
 
-  const bool cell1HasOwnedParticles = toInt64(cell1.getPossibleParticleOwnerships() & OwnershipState::owned);
-  if (not cell1HasOwnedParticles) {
+  if (not cell1.canHaveOwnedParticles()) {
     // Nothing to do if cell1 has no owned particles and we would only write to cell1 particles.
     if constexpr (not bidirectional) {
       if (not _useNewton3) {
@@ -253,9 +249,7 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
       }
     }
     // Nothing to do if all three cells cannot have owned particles.
-    const bool cell2HasOwnedParticles = toInt64(cell2.getPossibleParticleOwnerships() & OwnershipState::owned);
-    const bool cell3HasOwnedParticles = toInt64(cell3.getPossibleParticleOwnerships() & OwnershipState::owned);
-    if (not cell2HasOwnedParticles and not cell3HasOwnedParticles) {
+    if (not cell2.canHaveOwnedParticles() and not cell3.canHaveOwnedParticles()) {
       return;
     }
   }

--- a/src/autopas/baseFunctors/CellFunctor3B.h
+++ b/src/autopas/baseFunctors/CellFunctor3B.h
@@ -270,19 +270,11 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
 void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellAoSImpl(ParticleCell_T &cell) {
   // helper function
-  const auto interactParticles = [&f = this->_functor, n3 = this->_useNewton3](auto &p1, auto &p2, auto &p3) {
-    if (n3) {
-      f.AoSFunctor(p1, p2, p3, true);
-    } else {
-      if (not p1.isHalo()) {
-        f.AoSFunctor(p1, p2, p3, false);
-      }
-      if (not p2.isHalo()) {
-        f.AoSFunctor(p2, p1, p3, false);
-      }
-      if (not p3.isHalo()) {
-        f.AoSFunctor(p3, p1, p2, false);
-      }
+  const auto interactParticles = [this](auto &p1, auto &p2, auto &p3) {
+    this->_functor.AoSFunctor(p1, p2, p3, this->_useNewton3);
+    if (not this->_useNewton3) {
+      this->_functor.AoSFunctor(p2, p1, p3, false);
+      this->_functor.AoSFunctor(p3, p1, p2, false);
     }
   };
 
@@ -325,21 +317,18 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
 void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairAoSImpl(
     ParticleCell_T &cell1, ParticleCell_T &cell2, const std::array<double, 3> &sortingDirection) {
-  const auto interactParticles = [&f = this->_functor, n3 = this->_useNewton3](auto &p1, auto &p2, auto &p3,
-                                                                               const bool p2FromCell1) {
-    if (n3) {
-      f.AoSFunctor(p1, p2, p3, true);
-    } else {
-      f.AoSFunctor(p1, p2, p3, false);
+  const auto interactParticles = [this](auto &p1, auto &p2, auto &p3, const bool p2FromCell1) {
+    this->_functor.AoSFunctor(p1, p2, p3, this->_useNewton3);
+    if (not this->_useNewton3) {
       if (p2FromCell1) {
-        f.AoSFunctor(p2, p1, p3, false);  // because of no newton3 and p2 is still in cell1
+        this->_functor.AoSFunctor(p2, p1, p3, false);  // because of no newton3 and p2 is still in cell1
       } else {
         if constexpr (bidirectional) {
-          f.AoSFunctor(p2, p1, p3, false);
+          this->_functor.AoSFunctor(p2, p1, p3, false);
         }
       }
       if constexpr (bidirectional) {
-        f.AoSFunctor(p3, p1, p2, false);
+        this->_functor.AoSFunctor(p3, p1, p2, false);
       }
     }
   };
@@ -409,15 +398,13 @@ template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
 void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellTripleAoSImpl(
     ParticleCell_T &cell1, ParticleCell_T &cell2, ParticleCell_T &cell3,
     const std::array<double, 3> &sortingDirection) {
-  const auto interactParticles = [&f = this->_functor, n3 = this->_useNewton3](auto &p1, auto &p2, auto &p3) {
-    if (n3) {
-      f.AoSFunctor(p1, p2, p3, true);
-    } else {
-      f.AoSFunctor(p1, p2, p3, false);
+  const auto interactParticles = [this](auto &p1, auto &p2, auto &p3) {
+    this->_functor.AoSFunctor(p1, p2, p3, this->_useNewton3);
 
-      if constexpr (bidirectional) {
-        f.AoSFunctor(p2, p1, p3, false);
-        f.AoSFunctor(p3, p1, p2, false);
+    if constexpr (bidirectional) {
+      if (not this->_useNewton3) {
+        this->_functor.AoSFunctor(p2, p1, p3, false);
+        this->_functor.AoSFunctor(p3, p1, p2, false);
       }
     }
   };
@@ -451,11 +438,9 @@ void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCel
 template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
 void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellPairSoAImpl(ParticleCell_T &cell1,
                                                                                              ParticleCell_T &cell2) {
-  if (_useNewton3) {
-    _functor.SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, true);
-  } else {
-    _functor.SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, false);
-    if constexpr (bidirectional) {
+  _functor.SoAFunctorPair(cell1._particleSoABuffer, cell2._particleSoABuffer, _useNewton3);
+  if constexpr (bidirectional) {
+    if (not _useNewton3) {
       _functor.SoAFunctorPair(cell2._particleSoABuffer, cell1._particleSoABuffer, false);
     }
   }
@@ -465,11 +450,9 @@ template <class ParticleCell_T, class ParticleFunctor_T, bool bidirectional>
 void CellFunctor3B<ParticleCell_T, ParticleFunctor_T, bidirectional>::processCellTripleSoAImpl(ParticleCell_T &cell1,
                                                                                                ParticleCell_T &cell2,
                                                                                                ParticleCell_T &cell3) {
-  if (_useNewton3) {
-    _functor.SoAFunctorTriple(cell1._particleSoABuffer, cell2._particleSoABuffer, cell3._particleSoABuffer, true);
-  } else {
-    _functor.SoAFunctorTriple(cell1._particleSoABuffer, cell2._particleSoABuffer, cell3._particleSoABuffer, false);
-    if constexpr (bidirectional) {
+  _functor.SoAFunctorTriple(cell1._particleSoABuffer, cell2._particleSoABuffer, cell3._particleSoABuffer, _useNewton3);
+  if constexpr (bidirectional) {
+    if (not _useNewton3) {
       _functor.SoAFunctorTriple(cell2._particleSoABuffer, cell1._particleSoABuffer, cell3._particleSoABuffer, false);
       _functor.SoAFunctorTriple(cell3._particleSoABuffer, cell1._particleSoABuffer, cell2._particleSoABuffer, false);
     }

--- a/src/autopas/cells/ParticleCell.h
+++ b/src/autopas/cells/ParticleCell.h
@@ -139,6 +139,12 @@ class ParticleCell {
   [[nodiscard]] virtual std::array<double, 3> getCellLength() const = 0;
 
   /**
+   * Returns whether the cell can have owned particles based on its ownership state.
+   * @return true, if the cell can contain owned particles.
+   */
+  bool canHaveOwnedParticles() const { return static_cast<bool>(_ownershipState & autopas::OwnershipState::owned); }
+
+  /**
    * Get the type of particles contained in this cell. Possible values:
    * dummy: this cell is empty
    * owned: this cell can ONLY contain owned particles


### PR DESCRIPTION
# Description

This PR refactors the `CellFunctor` and `CellFunctor3B` to be more consistent and reduce code duplication.
Functionality is the same.
Main changes include
- Update template parameter names to new `_T` convention
- Combine N3 and NoN3 AoS functors to one method.
- *Update: Brought back after review.* Remove the `std::abs()` operation from the sorted cutoff checks. (Our sorting direction is always strictly from cell1 to cell2 and therefore we can save this operation)
- Change the particle ownership check logic slightly.


# How Has This Been Tested?
master commit: https://github.com/AutoPas/AutoPas/commit/6dbbab4b3b6ac32c7e2dcf375134af9e2f8fe356
commit for this PR: https://github.com/AutoPas/AutoPas/pull/1148/commits/ccb4f89befd1203e9815b53d8f5083f54d02eb6a

Build time is slightly faster for the new version, though not really noticeable in the full md-flexible compilation.
(Build Time comparison of a dummy program instantiating only `CellFunctor` and necessary includes. master = 0.58s, this PR = 0.55s)

I ran a constructed performance benchmark for cells with 8 and 64 particles and compared the version in master vs the new version. ( 500000 cells averaged over 3 runs).
The differences are mostly minor and for the low number of particles, the AoSFunctor is better with the new version.

| Configuration | 8 / master | 8 / new | Speedup | 64 / master | 64 / new | Speedup |
|---|---:|---:|---:|---:|---:|---:|
| AoS N3 bidirectional=true pair sorted | 73.3 | 69.4 | 5.2% | 2118.9 | 2060.2 | 2.8% |
| AoS N3 bidirectional=true pair unsorted | 53.6 | 48.5 | 9.5% | 3725.9 | 3736.6 | -0.3% |
| AoS noN3 bidirectional=true pair sorted | 72.9 | 70.8 | 2.9% | 3162.7 | 3174.6 | -0.4% |
| AoS noN3 bidirectional=true pair unsorted | 80.1 | 77.9 | 2.7% | 6503.4 | 6512.0 | -0.1% |
| AoS noN3 bidirectional=false pair sorted | 72.4 | 69.3 | 4.3% | 1903.0 | 1886.5 | 0.9% |
| AoS noN3 bidirectional=false pair unsorted | 53.4 | 50.5 | 5.4% | 3508.4 | 3504.7 | 0.1% |
| AoS N3 single cell | 110.5 | 112.1 | -1.5% | 5771.4 | 5919.3 | -2.6% |
| AoS noN3 single cell | 180.3 | 178.6 | 0.9% | 10482.5 | 10714.5 | -2.2% |
| SoA N3 bidirectional=true pair unsorted | 63.1 | 60.4 | 4.3% | 4061.2 | 4087.4 | -0.6% |
| SoA noN3 bidirectional=true pair unsorted | 113.4 | 109.5 | 3.5% | 7802.1 | 7818.3 | -0.2% |
| SoA noN3 bidirectional=false pair unsorted | 60.3 | 57.2 | 5.1% | 3926.5 | 3931.2 | -0.1% |
| SoA N3 single cell | 88.7 | 89.9 | -1.4% | 5313.4 | 5407.3 | -1.8% |
| SoA noN3 single cell | 88.5 | 89.3 | -0.9% | 5346.1 | 5406.1 | -1.1% |