### PR TITLE
Adding yaml files from the Newcome et al, 2025 paper

### DIFF
--- a/examples/md-flexible/input/explodingLiquidBig.yaml
+++ b/examples/md-flexible/input/explodingLiquidBig.yaml
@@ -1,0 +1,57 @@
+# This is a larger version of exploding liquid, used in Newcome et al., 2025 (https://doi.org/10.1007/978-3-031-97635-3_35)
+# In this paper, it was used with 6 MPI ranks, as a stress test for algorithm selection where the algorithmic profile
+# of a rank changes dramatically. Across 2 nodes on HSUper (https://www.hsu-hh.de/hpc/en/hsuper/), this took about an hour.
+# It would also be suitable for a 1 node, no MPI simulation.
+
+container                        :  [LinkedCells, VarVerletListsAsBuild, VerletLists, VerletListsCells, PairwiseVerletLists]
+traversal                            :  [lc_sliced, lc_sliced_c02, lc_c01, lc_c01_combined_SoA, lc_c04, lc_c04_HCP, lc_c04_combined_SoA, lc_c08, lc_c18, vl_list_iteration, vlc_c01, vlc_c08, vlc_c18, vlc_sliced, vlc_sliced_c02, vlp_c01, vlp_c18, vlp_sliced, vlp_sliced_c02]
+data-layout                      :  [AoS, SoA]
+newton3                          :  [enabled, disabled]
+vectorization-pattern            :  [1xVectorLength, 2xVectorLengthDiv2, VectorLengthDiv2x2, VectorLengthx1]
+verlet-rebuild-frequency         :  10
+verlet-skin-radius               :  0.6
+verlet-cluster-size              :  4
+selector-strategy                :  Fastest-Mean-Value
+tuning-strategies                :  []
+tuning-interval                  :  1000
+tuning-samples                   :  10
+functor                          :  Lennard-Jones-HWY
+cutoff                           :  3
+box-min                          :  [0, 0, 0]
+box-max                          :  [120, 480, 120]
+cell-size                        :  [1]
+deltaT                           :  0.00182367
+iterations                       :  100000
+boundary-type                    : [periodic, periodic, periodic]
+Sites:
+  0:
+    epsilon                      :  1.
+    sigma                        :  1.
+    mass                         :  1.
+Objects:                         
+  CubeClosestPacked:
+    0:  
+      box-length                 :  [120, 18, 120]
+      bottomLeftCorner           :  [0, 231, 0]
+      particle-spacing           :  1.
+      velocity                   :  [0, 0, 0]
+      particle-type-id           :  0
+  CubeUniform:
+    0:
+      numberOfParticles              :  100
+      box-length                     :  [120, 230, 120]
+      bottomLeftCorner               :  [0, 0, 0]
+      velocity                       :  [0, 0, 0]
+      particle-type-id               :  0
+    1:
+      numberOfParticles              :  100
+      box-length                     :  [120, 230, 120]
+      bottomLeftCorner               :  [0, 250, 0]
+      velocity                       :  [0, 0, 0]
+      particle-type-id               :  0
+no-end-config                    :  true
+no-progress-bar                  :  true
+# vtk-filename                     :  explodingLiquid
+# vtk-write-frequency              :  2000
+load-balancer                    :  none
+subdivide-dimension              :  [false, true, false]

--- a/examples/md-flexible/input/explodingLiquidBig.yaml
+++ b/examples/md-flexible/input/explodingLiquidBig.yaml
@@ -17,8 +17,8 @@ tuning-interval                  :  1000
 tuning-samples                   :  10
 functor                          :  Lennard-Jones-HWY
 cutoff                           :  3
-box-min                          :  [0, 0, 0]
-box-max                          :  [120, 480, 120]
+box-min                          :  [-0.5, 0, -0.5]
+box-max                          :  [120.5, 480, 120.5]
 cell-size                        :  [1]
 deltaT                           :  0.00182367
 iterations                       :  100000

--- a/examples/md-flexible/input/explodingLiquidBig.yaml
+++ b/examples/md-flexible/input/explodingLiquidBig.yaml
@@ -4,7 +4,7 @@
 # It would also be suitable for a 1 node, no MPI simulation.
 
 container                        :  [LinkedCells, VarVerletListsAsBuild, VerletLists, VerletListsCells, PairwiseVerletLists]
