### PR TITLE
all is not ALL

### DIFF
--- a/examples/md-flexible/src/configuration/YamlParser.cpp
+++ b/examples/md-flexible/src/configuration/YamlParser.cpp
@@ -7,7 +7,7 @@
 
 #include "autopas/options/TuningMetricOption.h"
 
-const std::string MDFlexParser::YamlParser::parseSequenceOneElementExpected(const YAML::Node node,
+std::string MDFlexParser::YamlParser::parseSequenceOneElementExpected(const YAML::Node& node,
                                                                             const std::string &errMsg,
                                                                             bool allThrowsError) {
   std::string value;
@@ -861,7 +861,9 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
         }
 
         const auto parsedOptions = LoadBalancerOption::parseOptions(loadBalancerString);
-
+        if (parsedOptions.empty()) {
+          throw std::runtime_error("No valid load balancer option found!");
+        }
         config.loadBalancer.value = *parsedOptions.begin();
 
 #ifndef MD_FLEXIBLE_ENABLE_ALLLBL

--- a/examples/md-flexible/src/configuration/YamlParser.cpp
+++ b/examples/md-flexible/src/configuration/YamlParser.cpp
@@ -7,9 +7,8 @@
 
 #include "autopas/options/TuningMetricOption.h"
 
-std::string MDFlexParser::YamlParser::parseSequenceOneElementExpected(const YAML::Node& node,
-                                                                            const std::string &errMsg,
-                                                                            bool allThrowsError) {
+std::string MDFlexParser::YamlParser::parseSequenceOneElementExpected(const YAML::Node &node, const std::string &errMsg,
+                                                                      bool allThrowsError) {
   std::string value;
   if (node.IsSequence()) {
     if (node.size() != 1) {
@@ -850,12 +849,12 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
       } else if (key == config.loadBalancer.name) {
         expected = "YAML-sequence of possible values.";
         description = config.loadBalancer.description;
-        
+
         // A common mistake is that users parse "all" to mean A Load-balancing Library (ALL). If this is received, make
         // it upper case, resulting in A Load-balancing Library being correctly parsed. To do so, we use
-        // parseSequenceOneElementExpected with allThrowsError=false to avoid the error.  
+        // parseSequenceOneElementExpected with allThrowsError=false to avoid the error.
         auto loadBalancerString =
-          parseSequenceOneElementExpected(node[key], "Pass Exactly one load balancer option!", false);
+            parseSequenceOneElementExpected(node[key], "Pass Exactly one load balancer option!", false);
         if (loadBalancerString == "all") {
           loadBalancerString = "ALL";
         }

--- a/examples/md-flexible/src/configuration/YamlParser.cpp
+++ b/examples/md-flexible/src/configuration/YamlParser.cpp
@@ -8,15 +8,22 @@
 #include "autopas/options/TuningMetricOption.h"
 
 const std::string MDFlexParser::YamlParser::parseSequenceOneElementExpected(const YAML::Node node,
-                                                                            const std::string &errMsg) {
+                                                                            const std::string &errMsg,
+                                                                            bool allThrowsError) {
+  std::string value;
   if (node.IsSequence()) {
     if (node.size() != 1) {
       throw std::runtime_error(errMsg);
     }
-    return autopas::utils::ArrayUtils::to_string(node, "", {"", ""});
+    value = autopas::utils::ArrayUtils::to_string(node, "", {"", ""});
   } else {
-    return node.as<std::string>();
+    value = node.as<std::string>();
   }
+  // "all" gets expanded into multiple options by ParseOption, so not single element.
+  if (allThrowsError and value == "all") {
+    throw std::runtime_error(errMsg + " - 'all' gets expanded into all possible options.");
+  }
+  return value;
 }
 
 const std::string MDFlexParser::YamlParser::makeErrorMsg(const YAML::Mark &mark, const std::string &key,
@@ -843,9 +850,17 @@ bool MDFlexParser::YamlParser::parseYamlFile(MDFlexConfig &config) {
       } else if (key == config.loadBalancer.name) {
         expected = "YAML-sequence of possible values.";
         description = config.loadBalancer.description;
+        
+        // A common mistake is that users parse "all" to mean A Load-balancing Library (ALL). If this is received, make
+        // it upper case, resulting in A Load-balancing Library being correctly parsed. To do so, we use
+        // parseSequenceOneElementExpected with allThrowsError=false to avoid the error.  
+        auto loadBalancerString =
+          parseSequenceOneElementExpected(node[key], "Pass Exactly one load balancer option!", false);
+        if (loadBalancerString == "all") {
+          loadBalancerString = "ALL";
+        }
 
-        const auto parsedOptions = LoadBalancerOption::parseOptions(
-            parseSequenceOneElementExpected(node[key], "Pass Exactly one load balancer option!"));
+        const auto parsedOptions = LoadBalancerOption::parseOptions(loadBalancerString);
 
         config.loadBalancer.value = *parsedOptions.begin();
 

--- a/examples/md-flexible/src/configuration/YamlParser.h
+++ b/examples/md-flexible/src/configuration/YamlParser.h
@@ -58,7 +58,7 @@ bool parseYamlFile(MDFlexConfig &config);
  * where all probably means "A Load-balancing Library (ALL)")
  * @return String representation of the parsed node
  */
-const std::string parseSequenceOneElementExpected(const YAML::Node node, const std::string &errMsg,
+std::string parseSequenceOneElementExpected(const YAML::Node& node, const std::string &errMsg,
                                                   bool allThrowsError = true);
 
 /**

--- a/examples/md-flexible/src/configuration/YamlParser.h
+++ b/examples/md-flexible/src/configuration/YamlParser.h
@@ -54,12 +54,12 @@ bool parseYamlFile(MDFlexConfig &config);
  * @param node The current YAML::Node, that should be parsed
  * @param errMsg The error message thrown if multiple options are passed
  * @param allThrowsError If true (default), the value "all" is rejected with errMsg, because parsing it as an option
- * would expand it into multiple options. Set to false if we want to allow "all" silently (e.g. for load-balancer, 
+ * would expand it into multiple options. Set to false if we want to allow "all" silently (e.g. for load-balancer,
  * where all probably means "A Load-balancing Library (ALL)")
  * @return String representation of the parsed node
  */
-std::string parseSequenceOneElementExpected(const YAML::Node& node, const std::string &errMsg,
-                                                  bool allThrowsError = true);
+std::string parseSequenceOneElementExpected(const YAML::Node &node, const std::string &errMsg,
+                                            bool allThrowsError = true);
 
 /**
  * Creates an error message for all non-object-keys

--- a/examples/md-flexible/src/configuration/YamlParser.h
+++ b/examples/md-flexible/src/configuration/YamlParser.h
@@ -53,9 +53,13 @@ bool parseYamlFile(MDFlexConfig &config);
  * Parses an input where exactly one option is expected and throws an error if a sequence of multiple options is given
  * @param node The current YAML::Node, that should be parsed
  * @param errMsg The error message thrown if multiple options are passed
+ * @param allThrowsError If true (default), the value "all" is rejected with errMsg, because parsing it as an option
+ * would expand it into multiple options. Set to false if we want to allow "all" silently (e.g. for load-balancer, 
+ * where all probably means "A Load-balancing Library (ALL)")
  * @return String representation of the parsed node
  */
-const std::string parseSequenceOneElementExpected(const YAML::Node node, const std::string &errMsg);
+const std::string parseSequenceOneElementExpected(const YAML::Node node, const std::string &errMsg,
+                                                  bool allThrowsError = true);
 
 /**
  * Creates an error message for all non-object-keys

--- a/examples/md-flexible/tests/configuration/YamlParserTest.cpp
+++ b/examples/md-flexible/tests/configuration/YamlParserTest.cpp
@@ -1,0 +1,70 @@
+/**
+ * @file YamlParserTest.cpp
+ * @author S. Newcome
+ * @date 26.06.2026
+ */
+
+#include "YamlParserTest.h"
+
+#include <yaml-cpp/yaml.h>
+
+#include "src/configuration/YamlParser.h"
+#include "src/domainDecomposition/LoadBalancerOption.h"
+
+using MDFlexParser::YamlParser::parseSequenceOneElementExpected;
+
+/**
+ * A scalar node holding a single value is returned unchanged.
+ */
+TEST_F(YamlParserTest, scalarReturnsValue) {
+  const auto node = YAML::Load("InvertedPressure");
+  EXPECT_EQ(parseSequenceOneElementExpected(node, "err"), "InvertedPressure");
+}
+
+/**
+ * A sequence holding exactly one value returns that value (without sequence decoration).
+ */
+TEST_F(YamlParserTest, singleElementSequenceReturnsValue) {
+  const auto node = YAML::Load("[InvertedPressure]");
+  EXPECT_EQ(parseSequenceOneElementExpected(node, "err"), "InvertedPressure");
+}
+
+/**
+ * A sequence with more than one element violates the single-element expectation and throws.
+ */
+TEST_F(YamlParserTest, multiElementSequenceThrows) {
+  const auto node = YAML::Load("[InvertedPressure, None]");
+  EXPECT_THROW(parseSequenceOneElementExpected(node, "err"), std::runtime_error);
+}
+
+/**
+ * By default "all" is rejected: parsed as an option it would expand into every option, violating the
+ * single-element expectation.
+ */
+TEST_F(YamlParserTest, allThrowsByDefault) {
+  EXPECT_THROW(parseSequenceOneElementExpected(YAML::Load("all"), "err"), std::runtime_error);
+  EXPECT_THROW(parseSequenceOneElementExpected(YAML::Load("[all]"), "err"), std::runtime_error);
+}
+
+/**
+ * With allThrowsError disabled, "all" is returned verbatim instead of throwing. This is the path the load
+ * balancer relies on, where "all" is meant as the single option "A Load-balancing Library (ALL)".
+ */
+TEST_F(YamlParserTest, allReturnedWhenNotThrowing) {
+  EXPECT_EQ(parseSequenceOneElementExpected(YAML::Load("all"), "err", false), "all");
+  EXPECT_EQ(parseSequenceOneElementExpected(YAML::Load("[all]"), "err", false), "all");
+}
+
+/**
+ * End-to-end check of the load balancer special case: the user's "all" is upper-cased to "ALL" and parsed into
+ * LoadBalancerOption::all rather than being rejected or expanded into every option.
+ */
+TEST_F(YamlParserTest, loadBalancerAllParsedAsALL) {
+  auto loadBalancerString = parseSequenceOneElementExpected(YAML::Load("[all]"), "err", false);
+  if (loadBalancerString == "all") {
+    loadBalancerString = "ALL";
+  }
+  const auto parsedOptions = LoadBalancerOption::parseOptions(loadBalancerString);
+  ASSERT_EQ(parsedOptions.size(), 1);
+  EXPECT_EQ(*parsedOptions.begin(), LoadBalancerOption::all);
+}

--- a/examples/md-flexible/tests/configuration/YamlParserTest.h
+++ b/examples/md-flexible/tests/configuration/YamlParserTest.h
@@ -1,0 +1,16 @@
+/**
+ * @file YamlParserTest.h
+ * @author S. Newcome
+ * @date 26.06.2026
+ */
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include "AutoPasTestBase.h"
+
+class YamlParserTest : public AutoPasTestBase {
+ public:
+  YamlParserTest() : AutoPasTestBase() {}
+};


### PR DESCRIPTION
# Description

In md-flexible, if you provide the load-balancer option as "all", because you want to use "A Load-balancing Library (ALL)", you instead get the inverted pressure load balancer.

- The  load-balncer should be a single option out of `InvertedPressure`, `ALL`, and `none`.
- `YamlParser::parseSequenceOneElementExpected` checks that only one sequence element has been provided. "all" is one sequence element, so it returns this.
- `<option>::parseOptions("all")` returns all options. In this case, it returns a set of `InvertedPressure`, `ALL`, and `none` in that order.
- We then take the first element (out of typically one element) of the returned set. In this case, this is `InvertedPressure`.

Two issues:
1. `YamlParser::parseSequenceOneElementExpected` doesn't handle "all" specially. This PR adds a check for this and throws an error if it is passed "all".
2. It is not unreasonable for users to write "all" in their input files to mean "ALL". This PR adds a optional bool to disable the above error throwing, uses this for the load-balancer input (multiple options here make no sense anyway), and then converts "all" into "ALL", before passing to `LoadBalancerOption::parseOptions`