### PR TITLE
Reducing buffer usage by only Migrating particles in rebuild steps

### DIFF
--- a/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
+++ b/examples/md-flexible/src/domainDecomposition/RegularGridDecomposition.cpp
@@ -161,7 +161,7 @@ void RegularGridDecomposition::exchangeHaloParticles(AutoPasType &autoPasContain
   using namespace autopas::utils::ArrayMath::literals;
 
   _haloParticles.clear();
-  const double haloWidth = _cutoffWidth + _skinWidth;
+  const double haloWidth = _cutoffWidth + 2 * _skinWidth;
 
   // since we currently don't have any halo particles, estimate the number by comparing box and halo volume and add 10%
   const auto localBoxDimensions = _localBoxMax - _localBoxMin;
@@ -513,7 +513,7 @@ void RegularGridDecomposition::collectHaloParticlesForLeftNeighbor(
   using autopas::utils::Math::isNearRel;
   using namespace autopas::utils::ArrayMath::literals;
 
-  const std::array<double, _dimensionCount> boxMin = _localBoxMin;
+  const std::array<double, _dimensionCount> boxMin = _localBoxMin - _skinWidth;
   const std::array<double, _dimensionCount> boxMax = [&]() {
     auto boxMax = _localBoxMax;
     boxMax[direction] = _localBoxMin[direction] + _cutoffWidth + _skinWidth;
@@ -530,7 +530,7 @@ void RegularGridDecomposition::collectHaloParticlesForRightNeighbor(
   using autopas::utils::Math::isNearRel;
   using namespace autopas::utils::ArrayMath::literals;
 
-  const std::array<double, _dimensionCount> boxMax = _localBoxMax;
+  const std::array<double, _dimensionCount> boxMax = _localBoxMax + _skinWidth;
   const std::array<double, _dimensionCount> boxMin = [&]() {
     auto boxMin = _localBoxMin;
     boxMin[direction] = _localBoxMax[direction] - _cutoffWidth - _skinWidth;

--- a/examples/sph-mpi/sph-main-mpi.cpp
+++ b/examples/sph-mpi/sph-main-mpi.cpp
@@ -195,23 +195,23 @@ void waitSend(MPI_Request &sendRequest) { MPI_Wait(&sendRequest, MPI_STATUS_IGNO
  * @param globalBoxMin
  * @param globalBoxMax
  */
-void getSendHalo(double boxMin, double boxMax, int diff, double &sendMin, double &sendMax, double cutoff, double &shift,
-                 const double globalBoxMin, const double globalBoxMax) {
+void getSendHalo(double boxMin, double boxMax, int diff, double &sendMin, double &sendMax, double cutoff, double skin,
+                 double &shift, const double globalBoxMin, const double globalBoxMax) {
   if (diff == 0) {
-    sendMin = boxMin;
-    sendMax = boxMax;
+    sendMin = boxMin - skin;
+    sendMax = boxMax + skin;
     shift = 0;
   } else if (diff == -1) {
-    sendMin = boxMin;
-    sendMax = boxMin + cutoff;
+    sendMin = boxMin - skin;
+    sendMax = boxMin + cutoff + skin;
     if (boxMin == globalBoxMin) {
       shift = globalBoxMax - globalBoxMin;
     } else {
       shift = 0;
     }
   } else if (diff == 1) {
-    sendMin = boxMax - cutoff;
-    sendMax = boxMax;
+    sendMin = boxMax - cutoff - skin;
+    sendMax = boxMax + skin;
     if (boxMax == globalBoxMax) {
       shift = globalBoxMin - globalBoxMax;
     } else {
@@ -235,7 +235,7 @@ void getSendHalo(double boxMin, double boxMax, int diff, double &sendMin, double
  * @param globalBoxMax
  */
 void getSendLeaving(double boxMin, double boxMax, int diff, double &sendMin, double &sendMax, double cutoff,
-                    double &shift, const double globalBoxMin, const double globalBoxMax) {
+                    double skin, double &shift, const double globalBoxMin, const double globalBoxMax) {
   if (diff == 0) {
     sendMin = boxMin;
     sendMax = boxMax;
@@ -288,7 +288,7 @@ void updateHaloParticles(AutoPasContainer &sphSystem, MPI_Comm &comm, const std:
         }
         // figure out which particles we send
         for (int i = 0; i < 3; ++i) {
-          getSendHalo(boxMin[i], boxMax[i], diff[i], requiredHaloMin[i], requiredHaloMax[i], cutoff, shift[i],
+          getSendHalo(boxMin[i], boxMax[i], diff[i], requiredHaloMin[i], requiredHaloMax[i], cutoff, skin, shift[i],
                       globalBoxMin[i], globalBoxMax[i]);
         }
 
@@ -318,6 +318,7 @@ void periodicBoundaryUpdate(AutoPasContainer &sphSystem, MPI_Comm &comm, const s
                             std::array<double, 3> globalBoxMin, std::array<double, 3> globalBoxMax) {
   std::array<double, 3> boxMin = sphSystem.getBoxMin();
   std::array<double, 3> boxMax = sphSystem.getBoxMax();
+  auto skin = sphSystem.getVerletSkin();
   std::array<double, 3> requiredHaloMin{0, 0, 0}, requiredHaloMax{0, 0, 0};
   std::array<int, 3> diff{0, 0, 0};
   std::array<double, 3> shift{0, 0, 0};
@@ -334,7 +335,7 @@ void periodicBoundaryUpdate(AutoPasContainer &sphSystem, MPI_Comm &comm, const s
         }
         // figure out which particles we send
         for (int i = 0; i < 3; ++i) {
-          getSendLeaving(boxMin[i], boxMax[i], diff[i], requiredHaloMin[i], requiredHaloMax[i], cutoff, shift[i],
+          getSendLeaving(boxMin[i], boxMax[i], diff[i], requiredHaloMin[i], requiredHaloMax[i], cutoff, skin, shift[i],
                          globalBoxMin[i], globalBoxMax[i]);
         }
         for (const auto &p : invalidParticles) {

--- a/examples/sph/sph-main.cpp
+++ b/examples/sph/sph-main.cpp
@@ -149,19 +149,19 @@ void addEnteringParticles(AutoPasContainer &sphSystem, std::vector<Particle> &in
  * @param cutoff
  * @param shift
  */
-void getRequiredHalo(double boxMin, double boxMax, int diff, double &reqMin, double &reqMax, double cutoff,
+void getRequiredHalo(double boxMin, double boxMax, int diff, double &reqMin, double &reqMax, double cutoff, double skin,
                      double &shift) {
   if (diff == 0) {
-    reqMin = boxMin;
-    reqMax = boxMax;
+    reqMin = boxMin - skin;
+    reqMax = boxMax + skin;
     shift = 0;
   } else if (diff == -1) {
-    reqMin = boxMax - cutoff;
-    reqMax = boxMax;
+    reqMin = boxMax - cutoff - skin;
+    reqMax = boxMax + skin;
     shift = boxMin - boxMax;
   } else if (diff == 1) {
-    reqMin = boxMin;
-    reqMax = boxMin + cutoff;
+    reqMin = boxMin - skin;
+    reqMax = boxMin + cutoff + skin;
     shift = boxMax - boxMin;
   }
 }
@@ -175,6 +175,7 @@ void getRequiredHalo(double boxMin, double boxMax, int diff, double &reqMin, dou
 void updateHaloParticles(AutoPasContainer &sphSystem) {
   std::array<double, 3> boxMin = sphSystem.getBoxMin();
   std::array<double, 3> boxMax = sphSystem.getBoxMax();
+  auto skin = sphSystem.getVerletSkin();
   std::array<double, 3> requiredHaloMin{0., 0., 0.}, requiredHaloMax{0., 0., 0.};
   std::array<int, 3> diff{0, 0, 0};
   std::array<double, 3> shift{0., 0., 0.};
@@ -189,7 +190,8 @@ void updateHaloParticles(AutoPasContainer &sphSystem) {
         }
         // figure out from where we get our halo particles
         for (int i = 0; i < 3; ++i) {
-          getRequiredHalo(boxMin[i], boxMax[i], diff[i], requiredHaloMin[i], requiredHaloMax[i], cutoff, shift[i]);
+          getRequiredHalo(boxMin[i], boxMax[i], diff[i], requiredHaloMin[i], requiredHaloMax[i], cutoff, skin,
+                          shift[i]);
         }
         for (auto iterator =
                  sphSystem.getRegionIterator(requiredHaloMin, requiredHaloMax, autopas::IteratorBehavior::owned);

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -367,14 +367,6 @@ class LogicHandler {
     const auto &boxMin = _currentContainer->getBoxMin();
     const auto &boxMax = _currentContainer->getBoxMax();
     Particle_T haloParticleCopy = haloParticle;
-    if (utils::inBox(haloParticleCopy.getR(), boxMin, boxMax)) {
-      utils::ExceptionHandler::exception(
-          "LogicHandler: Trying to add a halo particle that is not outside the box of the container.\n"
-          "Box Min {}\n"
-          "Box Max {}\n"
-          "{}",
-          utils::ArrayUtils::to_string(boxMin), utils::ArrayUtils::to_string(boxMax), haloParticleCopy.toString());
-    }
     haloParticleCopy.setOwnershipState(OwnershipState::halo);
     if (not _neighborListsAreValid.load(std::memory_order_relaxed)) {
       // If the neighbor lists are not valid, we can add the particle.

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -195,24 +195,25 @@ class LogicHandler {
     if (_tuningManager->tuningPhaseJustFinished()) {
       _iterationAfterLastTuningPhase = _iteration;
     }
+    std::vector<Particle_T> leavingParticles;
+
     // We will do a rebuild in this timestep
     if (not _neighborListsAreValid.load(std::memory_order_relaxed)) {
       _stepsSinceLastListRebuild = 0;
+      // The next call also adds particles to the container if doDataStructureUpdate is true.
+      auto leavingBufferParticles = collectLeavingParticlesFromBuffer(doDataStructureUpdate);
+
+      AutoPasLog(TRACE, "Initiating container update.");
+      leavingParticles = _currentContainer->updateContainer(not doDataStructureUpdate);
+      leavingParticles.insert(leavingParticles.end(), leavingBufferParticles.begin(), leavingBufferParticles.end());
+
+      // Subtract the amount of leaving particles from the number of owned particles.
+      _numParticlesOwned.fetch_sub(leavingParticles.size(), std::memory_order_relaxed);
+      // updateContainer deletes all halo particles.
+      std::for_each(_haloParticleBuffer.begin(), _haloParticleBuffer.end(), [](auto &buffer) { buffer.clear(); });
+      _numParticlesHalo.store(0, std::memory_order_relaxed);
     }
     ++_stepsSinceLastListRebuild;
-
-    // The next call also adds particles to the container if doDataStructureUpdate is true.
-    auto leavingBufferParticles = collectLeavingParticlesFromBuffer(doDataStructureUpdate);
-
-    AutoPasLog(TRACE, "Initiating container update.");
-    auto leavingParticles = _currentContainer->updateContainer(not doDataStructureUpdate);
-    leavingParticles.insert(leavingParticles.end(), leavingBufferParticles.begin(), leavingBufferParticles.end());
-
-    // Subtract the amount of leaving particles from the number of owned particles.
-    _numParticlesOwned.fetch_sub(leavingParticles.size(), std::memory_order_relaxed);
-    // updateContainer deletes all halo particles.
-    std::for_each(_haloParticleBuffer.begin(), _haloParticleBuffer.end(), [](auto &buffer) { buffer.clear(); });
-    _numParticlesHalo.store(0, std::memory_order_relaxed);
     return leavingParticles;
   }
 

--- a/src/autopas/LogicHandler.h
+++ b/src/autopas/LogicHandler.h
@@ -364,9 +364,20 @@ class LogicHandler {
    * @copydoc AutoPas::addHaloParticle()
    */
   void addHaloParticle(const Particle_T &haloParticle) {
-    const auto &boxMin = _currentContainer->getBoxMin();
-    const auto &boxMax = _currentContainer->getBoxMax();
+    // Halo particles can be inside the domain within a skin distance of the boundaries.
+    const auto &boxMin =
+        utils::ArrayMath::addScalar(_currentContainer->getBoxMin(), _currentContainer->getVerletSkin());
+    const auto &boxMax =
+        utils::ArrayMath::addScalar(_currentContainer->getBoxMax(), -_currentContainer->getVerletSkin());
     Particle_T haloParticleCopy = haloParticle;
+    if (utils::inBox(haloParticleCopy.getR(), boxMin, boxMax)) {
+      utils::ExceptionHandler::exception(
+          "LogicHandler: Trying to add a halo particle that is not outside the box of the container.\n"
+          "Box Min {}\n"
+          "Box Max {}\n"
+          "{}",
+          utils::ArrayUtils::to_string(boxMin), utils::ArrayUtils::to_string(boxMax), haloParticleCopy.toString());
+    }
     haloParticleCopy.setOwnershipState(OwnershipState::halo);
     if (not _neighborListsAreValid.load(std::memory_order_relaxed)) {
       // If the neighbor lists are not valid, we can add the particle.

--- a/tests/testAutopas/tests/autopasInterface/LogicHandlerTest.cpp
+++ b/tests/testAutopas/tests/autopasInterface/LogicHandlerTest.cpp
@@ -214,31 +214,42 @@ TEST_F(LogicHandlerTest, testParticleInBufferMoveAcrossPeriodicBoundaryForDynami
   ASSERT_FALSE(_logicHandler->getNeighborListsInvalidDoDynamicRebuild())
       << " The neighbor list is rebuilt as previously neighbor lists were invalid.\n";
 
-  // 0.3 skin + (boxMaxY - 0.15 skin) = boxMaxY + 0.15 skim -> particle is outside the boundary and has travelled less
+  // 0.3 skin + (boxMaxY - 0.15 skin) = boxMaxY + 0.15 skin -> particle is outside the boundary and has travelled less
   // than skin/2
   for (auto iter = _logicHandler->begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
     iter->addR(moveVec);
   }
   leavingParticles = _logicHandler->updateContainer();
-  EXPECT_EQ(leavingParticles.size(), 1) << "Exactly one particle has left the container \n";
-  EXPECT_EQ(_logicHandler->getContainer().getNumberOfParticles(), 0) << "No particle left in the container \n";
+  // Particle has moved outside the domain but is still within boxMaxY + skin, so not treated as leaving particle
+  EXPECT_EQ(leavingParticles.size(), 0) << "No particle has left the container \n";
+  EXPECT_EQ(_logicHandler->getContainer().getNumberOfParticles(), 1) << "Exactly one particle left in the container \n";
 
-  // shifting particle position to replicate periodic boundary effect
-  for (auto particle : leavingParticles) {
-    particle.addR(shiftVecPeriodicY);
-    _logicHandler->addParticle(particle);
-  }
+  // No periodic boundary handling needed as particle is still within boxMaxY + skin
+  // for (auto particle : leavingParticles) {
+  //  particle.addR(shiftVecPeriodicY);
+  //  _logicHandler->addParticle(particle);
+  //}
+
   // As neighbor lists are valid, particle is added to the buffer, so container will have 0 particles
-  EXPECT_EQ(_logicHandler->getContainer().getNumberOfParticles(), 0)
-      << "Particle added to the buffer, so container must still be empty. \n";
+  // EXPECT_EQ(_logicHandler->getContainer().getNumberOfParticles(), 1)
+  //    << "Particle added to the buffer, so container must still be empty. \n";
 
-  EXPECT_EQ(_logicHandler->getNumberOfParticlesOwned(), 1)
-      << "One particle added on the other side of periodic boundary \n";
+  EXPECT_EQ(_logicHandler->getNumberOfParticlesOwned(), 1) << "Owned particle slightly outside the domain \n";
 
-  _logicHandler->resetNeighborListsInvalidDoDynamicRebuild();
-  _logicHandler->checkNeighborListsInvalidDoDynamicRebuild();
-  ASSERT_FALSE(_logicHandler->getNeighborListsInvalidDoDynamicRebuild())
-      << " Particle has moved across the periodic boundary and more than half the skin, but as it is in the buffer, it "
-         "doesn't affect the container. \n";
+  // 0.3 skin + (boxMaxY + 0.15 skin) = boxMaxY + 0.45 skin -> particle is outside the boundary and has travelled more
+  // than skin/2
+  for (auto iter = _logicHandler->begin(autopas::IteratorBehavior::owned); iter.isValid(); ++iter) {
+    iter->addR(moveVec);
+  }
+
+  leavingParticles = _logicHandler->updateContainer();
+  // Particle has moved more than skin, so dynamic rebuild is triggered
+
+  ASSERT_TRUE(_logicHandler->getNeighborListsInvalidDoDynamicRebuild())
+      << " Particle has moved more than half the skin, so it will trigger the dynamic rebuild. \n";
+
+  // Particle is within boxMaxY + skin, but as it is a rebuild iteration, leaving particle is counted
+  EXPECT_EQ(leavingParticles.size(), 1) << "No particle has left the container \n";
+  EXPECT_EQ(_logicHandler->getContainer().getNumberOfParticles(), 0) << "Exactly one particle left in the container \n";
 }
 #endif


### PR DESCRIPTION
# Description

Currently, any particle that leaves the local domain is migrated to the neighboring domain and added to the buffer (in non-rebuild iterations). This is not necessary, as the particle, even though slightly outside, still maintains all the "neighborhood" relationships! 

## Closes Issues:
- #749 (we still keep the `updateContainer()` for incrementing counters)
- #823 will no longer be required.

## Changes:
- In update containers, leaving particles are only found and returned for rebuild iterations.
- No change required for `exchangeMigratingParticles()` 
- Change required in `exchangeHaloParticles()` to consider `skin` when checking for particles to be exchanged. $\rightarrow$ Although not sure, this is so obvious for a user simulator developer. (so maybe we need to document it better?) Corresponding changes in SPH examples were also made.
- Halo Particles can now be inside the domain (within `skin` distance from the boundary), so the check while adding halo particles was updated accordingly.

## Performance Results
Based on the equilibration run from the example cases, with some parameters changed.
### Single MPI rank
|| Case    | Master (time-s)      | New (time-s)| 
| -------------| ------------- | ------------- | ------------- | 
| 1 | default (skin 0.5/ rf 10) | Cell 2, Row 1 | 19398 |
| 2 | skin 1/ rf 10 | 18773 | 18545 |
| 3 | skin 1/ rf 35   | 18369 | 17849 |

Note: even in case 3, no interactions are missed; the minimum rebuild frequency was obtained from a run with dynamic rebuilding. But I just wanted to compare with static rebuilding.

For the case 3, we can compare more in detail the important results:
|    | Master (time-s)      | New (time-s)| 
| ------------- | ------------- | ------------- | 
| ForceUpdateTotal | 5836  | 5556 |
| UpdateContainer | 337 | 31.9 |
| Halo Particle Exchange | 10421 | 10467 | 
| Reflective boundary | 0.038 | 0.033 |
| Migrating Particles Exchange | 304.3  | 305.7 | 

$\rightarrow$ so, we save in the `updateContainer()` cost as well as in `ForceUpdateTotal()` (less remainder traversal time, as an eg. in iteration just before the rebuild, the remainderTraversal time in master is about 0.9 ms in comparison to .... this doesn't look right. :/ 

## Main Idea
Key idea is described in the screenshot below. 
<img width="400" height="600" alt="WhatsApp Image 2026-08-18 at 2 25 23 PM" src="https://github.com/user-attachments/assets/06fa7e1d-ad94-44b5-99e2-6f9b1c9b89d8" />


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Equilibration run --> checking potential energy, runtime performance (boundary, update container, and force update total)
- [x] Existing tests/ CI


# Reference
Screenshot from [LAMMPS paper](https://www.sciencedirect.com/science/article/pii/S0010465521002836?via%3Dihub) 

<img width="733" height="313" alt="Screenshot from 2026-08-21 14-05-48" src="https://github.com/user-attachments/assets/c0cd359c-c206-48b5-80ee-639878ab5f27" />