-traversal                            :  [lc_sliced, lc_sliced_c02, lc_c01, lc_c01_combined_SoA, lc_c04, lc_c04_HCP, lc_c04_combined_SoA, lc_c08, lc_c18, vl_list_iteration, vlc_c01, vlc_c08, vlc_c18, vlc_sliced, vlc_sliced_c02, vlp_c01, vlp_c18, vlp_sliced, vlp_sliced_c02]
+traversal                        :  [lc_sliced, lc_sliced_c02, lc_c01, lc_c01_combined_SoA, lc_c04, lc_c04_HCP, lc_c04_combined_SoA, lc_c08, lc_c18, vl_list_iteration, vlc_c01, vlc_c08, vlc_c18, vlc_sliced, vlc_sliced_c02, vlp_c01, vlp_c18, vlp_sliced, vlp_sliced_c02]
 data-layout                      :  [AoS, SoA]
 newton3                          :  [enabled, disabled]
 vectorization-pattern            :  [1xVectorLength, 2xVectorLengthDiv2, VectorLengthDiv2x2, VectorLengthx1]
@@ -38,17 +38,17 @@ Objects:
       particle-type-id           :  0
   CubeUniform:
     0:
-      numberOfParticles              :  100
-      box-length                     :  [120, 230, 120]
-      bottomLeftCorner               :  [0, 0, 0]
-      velocity                       :  [0, 0, 0]
-      particle-type-id               :  0
+      numberOfParticles          :  100
+      box-length                 :  [120, 230, 120]
+      bottomLeftCorner           :  [0, 0, 0]
+      velocity                   :  [0, 0, 0]
+      particle-type-id           :  0
     1:
-      numberOfParticles              :  100
-      box-length                     :  [120, 230, 120]
-      bottomLeftCorner               :  [0, 250, 0]
-      velocity                       :  [0, 0, 0]
-      particle-type-id               :  0
+      numberOfParticles          :  100
+      box-length                 :  [120, 230, 120]
+      bottomLeftCorner           :  [0, 250, 0]
+      velocity                   :  [0, 0, 0]
+      particle-type-id           :  0
 no-end-config                    :  true
 no-progress-bar                  :  true
 # vtk-filename                     :  explodingLiquid

--- a/examples/md-flexible/input/heatingSphere.yaml
+++ b/examples/md-flexible/input/heatingSphere.yaml
@@ -10,7 +10,7 @@ verlet-skin-radius               :  0.5
 verlet-cluster-size              :  4
 selector-strategy                :  Fastest-Mean-Value
 data-layout                      :  [AoS, SoA]
-traversal                            :  [lc_sliced, lc_sliced_c02, lc_c01, lc_c01_combined_SoA, lc_c04, lc_c04_HCP, lc_c04_combined_SoA, lc_c08, lc_c18, vl_list_iteration, vlc_c01, vlc_c08, vlc_c18, vlc_sliced, vlc_sliced_c02, vlp_c01, vlp_c18, vlp_sliced, vlp_sliced_c02]
+traversal                        :  [lc_sliced, lc_sliced_c02, lc_c01, lc_c01_combined_SoA, lc_c04, lc_c04_HCP, lc_c04_combined_SoA, lc_c08, lc_c18, vl_list_iteration, vlc_c01, vlc_c08, vlc_c18, vlc_sliced, vlc_sliced_c02, vlp_c01, vlp_c18, vlp_sliced, vlp_sliced_c02]
 vectorization-pattern            :  [1xVectorLength, 2xVectorLengthDiv2, VectorLengthDiv2x2, VectorLengthx1]
 tuning-strategies                :  []
 tuning-interval                  :  10000

