### PR TITLE
Application Library's documentation is now checked by the CI

### DIFF
--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: [ "", _md-flexible ]
+        config: [ "", _md-flexible, _applicationLibrary ]
     name: DocumentationCheck AutoPas${{ matrix.config }}
     env:
       # this is currently dictated by the autopas-build-doxygen container

--- a/applicationLibrary/Doxyfile.in
+++ b/applicationLibrary/Doxyfile.in
@@ -1,0 +1,45 @@
+PROJECT_NAME           = "applicationLibrary"
+PROJECT_LOGO           = @PROJECT_SOURCE_DIR@/docs/graphics/AutoPasLogo_Large.svg
+PROJECT_NUMBER         = @AutoPas_VERSION@
+STRIP_FROM_PATH        = @PROJECT_SOURCE_DIR@/applicationLibrary
+OUTPUT_DIRECTORY       = @CMAKE_CURRENT_BINARY_DIR@/doc_doxygen_applicationLibrary/
+INPUT                  = @PROJECT_SOURCE_DIR@/applicationLibrary
+FILE_PATTERNS          = *.h \
+                         *.cuh \
+                         *.cpp \
+                         *.cu
+RECURSIVE              = YES
+# Exclude any "tests" directory anywhere in the tree.
+EXCLUDE_PATTERNS       = */tests/*
+HTML_HEADER            = @AUTOPAS_SOURCE_DIR@/docs/AutoPasHeader.html
+
+# EXTRACT_ALL           = NO # default NO
+# EXTRACT_PRIVATE       = NO # default NO
+EXTRACT_PACKAGE         = YES # default NO
+EXTRACT_STATIC          = YES # default NO
+# EXTRACT_LOCAL_CLASSES = YES # default YES
+# EXTRACT_LOCAL_METHODS = NO # default NO
+EXTRACT_ANON_NSPACES    = YES # default NO
+# HIDE_UNDOC_MEMBERS    = NO # default NO
+# HIDE_UNDOC_CLASSES    = NO # default NO
+# HIDE_FRIEND_COMPOUNDS = NO # default NO
+# HIDE_IN_BODY_DOCS     = NO # default NO
+
+JAVADOC_AUTOBRIEF      = YES # default NO
+QT_AUTOBRIEF           = YES # default NO
+
+#QUIET                 = NO # default NO
+#WARNINGS              = YES # default YES
+#WARN_IF_UNDOCUMENTED  = YES # default YES
+#WARN_IF_DOC_ERROR     = YES # default YES
+WARN_NO_PARAMDOC       = YES # default NO
+
+
+# Macro expansion settings:
+MACRO_EXPANSION        = YES
+
+IMAGE_PATH             = @PROJECT_SOURCE_DIR@/docs/graphics
+TEMPLATE_RELATIONS     = YES
+HAVE_DOT               = YES
+GENERATE_XML           = YES
+USE_MATHJAX            = YES # default NO - Needed for latex equation rendering. Used e.g. in AxilrodTellerMutoFunctor.h

--- a/applicationLibrary/Doxyfile.in
+++ b/applicationLibrary/Doxyfile.in
@@ -3,7 +3,8 @@ PROJECT_LOGO           = @PROJECT_SOURCE_DIR@/docs/graphics/AutoPasLogo_Large.sv
 PROJECT_NUMBER         = @AutoPas_VERSION@
 STRIP_FROM_PATH        = @PROJECT_SOURCE_DIR@/applicationLibrary
 OUTPUT_DIRECTORY       = @CMAKE_CURRENT_BINARY_DIR@/doc_doxygen_applicationLibrary/
-INPUT                  = @PROJECT_SOURCE_DIR@/applicationLibrary
+INPUT                  = @PROJECT_SOURCE_DIR@/applicationLibrary \
+                         @PROJECT_SOURCE_DIR@/src/autopas/baseFunctors   # Needed for copydoc functions from the base functor
 FILE_PATTERNS          = *.h \
                          *.cuh \
                          *.cpp \

--- a/cmake/modules/autopas_doxygen.cmake
+++ b/cmake/modules/autopas_doxygen.cmake
@@ -36,6 +36,16 @@ if (DOXYGEN_FOUND)
         VERBATIM
     )
 
+    set(DOXYGEN_APPLICATIONLIBRARY_OUT ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_applicationLibrary)
+    configure_file(applicationLibrary/Doxyfile.in ${DOXYGEN_APPLICATIONLIBRARY_OUT} @ONLY)
+    add_custom_target(
+            doc_doxygen_applicationLibrary
+            COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_APPLICATIONLIBRARY_OUT}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            COMMENT "Generating documentation for applicationLibrary with Doxygen"
+            VERBATIM
+    )
+
     if(AUTOPAS_BUILD_EXAMPLES)
         set(DOXYGEN_MD-FLEXIBLE_OUT ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_md-flexible)
         # request to configure the file


### PR DESCRIPTION
# Description

As it says in the title. When Application Library was created, we never extended the documentation checks to also test it. This PR now does this.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Checked the CI