--- a/examples/md-flexible/input/heatingSphere.yaml
+++ b/examples/md-flexible/input/heatingSphere.yaml
@@ -15,7 +15,7 @@ vectorization-pattern            :  [1xVectorLength, 2xVectorLengthDiv2, VectorL
 tuning-strategies                :  []
 tuning-interval                  :  10000
 tuning-samples                   :  10
-functor                          :  Lennard-Jones HWY
+functor                          :  Lennard-Jones-HWY
 newton3                          :  [disabled, enabled]
 cutoff                           :  3
 box-min                          :  [0, 0, 0]

--- a/examples/md-flexible/input/heatingSphere.yaml
+++ b/examples/md-flexible/input/heatingSphere.yaml
@@ -1,0 +1,49 @@
+# Simulates a ball in the center of a large domain heating up and expanding to fill the entire domain.
+# Used in Newcome et al., 2025 (https://doi.org/10.1007/978-3-031-97635-3_35)
+# It is a good example for demonstrating dynamic algorithm selection within an experiment without MPI, but do not
+# expect as significant a speedup as from algorithm selection between entirely different simulations or within a
+# simulation with MPI.
+# Across half a node on HSUper (https://www.hsu-hh.de/hpc/en/hsuper/), this took about an hour.
+
+verlet-rebuild-frequency         :  10
+verlet-skin-radius               :  0.5
+verlet-cluster-size              :  4
+selector-strategy                :  Fastest-Mean-Value
+data-layout                      :  [AoS, SoA]
+traversal                            :  [lc_sliced, lc_sliced_c02, lc_c01, lc_c01_combined_SoA, lc_c04, lc_c04_HCP, lc_c04_combined_SoA, lc_c08, lc_c18, vl_list_iteration, vlc_c01, vlc_c08, vlc_c18, vlc_sliced, vlc_sliced_c02, vlp_c01, vlp_c18, vlp_sliced, vlp_sliced_c02]
+vectorization-pattern            :  [1xVectorLength, 2xVectorLengthDiv2, VectorLengthDiv2x2, VectorLengthx1]
+tuning-strategies                :  []
+tuning-interval                  :  10000
+tuning-samples                   :  10
+functor                          :  Lennard-Jones HWY
+newton3                          :  [disabled, enabled]
+cutoff                           :  3
+box-min                          :  [0, 0, 0]
+box-max                          :  [200, 200, 200]
+cell-size                        :  [0.5, 1]
+deltaT                           :  0.0001
+iterations                       :  150000
+boundary-type                    :  [reflective, reflective ,reflective]
+globalForce                      :  [0,0,0]
+Sites:
+  0:
+    epsilon                      :  1.
+    sigma                        :  1.
+    mass                         :  1.
+Objects:
+  Sphere:
+    0:
+      center                     :  [100, 100, 100]
+      radius                     :  10
+      particle-spacing           :  1.22462048
+      velocity                   :  [0, 0, 0]
+      particle-type-id           :  0
+thermostat:
+  initialTemperature             :  0.1
+  targetTemperature              :  100
+  deltaTemperature               :  0.1
+  thermostatInterval             :  100
+  addBrownianMotion              :  true
+no-end-config                    :  true
+no-progress-bar                  :  true
+log-level                        :  info

--- a/examples/md-flexible/input/particleMixing.yaml
+++ b/examples/md-flexible/input/particleMixing.yaml
@@ -22,8 +22,8 @@ traversal                        :  [lc_sliced, lc_sliced_c02, lc_c01, lc_c01_co
 newton3                          : [enabled, disabled]
 cell-size                        : [0.5, 1]
 vectorization-pattern            :  [1xVectorLength, 2xVectorLengthDiv2, VectorLengthDiv2x2, VectorLengthx1]
-box-min                          :  [-0.5, -0.5, -0.5]
-box-max                          :  [60.5, 60.5, 80.5]
+box-min                          :  [-0.561, -0.561, -0.561]
+box-max                          :  [60.561, 60.561, 80.5]
 tuning-interval                  :  5000
 tuning-samples                   : 30
 selector-strategy                : fastest-mean-value

--- a/examples/md-flexible/input/particleMixing.yaml
+++ b/examples/md-flexible/input/particleMixing.yaml
@@ -6,10 +6,10 @@
 # This is a large experiment: on 5 compute nodes, with 8 MPI ranks per node and 9 OMP threads per rank, this took 10
 # hours. It could be scaled down to run on less hardware and faster. It is designed primarily as a stress-test for
 # algorithm selection in which cell size factor becomes an important consideration - with ranks with mostly small
-# particles per prefering CSF 0.5 and those with mostly large particles preferring CSF 1.0, with this switching per-rank
+# particles preferring CSF 0.5 and those with mostly large particles preferring CSF 1.0, with this switching per-rank
 # as the particles switch. To show this, you will need at least a domain decomposition in the vertical direction.
 
-functor                          :  Lennard-Jones (12-6) HWY
+functor                          :  Lennard-Jones-HWY
 cutoff                           :  3
 verlet-skin-radius               :  0.3
 verlet-rebuild-frequency         :  30

--- a/examples/md-flexible/input/particleMixing.yaml
+++ b/examples/md-flexible/input/particleMixing.yaml
@@ -1,0 +1,63 @@
+# Simulates a dense layer of smaller and heavier particles above a layer of larger and lighter particles.
+# Is inspired by Rayleigh-Taylor experiments, but the parameters are largely unrealistic and this experiment should be
+# treated primarily as an algorithmic stress-test.
+# Used in Newcome et al., 2025 (https://doi.org/10.1007/978-3-031-97635-3_35) (referred to there as "Rayleigh-Taylor"
+# but we suggest referring to this experiment as "Particle Mixing" in future works)
+# This is a large experiment: on 5 compute nodes, with 8 MPI ranks per node and 9 OMP threads per rank, this took 10
+# hours. It could be scaled down to run on less hardware and faster. It is designed primarily as a stress-test for
+# algorithm selection in which cell size factor becomes an important consideration - with ranks with mostly small
+# particles per prefering CSF 0.5 and those with mostly large particles preferring CSF 1.0, with this switching per-rank
+# as the particles switch. To show this, you will need at least a domain decomposition in the vertical direction.
+
+functor                          :  Lennard-Jones (12-6) HWY
+cutoff                           :  3
+verlet-skin-radius               :  0.3
+verlet-rebuild-frequency         :  30
+deltaT                           :  0.00005
+iterations                       :  600000
+boundary-type                    : [periodic, periodic, reflective]
+globalForce                      :  [0, 0, -12.44]
+data-layout                          :  [AoS, SoA]
+traversal                            :  [lc_sliced, lc_sliced_c02, lc_c01, lc_c01_combined_SoA, lc_c04, lc_c04_HCP, lc_c04_combined_SoA, lc_c08, lc_c18, vl_list_iteration, vlc_c01, vlc_c08, vlc_c18, vlc_sliced, vlc_sliced_c02, vlp_c01, vlp_c18, vlp_sliced, vlp_sliced_c02]
+newton3                          : [enabled, disabled]
+cell-size                        : [0.5, 1]
+vectorization-pattern            :  [1xVectorLength, 2xVectorLengthDiv2, VectorLengthDiv2x2, VectorLengthx1]
+box-min                          :  [-0.5, -0.5, -0.5]
+box-max                          :  [60.5, 60.5, 80.5]
+tuning-interval                  :  5000
+tuning-samples                   : 30
+selector-strategy                : fastest-mean-value
+tuning-strategies                :  []
+Sites:
+  0:
+    epsilon                      :  0.5
+    sigma                        :  0.5
+    mass                         :  2
+  1:
+    epsilon                      :  1.
+    sigma                        :  1.
+    mass                         :  1.
+Objects:
+  CubeClosestPacked:
+    0:
+      particle-type-id           :  1
+      box-length                 :  [60, 60, 30]
+      particle-spacing           :  1.122
+      bottomLeftCorner           :  [0, 0, 0]
+      velocity                   :  [0, 0, 0]
+    1:
+      particle-type-id           :  0
+      box-length                 :  [60, 60, 30]
+      particle-spacing           :  0.6
+      bottomLeftCorner           :  [0, 0, 30.1]
+      velocity                   :  [0, 0, 0]
+thermostat:
+  initialTemperature             :  40
+  targetTemperature              :  40
+  deltaTemperature               :  10
+  thermostatInterval             :  100
+  addBrownianMotion              :  true
+load-balancer                    :  all
+load-balancing-interval          :  5000
+subdivide-dimension              :  [true, true, true]
+no-progress-bar                  :  true

--- a/examples/md-flexible/input/particleMixing.yaml
+++ b/examples/md-flexible/input/particleMixing.yaml
@@ -17,8 +17,8 @@ deltaT                           :  0.00005
 iterations                       :  600000
 boundary-type                    : [periodic, periodic, reflective]
 globalForce                      :  [0, 0, -12.44]
-data-layout                          :  [AoS, SoA]
-traversal                            :  [lc_sliced, lc_sliced_c02, lc_c01, lc_c01_combined_SoA, lc_c04, lc_c04_HCP, lc_c04_combined_SoA, lc_c08, lc_c18, vl_list_iteration, vlc_c01, vlc_c08, vlc_c18, vlc_sliced, vlc_sliced_c02, vlp_c01, vlp_c18, vlp_sliced, vlp_sliced_c02]
+data-layout                      :  [AoS, SoA]
+traversal                        :  [lc_sliced, lc_sliced_c02, lc_c01, lc_c01_combined_SoA, lc_c04, lc_c04_HCP, lc_c04_combined_SoA, lc_c08, lc_c18, vl_list_iteration, vlc_c01, vlc_c08, vlc_c18, vlc_sliced, vlc_sliced_c02, vlp_c01, vlp_c18, vlp_sliced, vlp_sliced_c02]
 newton3                          : [enabled, disabled]
 cell-size                        : [0.5, 1]
 vectorization-pattern            :  [1xVectorLength, 2xVectorLengthDiv2, VectorLengthDiv2x2, VectorLengthx1]


### PR DESCRIPTION
# Description

Adds the yaml input files from the Newcome et al., 2025 paper. Updated to match modern `master` branch (`verlet-skin-radius`, not `-per-timestep`; vector patterns)
